### PR TITLE
Allow DC metadata to be entered in transfer, persist to ingest

### DIFF
--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -78,6 +78,7 @@ identifyFileFormat_v0.0 = %clientScriptsDirectory%identifyFileFormat.py
 isMaildirAIP_v0.0 = %clientScriptsDirectory%isMaildirAIP.py
 indexAIP_v0.0 = %clientScriptsDirectory%indexAIP.py
 jsonMetadataToCSV_v0.0 = %clientScriptsDirectory%jsonMetadataToCSV.py
+loadDublinCore_v0.0 = %clientScriptsDirectory%loadDublinCore.py
 loadLabelsFromCSV_v0.0 = %clientScriptsDirectory%loadLabelsFromCSV.py
 manualNormalizationCheckForManualNormalizationDirectory_v0.0 = %clientScriptsDirectory%manualNormalizationCheckForManualNormalizationDirectory.py
 manualNormalizationCreateMetadataAndRestructure_v0.0 = %clientScriptsDirectory%manualNormalizationCreateMetadataAndRestructure.py

--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -105,6 +105,7 @@ restructureBagAIPToSIP_v0.0 = %clientScriptsDirectory%restructureBagAIPToSIP.py
 retryNormalizeRemoveNormalized_v0.0 = %clientScriptsDirectory%retryNormalizeRemoveNormalized.py
 sanitizeObjectNames_v0.0 = %clientScriptsDirectory%sanitizeObjectNames.py
 sanitizeSIPName_v0.0 = %clientScriptsDirectory%sanitizeSIPName.py
+saveDublinCore_v0.0 = %clientScriptsDirectory%saveDublinCore.py
 setDirectoryPermissionsForAppraisal_v0.0 = %clientScriptsDirectory%setDirectoryPermissionsForAppraisal.sh
 setFilePermission_v0.0 = chmod
 setMaildirFileGrpUseAndFileIDs_v0.0 = %clientScriptsDirectory%setMaildirFileGrpUseAndFileIDs.py

--- a/src/MCPClient/lib/clientScripts/createSIPfromTransferObjects.py
+++ b/src/MCPClient/lib/clientScripts/createSIPfromTransferObjects.py
@@ -81,6 +81,14 @@ if __name__ == '__main__':
         path = os.path.join(tmpSIPDir, directory)
         if not os.path.isdir(path):
             os.makedirs(path)
+
+    # Copy the JSON metadata file, if present;
+    # this contains a serialized copy of DC metadata entered in the dashboard UI
+    src = os.path.normpath(os.path.join(objectsDirectory, "..", "metadata", "dc.json"))
+    dst = os.path.join(tmpSIPDir, "metadata", "dc.json")
+    # This file only exists if any metadata was created during the transfer
+    if os.path.exists(src):
+        shutil.copy(src, dst)
     
     #copy processingMCP.xml file
     src = os.path.join(os.path.dirname(objectsDirectory[:-1]), "processingMCP.xml") 

--- a/src/MCPClient/lib/clientScripts/loadDublinCore.py
+++ b/src/MCPClient/lib/clientScripts/loadDublinCore.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python2
+
+import json
+import os
+import sys
+
+path = '/usr/share/archivematica/dashboard'
+if path not in sys.path:
+    sys.path.append(path)
+os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+from main import models
+
+# This is the UUID of SIP from the `MetadataAppliesToTypes` table
+INGEST_METADATA_TYPE = '3e48343d-e2d2-4956-aaa3-b54d26eb9761'
+
+
+def main(sip_uuid, dc_path):
+    # If there's no metadata, that's not an error, and just keep going
+    if not os.path.exists(dc_path):
+        print "DC metadata not found; exiting", "(at", dc_path + ")"
+        return 0
+
+    print "Loading DC metadata from", dc_path
+    with open(dc_path) as json_data:
+        data = json.load(json_data)
+    dc = models.DublinCore(metadataappliestoidentifier=sip_uuid,
+                           metadataappliestotype=INGEST_METADATA_TYPE)
+    for key, value in data.iteritems():
+        try:
+            setattr(dc, key, value)
+        except AttributeError:
+            print >> sys.stderr, "Invalid DC attribute:", key
+
+    dc.save()
+    return 0
+
+if __name__ == '__main__':
+    sip_uuid = sys.argv[1]
+    dc_path = sys.argv[2]
+    sys.exit(main(sip_uuid, dc_path))

--- a/src/MCPClient/lib/clientScripts/saveDublinCore.py
+++ b/src/MCPClient/lib/clientScripts/saveDublinCore.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python2
+
+import json
+import os
+import sys
+
+path = '/usr/share/archivematica/dashboard'
+if path not in sys.path:
+    sys.path.append(path)
+os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+from main import models
+
+FIELDS = [
+    'title', 'creator', 'subject', 'description', 'publisher', 'contributor',
+    'date', 'type', 'format', 'identifier', 'source', 'relation', 'language',
+    'coverage', 'rights'
+]
+
+
+def main(transfer_uuid, target_path):
+    jsonified = {}
+    try:
+        dc = models.DublinCore.objects.get(metadataappliestoidentifier=transfer_uuid)
+    except:
+        # There may not be any DC metadata for this transfer, and that's fine
+        print >> sys.stderr, "No DC metadata found; skipping"
+        return 0
+    for field in FIELDS:
+        attr = getattr(dc, field)
+        if attr:
+            jsonified[field] = attr
+
+    print "Saving the following properties to:", target_path
+    print jsonified
+
+    with open(target_path, 'w') as json_file:
+        json.dump(jsonified, json_file)
+    return 0
+
+if __name__ == '__main__':
+    transfer_uuid = sys.argv[1]
+    target_path = sys.argv[2]
+    sys.exit(main(transfer_uuid, target_path))

--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -371,3 +371,12 @@ UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink=@examineCon
 UPDATE MicroServiceChainLinks SET defaultNextChainLink=@examineContentsWatchDirectoryMSCL WHERE pk=@characterizeExtractMetadata;
 
 -- /Issue 5880
+
+-- Issue 6217
+-- Serialize JSON metadata to disk, so it can be pulled back into the DB later
+INSERT INTO StandardTasksConfigs (pk, requiresOutputLock, execute, arguments) VALUES ('ed6daadf-a594-4327-b85c-7219c5832369', 0, 'saveDublinCore_v0.0', '"%SIPUUID%" "%relativeLocation%metadata/dc.json"');
+INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES ('e5789749-00df-4b6c-af12-47eeabc8926a', '36b2e239-4a57-4aa5-8ebc-7a29139baca6', 'ed6daadf-a594-4327-b85c-7219c5832369', 'Serialize Dublin Core metadata to disk');
+INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, currentTask, defaultNextChainLink) values ('f378ec85-adcc-4ee6-ada2-bc90cfe20efb', 'Create SIP from Transfer', 'Failed', 'e5789749-00df-4b6c-af12-47eeabc8926a', '39a128e3-c35d-40b7-9363-87f75091e1ff');
+INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('12fb389b-06c4-43d4-b647-9727c410088f', 'f378ec85-adcc-4ee6-ada2-bc90cfe20efb', 0, '39a128e3-c35d-40b7-9363-87f75091e1ff', 'Completed successfully');
+UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink='f378ec85-adcc-4ee6-ada2-bc90cfe20efb' WHERE microServiceChainLink='8f639582-8881-4a8b-8574-d2f86dc4db3d';
+-- /Issue 6217

--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -379,4 +379,11 @@ INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES
 INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, currentTask, defaultNextChainLink) values ('f378ec85-adcc-4ee6-ada2-bc90cfe20efb', 'Create SIP from Transfer', 'Failed', 'e5789749-00df-4b6c-af12-47eeabc8926a', '39a128e3-c35d-40b7-9363-87f75091e1ff');
 INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('12fb389b-06c4-43d4-b647-9727c410088f', 'f378ec85-adcc-4ee6-ada2-bc90cfe20efb', 0, '39a128e3-c35d-40b7-9363-87f75091e1ff', 'Completed successfully');
 UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink='f378ec85-adcc-4ee6-ada2-bc90cfe20efb' WHERE microServiceChainLink='8f639582-8881-4a8b-8574-d2f86dc4db3d';
+
+-- Load Dublin Core metadata back from disk into the database
+INSERT INTO StandardTasksConfigs (pk, requiresOutputLock, execute, arguments) VALUES ('cc8a1a4f-ccc8-4639-947e-01d0a5fddbb7', 0, 'loadDublinCore_v0.0', '"%SIPUUID%" "%relativeLocation%metadata/dc.json"');
+INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES ('efb7bf8e-4624-4b52-bf90-e3d389099fd9', '36b2e239-4a57-4aa5-8ebc-7a29139baca6', 'cc8a1a4f-ccc8-4639-947e-01d0a5fddbb7', 'Load Dublin Core metadata from disk');
+INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, currentTask, defaultNextChainLink) values ('970b7d17-7a6b-4d51-808b-c94b78c0d97f', 'Clean up names', 'Failed', 'efb7bf8e-4624-4b52-bf90-e3d389099fd9', '7d728c39-395f-4892-8193-92f086c0546f');
+INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('5ffe0c72-5a98-4fa5-8281-a266471ffb2c', '970b7d17-7a6b-4d51-808b-c94b78c0d97f', 0, '15a2df8a-7b45-4c11-b6fa-884c9b7e5c67', 'Completed successfully');
+UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink='970b7d17-7a6b-4d51-808b-c94b78c0d97f' WHERE microServiceChainLink='a46e95fe-4a11-4d3c-9b76-c5d8ea0b094d';
 -- /Issue 6217

--- a/src/dashboard/src/components/transfer/urls.py
+++ b/src/dashboard/src/components/transfer/urls.py
@@ -25,5 +25,12 @@ urlpatterns = patterns('components.transfer.views',
     (r'(?P<uuid>' + settings.UUID_REGEX + ')/microservices/$', 'microservices'),
     (r'status/$', 'status'),
     (r'status/(?P<uuid>' + settings.UUID_REGEX + ')/$', 'status'),
-    (r'browser/$', 'browser')
+    (r'browser/$', 'browser'),
+    (r'(?P<uuid>' + settings.UUID_REGEX + ')/metadata/$',
+        'transfer_metadata_list'),
+    (r'(?P<uuid>' + settings.UUID_REGEX + ')/metadata/add/$',
+        'transfer_metadata_edit'),
+    (r'(?P<uuid>' + settings.UUID_REGEX + ')/metadata/(?P<id>\d+)/$',
+        'transfer_metadata_edit'),
+
 )

--- a/src/dashboard/src/templates/transfer/detail.html
+++ b/src/dashboard/src/templates/transfer/detail.html
@@ -33,6 +33,11 @@
         <li><a href="{% url 'components.rights.views.transfer_rights_list' uuid %}">List</a></li>
         <li><a href="{% url 'components.rights.views.transfer_rights_edit' uuid %}">Add</a></li>
       </ul>
+      <h5>Metadata</h5>
+      <ul>
+        <li><a href="{% url 'components.transfer.views.transfer_metadata_list' uuid %}">List</a></li>
+        <li><a href="{% url 'components.transfer.views.transfer_metadata_edit' uuid %}">Add</a></li>
+      </ul>
 
     </div>
   </div>

--- a/src/dashboard/src/templates/transfer/metadata_edit.html
+++ b/src/dashboard/src/templates/transfer/metadata_edit.html
@@ -45,16 +45,6 @@ $(document).ready(function() {
         <form class="form-stacked" method="post" action="{% url 'components.transfer.views.transfer_metadata_edit' uuid %}">
       {% endif %}
 
-        <div class="clearfix">
-          <label>Applies to</label>
-          <div class="input">
-            <select class="span7" disabled="disabled">
-              <option>{{ name }}</option>
-            </select>
-            <span class="help-block">Metadata can be added at the SIP/AIP level only</span>
-          </div>
-        </div>
-
         {% include "_form.html" %}
 
         <div class="actions">

--- a/src/dashboard/src/templates/transfer/metadata_edit.html
+++ b/src/dashboard/src/templates/transfer/metadata_edit.html
@@ -1,0 +1,136 @@
+{% extends "layout_fluid.html" %}
+{% load breadcrumb %}
+{% load url from future %}
+
+{% block js %}
+  <script type="text/javascript" src="{{ STATIC_URL }}js/contextual_help.js"></script>
+{% endblock %}
+
+{% block content %}
+<style>
+#contextual_help {
+  width: 220px;
+  background-color: #eee;
+  padding: 1em;
+  position: absolute;
+  left: 700px;
+}
+</style>
+
+<script>
+$(document).ready(function() {
+  archivematicaEnableContextualHelp();
+});
+</script>
+
+  <div class="row">
+    <div class="span16">
+
+      <ul class="breadcrumb">
+        {% breadcrumb_url 'Transfer' 'components.transfer.views.grid' %}
+        {% breadcrumb_url name 'components.transfer.views.detail' uuid %}
+        {% breadcrumb_url 'Metadata' 'components.transfer.views.transfer_metadata_list' uuid %}
+        {% if id %}
+          {% breadcrumb 'Edit' %}
+        {% else %}
+          {% breadcrumb 'Add' %}
+        {% endif %}
+      </ul>
+
+      <h1>Metadata<br /><small>{{ name }}</small></h1>
+
+      {% if id %}
+        <form class="form-stacked" method="post" action="{% url 'components.transfer.views.transfer_metadata_edit' uuid id %}">
+      {% else %}
+        <form class="form-stacked" method="post" action="{% url 'components.transfer.views.transfer_metadata_edit' uuid %}">
+      {% endif %}
+
+        <div class="clearfix">
+          <label>Applies to</label>
+          <div class="input">
+            <select class="span7" disabled="disabled">
+              <option>{{ name }}</option>
+            </select>
+            <span class="help-block">Metadata can be added at the SIP/AIP level only</span>
+          </div>
+        </div>
+
+        {% include "_form.html" %}
+
+        <div class="actions">
+          {% if id %}
+            <input type="submit" class="btn primary" value="Save" />
+          {% else %}
+            <input type="submit" class="btn primary" value="Create" />
+          {% endif %}
+          <a href="{% url 'components.transfer.views.transfer_metadata_list' uuid %}" class="btn">Cancel</a>
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+
+  <!-- define contextual help -->
+
+  <div id='id_title_help' style='display:none'>
+    <p>A name given to the resource. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+  <div id='id_creator_help' style='display:none'>
+    <p>An entity primarily responsible for making the resource. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+  <div id='id_subject_help' style='display:none'>
+    <p>The topic of the resource. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+  <div id='id_description_help' style='display:none'>
+    <p>An account of the resource. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+  <div id='id_publisher_help' style='display:none'>
+    <p>An entity responsible for making the resource available. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+  <div id='id_contributor_help' style='display:none'>
+    <p>An entity responsible for making contributions to the resource. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+  <div id='id_date_help' style='display:none'>
+    <p>A point or period of time associated with an event in the lifecycle of the resource. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+  <div id='id_type_help' style='display:none'>
+    <p>The nature or genre of the resource. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>) You may wish to use the DCMI type vocabulary provided here: <a href="http://dublincore.org/documents/dcmi-type-vocabulary/">http://dublincore.org/documents/dcmi-type-vocabulary/</a></p>
+  </div>
+
+  <div id='id_format_help' style='display:none'>
+    <p>The file format, physical medium, or dimensions of the resource. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>) Best practice  is to use a controlled vocabulary such as the list of Internet Media Types [MIME] provided here: <a href="http://www.iana.org/assignments/media-types/" target="_blank">http://www.iana.org/assignments/media-types/</a></p>
+  </div>
+
+  <div id='id_identifier_help' style='display:none'>
+    <p>An unambiguous reference to the resource within a given context. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+  <div id='id_source_help' style='display:none'>
+    <p>A related resource from which the described resource is derived. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+  <div id='id_relation_help' style='display:none'>
+    <p>A related resource. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+  <div id='id_language_help' style='display:none'>
+    <p>A language of the resource. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+  <div id='id_coverage_help' style='display:none'>
+    <p>The spatial or temporal topic of the resource, the spatial applicability of the resource, or the jurisdiction under which the resource is relevant. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+  <div id='id_rights_help' style='display:none'>
+    <p>Information about rights held in and over the resource. (<a href="http://dublincore.org/documents/dces/" target="_blank">ISO15836</a>)</p>
+  </div>
+
+{% endblock %}

--- a/src/dashboard/src/templates/transfer/metadata_list.html
+++ b/src/dashboard/src/templates/transfer/metadata_list.html
@@ -1,0 +1,44 @@
+{% extends "layout_fluid.html" %}
+{% load breadcrumb %}
+{% load url from future %}
+
+{% block content %}
+  <div class="row">
+    <div class="span12">
+
+      <ul class="breadcrumb">
+        {% breadcrumb_url 'Transfer' 'components.transfer.views.grid' %}
+        {% breadcrumb_url name 'components.transfer.views.detail' uuid %}
+        {% breadcrumb 'Metadata' %}
+      </ul>
+
+      <h1>Metadata<br /><small>{{ name }}</small></h1>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Applies to</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for item in metadata %}
+            <tr>
+              <td>{{ item }}</td>
+              <td>{{ name }}</td>
+              <td>
+                <a href='{% url 'components.transfer.views.transfer_metadata_edit' uuid item.id %}'>Edit</a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+
+      <div class="actions" style="padding-left: 1em;">
+        <a class="btn primary" href="{% url 'components.transfer.views.transfer_metadata_edit' uuid %}">Add</a>
+      </div>
+
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
These commits allow DC metadata to be entered in the transfer phase. This is implemented by adding a new DC form, which exists in the transfer phase, and saving the metadata to disk in between transfer and ingest.

To save and load DC metadata, the data is serialized to disk as JSON at the very end of a transfer using the new `saveDublinCore` microservice. This happens after the user selects to create a SIP, so it's unlikely that users would be able to try to manually edit metadata after it runs.

At the very beginning of ingest, immediately after the SIP is verified, the new `loadDublinCore` microservice looks for a `metadata/dc.json` file inside the SIP; if present, it populates the DC metadata for the SIP in the database using that file. This allows the DC metadata to be editable by hand during ingest, and makes sure it will be used in the final AIP METS.

~~To support this, this now persists the contents of the transfer's `metadata/` directory when creating a SIP. In the past, anything there would be discarded when creating a single SIP.~~

This PR's commit history is still p. messy, will get cleaned up on merge.
