### PR TITLE
Fix METS namespaces

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS.py
@@ -21,13 +21,13 @@
 # @subpackage archivematicaClientScript
 # @author Joseph Perry <joseph@artefactual.com>
 
-from archivematicaXMLNamesSpace import *
-
 import os
 import sys
 import lxml.etree as etree
 import MySQLdb
 from xml.sax.saxutils import quoteattr
+
+import archivematicaXMLNamesSpace as ns
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 import databaseInterface
 from archivematicaFunctions import escape
@@ -145,7 +145,7 @@ def createFileSec(path, parentBranch, structMapParent):
                         fileI.set("ADMID", "digiprov-" + item.__str__() + "-"    + myuuid.__str__())
 
                     Flocat = newChild(fileI, "FLocat")
-                    Flocat.set(xlinkBNS + "href", escape(pathSTR) )
+                    Flocat.set(ns.xlinkBNS + "href", escape(pathSTR) )
                     Flocat.set("LOCTYPE", "OTHER")
                     Flocat.set("OTHERLOCTYPE", "SYSTEM")
 
@@ -156,9 +156,10 @@ def createFileSec(path, parentBranch, structMapParent):
                     fptr.set("FILEID", escape(FILEID))
 
 if __name__ == '__main__':
-    root = etree.Element( "mets", \
-    nsmap = {None: metsNS, "xlink": xlinkNS}, \
-    attrib = { "{" + xsiNS + "}schemaLocation" : "http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd" } )
+    root = etree.Element("mets",
+        nsmap = {None: ns.metsNS, "xlink": ns.xlinkNS},
+        attrib = { "{" + ns.xsiNS + "}schemaLocation" : "http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd" }
+    )
 
     #cd /tmp/$UUID;
     opath = os.getcwd()

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -21,9 +21,8 @@
 # @package Archivematica
 # @subpackage archivematicaClientScript
 # @author Joseph Perry <joseph@artefactual.com>
-from archivematicaXMLNamesSpace import *
+import archivematicaXMLNamesSpace as ns
 import lxml.etree as etree
-from xml.sax.saxutils import quoteattr
 import os
 import re
 import sys
@@ -136,8 +135,8 @@ def getDublinCore(unit, id):
     row = c.fetchone()
     ret = None
     if row is not None:
-        ret = etree.Element("dublincore", nsmap={None:dctermsNS})
-        ret.set(xsiBNS+"schemaLocation", dctermsNS + " http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd")
+        ret = etree.Element("dublincore", nsmap={None:ns.dctermsNS})
+        ret.set(ns.xsiBNS+"schemaLocation", ns.dctermsNS + " http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd")
     while row is not None:
         #title, creator, subject, description, publisher, contributor, date, type, format, identifier, source, relation, language, coverage, rights = row
         for i, term in enumerate(field_list):
@@ -190,8 +189,8 @@ def createDMDIDSFromCSVParsedMetadataPart2(keys, values):
                 mdWrap = etree.SubElement(dmdSec, "mdWrap")
                 mdWrap.set("MDTYPE", "DC")
                 xmlData = etree.SubElement(mdWrap, "xmlData")
-                dc = etree.Element("dublincore", nsmap={None: dctermsNS})
-                dc.set(xsiBNS+"schemaLocation", dctermsNS + " http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd")
+                dc = etree.Element("dublincore", nsmap={None: ns.dctermsNS})
+                dc.set(ns.xsiBNS+"schemaLocation", ns.dctermsNS + " http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd")
                 xmlData.append(dc)
             if key.startswith("dc."):
                 key2 = key.replace("dc.", "", 1)
@@ -266,7 +265,7 @@ def createMDRefDMDSec(LABEL, itemdirectoryPath, directoryPathSTR):
     for item in root.findall("{http://www.loc.gov/METS/}dmdSec"):
         XPTR = "%s %s" % (XPTR, item.get("ID"))
     XPTR = XPTR.replace(" ", "'", 1) + "'))"
-    newChild(dmdSec, "mdRef", text=None, sets=[("LABEL", LABEL), (xlinkBNS +"href", directoryPathSTR), ("MDTYPE", "OTHER"), ("LOCTYPE","OTHER"), ("OTHERLOCTYPE", "SYSTEM"), ("XPTR", XPTR)])
+    newChild(dmdSec, "mdRef", text=None, sets=[("LABEL", LABEL), (ns.xlinkBNS +"href", directoryPathSTR), ("MDTYPE", "OTHER"), ("LOCTYPE","OTHER"), ("OTHERLOCTYPE", "SYSTEM"), ("XPTR", XPTR)])
     return (dmdSec, ID)
 
 
@@ -281,11 +280,11 @@ def createTechMD(fileUUID):
     mdWrap = etree.SubElement(techMD, "mdWrap")
     mdWrap.set("MDTYPE", "PREMIS:OBJECT")
     xmlData = etree.SubElement(mdWrap, "xmlData")
-    #premis = etree.SubElement( xmlData, "premis", nsmap={None: premisNS}, \
-    #    attrib = { "{" + xsiNS + "}schemaLocation" : "info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/premis.xsd" })
+    #premis = etree.SubElement( xmlData, "premis", nsmap={None: ns.premisNS}, \
+    #    attrib = { "{" + ns.xsiNS + "}schemaLocation" : "info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/premis.xsd" })
     #premis.set("version", "2.0")
 
-    #premis = etree.SubElement( xmlData, "premis", attrib = {xsiBNS+"type": "premis:file"})
+    #premis = etree.SubElement( xmlData, "premis", attrib = {ns.xsiBNS+"type": "premis:file"})
 
     sql = "SELECT fileSize, checksum FROM Files WHERE fileUUID = '%s';" % (fileUUID)
     c, sqlLock = databaseInterface.querySQL(sql)
@@ -297,9 +296,9 @@ def createTechMD(fileUUID):
     sqlLock.release()
 
     #OBJECT
-    object = etree.SubElement(xmlData, "object", nsmap={None: premisNS})
-    object.set( xsiBNS+"type", "file")
-    object.set(xsiBNS+"schemaLocation", premisNS + " http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd")
+    object = etree.SubElement(xmlData, "object", nsmap={None: ns.premisNS})
+    object.set(ns.xsiBNS+"type", "file")
+    object.set(ns.xsiBNS+"schemaLocation", ns.premisNS + " http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd")
     object.set("version", "2.2")
 
     objectIdentifier = etree.SubElement(object, "objectIdentifier")
@@ -421,8 +420,8 @@ def createDigiprovMD(fileUUID):
         mdWrap = etree.SubElement(digiprovMD, "mdWrap")
         mdWrap.set("MDTYPE", "PREMIS:EVENT")
         xmlData = etree.SubElement(mdWrap, "xmlData")
-        event = etree.SubElement(xmlData, "event", nsmap={None: premisNS})
-        event.set(xsiBNS+"schemaLocation", premisNS + " http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd")
+        event = etree.SubElement(xmlData, "event", nsmap={None: ns.premisNS})
+        event.set(ns.xsiBNS+"schemaLocation", ns.premisNS + " http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd")
         event.set("version", "2.2")
 
         eventIdentifier = etree.SubElement(event, "eventIdentifier")
@@ -572,12 +571,12 @@ def getIncludedStructMap():
             tree = etree.parse(structMapXmlPath)
             root = tree.getroot() #TDOD - not root to return, but sub element structMap
             #print etree.tostring(root)
-            structMap = root.find(metsBNS + "structMap")
+            structMap = root.find(ns.metsBNS + "structMap")
             id = structMap.get("ID")
             if not id:
                 structMap.set("ID", "structMap_2")
             ret.append(structMap)
-            for item in structMap.findall(".//" + metsBNS + "fptr"):
+            for item in structMap.findall(".//" + ns.metsBNS + "fptr"):
                 fileName = item.get("FILEID")
                 if fileName in fileNameToFileID:
                     #print fileName, " -> ", fileNameToFileID[fileName]
@@ -818,7 +817,7 @@ def createFileSec(directoryPath, parentDiv):
             if use == "original":
                 filesInThisDirectory.append(file)
             #<Flocat xlink:href="objects/file1-UUID" locType="other" otherLocType="system"/>
-            newChild(file, "FLocat", sets=[(xlinkBNS +"href",directoryPathSTR), ("LOCTYPE","OTHER"), ("OTHERLOCTYPE", "SYSTEM")])
+            newChild(file, "FLocat", sets=[(ns.xlinkBNS +"href",directoryPathSTR), ("LOCTYPE","OTHER"), ("OTHERLOCTYPE", "SYSTEM")])
             if includeAmdSec:
                 AMD, ADMID = getAMDSec(myuuid, directoryPathSTR, use, fileGroupType, fileGroupIdentifier, transferUUID, itemdirectoryPath, typeOfTransfer)
                 amdSecs.append(AMD)
@@ -857,11 +856,15 @@ if __name__ == '__main__':
         if len(grp) > 0:
             fileSec.append(grp)
 
-    rootNSMap = {None: metsNS}
-    rootNSMap.update(NSMAP)
-    root = etree.Element( "mets", \
-    nsmap = rootNSMap, \
-    attrib = { "{" + xsiNS + "}schemaLocation" : "http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version18/mets.xsd" } )
+    rootNSMap = {
+        None: ns.metsNS,
+        'xsi': ns.xsiNS,
+        'xlink': ns.xlinkNS,
+    }
+    root = etree.Element("mets",
+        nsmap = rootNSMap,
+        attrib = { "{" + ns.xsiNS + "}schemaLocation" : "http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version18/mets.xsd" },
+    )
     etree.SubElement(root,"metsHdr").set("CREATEDATE", databaseInterface.getUTCDate().split(".")[0])
 
 

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRights.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRights.py
@@ -23,17 +23,15 @@
 
 #/src/dashboard/src/main/models.py
 
-from archivematicaXMLNamesSpace import *
-
-import os
 import sys
 import uuid
 import lxml.etree as etree
+
+import archivematicaXMLNamesSpace as ns
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 from countryCodes import getCodeForCountry
 import databaseInterface
 from sharedVariablesAcrossModules import sharedVariablesAcrossModules
-from archivematicaFunctions import escape
 
 
 def formatDate(date):
@@ -57,8 +55,8 @@ def archivematicaGetRights(metadataAppliesToList, fileUUID):
         else:
             for row in rows:
                 valueDic= {}
-                rightsStatement = etree.Element("rightsStatement", nsmap={None: premisNS})
-                rightsStatement.set(xsiBNS+"schemaLocation", premisNS + " http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd")
+                rightsStatement = etree.Element("rightsStatement", nsmap={None: ns.premisNS})
+                rightsStatement.set(ns.xsiBNS+"schemaLocation", ns.premisNS + " http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd")
                 #rightsStatement.set("version", "2.1") #cvc-complex-type.3.2.2: Attribute 'version' is not allowed to appear in element 'rightsStatement'.
                 ret.append(rightsStatement)
                 for i in range(len(key)):

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRightsDspaceMDRef.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRightsDspaceMDRef.py
@@ -21,10 +21,11 @@
 # @subpackage archivematicaClientScript
 # @author Joseph Perry <joseph@artefactual.com>
 
-from archivematicaXMLNamesSpace import *
 import os
 import sys
 import lxml.etree as etree
+
+import archivematicaXMLNamesSpace as ns
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 import databaseInterface
 from sharedVariablesAcrossModules import sharedVariablesAcrossModules
@@ -42,7 +43,7 @@ def createMDRefDMDSec(LABEL, itemdirectoryPath, directoryPathSTR):
     XPTR = XPTR.replace(" ", "'", 1) + "'))"
     mdRef = etree.Element("mdRef")
     mdRef.set("LABEL", LABEL)
-    mdRef.set(xlinkBNS +"href", directoryPathSTR)
+    mdRef.set(ns.xlinkBNS +"href", directoryPathSTR)
     mdRef.set("MDTYPE", "OTHER")
     mdRef.set("OTHERMDTYPE", "METSRIGHTS")
     mdRef.set("LOCTYPE","OTHER")

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSTrim.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSTrim.py
@@ -22,10 +22,11 @@
 # @author Joseph Perry <joseph@artefactual.com>
 # @version svn: $Id$
 
-from archivematicaXMLNamesSpace import *
 import os
 import sys
 import lxml.etree as etree
+
+import archivematicaXMLNamesSpace as ns
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 import databaseInterface
 
@@ -39,21 +40,21 @@ def getTrimDmdSec(baseDirectoryPath, fileGroupIdentifier):
     mdWrap.set("MDTYPE", "DC")
     xmlData = etree.SubElement(mdWrap, "xmlData")
     
-    dublincore = etree.SubElement(xmlData, "dublincore", attrib=None, nsmap={None:dctermsNS})
-    dublincore.set(xsiBNS+"schemaLocation", dctermsNS + " http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd")
+    dublincore = etree.SubElement(xmlData, "dublincore", attrib=None, nsmap={None:ns.dctermsNS})
+    dublincore.set(ns.xsiBNS+"schemaLocation", ns.dctermsNS + " http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd")
     tree = etree.parse(os.path.join(baseDirectoryPath, "objects", "ContainerMetadata.xml"))
     root = tree.getroot()
     
     
-    etree.SubElement(dublincore, dctermsBNS + "title").text = root.find("Container/TitleFreeTextPart").text
-    etree.SubElement(dublincore, dctermsBNS + "provenance").text = "Department: %s; OPR: %s" % (root.find("Container/Department").text, root.find("Container/OPR").text)
-    etree.SubElement(dublincore, dctermsBNS + "isPartOf").text = root.find("Container/FullClassificationNumber").text
-    etree.SubElement(dublincore, dctermsBNS + "identifier").text = root.find("Container/RecordNumber").text.split('/')[-1]
+    etree.SubElement(dublincore, ns.dctermsBNS + "title").text = root.find("Container/TitleFreeTextPart").text
+    etree.SubElement(dublincore, ns.dctermsBNS + "provenance").text = "Department: %s; OPR: %s" % (root.find("Container/Department").text, root.find("Container/OPR").text)
+    etree.SubElement(dublincore, ns.dctermsBNS + "isPartOf").text = root.find("Container/FullClassificationNumber").text
+    etree.SubElement(dublincore, ns.dctermsBNS + "identifier").text = root.find("Container/RecordNumber").text.split('/')[-1]
     
     #get objects count
     sql = "SELECT fileUUID FROM Files WHERE removedTime = 0 AND %s = '%s' AND fileGrpUse='original';" % ('sipUUID', fileGroupIdentifier)
     rows = databaseInterface.queryAllSQL(sql)
-    etree.SubElement(dublincore, dctermsBNS + "extent").text = "%d digital objects" % (len(rows))
+    etree.SubElement(dublincore, ns.dctermsBNS + "extent").text = "%d digital objects" % (len(rows))
     
     sql = "SELECT currentLocation FROM Files WHERE removedTime = 0 AND %s = '%s' AND fileGrpUse='TRIM file metadata';" % ('sipUUID', fileGroupIdentifier)
     rows = databaseInterface.queryAllSQL(sql)
@@ -71,7 +72,7 @@ def getTrimDmdSec(baseDirectoryPath, fileGroupIdentifier):
             if maxDateMod ==  None or dateMod > maxDateMod:
                maxDateMod = dateMod
 
-    etree.SubElement(dublincore, dctermsBNS + "date").text = "%s/%s" % (minDateMod, maxDateMod)
+    etree.SubElement(dublincore, ns.dctermsBNS + "date").text = "%s/%s" % (minDateMod, maxDateMod)
     
     #print etree.tostring(dublincore, pretty_print = True)
     return ret
@@ -92,13 +93,13 @@ def getTrimFileDmdSec(baseDirectoryPath, fileGroupIdentifier, fileUUID):
         return None
     for row in rows:
         xmlFilePath = row[0].replace('%SIPDirectory%', baseDirectoryPath, 1)
-        dublincore = etree.SubElement(xmlData, "dublincore", attrib=None, nsmap={None:dctermsNS})
+        dublincore = etree.SubElement(xmlData, "dublincore", attrib=None, nsmap={None: ns.dctermsNS})
         tree = etree.parse(os.path.join(baseDirectoryPath, xmlFilePath))
         root = tree.getroot()
         
-        etree.SubElement(dublincore, dctermsBNS + "title").text = root.find("Document/TitleFreeTextPart").text
-        etree.SubElement(dublincore, dctermsBNS + "date").text = root.find("Document/DateModified").text
-        etree.SubElement(dublincore, dctermsBNS + "identifier").text = root.find("Document/RecordNumber").text
+        etree.SubElement(dublincore, ns.dctermsBNS + "title").text = root.find("Document/TitleFreeTextPart").text
+        etree.SubElement(dublincore, ns.dctermsBNS + "date").text = root.find("Document/DateModified").text
+        etree.SubElement(dublincore, ns.dctermsBNS + "identifier").text = root.find("Document/RecordNumber").text
         
     return ret
 
@@ -111,7 +112,7 @@ def getTrimFileAmdSec(baseDirectoryPath, fileGroupIdentifier, fileUUID):
         return None
     for row in rows:
         label = os.path.basename(row[0])
-        attrib = {"LABEL":label, xlinkBNS + "href":row[0].replace("%SIPDirectory%", "", 1), "MDTYPE":"OTHER", "OTHERMDTYPE":"CUSTOM", 'LOCTYPE':"OTHER", 'OTHERLOCTYPE':"SYSTEM"}
+        attrib = {"LABEL":label, ns.xlinkBNS + "href":row[0].replace("%SIPDirectory%", "", 1), "MDTYPE":"OTHER", "OTHERMDTYPE":"CUSTOM", 'LOCTYPE':"OTHER", 'OTHERLOCTYPE':"SYSTEM"}
         etree.SubElement(ret, "mdRef", attrib=attrib)
     return ret    
 
@@ -121,7 +122,7 @@ def getTrimAmdSec(baseDirectoryPath, fileGroupIdentifier):
     sql = "SELECT currentLocation FROM Files WHERE removedTime = 0 AND %s = '%s' AND fileGrpUse='TRIM container metadata';" % ('sipUUID', fileGroupIdentifier)
     rows = databaseInterface.queryAllSQL(sql)
     for row in rows:
-        attrib = {"LABEL":"ContainerMetadata.xml", xlinkBNS + "href":row[0].replace("%SIPDirectory%", "", 1), "MDTYPE":"OTHER", "OTHERMDTYPE":"CUSTOM", 'LOCTYPE':"OTHER", 'OTHERLOCTYPE':"SYSTEM"}
+        attrib = {"LABEL":"ContainerMetadata.xml", ns.xlinkBNS + "href":row[0].replace("%SIPDirectory%", "", 1), "MDTYPE":"OTHER", "OTHERMDTYPE":"CUSTOM", 'LOCTYPE':"OTHER", 'OTHERLOCTYPE':"SYSTEM"}
         etree.SubElement(ret, "mdRef", attrib=attrib)
     return ret
         


### PR DESCRIPTION
refs #6676

Fix the AIP METS to only declare the namespaces it's actually using, notably XSI, xlink, and METS as the default. Replace all `from archivematicaXMLNamesSpace import *` with explicit imports and update
references.
