### PR TITLE
Add directory tree microservice

### DIFF
--- a/src/MCPClient/debian/control
+++ b/src/MCPClient/debian/control
@@ -14,7 +14,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, archivematica-common,
  md5deep, mediainfo, nfs-common, openjdk-7-jre-headless, p7zip-full,
  pbzip2, postfix, python-fido, python-gearman, python-lxml,
  python-mysqldb, python-pyicu, python-rfc6266, readpst, sanitize-names,
- tesseract-ocr, tika, ufraw, unrar-free, uuid
+ tesseract-ocr, tika, tree, ufraw, unrar-free, uuid
 Description: MCP Client for Archivematica
   
   

--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -53,6 +53,7 @@ copyTransfersMetadataAndLogs_v0.0 = %clientScriptsDirectory%copyTransfersMetadat
 copyTransferSubmissionDocumentation_v0.0 = %clientScriptsDirectory%copyTransferSubmissionDocumentation.py
 createAIC_METS_v1.0 =  %clientScriptsDirectory%createAICMETS.py
 createDirectory_v0.0 = mkdir
+createDirectoryTree_v0.0 = tree
 createEvent_v0.0 = %clientScriptsDirectory%createEvent.py
 createMETS_v0.0 = %clientScriptsDirectory%archivematicaCreateMETS.py
 createMETS_v2.0 = %clientScriptsDirectory%archivematicaCreateMETS2.py

--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -506,3 +506,50 @@ UPDATE StandardTasksConfigs
 	SET arguments='--sipUUID "%SIPUUID%" --sipDirectory "%SIPDirectory%" --filePath "%relativeLocation%" --fileUUID "%fileUUID%" --eventIdentifierUUID "%taskUUID%" --date "%date%" --use "metadata" --disable-update-filegrpuse'
 	WHERE pk='34966164-9800-4ae1-91eb-0a0c608d72d5';
 -- /Issue 6565 OCR
+
+-- Issue 6566 Tree
+--
+-- First, some surgery: unify several of the "scan for virus" nodes, so that
+-- the directory tree microservice is guaranteed to run.
+SET @scanForViruses = '1c2550f1-3fc0-45d8-8bc4-4c06d720283b' COLLATE utf8_unicode_ci;
+UPDATE MicroServiceChainLinks SET defaultNextChainLink=@scanForViruses WHERE pk='38c591d4-b7ee-4bc0-b993-c592bf15d97d';
+UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink=@scanForViruses WHERE microServiceChainLink='38c591d4-b7ee-4bc0-b993-c592bf15d97d';
+UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink=@scanForViruses WHERE microServiceChainLink='d7e6404a-a186-4806-a130-7e6d27179a15';
+
+SET @treeChoiceChain = 'f6df8882-d076-441e-bb00-2f58d5eda098' COLLATE utf8_unicode_ci;
+SET @treeChain = 'df54fec1-dae1-4ea6-8d17-a839ee7ac4a7' COLLATE utf8_unicode_ci;
+SET @noTreeChain = 'e9eaef1e-c2e0-4e3b-b942-bfb537162795' COLLATE utf8_unicode_ci;
+set @treeMSCL = '4efe00da-6ed0-45dd-89ca-421b78c4b6be' COLLATE utf8_unicode_ci;
+
+SET @preTreeChoiceMSCL = '1c2550f1-3fc0-45d8-8bc4-4c06d720283b' COLLATE utf8_unicode_ci;
+set @postTreeMSCL = '2584b25c-8d98-44b7-beca-2b3ea2ea2505' COLLATE utf8_unicode_ci;
+
+SET @treeChoiceWatchMSCL = '559d9b14-05bf-4136-918a-de74a821b759' COLLATE utf8_unicode_ci;
+SET @treeChoiceWatchTC = '48416179-7ae4-47cc-a0aa-f9847da08c63' COLLATE utf8_unicode_ci;
+SET @treeChoiceWatchSTC = '760a9654-de3e-4ea7-bb76-eeff06acdf95' COLLATE utf8_unicode_ci;
+INSERT INTO StandardTasksConfigs (pk, requiresOutputLock, execute, arguments) VALUES (@treeChoiceWatchSTC, 0, 'moveTransfer_v0.0', '"%SIPDirectory%" "%sharedPath%watchedDirectories/workFlowDecisions/createTree/." "%SIPUUID%" "%sharedPath%"');
+INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES (@treeChoiceWatchTC, '36b2e239-4a57-4aa5-8ebc-7a29139baca6', @treechoiceWatchSTC, 'Move to generate transfer tree');
+INSERT INTO MicroServiceChainLinks (pk, microserviceGroup, defaultExitMessage, currentTask, defaultNextChainLink) VALUES (@treeChoiceWatchMSCL, 'Generate transfer structure diagram', 'Failed', @treeChoiceWatchTC, @MoveTransferToFailedLink);
+INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('d312ae33-3555-472e-803c-ef8076cb789b', @treeChoiceWatchMSCL, 0, NULL, 'Completed successfully');
+
+SET @treeChoiceMSCL = '56eebd45-5600-4768-a8c2-ec0114555a3d' COLLATE utf8_unicode_ci;
+SET @treeChoiceTC = 'f1ebd62a-fbf3-4790-88e8-4a3abec4ba00' COLLATE utf8_unicode_ci;
+INSERT INTO TasksConfigs (pk, taskType, description) VALUES (@treeChoiceTC, '61fb3874-8ef6-49d3-8a2d-3cb66e86a30c', 'Generate transfer structure diagram');
+INSERT INTO MicroServiceChainLinks (pk, microserviceGroup, defaultExitMessage, currentTask) VALUES (@treeChoiceMSCL, 'Generate transfer structure diagram', 'Failed', @treeChoiceTC);
+
+INSERT INTO MicroServiceChains (pk, startingLink, description) VALUES (@treeChoiceChain, @treeChoiceMSCL, 'Generate transfer structure diagram');
+INSERT INTO WatchedDirectories(pk, watchedDirectoryPath, chain, expectedType) VALUES ('e237217e-7b07-48f0-8129-36da0abfc97f', '%watchDirectoryPath%workFlowDecisions/createTree/', @treeChoiceChain, @watchedDirExpectTransfer);
+
+UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink=@treeChoiceWatchMSCL WHERE microServiceChainLink=@preTreeChoiceMSCL;
+UPDATE MicroServiceChainLinks SET defaultNextChainLink=@treeChoiceWatchMSCL WHERE pk=@preTreeChoiceMSCL;
+
+INSERT INTO StandardTasksConfigs (pk, requiresOutputLock, execute, arguments) VALUES ('f1a272df-bb3f-463e-95c0-6d2062bddfb8', 0, 'createDirectoryTree_v0.0', '"%SIPObjectsDirectory%" -o "%SIPDirectory%metadata/directory_tree.txt"');
+INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES ('ede67763-2a12-4e8f-8c36-e266d3f05c6b', '36b2e239-4a57-4aa5-8ebc-7a29139baca6', 'f1a272df-bb3f-463e-95c0-6d2062bddfb8', 'Save directory tree');
+INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, currentTask, defaultNextChainLink) values (@treeMSCL, 'Generate transfer structure diagram', 'Failed', 'ede67763-2a12-4e8f-8c36-e266d3f05c6b', @postTreeMSCL);
+INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('882486b7-034e-49b8-bc65-2f6d8946bdcd', @treeMSCL, 0, @postTreeMSCL, 'Completed successfully');
+
+INSERT INTO MicroServiceChains (pk, startingLink, description) VALUES (@treeChain, @treeMSCL, 'Yes');
+INSERT INTO MicroServiceChains (pk, startingLink, description) VALUES (@noTreeChain, @postTreeMSCL, 'No');
+INSERT INTO MicroServiceChainChoice (pk, choiceAvailableAtLink, chainAvailable) VALUES ('171c7418-53c1-4d00-bcac-f77012050d1b', @treeChoiceMSCL, @treeChain);
+INSERT INTO MicroServiceChainChoice (pk, choiceAvailableAtLink, chainAvailable) VALUES ('63f0e429-1435-48e2-8eb0-dcb68e507168', @treeChoiceMSCL, @noTreeChain);
+-- /Issue 6566 Tree

--- a/src/MCPServer/share/sharedDirectoryStructure/sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml
+++ b/src/MCPServer/share/sharedDirectoryStructure/sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml
@@ -55,5 +55,10 @@
       <appliesTo>7079be6d-3a25-41e6-a481-cee5f352fe6e</appliesTo>
       <goToChain>1170e555-cd4e-4b2f-a3d6-bfb09e8fcc53</goToChain>
     </preconfiguredChoice>
+    <!-- Transfer tree diagram -->
+    <preconfiguredChoice>
+      <appliesTo>56eebd45-5600-4768-a8c2-ec0114555a3d</appliesTo>
+      <goToChain>e9eaef1e-c2e0-4e3b-b942-bfb537162795</goToChain>
+    </preconfiguredChoice>
   </preconfiguredChoices>
 </processingMCP>

--- a/src/MCPServer/share/sharedDirectoryStructure/watchedDirectories/workFlowDecisions/createTree/.gitignore
+++ b/src/MCPServer/share/sharedDirectoryStructure/watchedDirectories/workFlowDecisions/createTree/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+\!.gitignore

--- a/src/dashboard/src/components/administration/views_processing.py
+++ b/src/dashboard/src/components/administration/views_processing.py
@@ -102,6 +102,14 @@ def index(request):
             "yes_option":   "5a9985d3-ce7e-4710-85c1-f74696770fa9",
             "no_option":    "1170e555-cd4e-4b2f-a3d6-bfb09e8fcc53",
         },
+        {
+            "name":         "tree",
+            "choice_uuid":  "56eebd45-5600-4768-a8c2-ec0114555a3d",
+            "label":        "Generate transfer tree",
+            "yes_option":   "df54fec1-dae1-4ea6-8d17-a839ee7ac4a7", # Generate transfer tree
+            "no_option":    "e9eaef1e-c2e0-4e3b-b942-bfb537162795",
+            "action":       "Generate transfer tree"
+        },
     ]
 
     # name: Value of the `name` attribute in the <input> HTML element


### PR DESCRIPTION
This adds a new microservice that uses `tree` to generate a simple ASCII diagram of the structure of the transfer, for future human reference.

refs #6566
