### PR TITLE
Fix approve transfer API

### DIFF
--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -209,9 +209,8 @@ def approve_transfer_via_mcp(directory, type, user_id):
                 # attempt to find appropriate choice
                 chain_to_execute = None
                 for choice in choices:
-                    chain = models.MicroServiceChain.objects.get(pk=choice.chainavailable)
-                    if chain.description == 'Approve transfer':
-                        chain_to_execute=chain.pk
+                    if choice.chainavailable.description == 'Approve transfer':
+                        chain_to_execute=choice.chainavailable.pk
 
                 # execute choice if found
                 if chain_to_execute != None:

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -15,13 +15,21 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-import os, json
-from django.http import Http404, HttpResponse, HttpResponseForbidden, HttpResponseServerError
+# stdlib, alphabetical
+import json
+import os
+
+# Core Django, alphabetical
 from django.db.models import Q
+from django.http import Http404, HttpResponseForbidden, HttpResponseServerError
+
+# External dependencies, alphabetical
 from tastypie.authentication import ApiKeyAuthentication
+
+# This project, alphabetical
 from contrib.mcp.client import MCPClient
-from main import models
 from components import helpers
+from main import models
 
 def authenticate_request(request):
     error = None
@@ -31,11 +39,9 @@ def authenticate_request(request):
 
     if authorized == True:
         client_ip = request.META['REMOTE_ADDR']
-        whitelist = helpers.get_setting('api_whitelist', '127.0.0.1').split("\r\n")
-        try:
-            whitelist.index(client_ip)
-            return
-        except:
+        whitelist = helpers.get_setting('api_whitelist', '127.0.0.1').split()
+        # logging.debug('client IP: %s, whitelist: %s', client_ip, whitelist)
+        if client_ip not in whitelist:
             error = 'Host/IP ' + client_ip + ' not authorized.'
     else:
         error = 'API key not valid.'
@@ -52,7 +58,6 @@ def unapproved_transfers(request):
         response = {}
 
         if auth_error == None:
-            message    = ''
             error      = None
             unapproved = []
 
@@ -126,7 +131,6 @@ def approve_transfer(request):
         response = {}
 
         if auth_error == None:
-            message = ''
             error   = None
 
             directory = request.POST.get('directory', '')
@@ -220,8 +224,9 @@ def approve_transfer_via_mcp(directory, type, user_id):
                 else:
                     error = 'Error: could not find MCP choice to execute.'
 
-            except:
+            except Exception:
                 error = 'Unable to find unapproved transfer directory.'
+                # logging.exception(error)
 
     else:
         error = 'Please specify a transfer directory.'

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -508,6 +508,11 @@ class MicroServiceChain(models.Model):
     class Meta:
         db_table = u'MicroServiceChains'
 
+    def __unicode__(self):
+        return u'MicroServiceChain ID: {uuid}; {desc}'.format(
+            uuid=self.id,
+            desc=self.description)
+
 class MicroServiceChainLink(models.Model):
     id = UUIDPkField()
     currenttask =  models.CharField(max_length=36, db_column='currentTask')
@@ -541,6 +546,12 @@ class MicroServiceChainChoice(models.Model):
 
     class Meta:
         db_table = u'MicroServiceChainChoice'
+
+    def __unicode__(self):
+        return u'MicroServiceChainChoice ID: {uuid} ({chain} at {choice})'.format(
+            uuid=self.id,
+            chain=self.chainavailable,
+            choice=self.choiceavailableatlink)
 
 class MicroServiceChoiceReplacementDic(models.Model):
     id = UUIDPkField()

--- a/src/dashboard/src/templates/administration/api.html
+++ b/src/dashboard/src/templates/administration/api.html
@@ -23,6 +23,8 @@
 
       <h4>IP whitelist</h4>
 
+      <p>Enter a whitespace-separated list of IPs or hostnames permitted to use the API.</p>
+
       <div style='width: 500px; height: 300px;'>
       <form method='POST'>
         <textarea name='whitelist' style='width: 500px; height: 300px;'>{{ whitelist }}</textarea>


### PR DESCRIPTION
MicroServiceChainChoice had been updated to have a foreign key to MicroServiceChain, but not all cases that used chainavailable were updated.  Fixed the last one.

Other cleanup while fixing this:
- Add instructions to API whitelist template specifying the format
- Whitelisted IPs for API are now whitespaces separated, instead of \r\n
- Clean up import list
- Add logging
- Add unicode function to MicroServiceChain & MicroServiceChainChoice

Supports artefactual/archivematica-storage-service#7
