### PR TITLE
CreateMETS2: fix conversion of unicode documents into str

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -349,7 +349,7 @@ def createTechMD(fileUUID):
         # This needs to be converted into an str because lxml doesn't accept
         # XML documents in unicode strings if the document contains an
         # encoding declaration.
-        output = etree.XML(str(document), parser)
+        output = etree.XML(document.encode("utf-8"), parser)
         objectCharacteristicsExtension.append(output)
     sqlLock.release()
 


### PR DESCRIPTION
If an XML document string includes an encoding declaration, etree will refuse to parse the document if it's a unicode string. This fixes up the way it was converting into a bytestring before.
