### PR TITLE
JSON metadata conversion: support repeated columns

### DIFF
--- a/src/MCPClient/lib/clientScripts/jsonMetadataToCSV.py
+++ b/src/MCPClient/lib/clientScripts/jsonMetadataToCSV.py
@@ -7,9 +7,27 @@ import sys
 
 
 def fetch_keys(objects):
+    """
+    Returns a list of keys in a set of dicts suitable for use as a
+    CSV header row.
+    If values in the dict are lists, then the header row will contain
+    N occurrences of the key, where N is the largest list under that
+    key in the set of dicts.
+    """
+    # Track the occurrence of each set of keys; we'll need to produce
+    # one column for each occurrence of that key if its value in the
+    # JSON object is an array.
+    occurrence_count = {}
     keys = set()
-    for object in objects:
-        keys.update(object.keys())
+
+    for o in objects:
+        o_keys = o.keys()
+        for key in o_keys:
+            if isinstance(o[key], list):
+                occurrence = len(o[key])
+                if key not in occurrence_count or occurrence_count[key] < occurrence:
+                    occurrence_count[key] = occurrence
+        keys.update(o_keys)
 
     # Column order is otherwise unimportant, but
     # "filename" and "parts" must be column 0.
@@ -22,14 +40,57 @@ def fetch_keys(objects):
         keys.remove('parts')
         keys.insert(0, 'parts')
 
+    # now we need to update the list to ensure there are the right numbers
+    # of occurrences.
+    for key, count in occurrence_count.iteritems():
+        index = keys.index(key) + 1
+        for _ in range(count - 1):
+            keys.insert(index, key)
+
     return keys
 
 
-# DictWriter will fail if any Unicode characters are in the keys or
-# values in a dict passed to writerow(). This encodes them all to
-# UTF-8 bytestrings.
+def shallow_flatten(array):
+    out = []
+    for item in array:
+        if isinstance(item, (list, tuple, set)):
+            for i in item:
+                out.append(i)
+        else:
+            out.append(item)
+    return out
+
+
+def encode_item(item):
+    """
+    Wraps str.encode by recursively encoding lists.
+    """
+    if isinstance(item, basestring):
+        return item.encode('utf-8')
+    else:
+        return [i.encode('utf-8') for i in item]
+
+
 def fix_encoding(row):
-    return {key.encode('utf-8'): value.encode('utf-8') for key, value in row.iteritems()}
+    """
+    Python's CSV writers will fail if any Unicode characters are in the
+    keys or values passed to writerow(). This encodes them all to
+    UTF-8 bytestrings.
+    """
+    return {key.encode('utf-8'): encode_item(value) for key, value in row.iteritems()}
+
+
+def object_to_row(row, headers):
+    """
+    Takes a dict and returns a row suitable for serialization to CSV.
+    The `headers` argument is mandatory and determines the order
+    of values.
+    """
+    def sort_row(keyvalue):
+        return headers.index(keyvalue[0])
+    row = sorted(row.items(), key=sort_row)
+    row = [kv[1] for kv in row]
+    return shallow_flatten(row)
 
 
 def main(sip_uuid, json_metadata):
@@ -45,10 +106,17 @@ def main(sip_uuid, json_metadata):
     output = basename + '.csv'
 
     with open(output, 'w') as dest:
-        writer = csv.DictWriter(dest, fetch_keys(parsed))
-        writer.writeheader()
+        # Note that we unfortunately can't use DictWriter here because of
+        # the unusual way in which we deal with repeated items.
+        # The JSON handles multiple occurrences of a subject via an array,
+        # for instance {'dc.subject': ['foo', 'bar', 'baz']}
+        # In CSV, we handle this by repeating the column. DictWriter is not
+        # really capable of handling this.
+        writer = csv.writer(dest)
+        headers = fetch_keys(parsed)
+        writer.writerow(headers)
         for row in parsed:
-            writer.writerow(fix_encoding(row))
+            writer.writerow(object_to_row(fix_encoding(row), headers))
 
     return 0
 

--- a/src/MCPClient/tests/test_json_conversion.py
+++ b/src/MCPClient/tests/test_json_conversion.py
@@ -4,6 +4,9 @@ import subprocess
 JSON = '[{"dc.title": "This is a test item", "filename": "objects/test.txt"}]'
 CSV = 'filename,dc.title\r\nobjects/test.txt,This is a test item\r\n'
 
+JSON_MULTICOLUMN = '[{"filename": "objects/test.txt", "dc.subject": ["foo", "bar", "baz"], "dc.title": "This is a test item"}]'
+CSV_MULTICOLUMN = 'filename,dc.subject,dc.subject,dc.subject,dc.title\r\nobjects/test.txt,foo,bar,baz,This is a test item\r\n'
+
 
 def test_json_csv_conversion(tmpdir):
     json_path = os.path.join(str(tmpdir), 'metadata.json')
@@ -15,3 +18,15 @@ def test_json_csv_conversion(tmpdir):
         csvdata = csvfile.read()
 
     assert csvdata == CSV
+
+
+def test_json_csv_conversion_with_repeated_columns(tmpdir):
+    json_path = os.path.join(str(tmpdir), 'metadata.json')
+    csv_path = os.path.join(str(tmpdir), 'metadata.csv')
+    with open(json_path, 'w') as jsonfile:
+        jsonfile.write(JSON_MULTICOLUMN)
+    subprocess.call(['lib/clientScripts/jsonMetadataToCSV.py', '', json_path])
+    with open(csv_path) as csvfile:
+        csvdata = csvfile.read()
+
+    assert csvdata == CSV_MULTICOLUMN


### PR DESCRIPTION
This allows arrays to be provided as arguments to an object key in the JSON metadata. If an array is present, then the column will be repeated multiple times in the output CSV to provide room for multiple results for compatibility with how we support repeated values in CSV.

Sample JSON input:

``` json
[
    {
        "filename": "objects/foo.txt",
        "dc.title": "This is an object",
        "dc.subject": ["Subject 1", "Subject 2"]
    }
]
```

Which produces:

``` csv
filename,dc.subject,dc.subject,dc.title
objects/foo.txt,Subject 1,Subject 2,This is an object
```

refs #6266
