### PR TITLE
Update dev-helper to delete pyc's, pyo's, & clear backlog, storage

### DIFF
--- a/dev-helper
+++ b/dev-helper
@@ -139,6 +139,20 @@ function erase-indexes() {
   fi
 }
 
+function clear-storage() {
+  part="clear transfer backlog and AIP storage?"
+  echo -n "\"Would you like to ${part}?\" (y/N) "
+  read a
+  if [[ $a == "Y" || $a == "y" ]]; then
+    set -x
+    sudo rm -rf /var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog/originals/*
+    sudo rm -rf /var/archivematica/sharedDirectory/www/AIPsStore/????
+    set +x
+  else
+    echo "Not going to ${part}"
+  fi
+}
+
 function restart() {
   part="restart archivematica services"
   echo -n "\"Would you like to ${part}?\" (y/N) "
@@ -246,6 +260,7 @@ git-pull
 package-update
 recreate-db
 erase-indexes
+clear-storage
 restart
 update-sampledata
 export-sampledata

--- a/localDevSetup/recreateDB.sh
+++ b/localDevSetup/recreateDB.sh
@@ -29,6 +29,10 @@ password="demo"
 echo "Removing existing units"
 sudo ./removeUnitsFromWatchedDirectories.py
 sudo rm -rf /var/archivematica/sharedDirectory/tmp/tmp*
+sudo rm -rf /var/archivematica/sharedDirectory/www/thumbnails/*
+
+# Delete pyc's & pyo's
+find ../src -name '*.py[o|c]' -delete
 
 set -e
 echo -n "Enter the DATABASE root password (Hit enter if blank):"


### PR DESCRIPTION
refs #6247

Update dev-helper to delete pyc's and pyo's when the DB is recreated, as well as deleting thumbnails. Add new option to clear the transfer backlog and default AIP storage location.
