### PR TITLE
Add new bulk_extractor "examine contents" microservice

### DIFF
--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -64,6 +64,7 @@ createSIPsfromTRIMTransferContainers_v0.0 = %clientScriptsDirectory%createSIPsfr
 determineAIPVersionKeyExitCode_v0.0 = %clientScriptsDirectory%determineAIPVersionKeyExitCode.py
 echo_v0.0 = /bin/echo
 emailFailReport_v0.0 = %clientScriptsDirectory%emailFailReport.py
+examineContents_v0.0 = %clientScriptsDirectory%examineContents.py
 extractBagTransfer_v0.0 = %clientScriptsDirectory%extractBagTransfer.py
 extractContents_v0.0 = %clientScriptsDirectory%extractContents.py
 extractMaildirAttachments_v0.0 = %clientScriptsDirectory%extractMaildirAttachments.py

--- a/src/MCPClient/lib/clientScripts/examineContents.py
+++ b/src/MCPClient/lib/clientScripts/examineContents.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python2
+import os
+import subprocess
+import sys
+
+
+def main(target, output):
+    args = [
+        'bulk_extractor', target, '-o', output,
+        '-M', '250', '-q', '-1'
+    ]
+    try:
+        os.makedirs(output)
+        subprocess.call(args)
+        return 0
+    except Exception as e:
+        return e
+
+if __name__ == '__main__':
+    target = sys.argv[1]
+    sipdir = sys.argv[2]
+    file_uuid = sys.argv[3]
+    output = os.path.join(sipdir, 'logs', 'bulk-' + file_uuid)
+    sys.exit(main(target, output))

--- a/src/dashboard/src/components/administration/views_processing.py
+++ b/src/dashboard/src/components/administration/views_processing.py
@@ -125,6 +125,11 @@ def index(request):
             "label": "Reminder: add metadata if desired",
             "choice_uuid": "eeb23509-57e2-4529-8857-9d62525db048",
         },
+        {
+            "name":  "examine",
+            "label": "Examine contents",
+            "choice_uuid": "accea2bf-ba74-4a3a-bb97-614775c74459"
+        },
     ]
 
     populate_select_fields_with_chain_choice_options(chain_choice_fields)

--- a/src/dashboard/src/components/ingest/urls.py
+++ b/src/dashboard/src/components/ingest/urls.py
@@ -38,6 +38,7 @@ urlpatterns = patterns('components.ingest.views',
     url(r'normalization-report/(?P<uuid>' + settings.UUID_REGEX + ')/$', 'ingest_normalization_report'),
     url(r'preview/aip/(?P<jobuuid>' + settings.UUID_REGEX + ')/$', 'ingest_browse_aip'),
     url(r'preview/normalization/(?P<jobuuid>' + settings.UUID_REGEX + ')/$', 'ingest_browse_normalization'),
+    url(r'preview/logs/(?P<transferuuid>' + settings.UUID_REGEX + ')/$', 'ingest_browse_logs'),
     url(r'backlog/process/(?P<transfer_uuid>' + settings.UUID_REGEX + ')/', 'process_transfer'),
     url(r'backlog/file/download/(?P<uuid>' + settings.UUID_REGEX + ')/', 'transfer_file_download'),
     url(r'backlog/$', 'transfer_backlog')

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -387,6 +387,22 @@ def ingest_browse_aip(request, jobuuid):
 
     return render(request, 'ingest/aip_browse.html', locals())
 
+def ingest_browse_logs(request, transferuuid):
+    """
+    Displays a preview browser for logs from transfers. This is primarily intended
+    for use with transfers in the transfer backlog, but can work with any transfer.
+    """
+    transfer = models.Transfer.objects.get(pk=transferuuid)
+    title = 'Review transfer logs'
+    shared_dir = helpers.get_server_config_value('sharedDirectory')
+    path = transfer.currentlocation.replace('%sharedPath%', shared_dir)
+    name = utils.get_directory_name(path)
+    directory = os.path.join(path, 'logs')
+    with open('/tmp/dir.log', 'a') as log:
+        print >> log, name
+
+    return render(request, 'ingest/aip_browse.html', locals())
+
 @decorators.elasticsearch_required()
 def transfer_backlog(request):
     # deal with transfer mode

--- a/src/dashboard/src/templates/ingest/backlog/search.html
+++ b/src/dashboard/src/templates/ingest/backlog/search.html
@@ -62,6 +62,9 @@
             <div>Files</div>
           </th>
           <th>
+            <div>Logs</div>
+          </th>
+          <th>
             <div>Ingested?</div>
           </th>
         </thead>
@@ -72,6 +75,7 @@
             <td>{{ term_usage.term }}</td>
             <td>{{ term_usage.accession }}</td>
             <td>{{ term_usage.count }} files</td>
+            <td><a href='/ingest/preview/logs/{{ term_usage.term }}/' target='_blank'>View logs</a></td>
             <td>
               {% if awaiting_creation|keyvalue:term_usage.term %}
                 <a href='/ingest/backlog/process/{{ term_usage.term }}/' target='_blank' class='creation btn'>Create SIP</a>


### PR DESCRIPTION
This adds a new "examine contents" microservice, which runs bulk_extractor in order to try and extract useful data from files. It's usually used with disk images, but can be run on any kind of file. Logs are stored in the SIP/AIP and can be viewed from transfer backlog.

This depends on #2 and shouldn't get merged first.
