### PR TITLE
updates to ffmpeg use

### DIFF
--- a/src/SIPCreationTools/lib/restructureForCompliance/restructureForCompliance.sh
+++ b/src/SIPCreationTools/lib/restructureForCompliance/restructureForCompliance.sh
@@ -33,6 +33,14 @@ if [ -d "$target" ]; then
 	mkdir "${target}/metadata/submissionDocumentation"
 	mkdir "${target}/objects"
 	mv "$temp"/* "${target}objects/." 
+elif [ -f "$target" -a ! -d "$(dirname $target)/$(basename ${target%.*})" ]; then
+	mkdir -p "$(dirname $target)/$(basename ${target%.*})/objects"
+	mv "$target" "$(dirname $target)/$(basename ${target%.*})/objects/"
+
+	mkdir "$(dirname $target)/$(basename ${target%.*})/logs"
+	mkdir "$(dirname $target)/$(basename ${target%.*})/logs/fileMeta"
+	mkdir "$(dirname $target)/$(basename ${target%.*})/metadata"
+	mkdir "$(dirname $target)/$(basename ${target%.*})/metadata/submissionDocumentation"
 else
 	echo Error: Needs SIP directory as argument 1>&2
 	exit 1

--- a/src/SIPCreationTools/lib/restructureForCompliance/restructureForCompliance.sh
+++ b/src/SIPCreationTools/lib/restructureForCompliance/restructureForCompliance.sh
@@ -24,11 +24,9 @@
 target=$1
 
 if [ -d "$target" ]; then
-	temp="/tmp/`uuid`"
-	mkdir "$temp"
+	mkdir "${target}objects"
+	mv $(find "$target" -mindepth 1 -maxdepth 1 ! -name "objects") "${target}objects/"
 
-	mv "$target"/* "$temp/."
-	
 	mkdir "${target}logs"
 	mkdir "${target}logs/fileMeta"
 	mkdir "${target}metadata"

--- a/src/SIPCreationTools/lib/restructureForCompliance/restructureForCompliance.sh
+++ b/src/SIPCreationTools/lib/restructureForCompliance/restructureForCompliance.sh
@@ -24,14 +24,14 @@
 target=$1
 
 if [ -d "$target" ]; then
-	mkdir "${target}objects"
+	mkdir "${target}/objects"
 	mv $(find "$target" -mindepth 1 -maxdepth 1 ! -name "objects") "${target}objects/"
 
-	mkdir "${target}logs"
-	mkdir "${target}logs/fileMeta"
-	mkdir "${target}metadata"
-	mkdir "${target}metadata/submissionDocumentation"
-	mkdir "${target}objects"
+	mkdir "${target}/logs"
+	mkdir "${target}/logs/fileMeta"
+	mkdir "${target}/metadata"
+	mkdir "${target}/metadata/submissionDocumentation"
+	mkdir "${target}/objects"
 	mv "$temp"/* "${target}objects/." 
 else
 	echo Error: Needs SIP directory as argument 1>&2

--- a/src/SIPCreationTools/lib/restructureForCompliance/restructureForCompliance.sh
+++ b/src/SIPCreationTools/lib/restructureForCompliance/restructureForCompliance.sh
@@ -34,7 +34,7 @@ elif [ -f "$target" -a ! -d "$(dirname $target)/$(basename ${target%.*})" ]; the
 	mkdir -p "$(dirname $target)/$(basename ${target%.*})/logs/fileMeta"
 	mkdir -p "$(dirname $target)/$(basename ${target%.*})/metadata/submissionDocumentation"
 else
-	echo Error: Needs SIP directory as argument 1>&2
+	echo Error: Needs SIP directory or file as argument 1>&2
 	exit 1
 fi 
 

--- a/src/SIPCreationTools/lib/restructureForCompliance/restructureForCompliance.sh
+++ b/src/SIPCreationTools/lib/restructureForCompliance/restructureForCompliance.sh
@@ -31,8 +31,6 @@ if [ -d "$target" ]; then
 	mkdir "${target}/logs/fileMeta"
 	mkdir "${target}/metadata"
 	mkdir "${target}/metadata/submissionDocumentation"
-	mkdir "${target}/objects"
-	mv "$temp"/* "${target}objects/." 
 elif [ -f "$target" -a ! -d "$(dirname $target)/$(basename ${target%.*})" ]; then
 	mkdir -p "$(dirname $target)/$(basename ${target%.*})/objects"
 	mv "$target" "$(dirname $target)/$(basename ${target%.*})/objects/"

--- a/src/SIPCreationTools/lib/restructureForCompliance/restructureForCompliance.sh
+++ b/src/SIPCreationTools/lib/restructureForCompliance/restructureForCompliance.sh
@@ -26,19 +26,13 @@ target=$1
 if [ -d "$target" ]; then
 	mkdir "${target}/objects"
 	mv $(find "$target" -mindepth 1 -maxdepth 1 ! -name "objects") "${target}objects/"
-
-	mkdir "${target}/logs"
-	mkdir "${target}/logs/fileMeta"
-	mkdir "${target}/metadata"
-	mkdir "${target}/metadata/submissionDocumentation"
+	mkdir -p "${target}/logs/fileMeta"
+	mkdir -p "${target}/metadata/submissionDocumentation"
 elif [ -f "$target" -a ! -d "$(dirname $target)/$(basename ${target%.*})" ]; then
 	mkdir -p "$(dirname $target)/$(basename ${target%.*})/objects"
 	mv "$target" "$(dirname $target)/$(basename ${target%.*})/objects/"
-
-	mkdir "$(dirname $target)/$(basename ${target%.*})/logs"
-	mkdir "$(dirname $target)/$(basename ${target%.*})/logs/fileMeta"
-	mkdir "$(dirname $target)/$(basename ${target%.*})/metadata"
-	mkdir "$(dirname $target)/$(basename ${target%.*})/metadata/submissionDocumentation"
+	mkdir -p "$(dirname $target)/$(basename ${target%.*})/logs/fileMeta"
+	mkdir -p "$(dirname $target)/$(basename ${target%.*})/metadata/submissionDocumentation"
 else
 	echo Error: Needs SIP directory as argument 1>&2
 	exit 1

--- a/src/transcoder/share/mysql
+++ b/src/transcoder/share/mysql
@@ -2786,7 +2786,7 @@ audioCodec="pcm_s16le"
 videoCodec="ffv1"
 
 command="ffmpeg -vsync passthrough -i \"${inputFile}\" -map 0:v -map 0:a "
-command="${command} -vcodec ${videoCodec} "
+command="${command} -vcodec ${videoCodec} -g 1 "
 command="${command} -acodec ${audioCodec}"
 command="${command} ${outputFile}"
 

--- a/src/transcoder/share/mysql
+++ b/src/transcoder/share/mysql
@@ -3408,7 +3408,7 @@ INSERT INTO Commands
     (commandType, command, outputLocation, eventDetailCommand, verificationCommand, description) 
     VALUES (
     (SELECT pk FROM CommandTypes WHERE type = 'bashScript'),
-    ('ffmpeg -i "%fileFullName%"  -ac `ffprobe "%fileFullName%" -show_streams 2>&1 | grep "codec_type=audio" -c` -ac 2 -ab 192000 "%outputDirectory%%prefix%%fileName%%postfix%.mp3"'),
+    ('ffmpeg -i "%fileFullName%" -ac 2 -ab 192000 "%outputDirectory%%prefix%%fileName%%postfix%.mp3"'),
     '%outputDirectory%%prefix%%fileName%%postfix%.mp3',
     @ffmpegEventDetailCommandID,
     @standardVerificationCommand,

--- a/src/transcoder/share/mysql
+++ b/src/transcoder/share/mysql
@@ -2784,33 +2784,13 @@ inputFile="%fileFullName%"
 outputFile="%outputDirectory%%prefix%%fileName%%postfix%.mkv"
 audioCodec="pcm_s16le"
 videoCodec="ffv1"
-audioStreamCount=`ffprobe "${inputFile}" -show_streams 2>&1 | grep "codec_type=audio" -c`
-videoStreamCount=`ffprobe "${inputFile}" -show_streams 2>&1 | grep "codec_type=video" -c`
+###audioStreamCount=`ffprobe "${inputFile}" -show_streams 2>&1 | grep "codec_type=audio" -c`
+###videoStreamCount=`ffprobe "${inputFile}" -show_streams 2>&1 | grep "codec_type=video" -c`
 
-command="ffmpeg -i \"${inputFile}\" "
-if [ ${audioStreamCount} -ge 1 ] ; then
+command="ffmpeg -i \"${inputFile}\" -map 0:v -map 0:a "
 command="${command} -vcodec ${videoCodec} "
-fi
-
-if [ ${videoStreamCount} -ge 1 ] ; then
 command="${command} -acodec ${audioCodec}"
-fi
-
 command="${command} ${outputFile}"
-
-addAudioStream=" -acodec ${audioCodec}  -newaudio"
-addVideoStream=" -vcodec ${videoCodec}  -newvideo"
-
-#add additional audio channels
-for (( c=1; c<${audioStreamCount}; c++ )); do 
-command="${command} ${addAudioStream}"
-#echo $command
-done
-
-for (( c=1; c<${videoStreamCount}; c++ )); do 
-command="${command} ${addVideoStream}"
-#echo $command
-done
 
 echo $command
 eval $command

--- a/src/transcoder/share/mysql
+++ b/src/transcoder/share/mysql
@@ -2785,7 +2785,7 @@ outputFile="%outputDirectory%%prefix%%fileName%%postfix%.mkv"
 audioCodec="pcm_s16le"
 videoCodec="ffv1"
 
-command="ffmpeg -i \"${inputFile}\" -map 0:v -map 0:a "
+command="ffmpeg -vsync passthrough -i \"${inputFile}\" -map 0:v -map 0:a "
 command="${command} -vcodec ${videoCodec} "
 command="${command} -acodec ${audioCodec}"
 command="${command} ${outputFile}"

--- a/src/transcoder/share/mysql
+++ b/src/transcoder/share/mysql
@@ -3420,7 +3420,7 @@ INSERT INTO Commands
     (commandType, command, outputLocation, eventDetailCommand, verificationCommand, description) 
     VALUES (
     (SELECT pk FROM CommandTypes WHERE type = 'bashScript'),
-    ('ffmpeg -i "%fileFullName%" -ac `ffprobe "%fileFullName%" -show_streams 2>&1 | grep "codec_type=audio" -c` "%outputDirectory%%prefix%%fileName%%postfix%.wav"'),
+    ('ffmpeg -i "%fileFullName%" "%outputDirectory%%prefix%%fileName%%postfix%.wav"'),
     '%outputDirectory%%prefix%%fileName%%postfix%.wav',
     @ffmpegEventDetailCommandID,
     @standardVerificationCommand,

--- a/src/transcoder/share/mysql
+++ b/src/transcoder/share/mysql
@@ -2784,8 +2784,6 @@ inputFile="%fileFullName%"
 outputFile="%outputDirectory%%prefix%%fileName%%postfix%.mkv"
 audioCodec="pcm_s16le"
 videoCodec="ffv1"
-###audioStreamCount=`ffprobe "${inputFile}" -show_streams 2>&1 | grep "codec_type=audio" -c`
-###videoStreamCount=`ffprobe "${inputFile}" -show_streams 2>&1 | grep "codec_type=video" -c`
 
 command="ffmpeg -i \"${inputFile}\" -map 0:v -map 0:a "
 command="${command} -vcodec ${videoCodec} "

--- a/src/transcoder/share/mysql
+++ b/src/transcoder/share/mysql
@@ -2745,7 +2745,7 @@ INSERT INTO Commands
     (commandType, command, outputLocation, eventDetailCommand, verificationCommand, description) 
     VALUES (
     (SELECT pk FROM CommandTypes WHERE type = 'bashScript'),
-    ('ffmpeg -i "%fileFullName%" -vcodec libx264 -preset medium -crf 18 "%outputDirectory%%prefix%%fileName%%postfix%.mp4"'),
+    ('ffmpeg -i "%fileFullName%" -vcodec libx264 -pix_fmt yuv420p -preset medium -crf 18 "%outputDirectory%%prefix%%fileName%%postfix%.mp4"'),
     '%outputDirectory%%prefix%%fileName%%postfix%.mp4',
     @ffmpegEventDetailCommandID,
     @standardVerificationCommand,

--- a/src/transcoder/share/mysql
+++ b/src/transcoder/share/mysql
@@ -2735,7 +2735,7 @@ INSERT INTO Commands
     -- VALUES SELECT pk FROM FileIDS WHERE description = 'Normalize Defaults'
     VALUES (
     (SELECT pk FROM CommandTypes WHERE type = 'bashScript'),
-    ('echo program=\\"ffmpeg\\"\\; version=\\"`ffmpeg 2>&1 | grep \"FFmpeg version\"`\\"'),
+    ('echo program=\\"ffmpeg\\"\\; version=\\"`ffmpeg 2>&1 | grep --ignore-case \"FFmpeg version\"`\\"'),
     ('Get event detail text for ffmpeg extraction')
 );
 
@@ -3398,7 +3398,7 @@ INSERT INTO Commands
     (commandType, command, description) 
     VALUES (
     (SELECT pk FROM CommandTypes WHERE type = 'bashScript'),
-    ('echo program=\\"ffmpeg\\"\\; version=\\"`ffmpeg 2>&1 | grep \"FFmpeg version\"`\\"'),
+    ('echo program=\\"ffmpeg\\"\\; version=\\"`ffmpeg 2>&1 | grep --ignore-case \"FFmpeg version\"`\\"'),
     ('Get event detail text for ffmpeg extraction')
 );
 


### PR DESCRIPTION
These commits presume using a modern version of ffmpeg, 0.9 or later. I used the -map option to cut down the number of lines needed to direct all audiovisual tracks from the input to output in the ffv1 encoding. There's other cleanup to make sure this script still works with modern ffmpegs and some fixes to audio transcoding commands. In a digipres environment I think it's wise to stick to single frame gops with ffv1 use in increase error resilience and added this (it will cause a very minor increase in the resulting file size).
