### PR TITLE
identifyFileFormat: Write identification into Events

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaFITS.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaFITS.py
@@ -32,7 +32,6 @@ from archivematicaFunctions import getTagged
 from archivematicaFunctions import escapeForCommand
 from databaseFunctions import insertIntoFPCommandOutput
 from databaseFunctions import insertIntoEvents
-from databaseFunctions import insertIntoFilesIDs
 import databaseInterface
 
 databaseInterface.printSQL = False
@@ -101,93 +100,9 @@ def formatValidationFITSAssist(fits):
     return tuple([eventDetailText, eventOutcomeText, eventOutcomeDetailNote]) #tuple([1, 2, 3]) returns (1, 2, 3).
 
 
-def formatIdentificationFITSAssist(fits, fileUUID):
-    global exitCode
-    prefix = "{http://www.nationalarchives.gov.uk/pronom/FileCollection}"
-    formatIdentification = None
-
-    tools = getTagged(getTagged(fits, FITSNS + "toolOutput")[0], FITSNS + "tool")
-    for tool in tools:
-        if tool.get("name") == "Droid":
-            formatIdentification = tool
-            break
-    if formatIdentification == None:
-        print >>sys.stderr, "No format identification tool output (Droid)."
-        exitCode += 5
-        raise Exception('Droid', 'not present')
-
-    # <eventDetail>program="DROID"; version="3.0"</eventDetail>
-    eventDetailText = 'program="%s"; version="%s"' % (formatIdentification.get("name"), formatIdentification.get("version"))
-
-
-    fileCollection = getTagged(formatIdentification, prefix + "FileCollection")[0]
-    IdentificationFile = getTagged(fileCollection, prefix + "IdentificationFile")[0]
-    eventOutcomeText =  IdentificationFile.get( "IdentQuality")
-
-    # <eventOutcomeDetailNote>fmt/116</eventOutcomeDetailNote>
-    # <FileFormatHit />
-    fileFormatHits = getTagged(IdentificationFile, prefix + "FileFormatHit")
-    eventOutcomeDetailNotes = []
-    eventOutcomeDetailNote = ""
-    for fileFormatHit in fileFormatHits:
-        format = etree.Element("format")
-        if len(fileFormatHit):
-            formatIDSQL = {
-                "fileUUID": fileUUID,
-                "formatName": "",
-                "formatVersion": "",
-                "formatRegistryName": "PRONOM",
-                "formatRegistryKey": "",
-            }
-            eventOutcomeDetailNote = getTagged(fileFormatHit, prefix + "PUID")[0].text
-
-            formatName = getTagged(fileFormatHit, prefix + "Name")
-            formatVersion = getTagged(fileFormatHit, prefix + "Version")
-
-            if len(formatName):
-                formatIDSQL["formatName"] = formatName[0].text
-            if len(formatVersion):
-                formatIDSQL["formatVersion"] = formatVersion[0].text
-
-            PUID = getTagged(fileFormatHit, prefix + "PUID")
-            if len(PUID):
-                formatIDSQL["formatRegistryKey"] = PUID[0].text
-            formats.append(format)
-            print formatIDSQL
-            insertIntoFilesIDs(fileUUID=fileUUID,
-                               formatName=formatIDSQL["formatName"],
-                               formatVersion=formatIDSQL["formatVersion"],
-                               formatRegistryName=formatIDSQL["formatRegistryName"],
-                               formatRegistryKey=formatIDSQL["formatRegistryKey"])
-        else:
-            eventOutcomeDetailNote = "No Matching Format Found"
-            formatDesignation = etree.SubElement(format, "formatDesignation")
-            etree.SubElement(formatDesignation, "formatName").text = "Unknown"
-            formats.append(format)
-        eventOutcomeDetailNotes.append(eventOutcomeDetailNote)
-    return eventDetailText, eventOutcomeText, eventOutcomeDetailNotes
-
 def includeFits(fits, xmlFile, date, eventUUID, fileUUID):
     global exitCode
     #TO DO... Gleam the event outcome information from the output
-
-
-    # Use the FITS output to populate format identification events, as well as
-    # the format identification information from DROID.  This information will
-    # be used in the METS file.
-    # FIXME: FITS should not be used for file identification unless it is
-    # selected by the user, but removing this breaks the METS output (see #6160,
-    # #6161).
-    eventDetailText, eventOutcomeText, eventOutcomeDetailNotes = formatIdentificationFITSAssist(fits, fileUUID)
-
-    for eventOutcomeDetailNote in eventOutcomeDetailNotes:
-        insertIntoEvents(fileUUID=fileUUID,
-                         eventIdentifierUUID=str(uuid.uuid4()),
-                         eventType="format identification",
-                         eventDateTime=date,
-                         eventDetail=eventDetailText,
-                         eventOutcome=eventOutcomeText,
-                         eventOutcomeDetailNote=eventOutcomeDetailNote)
 
     try:
         eventDetailText, eventOutcomeText, eventOutcomeDetailNote = formatValidationFITSAssist(fits)

--- a/src/MCPClient/lib/clientScripts/identifyFileFormat.py
+++ b/src/MCPClient/lib/clientScripts/identifyFileFormat.py
@@ -7,7 +7,7 @@ import uuid
 
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 from executeOrRunSubProcess import executeOrRun
-from databaseFunctions import insertIntoEvents
+from databaseFunctions import insertIntoEvents, insertIntoFilesIDs
 from databaseInterface import getUTCDate
 
 path = '/usr/share/archivematica/dashboard'
@@ -67,6 +67,24 @@ def write_identification_event(file_uuid, command, format=None, success=True):
                      eventOutcomeDetailNote=format)
 
 
+def write_file_id(file_uuid, format=None, output=''):
+    if format.pronom_id:
+        format_registry = 'PRONOM'
+        key = format.pronom_id
+    else:
+        format_registry = 'Archivematica Format Policy Registry'
+        key = output
+
+    # Sometimes, this is null instead of an empty string
+    version = format.version or ''
+
+    insertIntoFilesIDs(fileUUID=file_uuid,
+                       formatName=format.description,
+                       formatVersion=version,
+                       formatRegistryName=format_registry,
+                       formatRegistryKey=key)
+
+
 def main(command_uuid, file_path, file_uuid):
     print "IDCommand UUID:", command_uuid
     print "File: ({}) {}".format(file_uuid, file_path)
@@ -119,6 +137,7 @@ def main(command_uuid, file_path, file_uuid):
     print "{} identified as a {}".format(file_path, version.description)
 
     write_identification_event(file_uuid, command, format=version.pronom_id)
+    write_file_id(file_uuid, format=version, output=output)
 
     return 0
 


### PR DESCRIPTION
This replaces the old archivematicaFITS event-writing code, which will allow us to remove archivematicaFITS and merge #6.
