### PR TITLE
Switch from openfits to FITS

### DIFF
--- a/externals/fits/archivematicaConfigs/fits.xml
+++ b/externals/fits/archivematicaConfigs/fits.xml
@@ -2,30 +2,39 @@
 <fits_configuration>
 
 	<!-- Order of the tools determines preference -->
-	<tools>		
+	<tools>
 		<!-- exclude-exts attribute is a comma delimited list of file extensions that the tool should not try to process -->
-		<tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.AudioInfo"/>
-		<tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts=""/> 		   
-	 	<tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps"/>	 	 
-	 	<tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="txt,wps,vsd"/>
-	 	<!-- <tool class="edu.harvard.hul.ois.fits.tools.droid.Droid"  exclude-exts=""/> -->
-	 	<tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" exclude-exts="dng,zip,odb,ott,odg,otg,odp,otp,ods,ots,odc,otc,odi,oti,odf,otf,odm,oth"/>	
+		<tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.AudioInfo" include-exts="wav"/>
+		<tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.ADLTool" include-exts="adl"/>
+		<tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,arw,adl,eml"/>
+		<tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl"/>
+		<tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="txt,wps,vsd"/>
+		<!-- We disable DROID because we have a separate microservice for file ID -->
+		<!-- <tool class="edu.harvard.hul.ois.fits.tools.droid.Droid"  exclude-exts="dng"/> -->
+		<tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" exclude-exts="dng,zip,odb,ott,odg,otg,odp,otp,ods,ots,odc,otc,odi,oti,odf,otf,odm,oth"/>
 		<tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo"/>
-		<tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata"/>	
-		<tool class="edu.harvard.hul.ois.fits.tools.ffident.FFIdent" exclude-exts="dng,wps,vsd"/>		
+		<tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml"/>
+		<tool class="edu.harvard.hul.ois.fits.tools.ffident.FFIdent" exclude-exts="dng,wps,vsd"/>
+		<tool class="edu.harvard.hul.ois.fits.tools.tika.TikaTool"/>
 	</tools>
-		
+
 	<output>
 		<dataConsolidator class="edu.harvard.hul.ois.fits.consolidation.OISConsolidator"/>
 		<display-tool-output>true</display-tool-output>
-		<report-conflicts>true</report-conflicts>	
+		<report-conflicts>true</report-conflicts>
 		<validate-tool-output>true</validate-tool-output>
 		<internal-output-schema>xml/fits_output.xsd</internal-output-schema>
 		<external-output-schema>http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd</external-output-schema>
 		<fits-xml-namespace>http://hul.harvard.edu/ois/xml/ns/fits/fits_output</fits-xml-namespace>
+		<enable-statistics>false</enable-statistics>
+		<enable-checksum>false</enable-checksum>
 	</output>
-	
+
+	<process>
+		<max-threads>20</max-threads>
+	</process>
+
 	<!-- file name of the droid signature file to use in tools/droid/-->
-	<droid_sigfile>DROID_SignatureFile_V35.xml</droid_sigfile>
-	
+	<droid_sigfile>DROID_SignatureFile_V67.xml</droid_sigfile>
+
 </fits_configuration>

--- a/src/MCPClient/debian/control
+++ b/src/MCPClient/debian/control
@@ -8,7 +8,7 @@ Homepage: http://archivematica.org
 
 Package: archivematica-mcp-client
 Architecture: i386 amd64 
-Depends: ${shlibs:Depends}, ${misc:Depends}, logapp, gearman, python-gearman, uuid, clamav, clamav-daemon, unrar-free, p7zip-full, nfs-common, python-lxml, openfits, bagit, md5deep, archivematica-common, python-mysqldb, python-pyicu, libxml2-utils, openjdk-7-jre-headless, python-rfc6266, postfix, mediainfo, python-fido, tika, atool, pbzip2, sanitize-names, imagemagick, ffmpeg, libavcodec-extra-53, inkscape, readpst, ufraw
+Depends: ${shlibs:Depends}, ${misc:Depends}, logapp, gearman, python-gearman, uuid, clamav, clamav-daemon, unrar-free, p7zip-full, nfs-common, python-lxml, fits, bagit, md5deep, archivematica-common, python-mysqldb, python-pyicu, libxml2-utils, openjdk-7-jre-headless, python-rfc6266, postfix, mediainfo, python-fido, tika, atool, pbzip2, sanitize-names, imagemagick, ffmpeg, libavcodec-extra-53, inkscape, readpst, ufraw
 Description: MCP Client for Archivematica
   
   

--- a/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
@@ -37,13 +37,14 @@ if __name__ == '__main__':
     date = sys.argv[3]
     taskUUID = sys.argv[4]
 
-    command = 'clamdscan  - <"' + escapeForCommand(target).replace("$", "\\$") + '"'
-    print >>sys.stderr, command
-    commandVersion = "clamdscan -V"
-    eventOutcome = "Pass"
+    with open(target) as file_:
+        command = ['clamdscan', '-']
+        print >> sys.stderr, ' '.join(command), '<', target
+        commandVersion = "clamdscan -V"
+        eventOutcome = "Pass"
 
-    clamscanOutput = executeOrRun("bashScript", command, printing=False)
-    clamscanVersionOutput = executeOrRun("command", commandVersion, printing=False)
+        clamscanOutput = executeOrRun("command", command, printing=False, stdIn=file_)
+        clamscanVersionOutput = executeOrRun("command", commandVersion, printing=False)
 
     if clamscanOutput[0] or clamscanVersionOutput[0]:
         if clamscanVersionOutput[0]:

--- a/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
 
     with open(target) as file_:
         command = ['clamdscan', '-']
-        print >> sys.stderr, ' '.join(command), '<', target
+        print >> sys.stdout, ' '.join(command), '<', target
         commandVersion = "clamdscan -V"
         eventOutcome = "Pass"
 

--- a/src/MCPClient/lib/clientScripts/archivematicaFITS.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaFITS.py
@@ -140,7 +140,7 @@ if __name__ == '__main__':
 
     tempFile="/tmp/" + uuid.uuid4().__str__()
 
-    command = "openfits -i \"" + escapeForCommand(target) + "\" -o \"" + tempFile + "\""
+    command = "fits.sh -i \"" + escapeForCommand(target) + "\" -o \"" + tempFile + "\""
     try:
         p = subprocess.Popen(shlex.split(command), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 


### PR DESCRIPTION
The currently-packaged version of FITS is 0.8.0.

This also updates the XML file to use the FITS 0.8.0 version while retaining our custom settings, and disables checksum generation (which was not an option before).
