### PR TITLE
change hardcoded archivematica uid (333) in server to query os for uid

### DIFF
--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -45,6 +45,7 @@ import MySQLdb
 import signal
 import os
 import pyinotify
+from pwd import getpwnam
 # from archivematicaReplacementDics import replacementDics
 # from MCPlogging import *
 # from MCPloggingSQL import getUTCDate
@@ -294,7 +295,7 @@ if __name__ == '__main__':
 
     import getpass
     print "user: ", getpass.getuser()
-    os.setuid(333)
+    os.setuid(getpwnam('archivematica').pw_uid)
 
     t = threading.Thread(target=debugMonitor)
     t.daemon = True


### PR DESCRIPTION
Hi,

we had to change the MCPServer everytime after merges or checking out branches because our archivematica hasn't got the uid 333.

Cheers Marco (from ZIB)
