### PR TITLE
Ensure paths are treated internally as base64 everywhere

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -432,7 +432,8 @@ def pad_destination_filepath_if_it_already_exists(filepath, original=None, attem
 
 def download(request):
     shared_dir = os.path.realpath(helpers.get_client_config_value('sharedDirectoryMounted'))
-    requested_filepath = os.path.realpath('/' + request.GET.get('filepath', ''))
+    filepath = base64.b64decode(request.GET.get('filepath', ''))
+    requested_filepath = os.path.realpath('/' + filepath)
 
     # respond with 404 if a non-Archivematica file is requested
     try:

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -66,10 +66,10 @@ def directory_to_dict(path, directory={}, entry=False):
     if (entry == False):
         entry = directory
         # remove leading slash
-        entry['parent'] = os.path.dirname(path)[1:]
+        entry['parent'] = base64.b64encode(os.path.dirname(path)[1:])
 
     # set standard entry properties
-    entry['name'] = os.path.basename(path)
+    entry['name'] = base64.b64encode(os.path.basename(path))
     entry['children'] = []
 
     # define entries
@@ -78,7 +78,7 @@ def directory_to_dict(path, directory={}, entry=False):
         new_entry = None
         if file[0] != '.':
             new_entry = {}
-            new_entry['name'] = file
+            new_entry['name'] = base64.b64encode(file)
             entry['children'].append(new_entry)
 
         # if entry is a directory, recurse
@@ -94,9 +94,9 @@ import archivematicaFunctions
 def directory_children_proxy_to_storage_server(request, location_uuid, basePath=False):
     path = ''
     if (basePath):
-        path = path + basePath
-    path = path + request.GET.get('base_path', '')
-    path = path + request.GET.get('path', '')
+        path = base64.b64decode(basePath)
+    path = path + base64.b64decode(request.GET.get('base_path', ''))
+    path = path + base64.b64decode(request.GET.get('path', ''))
     path = base64.b64encode(path)
 
     response = storage_service.browse_location(location_uuid, path)

--- a/src/dashboard/src/media/js/transfer/component_directory_select.js
+++ b/src/dashboard/src/media/js/transfer/component_directory_select.js
@@ -26,8 +26,8 @@ function createDirectoryPicker(locationUUID, baseDirectory, modalCssId, targetCs
   });
 
   selector.structure = {
-    'name': baseDirectory.replace(/\\/g,'/').replace( /.*\//, '' ),      // parse out path basename
-    'parent': baseDirectory.replace(/\\/g,'/').replace(/\/[^\/]*$/, ''), // parse out path directory
+    'name': Base64.encode(baseDirectory.replace(/\\/g,'/').replace( /.*\//, '' )),      // parse out path basename
+    'parent': Base64.encode(baseDirectory.replace(/\\/g,'/').replace(/\/[^\/]*$/, '')), // parse out path directory
     'children': []
   };
 
@@ -57,7 +57,12 @@ function createDirectoryPicker(locationUUID, baseDirectory, modalCssId, targetCs
         $transferPathRowEl.remove();
       });
 
-      $transferPathEl.html(result.path);
+      // result.path is base64-encoded from the server
+      // NOTE: If this value needs to get communicated somewhere else,
+      //       for instance if transfer starts are moved into the
+      //       storage service in the future, this value will need to
+      //       be base64-encoded again.
+      $transferPathEl.html(Base64.decode(result.path));
       $transferPathRowEl.append($transferPathEl);
       $transferPathRowEl.append($transferPathDeleteRl);
       $('#' + targetCssId).append($transferPathRowEl);


### PR DESCRIPTION
- filesystem_ajax now also uses base64 between the dashboard and itself,
  instead of doing a translation before paths are sent to the SS.
- directory_to_dict path helper also translates parent directories.
- Filesystem browser uses base64 paths everywhere outside of HTML
  representation.

@hwesta, are you okay with pushing base64 changes deeper into the filesystem browser JS code like this?
