### PR TITLE
Add new transcribe files microservice

### DIFF
--- a/src/MCPClient/debian/control
+++ b/src/MCPClient/debian/control
@@ -14,7 +14,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, archivematica-common,
  md5deep, mediainfo, nfs-common, openjdk-7-jre-headless, p7zip-full,
  pbzip2, postfix, python-fido, python-gearman, python-lxml,
  python-mysqldb, python-pyicu, python-rfc6266, readpst, sanitize-names,
- tika, ufraw, unrar-free, uuid
+ tesseract-ocr, tika, ufraw, unrar-free, uuid
 Description: MCP Client for Archivematica
   
   

--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -48,6 +48,7 @@ checkForSubmissionDocumenation_v0.0 = %clientScriptsDirectory%checkForSubmission
 checkTransferDirectoryForObjects_v0.0 = %clientScriptsDirectory%checkTransferDirectoryForObjects.py
 compressAIP_v0.0 = %clientScriptsDirectory%compressAIP.py
 copy_v0.0 = cp
+copyRecursive_v0.0 = %clientScriptsDirectory%copyRecursiveIfExists.sh
 copyTransfersMetadataAndLogs_v0.0 = %clientScriptsDirectory%copyTransfersMetadataAndLogs.py
 copyTransferSubmissionDocumentation_v0.0 = %clientScriptsDirectory%copyTransferSubmissionDocumentation.py
 createAIC_METS_v1.0 =  %clientScriptsDirectory%createAICMETS.py

--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -110,6 +110,7 @@ setFilePermission_v0.0 = chmod
 setMaildirFileGrpUseAndFileIDs_v0.0 = %clientScriptsDirectory%setMaildirFileGrpUseAndFileIDs.py
 setSIPQuarantine_v0.0 = %clientScriptsDirectory%quarantineSIP.sh
 test_v0.0 = test
+transcribeFile_v0.0 = %clientScriptsDirectory%archivematicaTranscribeFile.py
 trimCreateRightsEntries_v0.0 = %clientScriptsDirectory%trimCreateRightsEntries.py
 trimRestructureForCompliance_v0.0 = %clientScriptsDirectory%trimRestructureForCompliance.py
 trimVerifyChecksums_v0.0 = %clientScriptsDirectory%trimVerifyChecksums.py

--- a/src/MCPClient/lib/clientScripts/archivematicaAssignFileUUID.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaAssignFileUUID.py
@@ -39,6 +39,7 @@ if __name__ == '__main__':
     parser.add_option("-S",  "--sipUUID", action="store", dest="sipUUID", default="")
     parser.add_option("-T",  "--transferUUID", action="store", dest="transferUUID", default="")
     parser.add_option("-e",  "--use", action="store", dest="use", default="original")
+    parser.add_option("--disable-update-filegrpuse", action="store_false", dest="update_use", default=True)
 
 
     (opts, args) = parser.parse_args()
@@ -51,8 +52,9 @@ if __name__ == '__main__':
         fileUUID = uuid.uuid4().__str__()
     else:
         print >>sys.stderr, "File already has UUID:", fileUUID
-        sql = """UPDATE Files SET fileGrpUse='%s' WHERE fileUUID = '%s';""" % (opts.use, fileUUID)
-        databaseInterface.runSQL(sql)
+        if opts.update_use:
+            sql = """UPDATE Files SET fileGrpUse='%s' WHERE fileUUID = '%s';""" % (opts.use, fileUUID)
+            databaseInterface.runSQL(sql)
         exit(0) 
 
 

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -752,21 +752,23 @@ def createFileSec(directoryPath, parentDiv):
                     
                     etree.SubElement(trimFileDiv, "fptr", FILEID=fileId)
 
-        elif use == "preservation":
-            sql = "SELECT * FROM Derivations WHERE derivedFileUUID = '" + myuuid + "';"
-            c, sqlLock = databaseInterface.querySQL(sql)
-            row = c.fetchone()
-            while row != None:
-                GROUPID = "Group-%s" % (row[1])
-                row = c.fetchone()
-            sqlLock.release()
-
-        elif use == "license" or use == "text/ocr" or use == "DSPACEMETS":
+        # Dspace transfers are treated specially, but some of these fileGrpUses
+        # may be encountered in other types
+        elif typeOfTransfer == "Dspace" and (use == "license" or use == "text/ocr" or use == "DSPACEMETS"):
             sql = """SELECT fileUUID FROM Files WHERE removedTime = 0 AND %s = '%s' AND fileGrpUse = 'original' AND originalLocation LIKE '%s/%%'""" % (fileGroupType, fileGroupIdentifier, MySQLdb.escape_string(os.path.dirname(originalLocation)).replace("%", "\%"))
             c, sqlLock = databaseInterface.querySQL(sql)
             row = c.fetchone()
             while row != None:
                 GROUPID = "Group-%s" % (row[0])
+                row = c.fetchone()
+            sqlLock.release()
+
+        elif use == "preservation" or use == "text/ocr":
+            sql = "SELECT * FROM Derivations WHERE derivedFileUUID = '" + myuuid + "';"
+            c, sqlLock = databaseInterface.querySQL(sql)
+            row = c.fetchone()
+            while row != None:
+                GROUPID = "Group-%s" % (row[1])
                 row = c.fetchone()
             sqlLock.release()
 

--- a/src/MCPClient/lib/clientScripts/archivematicaTranscribeFile.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaTranscribeFile.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python2
+
+from __future__ import print_function
+import datetime
+import os
+import subprocess
+import sys
+from tempfile import gettempdir
+from uuid import uuid4
+
+path = '/usr/share/archivematica/dashboard'
+if path not in sys.path:
+    sys.path.append(path)
+os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+
+from main.models import Derivation, File, FileFormatVersion
+from fpr.models import FPRule
+
+path = '/usr/lib/archivematica/archivematicaCommon'
+if path not in sys.path:
+    sys.path.append(path)
+
+from dicts import ReplacementDict
+from executeOrRunSubProcess import executeOrRun
+import databaseFunctions
+import fileOperations
+
+
+def insert_transcription_event(status, file_uuid, rule, relative_location):
+    outcome = "transcribed" if status is 0 else "not transcribed"
+
+    tool = rule.command.tool
+    event_detail = u"program={}; version={}; command=\"{}\"".format(tool.description, tool.version, rule.command.command.replace('"', r'\"'))
+
+    event_uuid = str(uuid4())
+
+    databaseFunctions.insertIntoEvents(
+        fileUUID=file_uuid,
+        eventIdentifierUUID=event_uuid,
+        eventType="transcription",
+        eventDetail=event_detail,
+        eventOutcome=outcome,
+        eventOutcomeDetailNote=relative_location
+    )
+
+    return event_uuid
+
+
+def insert_file_into_database(file_uuid, sip_uuid, event_uuid, rule, output_path, relative_path):
+    transcription_uuid = str(uuid4())
+    today = str(datetime.date.today())
+    fileOperations.addFileToSIP(
+        relative_path,
+        transcription_uuid,
+        sip_uuid,
+        task_uuid,
+        today,
+        sourceType="creation",
+        use="text/ocr"
+    )
+
+    fileOperations.updateSizeAndChecksum(
+        transcription_uuid,
+        output_path,
+        today,
+        str(uuid4())
+    )
+
+    databaseFunctions.insertIntoDerivations(
+        sourceFileUUID=file_uuid,
+        derivedFileUUID=transcription_uuid,
+        relatedEventUUID=event_uuid
+    )
+
+
+def fetch_rules_for(file_):
+    try:
+        format = FileFormatVersion.objects.get(file_uuid=file_)
+        return FPRule.objects.filter(format=format.format_version,
+                                     purpose='transcription')
+    except FileFormatVersion.DoesNotExist:
+        return []
+
+
+def fetch_rules_for_derivatives(file_):
+    derivs = Derivation.objects.filter(source_file=file_)
+    for deriv in derivs:
+        derived_file = deriv.derived_file
+        # Don't bother OCRing thumbnails
+        if derived_file.filegrpuse == 'thumbnail':
+            continue
+
+        rules = fetch_rules_for(derived_file)
+        if rules:
+            return (derived_file, rules)
+
+    return None, []
+
+
+def main(task_uuid, file_uuid):
+    succeeded = True
+
+    file_ = File.objects.get(uuid=file_uuid)
+
+    # Normally we don't transcribe derivatives (access copies, preservation copies);
+    # however, some useful transcription tools can't handle some formats that
+    # are common as the primary copies. For example, tesseract can't handle JPEG2000.
+    # If there are no rules for the primary format passed in, try to look at each
+    # derivative until a transcribable derivative is found.
+    #
+    # Skip derivatives to avoid double-scanning them; only look at them as a fallback.
+    if file_.filegrpuse != "original":
+        print('{} is not an original; not transcribing'.format(file_uuid), file=sys.stderr)
+        return 0
+
+    rules = fetch_rules_for(file_)
+    if not rules:
+        file_, rules = fetch_rules_for_derivatives(file_)
+
+    if not rules:
+        print('No rules found for file {} and its derivatives; not transcribing'.format(file_uuid), file=sys.stderr)
+        return 0
+    else:
+        print('Transcribing {} derivative {}'.format(file_.filegrpuse, file_.uuid), file=sys.stderr)
+
+    rd = ReplacementDict.frommodel(file_=file_, type_='file')
+
+    for rule in rules:
+        script = rule.command.command
+        if rule.command.script_type in ('bashScript', 'command'):
+            script, = rd.replace(script)
+            args = []
+        else:
+            args = rd.to_gnu_options
+
+        exitstatus, stdout, stderr = executeOrRun(rule.command.script_type,
+                                                  script, arguments=args)
+        if exitstatus != 0:
+            succeeded = False
+
+
+        output_path = rd.replace(rule.command.output_location)[0]
+        relative_path = output_path.replace(rd['%SIPDirectory%'], '%SIPDirectory%')
+        event = insert_transcription_event(exitstatus, file_uuid, rule, relative_path)
+
+        if os.path.isfile(output_path):
+            insert_file_into_database(file_uuid, rd['%SIPUUID%'], event, rule, output_path, relative_path)
+
+    return 0 if succeeded else 1
+
+
+if __name__ == '__main__':
+    task_uuid = sys.argv[1]
+    file_uuid = sys.argv[2]
+    transcribe = sys.argv[3]
+
+    if transcribe == 'False':
+        print('Skipping transcription')
+        sys.exit(0)
+
+    sys.exit(main(task_uuid, file_uuid))

--- a/src/MCPClient/lib/clientScripts/copyRecursiveIfExists.sh
+++ b/src/MCPClient/lib/clientScripts/copyRecursiveIfExists.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+test -e "$1" || exit 0
+cp -R "$1" "$2"

--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -492,4 +492,11 @@ INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, cu
 
 INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('22ebafb1-3ec3-406a-939d-4eb9f3b8bbd1', @transcribeChoiceMSCL, 0, @transcribeFileMSCL, 'Completed successfully');
 INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('804d4d23-e81b-4d81-8e67-1a3b5470c841', @transcribeFileMSCL, 0, @postTranscribeMSCL, 'Completed successfully');
+
+-- Copy OCR data into DIP
+INSERT INTO StandardTasksConfigs (pk, requiresOutputLock, execute, arguments) VALUES ('5c4f877f-b352-4977-b51b-53ebc437b08c', 0, 'copyRecursive_v0.0', '"%SIPObjectsDirectory%metadata/OCRfiles" "%SIPDirectory%DIP"');
+INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES ('102cd6b0-5d30-4e04-9b62-4e9f12d74549', '36b2e239-4a57-4aa5-8ebc-7a29139baca6', '5c4f877f-b352-4977-b51b-53ebc437b08c', 'Copy OCR data to DIP directory');
+INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, currentTask, defaultNextChainLink) values ('43c72f8b-3cea-4b4c-b99d-cfdefdfcc270', 'Prepare DIP', 'Failed', '102cd6b0-5d30-4e04-9b62-4e9f12d74549', '7d728c39-395f-4892-8193-92f086c0546f');
+INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('95ba6779-2ed2-47ea-a7ad-df4a4cf3764d', '43c72f8b-3cea-4b4c-b99d-cfdefdfcc270', 0, '6ee25a55-7c08-4c9a-a114-c200a37146c4', 'Completed successfully');
+UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink='43c72f8b-3cea-4b4c-b99d-cfdefdfcc270' WHERE microServiceChainLink='ad011cc2-b0eb-4f51-96bb-400149a2ea11';
 -- /Issue 6565 OCR

--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -499,4 +499,10 @@ INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES
 INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, currentTask, defaultNextChainLink) values ('43c72f8b-3cea-4b4c-b99d-cfdefdfcc270', 'Prepare DIP', 'Failed', '102cd6b0-5d30-4e04-9b62-4e9f12d74549', '7d728c39-395f-4892-8193-92f086c0546f');
 INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('95ba6779-2ed2-47ea-a7ad-df4a4cf3764d', '43c72f8b-3cea-4b4c-b99d-cfdefdfcc270', 0, '6ee25a55-7c08-4c9a-a114-c200a37146c4', 'Completed successfully');
 UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink='43c72f8b-3cea-4b4c-b99d-cfdefdfcc270' WHERE microServiceChainLink='ad011cc2-b0eb-4f51-96bb-400149a2ea11';
+
+-- "Assign file UUIDs to metadata" - disable updating the fileGrpUse to avoid
+-- clobbering the fileGrpUse set by the Transcribe microservice
+UPDATE StandardTasksConfigs
+	SET arguments='--sipUUID "%SIPUUID%" --sipDirectory "%SIPDirectory%" --filePath "%relativeLocation%" --fileUUID "%fileUUID%" --eventIdentifierUUID "%taskUUID%" --date "%date%" --use "metadata" --disable-update-filegrpuse'
+	WHERE pk='34966164-9800-4ae1-91eb-0a0c608d72d5';
 -- /Issue 6565 OCR

--- a/src/MCPServer/share/sharedDirectoryStructure/sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml
+++ b/src/MCPServer/share/sharedDirectoryStructure/sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml
@@ -50,5 +50,10 @@
       <appliesTo>accea2bf-ba74-4a3a-bb97-614775c74459</appliesTo>
       <goToChain>e0a39199-c62a-4a2f-98de-e9d1116460a8</goToChain>
     </preconfiguredChoice>
+    <!-- Transcribe file -->
+    <preconfiguredChoice>
+      <appliesTo>7079be6d-3a25-41e6-a481-cee5f352fe6e</appliesTo>
+      <goToChain>1170e555-cd4e-4b2f-a3d6-bfb09e8fcc53</goToChain>
+    </preconfiguredChoice>
   </preconfiguredChoices>
 </processingMCP>

--- a/src/archivematicaCommon/lib/dicts.py
+++ b/src/archivematicaCommon/lib/dicts.py
@@ -104,7 +104,6 @@ class ReplacementDict(dict):
             except:
                 sip = file_.transfer
 
-
         rd = ReplacementDict()
         if sip:
             if isinstance(sip, models.Transfer):

--- a/src/dashboard/src/components/administration/views_processing.py
+++ b/src/dashboard/src/components/administration/views_processing.py
@@ -95,6 +95,13 @@ def index(request):
             "yes_option":   "9efab23c-31dc-4cbd-a39d-bb1665460cbe", # Store AIP
             "action":       "Store AIP"
         },
+        {
+            "name":         "transcribe_file",
+            "choice_uuid":  "7079be6d-3a25-41e6-a481-cee5f352fe6e",
+            "label":        "Transcribe files (OCR)",
+            "yes_option":   "5a9985d3-ce7e-4710-85c1-f74696770fa9",
+            "no_option":    "1170e555-cd4e-4b2f-a3d6-bfb09e8fcc53",
+        },
     ]
 
     # name: Value of the `name` attribute in the <input> HTML element


### PR DESCRIPTION
This adds a new "transcribe files" microservice. The primary initial usecase is OCR. Transcription commands are FPR commands, like normalization. OCR should be saved into a SIP in objects/metadata/OCRfiles.

OCR data will be included in a DIP if it exists, and will be copied into an `OCRfiles` directory at the root of the DIP.

Requirements are here: https://www.archivematica.org/wiki/OCR_text_in_DIP

This depends on #22.

~~Note that this isn't 100% ready to merge: I need to unify the post-normalization chains first. Currently transcribeFile is only called in one of them.~~
