### PR TITLE
FPR rule commandline tool

### DIFF
--- a/src/archivematicaCommon/lib/utilities/add-format
+++ b/src/archivematicaCommon/lib/utilities/add-format
@@ -1,0 +1,1 @@
+add-fpr-rule

--- a/src/archivematicaCommon/lib/utilities/add-fpr-rule
+++ b/src/archivematicaCommon/lib/utilities/add-fpr-rule
@@ -79,11 +79,15 @@ def save_object(obj):
     return connection.queries[-1]['sql']
 
 
+def ask_for_field(field):
+    print(field + ":", file=sys.stderr)
+    return sys.stdin.readline().rstrip("\n", 1)
+
+
 def create_format():
     obj = FormatVersion()
 
-    print("format")
-    format_description = sys.stdin.readline()[0:-1]
+    format_description = ask_for_field("format")
     try:
         format = Format.objects.get(description=format_description)
     except Format.DoesNotExist:
@@ -92,8 +96,7 @@ def create_format():
         print(sql + ";")
 
     if not format.group:
-        print("format_group")
-        group_description = sys.stdin.readline()[0:-1]
+        group_description = ask_for_field("format_group")
         try:
             group = FormatGroup.objects.get(description=group_description)
         except FormatGroup.DoesNotExist:
@@ -103,8 +106,7 @@ def create_format():
         format.group = group
 
     for field in FORMAT_FIELDS:
-        print(field + ":", file=sys.stderr)
-        val = sys.stdin.readline()[0:-1]
+        val = ask_for_field(field)
         if val:
             setattr(obj, field, val)
 
@@ -120,8 +122,7 @@ def create_rule(kind, command_file=None):
             with open(command_file) as command:
                 val = command.read()
         else:
-            print(field + ":", file=sys.stderr)
-            val = sys.stdin.readline()[0:-1]
+            val = ask_for_field(field)
 
         # Empty values should be NULL, not empty strings
         if val:

--- a/src/archivematicaCommon/lib/utilities/add-fpr-rule
+++ b/src/archivematicaCommon/lib/utilities/add-fpr-rule
@@ -73,12 +73,16 @@ def save_object(obj):
     return connection.queries[-1]['sql']
 
 
-def create_rule(kind, command=None):
+def create_rule(kind, command_file=None):
     klass, fields = NAME_MAP[kind]
     obj = klass()
     for field in fields:
-        print(field + ":", file=sys.stderr)
-        val = sys.stdin.readline()[0:-1]
+        if command_file and field in ("command", "script"):
+            with open(command_file) as command:
+                val = command.read()
+        else:
+            print(field + ":", file=sys.stderr)
+            val = sys.stdin.readline()[0:-1]
 
         # Empty values should be NULL, not empty strings
         if val:
@@ -101,6 +105,6 @@ if __name__ == '__main__':
     opts = parser.parse_args()
 
     try:
-        create_rule(opts.kind, opts.command)
+        create_rule(opts.kind, command_file=opts.command)
     except KeyboardInterrupt:
         sys.exit("\nAborting")

--- a/src/archivematicaCommon/lib/utilities/add-fpr-rule
+++ b/src/archivematicaCommon/lib/utilities/add-fpr-rule
@@ -75,7 +75,7 @@ def create_rule(kind, command=None):
     klass, fields = NAME_MAP[kind]
     obj = klass()
     for field in fields:
-        print(field + ":")
+        print(field + ":", file=sys.stderr)
         val = sys.stdin.readline()[0:-1]
 
         # Empty values should be NULL, not empty strings
@@ -85,10 +85,10 @@ def create_rule(kind, command=None):
     if hasattr(obj, "replaces") and obj.replaces:
         obj.replaces.enabled = False
         sql = save_object(obj.replaces)
-        print(sql + ";", file=sys.stderr)
+        print(sql + ";")
 
     sql = save_object(obj)
-    print(sql + ";", file=sys.stderr)
+    print(sql + ";")
 
 
 if __name__ == '__main__':
@@ -101,4 +101,4 @@ if __name__ == '__main__':
     try:
         create_rule(opts.kind, opts.command)
     except KeyboardInterrupt:
-        print("\nAborting")
+        sys.exit("\nAborting")

--- a/src/archivematicaCommon/lib/utilities/add-fpr-rule
+++ b/src/archivematicaCommon/lib/utilities/add-fpr-rule
@@ -22,6 +22,7 @@ IDCOMMAND_FIELDS = (
 )
 
 IDRULE_FIELDS = (
+    "command_output",
     "command_id",
     "format_id",
 )
@@ -46,6 +47,7 @@ FPCOMMAND_FIELDS = (
 
 
 FPRULE_FIELDS = (
+    "purpose",
     "command_id",
     "format_id",
 )

--- a/src/archivematicaCommon/lib/utilities/add-fpr-rule
+++ b/src/archivematicaCommon/lib/utilities/add-fpr-rule
@@ -10,7 +10,13 @@ os.environ["DJANGO_SETTINGS_MODULE"] = "settings.local"
 
 from django.db import connection
 
-from fpr.models import IDCommand, IDRule, IDTool, Format, FormatVersion, FPCommand, FPRule, FPTool
+from fpr.models import IDCommand, IDRule, IDTool, Format, FormatGroup, FormatVersion, FPCommand, FPRule, FPTool
+
+FORMAT_FIELDS = (
+    "description",
+    "pronom_id",
+    "version",
+)
 
 IDCOMMAND_FIELDS = (
     "description",
@@ -73,6 +79,39 @@ def save_object(obj):
     return connection.queries[-1]['sql']
 
 
+def create_format():
+    obj = FormatVersion()
+
+    print("format")
+    format_description = sys.stdin.readline()[0:-1]
+    try:
+        format = Format.objects.get(description=format_description)
+    except Format.DoesNotExist:
+        format = Format(description=format_description)
+        sql = save_object(format)
+        print(sql + ";")
+
+    if not format.group:
+        print("format_group")
+        group_description = sys.stdin.readline()[0:-1]
+        try:
+            group = FormatGroup.objects.get(description=group_description)
+        except FormatGroup.DoesNotExist:
+            group = FormatGroup(description=group_description)
+            sql = save_object(group)
+            print(sql + ";")
+        format.group = group
+
+    for field in FORMAT_FIELDS:
+        print(field + ":", file=sys.stderr)
+        val = sys.stdin.readline()[0:-1]
+        if val:
+            setattr(obj, field, val)
+
+    sql = save_object(obj)
+    print(sql + ";")
+
+
 def create_rule(kind, command_file=None):
     klass, fields = NAME_MAP[kind]
     obj = klass()
@@ -105,6 +144,9 @@ if __name__ == '__main__':
     opts = parser.parse_args()
 
     try:
-        create_rule(opts.kind, command_file=opts.command)
+        if os.path.basename(sys.argv[0]) == "add-format":
+            create_format()
+        else:
+            create_rule(opts.kind, command_file=opts.command)
     except KeyboardInterrupt:
         sys.exit("\nAborting")

--- a/src/archivematicaCommon/lib/utilities/add-fpr-rule
+++ b/src/archivematicaCommon/lib/utilities/add-fpr-rule
@@ -1,0 +1,104 @@
+#!/usr/bin/python
+
+from __future__ import print_function
+from argparse import ArgumentParser
+import os
+import sys
+
+sys.path.append('/usr/share/archivematica/dashboard')
+os.environ["DJANGO_SETTINGS_MODULE"] = "settings.local"
+
+from django.db import connection
+
+from fpr.models import IDCommand, IDRule, IDTool, Format, FormatVersion, FPCommand, FPRule, FPTool
+
+IDCOMMAND_FIELDS = (
+    "description",
+    "config",
+    "replaces_id",
+    "script",
+    "script_type",
+    "tool_id",
+)
+
+IDRULE_FIELDS = (
+    "command_id",
+    "format_id",
+)
+
+IDTOOL_FIELDS = (
+    "description",
+    "version",
+)
+
+FPCOMMAND_FIELDS = (
+    "description",
+    "tool_id",
+    "command_usage",
+    "command",
+    "script_type",
+    "output_location",
+    "output_format_id",
+    "verification_command_id",
+    "event_detail_command_id",
+    "replaces_id",
+)
+
+
+FPRULE_FIELDS = (
+    "command_id",
+    "format_id",
+)
+
+FPTOOL_FIELDS = (
+    "description",
+    "version",
+)
+
+
+NAME_MAP = {
+    "idcommand": (IDCommand, IDCOMMAND_FIELDS),
+    "idrule": (IDRule, IDRULE_FIELDS),
+    "idtool": (IDTool, IDTOOL_FIELDS),
+    "fpcommand": (FPCommand, FPCOMMAND_FIELDS),
+    "fprule": (FPRule, FPRULE_FIELDS),
+    "fptool": (FPTool, FPTOOL_FIELDS),
+}
+
+
+def save_object(obj):
+    obj.save()
+    return connection.queries[-1]['sql']
+
+
+def create_rule(kind, command=None):
+    klass, fields = NAME_MAP[kind]
+    obj = klass()
+    for field in fields:
+        print(field + ":")
+        val = sys.stdin.readline()[0:-1]
+
+        # Empty values should be NULL, not empty strings
+        if val:
+            setattr(obj, field, val)
+
+    if hasattr(obj, "replaces") and obj.replaces:
+        obj.replaces.enabled = False
+        sql = save_object(obj.replaces)
+        print(sql + ";", file=sys.stderr)
+
+    sql = save_object(obj)
+    print(sql + ";", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument("kind", help="Type of FPR rule to create")
+    parser.add_argument("command", nargs="?", default=None,
+                        help="Path to command source code (optional)")
+    opts = parser.parse_args()
+
+    try:
+        create_rule(opts.kind, opts.command)
+    except KeyboardInterrupt:
+        print("\nAborting")


### PR DESCRIPTION
This pull request adds a new commandline tool which generates FPR rules. It immediately applies the change to the local database, and also emits SQL to stdout that can be captured to reapply the change at a later point in time. That new SQL can be added to `fpr_dev.sql` files, or applied to the FPR server.

This is still WIP, so please request features and etc.!

Planned features:
- Add new FPR formats.
- Name linked objects by their description instead of UUID.
