### PR TITLE
dev-helper: be less incredulous about clearing transfer backlog

### DIFF
--- a/dev-helper
+++ b/dev-helper
@@ -140,7 +140,7 @@ function erase-indexes() {
 }
 
 function clear-storage() {
-  part="clear transfer backlog and AIP storage?"
+  part="clear transfer backlog and AIP storage"
   echo -n "\"Would you like to ${part}?\" (y/N) "
   read a
   if [[ $a == "Y" || $a == "y" ]]; then


### PR DESCRIPTION
Every dev-helper question (`Would you like to ${part}?`) already includes a question mark. Including the question mark in the `$part` string meant there were two question marks.
