### PR TITLE
Support JSON metadata

### DIFF
--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -75,6 +75,7 @@ identifyDspaceFiles_v0.0 = %clientScriptsDirectory%identifyDspaceFiles.py
 identifyFileFormat_v0.0 = %clientScriptsDirectory%identifyFileFormat.py
 isMaildirAIP_v0.0 = %clientScriptsDirectory%isMaildirAIP.py
 indexAIP_v0.0 = %clientScriptsDirectory%indexAIP.py
+jsonMetadataToCSV_v0.0 = %clientScriptsDirectory%jsonMetadataToCSV.py
 loadLabelsFromCSV_v0.0 = %clientScriptsDirectory%loadLabelsFromCSV.py
 manualNormalizationCheckForManualNormalizationDirectory_v0.0 = %clientScriptsDirectory%manualNormalizationCheckForManualNormalizationDirectory.py
 manualNormalizationCreateMetadataAndRestructure_v0.0 = %clientScriptsDirectory%manualNormalizationCreateMetadataAndRestructure.py

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -159,7 +159,7 @@ def createDMDIDSFromCSVParsedMetadataDirectories(directory):
         if directory == key:
             return createDMDIDSFromCSVParsedMetadataPart2(compoundMetadataCSVkey, values)
 
-                
+
 def createDMDIDSFromCSVParsedMetadataPart2(keys, values):
     global globalDmdSecCounter
     global dmdSecs
@@ -171,7 +171,7 @@ def createDMDIDSFromCSVParsedMetadataPart2(keys, values):
         value = values[i]
         if key.startswith("dc.") or key.startswith("dcterms."):
             #print "dc item: ", key, value
-            if dc == None:
+            if dc is None:
                 globalDmdSecCounter += 1
                 dmdSec = etree.Element("dmdSec")
                 dmdSecs.append(dmdSec)
@@ -181,18 +181,17 @@ def createDMDIDSFromCSVParsedMetadataPart2(keys, values):
                 mdWrap = etree.SubElement(dmdSec, "mdWrap")
                 mdWrap.set("MDTYPE", "DC")
                 xmlData = etree.SubElement(mdWrap, "xmlData")
-                dc = etree.Element( "dublincore", nsmap = {None: dctermsNS} )
+                dc = etree.Element("dublincore", nsmap={None: dctermsNS})
                 dc.set(xsiBNS+"schemaLocation", dctermsNS + " http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd")
                 xmlData.append(dc)
             if key.startswith("dc."):
                 key2 = key.replace("dc.", "", 1)
-            elif  key.startswith("dcterms."):
+            elif key.startswith("dcterms."):
                 key2 = key.replace("dcterms.", "", 1)
             value = value.decode('utf-8')
             etree.SubElement(dc, key2).text = value
-        else: #not a dublin core item
-            #print "non dc: ", key, value
-            if other == None:
+        else:  # not a dublin core item
+            if other is None:
                 globalDmdSecCounter += 1
                 dmdSec = etree.Element("dmdSec")
                 dmdSecs.append(dmdSec)
@@ -204,13 +203,12 @@ def createDMDIDSFromCSVParsedMetadataPart2(keys, values):
                 mdWrap.set("OTHERMDTYPE", "CUSTOM")
                 other = etree.SubElement(mdWrap, "xmlData")
             etree.SubElement(other, normalizeNonDcElementName(key)).text = value
-    return  " ".join(ret)
-            
-    
+    return " ".join(ret)
+
 
 def createDublincoreDMDSecFromDBData(type, id):
     dc = getDublinCore(type, id)
-    if dc == None:
+    if dc is None:
         transfers = os.path.join(baseDirectoryPath, "objects/metadata/transfers/")
         if not os.path.isdir(transfers):
             return None

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSMetadataCSV.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSMetadataCSV.py
@@ -38,16 +38,17 @@ compoundMetadataCSVkey = []
 compoundMetadataCSV = {}
 
 
-CSVMetadata=(simpleMetadataCSVkey, simpleMetadataCSV, compoundMetadataCSVkey, compoundMetadataCSV)
+CSVMetadata = (simpleMetadataCSVkey, simpleMetadataCSV,
+               compoundMetadataCSVkey, compoundMetadataCSV)
 
 
 def parseMetadata(SIPPath):
-    ret = ({},{})
     transfersPath = os.path.join(SIPPath, "objects", "metadata", "transfers")
     if not os.path.isdir(transfersPath):
         return
     for transfer in os.listdir(transfersPath):
-        metadataCSVFilePath = os.path.join(transfersPath, transfer, "metadata.csv")
+        metadataCSVFilePath = os.path.join(transfersPath,
+                                           transfer, "metadata.csv")
         if os.path.isfile(metadataCSVFilePath):
             try:
                 parseMetadtaCSV(metadataCSVFilePath)
@@ -55,17 +56,17 @@ def parseMetadata(SIPPath):
                 print >>sys.stderr, type(inst)     # the exception instance
                 print >>sys.stderr, inst.args
                 print >>sys.stderr, "error parsing: ", metadataCSVFilePath
-                traceback.print_exc(file=sys.stdout) 
-                sharedVariablesAcrossModules.globalErrorCount +=1
-        
-    
+                traceback.print_exc(file=sys.stdout)
+                sharedVariablesAcrossModules.globalErrorCount += 1
+
+
 def parseMetadtaCSV(metadataCSVFilePath):
     with open(metadataCSVFilePath, 'rb') as f:
         reader = csv.reader(f)
         firstRow = True
         type = ""
         for row in reader:
-            if firstRow: #header row
+            if firstRow:  # header row
                 type = row[0].lower()
                 if type == "filename":
                     CSVMetadata[0].extend(row)
@@ -74,16 +75,15 @@ def parseMetadtaCSV(metadataCSVFilePath):
                 else:
                     print >>sys.stderr, "error parsing: ", metadataCSVFilePath
                     print >>sys.stderr, "unsupported: ", type
-                    sharedVariablesAcrossModules.globalErrorCount +=1
+                    sharedVariablesAcrossModules.globalErrorCount += 1
                     return
                 firstRow = False
-            
-            else: #data row
+
+            else:  # data row
                 if type == "filename":
-                    simpleMetadataCSV[row[0]] = row 
+                    simpleMetadataCSV[row[0]] = row
                 elif type == "parts":
                     directory = row[0]
                     if directory.endswith("/"):
                         directory = directory[:-1]
-                    compoundMetadataCSV[directory] = row 
-                
+                    compoundMetadataCSV[directory] = row

--- a/src/MCPClient/lib/clientScripts/jsonMetadataToCSV.py
+++ b/src/MCPClient/lib/clientScripts/jsonMetadataToCSV.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python -OO
+
+import csv
+import json
+import os
+import sys
+
+
+def fetch_keys(objects):
+    keys = set()
+    for object in objects:
+        keys.update(object.keys())
+
+    # Column order is otherwise unimportant, but
+    # "filename" and "parts" must be column 0.
+    # (They are mutually exclusive.)
+    keys = list(keys)
+    if 'filename' in keys:
+        keys.remove('filename')
+        keys.insert(0, 'filename')
+    elif 'parts' in keys:
+        keys.remove('parts')
+        keys.insert(0, 'parts')
+
+    return keys
+
+
+# DictWriter will fail if any Unicode characters are in the keys or
+# values in a dict passed to writerow(). This encodes them all to
+# UTF-8 bytestrings.
+def fix_encoding(row):
+    return {key.encode('utf-8'): value.encode('utf-8') for key, value in row.iteritems()}
+
+
+def main(sip_uuid, json_metadata):
+    # Many transfers won't have JSON metadata, so just exit without
+    # any further processing if that's the case
+    if not os.path.exists(json_metadata):
+        return 0
+
+    with open(json_metadata) as data:
+        parsed = json.load(data)
+
+    basename, _ = os.path.splitext(json_metadata)
+    output = basename + '.csv'
+
+    with open(output, 'w') as dest:
+        writer = csv.DictWriter(dest, fetch_keys(parsed))
+        writer.writeheader()
+        for row in parsed:
+            writer.writerow(fix_encoding(row))
+
+    return 0
+
+if __name__ == '__main__':
+    try:
+        sip_uuid, json_metadata = sys.argv[1:]
+    except ValueError:
+        sys.exit("SIP UUID or path to JSON metadata not provided!")
+
+    sys.exit(main(sip_uuid, json_metadata))

--- a/src/MCPClient/tests/test_json_conversion.py
+++ b/src/MCPClient/tests/test_json_conversion.py
@@ -1,0 +1,17 @@
+import os
+import subprocess
+
+JSON = '[{"dc.title": "This is a test item", "filename": "objects/test.txt"}]'
+CSV = 'filename,dc.title\r\nobjects/test.txt,This is a test item\r\n'
+
+
+def test_json_csv_conversion(tmpdir):
+    json_path = os.path.join(str(tmpdir), 'metadata.json')
+    csv_path = os.path.join(str(tmpdir), 'metadata.csv')
+    with open(json_path, 'w') as jsonfile:
+        jsonfile.write(JSON)
+    subprocess.call(['lib/clientScripts/jsonMetadataToCSV.py', '', json_path])
+    with open(csv_path) as csvfile:
+        csvdata = csvfile.read()
+
+    assert csvdata == CSV

--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -213,3 +213,11 @@ UPDATE StandardTasksConfigs SET arguments='"%SIPUUID%" "%SIPName%" "%SIPDirector
 UPDATE StandardTasksConfigs SET arguments='"%AIPsStore%" "%SIPDirectory%%AIPFilename%" "%SIPUUID%" "%SIPName%" "%SIPType%"' WHERE pk='7df9e91b-282f-457f-b91a-ad6135f4337d';
 
 -- /Issue 5803 AIC
+
+-- Issue 6261
+INSERT INTO StandardTasksConfigs (pk, requiresOutputLock, execute, arguments) VALUES ('44d3789b-10ad-4a9c-9984-c2fe503c8720', 0, 'jsonMetadataToCSV_v0.0', '"%SIPUUID%" "%SIPDirectory%metadata/metadata.json"');
+INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES ('f0e49772-3e2b-480d-8c06-023efc670dcd', '36b2e239-4a57-4aa5-8ebc-7a29139baca6', '44d3789b-10ad-4a9c-9984-c2fe503c8720', 'Process transfer JSON metadata');
+INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, currentTask, defaultNextChainLink) values ('8c8bac29-4102-4fd2-9d0a-a3bd2e607566', 'Reformat metadata files', 'Failed', 'f0e49772-3e2b-480d-8c06-023efc670dcd', '61c316a6-0a50-4f65-8767-1f44b1eeb6dd');
+INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('abe6c490-9749-46fc-98aa-a6814a507d72', '8c8bac29-4102-4fd2-9d0a-a3bd2e607566', 0, 'f1bfce12-b637-443f-85f8-b6450ca01a13', 'Completed successfully');
+UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink='8c8bac29-4102-4fd2-9d0a-a3bd2e607566' WHERE microServiceChainLink='370aca94-65ab-4f2a-9d7d-294a62c8b7ba';
+-- /Issue 6261


### PR DESCRIPTION
This allows JSON metadata to be supported, in addition to CSV metadata.

JSON metadata follows a similar format. It should contain an array of objects, one object per file to represent. Its keys should contain data in the same format that the CSV columns would contain. Rather than have separate JSON metadata code in archivematicaCreateMETS2, this just adds a new microservice to translate JSON into CSV at the end of ingest.

Supported JSON resembles this:

``` json
[
    {
        "filename": "foo.txt",
        "dc.title": "Some text file",
        "dc.author": "Me"
    }
]
```

In addition, this branch also adds supported for qualified Dublin Core. A couple of cleanups in these areas of code snuck in too.

This needs to be squashed when it's merged.
