### PR TITLE
Deal more gracefully with non-ASCII, non-Unicode paths

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS.py
@@ -28,10 +28,9 @@ import sys
 import lxml.etree as etree
 import MySQLdb
 from xml.sax.saxutils import quoteattr
-#from archivematicaCreateMETS2 import escape
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 import databaseInterface
-#from archivematicaFunctions import escape
+from archivematicaFunctions import escape
 
 
 UUIDsDic={}
@@ -55,10 +54,6 @@ XMLFile = opts.xmlFile
 includeAmdSec = opts.amdSec
 basePathString = "%%%s%%" % (opts.basePathString)
 fileGroupIdentifier = opts.fileGroupIdentifier
-
-def escape(string):
-    string = string.decode('utf-8')
-    return string
 
 
 def newChild(parent, tag, text=None, tailText=None):

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -628,7 +628,7 @@ def createFileSec(directoryPath, structMapDiv):
                 originalLocation = row[1]
                 if derivedFromOriginalName != None:
                     originalLocation = derivedFromOriginalName
-                originalName = os.path.basename(originalLocation) + u"/" #+ u"/" keeps normalized after original / is very uncommon in a file name
+                originalName = os.path.basename(originalLocation) + "/" #+ u"/" keeps normalized after original / is very uncommon in a file name
                 directoryContentsTuples.append((originalName, item,)) 
                 row = c.fetchone()
             sqlLock.release()

--- a/src/MCPClient/lib/clientScripts/restructureForCompliance.py
+++ b/src/MCPClient/lib/clientScripts/restructureForCompliance.py
@@ -40,7 +40,11 @@ def restructureTRIMForComplianceFileUUIDsAssigned(unitPath, unitIdentifier, unit
         reqDirPath = os.path.join(unitPath, dir)
         if not os.path.isdir(reqDirPath):
             os.mkdir(reqDirPath)
-    
+
+    # The types returned by os.listdir() depends on the type of the argument
+    # passed to it. In this case, we want all of the returned names to be
+    # bytestrings because they may contain arbitrary, non-Unicode characters.
+    unitPath = str(unitPath)
     for item in os.listdir(unitPath):
         if item in requiredDirectories:
             continue
@@ -83,7 +87,11 @@ def restructureTRIMForComplianceFileUUIDsAssigned(unitPath, unitIdentifier, unit
 def restructureBagForComplianceFileUUIDsAssigned(unitPath, unitIdentifier, unitIdentifierType, unitPathReplaceWith = "%transferDirectory%"):
     bagFileDefaultDest = os.path.join(unitPath, "logs", "BagIt")
     requiredDirectories.append(bagFileDefaultDest)
-    unitDataPath = os.path.join(unitPath, "data")
+    # This needs to be cast to a string since we're calling os.path.join(),
+    # and any of the other arguments could contain arbitrary, non-Unicode
+    # characters.
+    unitPath = str(unitPath)
+    unitDataPath = str(os.path.join(unitPath, "data"))
     for dir in requiredDirectories:
         dirPath = os.path.join(unitPath, dir)
         dirDataPath = os.path.join(unitPath, "data", dir)
@@ -126,6 +134,7 @@ def restructureForComplianceFileUUIDsAssigned(unitPath, unitIdentifier, unitIden
     print unitUUID, unitType
 
 def restructureDirectory(unitPath):
+    unitPath = str(unitPath)
     for dir in requiredDirectories:
         dirPath = os.path.join(unitPath, dir)
         if not os.path.isdir(dirPath):

--- a/src/MCPServer/lib/unitTransfer.py
+++ b/src/MCPServer/lib/unitTransfer.py
@@ -102,7 +102,7 @@ class unitTransfer(unit):
             while row != None:
                 #print row
                 UUID = row[0]
-                currentPath = row[1].encode("utf-8")
+                currentPath = row[1]
                 fileGrpUse = row[2]
                 #print currentPath in self.fileList, row
                 if currentPath in self.fileList:

--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -83,3 +83,17 @@ UPDATE MicroServiceChains SET startingLink=@extractDeleteChoiceMSCL WHERE pk=@ex
 UPDATE StandardTasksConfigs SET arguments='"%SIPUUID%" "%transferDirectory%" "%date%" "%taskUUID%" "%DeletePackage%"' WHERE pk='8fad772e-7d2e-4cdd-89e6-7976152b6696';
 
 -- /Issue 5895
+
+-- Issue 6067
+-- All of these columns may at some point contain a non-Unicode filename,
+-- so they need to be one of the various binary datatypes instead of "text"
+ALTER TABLE Tasks MODIFY fileName longblob;
+ALTER TABLE Tasks MODIFY arguments varbinary(1000);
+ALTER TABLE Tasks MODIFY stdOut longblob;
+ALTER TABLE Tasks MODIFY stdError longblob;
+
+ALTER TABLE Files MODIFY originalLocation longblob;
+ALTER TABLE Files MODIFY currentLocation longblob;
+
+ALTER TABLE Events MODIFY eventOutcomeDetailNote longblob;
+-- /Issue 6067

--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -110,8 +110,12 @@ def escapeForCommand(string):
         #ret = ret.replace("$", "\\$")
     return ret
 
+# This replaces non-unicode characters with a replacement character,
+# and is primarily used for arbitrary strings (e.g. filenames, paths)
+# that might not be valid unicode to begin with.
 def escape(string):
-    #string = string.decode('utf-8')
+    if isinstance(string, basestring):
+        string = string.decode('utf-8', errors='replace')
     return string
 
 

--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -27,7 +27,7 @@ def _storage_api():
     # If the URL doesn't end in a /, add one
     if storage_service_url[-1] != '/':
         storage_service_url+='/'
-    storage_service_url = storage_service_url+'api/v1/'
+    storage_service_url = storage_service_url+'api/v2/'
     logging.debug("Storage service URL: {}".format(storage_service_url))
     api = slumber.API(storage_service_url)
     return api

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -233,7 +233,7 @@ def aip_delete(request, uuid):
 
 def aip_download(request, uuid):
     server_url = helpers.get_setting('storage_service_url', None)
-    redirect_url = server_url + 'api/v1/file/' + uuid + '/download'
+    redirect_url = server_url + 'api/v2/file/' + uuid + '/download'
     return HttpResponseRedirect(redirect_url)
 
 def aip_file_download(request, uuid):
@@ -269,7 +269,7 @@ def aip_file_download(request, uuid):
     )
 
     server_url = helpers.get_setting('storage_service_url', None)
-    redirect_url = server_url + 'api/v1/file/' + aip.uuid + '/extract_file/?relative_path_to_file=' + file_relative_path
+    redirect_url = server_url + 'api/v2/file/' + aip.uuid + '/extract_file/?relative_path_to_file=' + file_relative_path
     return HttpResponseRedirect(redirect_url)
 
 def send_thumbnail(request, fileuuid):

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -17,6 +17,7 @@
 
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.db import connection
+import base64
 import os
 from subprocess import call
 import shutil
@@ -96,6 +97,7 @@ def directory_children_proxy_to_storage_server(request, location_uuid, basePath=
         path = path + basePath
     path = path + request.GET.get('base_path', '')
     path = path + request.GET.get('path', '')
+    path = base64.b64encode(path)
 
     response = storage_service.browse_location(location_uuid, path)
 
@@ -189,7 +191,9 @@ def get_temp_directory(request):
 
 def copy_transfer_component(request):
     transfer_name = archivematicaFunctions.unicodeToStr(request.POST.get('name', ''))
-    path = archivematicaFunctions.unicodeToStr(request.POST.get('path', ''))
+    # Note that the path may contain arbitrary, non-unicode characters,
+    # and hence is POSTed to the server base64-encoded
+    path = base64.b64decode(request.POST.get('path', ''))
     destination = archivematicaFunctions.unicodeToStr(request.POST.get('destination', ''))
 
     error = None

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -44,6 +44,7 @@ sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 import elasticSearchFunctions, databaseInterface, databaseFunctions
 from archivematicaCreateStructuredDirectory import createStructuredDirectory
 from archivematicaCreateStructuredDirectory import createManualNormalizedDirectoriesList
+from archivematicaFunctions import escape
 sys.path.append("/usr/lib/archivematica/archivematicaCommon/externals")
 import pyes, requests
 from components.archival_storage.forms import StorageSearchForm
@@ -276,6 +277,8 @@ def ingest_normalization_report(request, uuid, current_page=None):
     sipname = utils.get_directory_name_from_job(job)
 
     objects = getNormalizationReportQuery(sipUUID=uuid)
+    for o in objects:
+        o['location'] = escape(o['location'])
 
     results_per_page = 10
 

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -191,6 +191,7 @@ class File(models.Model):
     uuid = models.CharField(max_length=36, primary_key=True, db_column='fileUUID')
     sip = models.ForeignKey(SIP, db_column='sipUUID', to_field = 'uuid')
     transfer = models.ForeignKey(Transfer, db_column='transferUUID', to_field = 'uuid')
+    # both actually `longblob` in the database
     originallocation = models.TextField(db_column='originalLocation')
     currentlocation = models.TextField(db_column='currentLocation')
     filegrpuse = models.TextField(db_column='fileGrpUse')
@@ -232,12 +233,19 @@ class Task(models.Model):
     job = models.ForeignKey(Job, db_column='jobuuid', to_field = 'jobuuid')
     createdtime = models.DateTimeField(db_column='createdTime')
     fileuuid = models.CharField(max_length=36, db_column='fileUUID', blank=True)
+    # Actually a `longblob` in the database, since filenames may contain
+    # arbitrary non-unicode characters - other blob and binary fields
+    # have these types for the same reason.
+    # Note that Django doesn't have a specific blob type, hence the use of
+    # the char field types instead.
     filename = models.CharField(max_length=100, db_column='fileName', blank=True)
     execution = models.CharField(max_length=250, db_column='exec', blank=True)
+    # actually a `varbinary(1000)` in the database
     arguments = models.CharField(max_length=1000, blank=True)
     starttime = models.DateTimeField(db_column='startTime')
     client = models.CharField(max_length=50, blank=True)
     endtime = models.DateTimeField(db_column='endTime')
+    # both actually `longblobs` in the database
     stdout = models.TextField(db_column='stdOut', blank=True)
     stderror = models.TextField(db_column='stdError', blank=True)
     exitcode = models.IntegerField(null=True, db_column='exitCode', blank=True)

--- a/src/dashboard/src/main/views.py
+++ b/src/dashboard/src/main/views.py
@@ -27,6 +27,7 @@ from components import helpers
 import components.decorators as decorators
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 import elasticSearchFunctions
+from archivematicaFunctions import escape
 
 """ @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
       Home
@@ -107,6 +108,15 @@ def tasks(request, uuid):
 
     if (len(objects) == 0):
         return tasks_subjobs(request, uuid)
+
+    # Filenames can be any encoding - we want to be able to display
+    # unicode, while just displaying unicode replacement characters
+    # for any other encoding present.
+    for item in objects:
+        item.filename = escape(item.filename)
+        item.arguments = escape(item.arguments)
+        item.stdout = escape(item.stdout)
+        item.stderror = escape(item.stderror)
 
     page    = helpers.pager(objects, django_settings.TASKS_PER_PAGE, request.GET.get('page', None))
     objects = page['objects']

--- a/src/dashboard/src/media/js/file-explorer.js
+++ b/src/dashboard/src/media/js/file-explorer.js
@@ -252,6 +252,12 @@
           var child = entry.children[index]
             , allowDisplay = true;
 
+          // File paths from the storage service are base64-encoded because
+          // they may contain arbitrary non-unicode characters.
+          // They're base64-decoded here for viewing, but will be
+          // re-encoded prior to being sent back to the server.
+          child.attributes.name = Base64.decode(child.attributes.name);
+
           if (self.entryDisplayFilter) {
             allowDisplay = self.entryDisplayFilter(child);
           }

--- a/src/dashboard/src/media/js/transfer/component_form.js
+++ b/src/dashboard/src/media/js/transfer/component_form.js
@@ -44,10 +44,13 @@ var TransferComponentFormView = Backbone.View.extend({
     );
   },
 
+  // This function is solely used for paths to be POSTed to the server,
+  // so all paths must be base64-encoded to guard against
+  // potential non-unicode characters
   addedPaths: function() {
     var paths = [];
     $('.transfer_path').each(function() {
-      paths.push($(this).text());
+      paths.push(Base64.encode($(this).text()));
     });
     return paths;
   },

--- a/src/dashboard/src/media/js/vendor/base64.js
+++ b/src/dashboard/src/media/js/vendor/base64.js
@@ -1,0 +1,216 @@
+/*
+Copyright (c) 2008 Fred Palmer fred.palmer_at_gmail.com
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+function StringBuffer()
+{ 
+    this.buffer = []; 
+} 
+
+StringBuffer.prototype.append = function append(string)
+{ 
+    this.buffer.push(string); 
+    return this; 
+}; 
+
+StringBuffer.prototype.toString = function toString()
+{ 
+    return this.buffer.join(""); 
+}; 
+
+var Base64 =
+{
+    codex : "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
+
+    encode : function (input)
+    {
+        var output = new StringBuffer();
+
+        var enumerator = new Utf8EncodeEnumerator(input);
+        while (enumerator.moveNext())
+        {
+            var chr1 = enumerator.current;
+
+            enumerator.moveNext();
+            var chr2 = enumerator.current;
+
+            enumerator.moveNext();
+            var chr3 = enumerator.current;
+
+            var enc1 = chr1 >> 2;
+            var enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
+            var enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
+            var enc4 = chr3 & 63;
+
+            if (isNaN(chr2))
+            {
+                enc3 = enc4 = 64;
+            }
+            else if (isNaN(chr3))
+            {
+                enc4 = 64;
+            }
+
+            output.append(this.codex.charAt(enc1) + this.codex.charAt(enc2) + this.codex.charAt(enc3) + this.codex.charAt(enc4));
+        }
+
+        return output.toString();
+    },
+
+    decode : function (input)
+    {
+        var output = new StringBuffer();
+
+        var enumerator = new Base64DecodeEnumerator(input);
+        while (enumerator.moveNext())
+        {
+            var charCode = enumerator.current;
+
+            if (charCode < 128)
+                output.append(String.fromCharCode(charCode));
+            else if ((charCode > 191) && (charCode < 224))
+            {
+                enumerator.moveNext();
+                var charCode2 = enumerator.current;
+
+                output.append(String.fromCharCode(((charCode & 31) << 6) | (charCode2 & 63)));
+            }
+            else
+            {
+                enumerator.moveNext();
+                var charCode2 = enumerator.current;
+
+                enumerator.moveNext();
+                var charCode3 = enumerator.current;
+
+                output.append(String.fromCharCode(((charCode & 15) << 12) | ((charCode2 & 63) << 6) | (charCode3 & 63)));
+            }
+        }
+
+        return output.toString();
+    }
+}
+
+
+function Utf8EncodeEnumerator(input)
+{
+    this._input = input;
+    this._index = -1;
+    this._buffer = [];
+}
+
+Utf8EncodeEnumerator.prototype =
+{
+    current: Number.NaN,
+
+    moveNext: function()
+    {
+        if (this._buffer.length > 0)
+        {
+            this.current = this._buffer.shift();
+            return true;
+        }
+        else if (this._index >= (this._input.length - 1))
+        {
+            this.current = Number.NaN;
+            return false;
+        }
+        else
+        {
+            var charCode = this._input.charCodeAt(++this._index);
+
+            // "\r\n" -> "\n"
+            //
+            if ((charCode == 13) && (this._input.charCodeAt(this._index + 1) == 10))
+            {
+                charCode = 10;
+                this._index += 2;
+            }
+
+            if (charCode < 128)
+            {
+                this.current = charCode;
+            }
+            else if ((charCode > 127) && (charCode < 2048))
+            {
+                this.current = (charCode >> 6) | 192;
+                this._buffer.push((charCode & 63) | 128);
+            }
+            else
+            {
+                this.current = (charCode >> 12) | 224;
+                this._buffer.push(((charCode >> 6) & 63) | 128);
+                this._buffer.push((charCode & 63) | 128);
+            }
+
+            return true;
+        }
+    }
+}
+
+function Base64DecodeEnumerator(input)
+{
+    this._input = input;
+    this._index = -1;
+    this._buffer = [];
+}
+
+Base64DecodeEnumerator.prototype =
+{
+    current: 64,
+
+    moveNext: function()
+    {
+        if (this._buffer.length > 0)
+        {
+            this.current = this._buffer.shift();
+            return true;
+        }
+        else if (this._index >= (this._input.length - 1))
+        {
+            this.current = 64;
+            return false;
+        }
+        else
+        {
+            var enc1 = Base64.codex.indexOf(this._input.charAt(++this._index));
+            var enc2 = Base64.codex.indexOf(this._input.charAt(++this._index));
+            var enc3 = Base64.codex.indexOf(this._input.charAt(++this._index));
+            var enc4 = Base64.codex.indexOf(this._input.charAt(++this._index));
+
+            var chr1 = (enc1 << 2) | (enc2 >> 4);
+            var chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
+            var chr3 = ((enc3 & 3) << 6) | enc4;
+
+            this.current = chr1;
+
+            if (enc3 != 64)
+                this._buffer.push(chr2);
+
+            if (enc4 != 64)
+                this._buffer.push(chr3);
+
+            return true;
+        }
+    }
+};

--- a/src/dashboard/src/templates/transfer/browser.html
+++ b/src/dashboard/src/templates/transfer/browser.html
@@ -10,6 +10,7 @@
   <script type="text/javascript" src="{{ STATIC_URL }}vendor/jquery.event.drop-1.1.js"></script>
   <script type="text/javascript" src="{{ STATIC_URL }}js/file-explorer.js"></script>
   <script type="text/javascript" src="{{ STATIC_URL }}js/file_browser.js"></script>
+  <script type="text/javascript" src="{{ STATIC_URL }}js/vendor/base64.js"></script>
   <script type="text/javascript" src="{{ STATIC_URL }}js/transfer/backlog_browser.js"></script>
 {% endblock %}
 

--- a/src/dashboard/src/templates/transfer/grid.html
+++ b/src/dashboard/src/templates/transfer/grid.html
@@ -22,6 +22,7 @@
   <script type="text/javascript" src="{{ STATIC_URL }}js/file-explorer.js"></script>
   <script type="text/javascript" src="{{ STATIC_URL }}js/directory_picker.js"></script>
   <script type="text/javascript" src="{{ STATIC_URL }}js/transfer/component_directory_select.js"></script>
+  <script type="text/javascript" src="{{ STATIC_URL }}js/vendor/base64.js"></script>
 
   <script type="text/javascript">
 

--- a/src/sanitizeNames/lib/sanitizeNames.py
+++ b/src/sanitizeNames/lib/sanitizeNames.py
@@ -36,7 +36,6 @@ def transliterate(basename):
     
 def sanitizeName(basename):
     ret = ""
-    basename = basename.decode('utf8')
     basename = transliterate(basename)
     for c in basename:
         if c in valid:


### PR DESCRIPTION
It's possible for users to attempt to begin transfers using files whose names contain non-Unicode, non-ASCII characters. Since communication to/from the storage service and between the dashboard and JS frontend occurs via JSON responses, which mandates Unicode, it's necessary to find an alternate way to represent paths.

This moves to communicate paths back and forth in base64 encoding, and vendors a JS base64 library to let the UI decode and encode paths as appropriate.

This depends on v2 of the storage service API, in artefactual/archivematica-storage-service#3.
