### PR TITLE
Add disk image transfer metadata form

### DIFF
--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -57,6 +57,7 @@ createDirectoryTree_v0.0 = tree
 createEvent_v0.0 = %clientScriptsDirectory%createEvent.py
 createMETS_v0.0 = %clientScriptsDirectory%archivematicaCreateMETS.py
 createMETS_v2.0 = %clientScriptsDirectory%archivematicaCreateMETS2.py
+createTransferMetadata_v0.0 = %clientScriptsDirectory%archivematicaTransferMetadata.py
 createPointerFile_v0.0 = %clientScriptsDirectory%createPointerFile.py
 createSIPfromTransferObjects_v0.0 = %clientScriptsDirectory%createSIPfromTransferObjects.py
 createSIPsfromTRIMTransferContainers_v0.0 = %clientScriptsDirectory%createSIPsfromTRIMTransferContainers.py

--- a/src/MCPClient/lib/clientScripts/archivematicaTransferMetadata.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaTransferMetadata.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python2
+
+from __future__ import print_function
+from argparse import ArgumentParser
+from lxml import etree
+import sys
+
+sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+import databaseInterface
+
+def fetch_set_uuid(sip_uuid):
+    sql = """SELECT pk FROM TransferMetadataSets
+    INNER JOIN Transfers ON transferMetadataSetRowUUID = pk
+    WHERE transferUUID = '{}'
+    """.format(sip_uuid)
+    cursor, sql_lock = databaseInterface.querySQL(sql)
+    results = cursor.fetchone()
+    sql_lock.release()
+
+    # Will be empty if no metadata was saved
+    if not results:
+        return
+    else:
+        set_uuid, = results
+
+    return set_uuid
+
+def fetch_fields_and_values(sip_uuid):
+    set_uuid = fetch_set_uuid(sip_uuid)
+    if set_uuid is None:
+        return []
+
+    sql = """SELECT fieldName, fieldValue FROM TransferMetadataFieldValues FV
+    INNER JOIN TransferMetadataFields F ON FV.fieldUUID = F.pk
+    WHERE FV.setUUID = '{}' AND fieldValue <> ''
+    """.format(set_uuid)
+    cursor, sql_lock = databaseInterface.querySQL(sql)
+
+    results = cursor.fetchall()
+    sql_lock.release()
+
+    return results
+
+def build_element(label, value, root):
+    element = etree.SubElement(root, label)
+    element.text = value
+    return element
+
+if __name__ == '__main__':
+    parser = ArgumentParser(description='Create a generic XML document from transfer metadata')
+    parser.add_argument('-S', '--sipUUID', action='store', dest='sip_uuid')
+    parser.add_argument('-x', '--xmlFile', action='store', dest='xml_file')
+    opts = parser.parse_args()
+
+    root = etree.Element('transfer_metadata')
+
+    values = fetch_fields_and_values(opts.sip_uuid)
+    elements = [build_element(label, value, root) for (label, value) in values]
+
+    # If there is no transfer metadata, skip writing the XML
+    if not elements:
+        sys.exit()
+
+    tree = etree.ElementTree(root)
+    tree.write(opts.xml_file, pretty_print=True, xml_declaration=True)
+
+    print(etree.tostring(tree))

--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -652,4 +652,11 @@ INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
 
 INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
   VALUES ('6836caa4-8a0f-465e-be1b-4d8c547a7bf4', 'cae76c7f-4d8e-48ee-9522-4b3fbf492516', 'Kryoflux');
+
+-- Write the metadata to disk right before moving to SIP or transfer backlog
+INSERT INTO StandardTasksConfigs (pk, requiresOutputLock, execute, arguments) VALUES ('290c1989-4d8a-4b6e-80bd-9ff43439aeca', 0, 'createTransferMetadata_v0.0', '--sipUUID "%SIPUUID%" --xmlFile "%SIPDirectory%"metadata/transfer_metadata.xml');
+INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES ('81304470-37ef-4abb-99d9-ca075a9f440e', '36b2e239-4a57-4aa5-8ebc-7a29139baca6', '290c1989-4d8a-4b6e-80bd-9ff43439aeca', 'Create transfer metadata XML');
+INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, currentTask) values ('db99ab43-04d7-44ab-89ec-e09d7bbdc39d', 'Complete transfer', 'Failed', '81304470-37ef-4abb-99d9-ca075a9f440e');
+INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('e7837301-3891-4d0f-8b86-6f0a95d5a30b', 'db99ab43-04d7-44ab-89ec-e09d7bbdc39d', 0, 'd27fd07e-d3ed-4767-96a5-44a2251c6d0a', 'Completed successfully');
+UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink='db99ab43-04d7-44ab-89ec-e09d7bbdc39d' WHERE microServiceChainLink='eb52299b-9ae6-4a1f-831e-c7eee0de829f';
 -- /Issue 5356 Transfer metadata

--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -553,3 +553,103 @@ INSERT INTO MicroServiceChains (pk, startingLink, description) VALUES (@noTreeCh
 INSERT INTO MicroServiceChainChoice (pk, choiceAvailableAtLink, chainAvailable) VALUES ('171c7418-53c1-4d00-bcac-f77012050d1b', @treeChoiceMSCL, @treeChain);
 INSERT INTO MicroServiceChainChoice (pk, choiceAvailableAtLink, chainAvailable) VALUES ('63f0e429-1435-48e2-8eb0-dcb68e507168', @treeChoiceMSCL, @noTreeChain);
 -- /Issue 6566 Tree
+
+-- Issue 5356 Transfer metadata
+ALTER TABLE Transfers
+	ADD COLUMN transferMetadataSetRowUUID VARCHAR(36),
+	ADD CONSTRAINT FOREIGN KEY (transferMetadataSetRowUUID) REFERENCES TransferMetadataSets (pk) ON DELETE CASCADE;
+
+INSERT INTO Taxonomies (pk, name) VALUES ('312fc2b3-d786-458d-a762-57add7f96c22', 'Disk media formats');
+INSERT INTO Taxonomies (pk, name) VALUES ('f6980e68-bac2-46db-842b-da4eba4ba418', 'Disk media densities');
+INSERT INTO Taxonomies (pk, name) VALUES ('31e0bdc9-1114-4427-9f37-ca284577dcac', 'Filesystem types');
+INSERT INTO Taxonomies (pk, name) VALUES ('fbf318db-4908-4971-8273-1094d2ba29a6', 'Disk imaging interfaces');
+INSERT INTO Taxonomies (pk, name) VALUES ('cc4231ef-9886-4722-82ec-917e60d3b2c7', 'Disk image format');
+INSERT INTO Taxonomies (pk, name) VALUES ('cae76c7f-4d8e-48ee-9522-4b3fbf492516', 'Disk imaging software');
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, sortOrder)
+    VALUES ('fc69452c-ca57-448d-a46b-873afdd55e15', UNIX_TIMESTAMP(), 'Media number', 'media_number', 'text', 0);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, sortOrder)
+    VALUES ('a9a4efa8-d8ab-4b32-8875-b10da835621c', UNIX_TIMESTAMP(), 'Label text', 'label_text', 'textarea', 1);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, sortOrder)
+    VALUES ('367ef53b-49d6-4a4e-8b2f-10267d6a7db1', UNIX_TIMESTAMP(), 'Media manufacture', 'media_manufacture', 'text', 2);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, sortOrder)
+    VALUES ('277727e4-b621-4f68-acb4-5689f81f31cd', UNIX_TIMESTAMP(), 'Serial number', 'serial_number', 'text', 3);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, optionTaxonomyUUID, sortOrder)
+    VALUES ('13f97ff6-b312-4ab6-aea1-8438a55ae581', UNIX_TIMESTAMP(), 'Media format', 'media_format', 'select', '312fc2b3-d786-458d-a762-57add7f96c22', 4);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, optionTaxonomyUUID, sortOrder)
+    VALUES ('a0d80573-e6ef-412e-a7a7-69bdfe3f6f8f', UNIX_TIMESTAMP(), 'Media density', 'media_density', 'select', 'f6980e68-bac2-46db-842b-da4eba4ba418', 5);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, optionTaxonomyUUID, sortOrder)
+    VALUES ('c9344f6f-f881-4d2e-9ffa-26b7f5e42a11', UNIX_TIMESTAMP(), 'Source filesystem', 'source_filesystem', 'select', '31e0bdc9-1114-4427-9f37-ca284577dcac', 6);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, sortOrder)
+    VALUES ('7ab79b42-1c84-420e-9169-e6bdf20141df', UNIX_TIMESTAMP(), 'Imaging process notes', 'imaging_process_notes', 'textarea', 7);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, optionTaxonomyUUID, sortOrder)
+    VALUES ('af677693-524d-42af-be6c-d0f6a8976db1', UNIX_TIMESTAMP(), 'Imaging interface', 'imaging_interface', 'select', 'fbf318db-4908-4971-8273-1094d2ba29a6', 8);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, sortOrder)
+    VALUES ('2c1844af-1217-4fdb-afbe-a052a91b7265', UNIX_TIMESTAMP(), 'Examiner', 'examiner', 'text', 9);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, sortOrder)
+    VALUES ('38df3f82-5695-46d3-b4e2-df68a872778a', UNIX_TIMESTAMP(), 'Imaging date', 'imaging_date', 'text', 10);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, sortOrder)
+    VALUES ('32f0f054-96d1-42ed-add6-7aa053237b02', UNIX_TIMESTAMP(), 'Imaging success', 'imaging_success', 'text', 11);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, optionTaxonomyUUID, sortOrder)
+    VALUES ('d3b5b380-8901-4e68-8c40-3d59578810f4', UNIX_TIMESTAMP(), 'Image format', 'image_format', 'select', 'cc4231ef-9886-4722-82ec-917e60d3b2c7', 12);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, optionTaxonomyUUID, sortOrder)
+    VALUES ('0c1b4233-fbe7-463f-8346-be6542574b86', UNIX_TIMESTAMP(), 'Imaging software', 'imaging_software', 'select', 'cae76c7f-4d8e-48ee-9522-4b3fbf492516', 13);
+
+INSERT INTO TransferMetadataFields (pk, createdTime, fieldLabel, fieldName, fieldType, sortOrder)
+    VALUES ('0a9e346a-f08c-4e0d-9753-d9733f7205e5', UNIX_TIMESTAMP(), 'Image fixity', 'image_fixity', 'textarea', 14);
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('867ab18d-e860-445f-a254-8fcdebfe95b6', '312fc2b3-d786-458d-a762-57add7f96c22', '3.5" floppy');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('c41922d6-e716-4822-a385-e2fb0009465b', '312fc2b3-d786-458d-a762-57add7f96c22', '5.25" floppy');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('e4edb250-d70a-4f63-8234-948b05b1163e', 'f6980e68-bac2-46db-842b-da4eba4ba418', 'Single density');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('82a367f5-8157-4ac4-a5eb-3b59aac78d16', 'f6980e68-bac2-46db-842b-da4eba4ba418', 'Double density');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('0d6d40b5-8bf8-431d-8dd2-23d6b0b17ca0', '31e0bdc9-1114-4427-9f37-ca284577dcac', 'FAT');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('db34d5e1-0c93-4faa-bb1c-c5f5ebae6764', '31e0bdc9-1114-4427-9f37-ca284577dcac', 'HFS');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('35097f1b-094a-40bc-ba0c-f1260b50042a', 'fbf318db-4908-4971-8273-1094d2ba29a6', 'Catweasel');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('53e7764a-f711-486d-a0aa-8ec10d1d8da5', 'fbf318db-4908-4971-8273-1094d2ba29a6', 'Firewire');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('6774c7ce-a760-4f29-a7a3-b948f3769f71', 'fbf318db-4908-4971-8273-1094d2ba29a6', 'USB');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('6e368167-ea3e-45cd-adf2-60513a7e1802', 'fbf318db-4908-4971-8273-1094d2ba29a6', 'IDE');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('fcefbea2-848c-4685-9032-18a87cbc7a04', 'cc4231ef-9886-4722-82ec-917e60d3b2c7', 'AFF3');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('a3a6e30d-810f-4300-8461-1b41a7b383f1', 'cc4231ef-9886-4722-82ec-917e60d3b2c7', 'AD1');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('38ad5611-f05a-45d4-ac20-541c89bf0167', 'cae76c7f-4d8e-48ee-9522-4b3fbf492516', 'FTK imager 3.1.0.1514');
+
+INSERT INTO TaxonomyTerms (pk, taxonomyUUID, term)
+  VALUES ('6836caa4-8a0f-465e-be1b-4d8c547a7bf4', 'cae76c7f-4d8e-48ee-9522-4b3fbf492516', 'Kryoflux');
+-- /Issue 5356 Transfer metadata

--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -98,3 +98,10 @@ class ArchivistsToolkitConfigForm(ModelForm):
  
     class Meta:
         model = ArchivistsToolkitConfig
+
+class TaxonomyTermForm(ModelForm):
+    class Meta:
+        model = models.TaxonomyTerm
+        widgets = {
+            "term": TextInput(attrs=settings.INPUT_ATTRS)
+        }

--- a/src/dashboard/src/components/administration/urls.py
+++ b/src/dashboard/src/components/administration/urls.py
@@ -16,6 +16,7 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import patterns
+from django.conf import settings
 
 urlpatterns = patterns('components.administration.views',
     (r'^$', 'administration'),
@@ -32,4 +33,8 @@ urlpatterns = patterns('components.administration.views',
     (r'api/$', 'api'),
     (r'general/$', 'general'),
     (r'version/$', 'version'),
+    (r'taxonomy/term/(?P<term_uuid>' + settings.UUID_REGEX + ')/$', 'term_detail'),
+    (r'taxonomy/term/(?P<term_uuid>' + settings.UUID_REGEX + ')/delete/$', 'term_delete'),
+    (r'taxonomy/(?P<taxonomy_uuid>' + settings.UUID_REGEX + ')/$', 'terms'),
+    (r'taxonomy/$', 'taxonomy'),
 )

--- a/src/dashboard/src/components/transfer/urls.py
+++ b/src/dashboard/src/components/transfer/urls.py
@@ -20,6 +20,13 @@ from django.conf import settings
 
 urlpatterns = patterns('components.transfer.views',
     (r'^$', 'grid'),
+
+    # Transfer metadata set functions
+    (r'^create_metadata_set_uuid/$', 'create_metadata_set_uuid'),
+    (r'^rename_metadata_set/(?P<set_uuid>' + settings.UUID_REGEX + ')/(?P<placeholder_id>[\w\-]+)/$', 'rename_metadata_set'),
+    (r'^cleanup_metadata_set/(?P<set_uuid>' + settings.UUID_REGEX + ')/$', 'cleanup_metadata_set'),
+
+    (r'component/(?P<uuid>' + settings.UUID_REGEX + ')/$', 'component'),
     (r'(?P<uuid>' + settings.UUID_REGEX + ')/$', 'detail'),
     (r'(?P<uuid>' + settings.UUID_REGEX + ')/delete/$', 'delete'),
     (r'(?P<uuid>' + settings.UUID_REGEX + ')/microservices/$', 'microservices'),

--- a/src/dashboard/src/components/transfer/views.py
+++ b/src/dashboard/src/components/transfer/views.py
@@ -20,11 +20,11 @@ import json
 import logging
 from lxml import etree
 import os
+from uuid import uuid4
 
 from django.db.models import Max
 from django.conf import settings as django_settings
 from django.contrib import messages
-from django.core.exceptions import ObjectDoesNotExist 
 from django.core.urlresolvers import reverse
 from django.shortcuts import render, redirect
 from django.http import Http404, HttpResponse
@@ -65,6 +65,68 @@ def grid(request):
     uid = request.user.id
     hide_features = helpers.hidden_features()
     return render(request, 'transfer/grid.html', locals())
+
+def component(request, uuid):
+    messages = []
+    fields_saved = False
+
+    # get set/field data and initialize dict of form field values
+    metadata_set, created = models.TransferMetadataSet.objects.get_or_create(
+        pk=uuid, defaults={'createdbyuserid': request.user.id}
+    )
+    if created:
+        metadata_set.save()
+    fields = models.TransferMetadataField.objects.all().order_by('sortorder')
+    values = {}  # field values
+    options = [] # field options (for value selection)
+
+    for field in fields:
+        if field.optiontaxonomy is not None:
+            # check for newly added terms
+            new_term = request.POST.get('add_to_' + field.pk, '')
+            if new_term != '':
+                term = models.TaxonomyTerm()
+                term.taxonomy = field.optiontaxonomy
+                term.term = new_term
+                term.save()
+                messages.append('Term added.')
+
+            # load taxonomy terms into option values
+            optionvalues = ['']
+            for term in field.optiontaxonomy.taxonomyterm_set.iterator():
+                optionvalues.append(term.term)
+            options.append({
+                'field':   field,
+                'options': optionvalues
+            })
+
+            # determine whether field should allow new terms to be specified
+            field.allownewvalue = True
+            # support allownewvalue
+            # by loading taxonomy and checked if it's open
+        try:
+            field_value = models.TransferMetadataFieldValue.objects.get(
+                field=field,
+                set=metadata_set
+            )
+            values[(field.fieldname)] = field_value.fieldvalue
+        except models.TransferMetadataFieldValue.DoesNotExist:
+            if request.method == 'POST':
+                field_value = models.TransferMetadataFieldValue()
+                field_value.field = field
+                field_value.set = metadata_set
+            else:
+                values[(field.fieldname)] = ''
+        if request.method == 'POST':
+            field_value.fieldvalue = request.POST.get(field.fieldname, '')
+            field_value.save()
+            fields_saved = True
+            values[(field.fieldname)] = field_value.fieldvalue # override initially loaded value, if any
+
+    if fields_saved:
+        messages.append('Metadata saved.')
+
+    return render(request, 'transfer/component.html', locals())
 
 def status(request, uuid=None):
     # Equivalent to: "SELECT SIPUUID, MAX(createdTime) AS latest FROM Jobs GROUP BY SIPUUID
@@ -118,6 +180,7 @@ def detail(request, uuid):
     jobs = models.Job.objects.filter(sipuuid=uuid)
     name = utils.get_directory_name_from_job(jobs[0])
     is_waiting = jobs.filter(currentstep='Awaiting decision').count() > 0
+    set_uuid = models.Transfer.objects.get(uuid=uuid).transfermetadatasetrow_id
     return render(request, 'transfer/detail.html', locals())
 
 def microservices(request, uuid):
@@ -159,7 +222,7 @@ def transfer_metadata_edit(request, uuid, id=None):
             dc = models.DublinCore.objects.get(metadataappliestotype__exact=1,
                     metadataappliestoidentifier__exact=uuid)
             return redirect('components.transfer.views.transfer_metadata_edit', uuid, dc.id)
-        except ObjectDoesNotExist:
+        except models.DublinCore.DoesNotExist:
             dc = models.DublinCore(
                 metadataappliestotype=transfer_metadata_type_id(),
                 metadataappliestoidentifier=uuid
@@ -187,3 +250,65 @@ def transfer_metadata_edit(request, uuid, id=None):
         name = utils.get_directory_name_from_job(jobs[0])
 
     return render(request, 'transfer/metadata_edit.html', locals())
+
+def create_metadata_set_uuid(request):
+    """
+    Transfer metadata sets are used to associate a group of metadata field values with
+    a transfer. The transfer metadata set UUID is relayed to the MCP chain by including
+    it in a row in a pre-created Transfers table entry.
+    """
+    response = {}
+    response['uuid'] = str(uuid4())
+
+    return HttpResponse(
+        json.dumps(response),
+        mimetype='application/json'
+    )
+
+def rename_metadata_set(request, set_uuid, placeholder_id):
+    response = {}
+
+    try:
+        path = request.POST['path']
+        fields = models.TransferMetadataFieldValue.objects.filter(set_id=set_uuid, filepath=placeholder_id)
+        fields.update(filepath=path)
+        response['status'] = 'Success'
+    except KeyError:
+        response['status'] = 'Failure'
+        response['message'] = 'Updated path was not provided.'
+    except Exception as e:
+        if not e.message:
+            message = 'Unable to update transfer metadata set: contact administrator.'
+        else:
+            message = e.message
+        response['status'] = 'Failure'
+        response['message'] = message
+
+    return HttpResponse(
+        json.dumps(response),
+        mimetype='application/json'
+    )
+
+def cleanup_metadata_set(request, set_uuid):
+    """
+    Cleans up any unassigned metadata forms for the given set_uuid.
+    Normally these are created with placeholder IDs, then asssigned the
+    permanent path within the component after a component is added.
+    However, if the user enters a metadata form and then starts the
+    transfer without adding a new component, this placeholder form
+    needs to be cleaned up before starting the transfer.
+    """
+    response = {}
+
+    try:
+        objects = models.TransferMetadataFieldValue.objects.filter(set_id=set_uuid)
+        response['deleted_objects'] = len(objects)
+        objects.delete()
+        models.TransferMetadataSet.objects.get(id=set_uuid).delete()
+    except Exception as e:
+        response['message'] = e.message
+
+    return HttpResponse(
+        json.dumps(response),
+        mimetype='application/json'
+    )

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -219,6 +219,7 @@ class Transfer(models.Model):
     currentlocation = models.TextField(db_column='currentLocation')
     type = models.CharField(max_length=50, db_column='type')
     accessionid = models.TextField(db_column='accessionID')
+    transfermetadatasetrow = models.ForeignKey('TransferMetadataSet', db_column='transferMetadataSetRowUUID', to_field='id', null=True)
     # ...
     hidden = models.BooleanField(default=False, blank=False)
 
@@ -626,3 +627,64 @@ class AtkDIPObjectResourcePairing(models.Model):
 
     class Meta:
         db_table = u'AtkDIPObjectResourcePairing'
+
+class TransferMetadataSet(models.Model):
+    id = UUIDPkField()
+    createdtime = models.DateTimeField(db_column='createdTime', auto_now_add=True)
+    createdbyuserid = models.IntegerField(db_column='createdByUserID')
+
+    class Meta:
+        db_table = u'TransferMetadataSets'
+
+class TransferMetadataField(models.Model):
+    id = UUIDPkField()
+    createdtime = models.DateTimeField(db_column='createdTime', auto_now_add=True)
+    fieldlabel = models.CharField(max_length=50, blank=True, db_column='fieldLabel')
+    fieldname = models.CharField(max_length=50, db_column='fieldName')
+    fieldtype = models.CharField(max_length=50, db_column='fieldType')
+    optiontaxonomy = models.ForeignKey('Taxonomy', db_column='optionTaxonomyUUID', to_field='id', null=True)
+    sortorder = models.IntegerField(default=0, db_column='sortOrder')
+
+    class Meta:
+        db_table = u'TransferMetadataFields'
+
+    def __unicode__(self):
+        return self.fieldlabel
+
+class TransferMetadataFieldValue(models.Model):
+    id = UUIDPkField()
+    createdtime = models.DateTimeField(db_column='createdTime', auto_now_add=True)
+    set = models.ForeignKey('TransferMetadataSet', db_column='setUUID', to_field='id')
+    field = models.ForeignKey('TransferMetadataField', db_column='fieldUUID', to_field='id')
+    fieldvalue = models.TextField(blank=True, db_column='fieldValue')
+
+    class Meta:
+        db_table = u'TransferMetadataFieldValues'
+
+# Taxonomies and their field definitions are in separate tables
+# to leave room for future expansion. The possible taxonomy terms are
+# designed to be editable, and forms to do so exist. (Forms for editing and
+# defining new fields are present in the code but currently disabled.)
+class Taxonomy(models.Model):
+    id = UUIDPkField()
+    createdtime = models.DateTimeField(db_column='createdTime', auto_now_add=True)
+    name = models.CharField(max_length=255, blank=True, db_column='name')
+    type = models.CharField(max_length=50, default='open')
+
+    class Meta:
+        db_table = u'Taxonomies'
+
+    def __unicode__(self):
+        return self.name
+
+class TaxonomyTerm(models.Model):
+    id = UUIDPkField()
+    createdtime = models.DateTimeField(db_column='createdTime', auto_now_add=True)
+    taxonomy = models.ForeignKey('Taxonomy', db_column='taxonomyUUID', to_field='id')
+    term = models.CharField(max_length=255, db_column='term')
+
+    class Meta:
+        db_table = u'TaxonomyTerms'
+
+    def __unicode__(self):
+        return self.term

--- a/src/dashboard/src/main/templatetags/keyvalue.py
+++ b/src/dashboard/src/main/templatetags/keyvalue.py
@@ -21,4 +21,4 @@ register = Library()
 
 @register.filter
 def keyvalue(d, key):
-    return d[key]
+    return d.get(key)

--- a/src/dashboard/src/main/views.py
+++ b/src/dashboard/src/main/views.py
@@ -34,6 +34,22 @@ from archivematicaFunctions import escape
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ """
 
 def home(request):
+    # clean up user's session-specific data
+    if 'user_temp_data_cleanup_ran' not in request.session:
+        # create all transfer metadata sets created by user
+        transfer_metadata_sets = models.TransferMetadataSet.objects.filter(createdbyuserid=1)
+
+        # check each set to see if, and related data, should be deleted
+        for set in transfer_metadata_sets:
+            # delete transfer metadata set and field values if no corresponding transfer exists
+            try:
+                models.Transfer.objects.get(transfermetadatasetrow=set)
+            except models.Transfer.DoesNotExist:
+                for field_value in set.transfermetadatafieldvalue_set.iterator():
+                    field_value.delete()
+                set.delete()
+        request.session['user_temp_data_cleanup_ran'] = True
+
     if 'first_login' in request.session and request.session['first_login']:
         request.session.first_login = False
         for feature_setting in helpers.feature_settings().values():

--- a/src/dashboard/src/media/css/transfer_grid.css
+++ b/src/dashboard/src/media/css/transfer_grid.css
@@ -38,13 +38,35 @@
   margin-right: 10px;
 }
 
+#start_transfer_button {
+  margin-right: 10px;
+}
+
+#transfer_metadata_edit_button {
+  display: none;
+}
+
 #path_source_select {
   margin-right: 10px;
 }
 
 #path_container {
+  width: 844px;
   margin-top: 20px;
   margin-bottom: 10px;
+}
+
+.transfer_path_icons {
+  float: right;
+  clear: both;
+}
+
+.transfer_path_delete_icon, .transfer_path_edit_icon {
+  margin-left: .5em;
+}
+
+.transfer_path_edit_icon {
+  display: none;
 }
 
 .microservice-group {

--- a/src/dashboard/src/templates/administration/taxonomy.html
+++ b/src/dashboard/src/templates/administration/taxonomy.html
@@ -1,0 +1,47 @@
+{% extends "layout_fluid.html" %}
+{% load breadcrumb %}
+% load url from future %}
+
+{% block title %}Administration{% endblock %}
+{% block h1 %}Administration{% endblock %}
+{% block page_id %}Administration{% endblock %}
+
+{% block js %}
+{% endblock %}
+
+{% block css %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="row">
+
+    {% include "administration/sidebar.html" %}
+
+    <div class="span12">
+
+      <h3>Taxonomies</h3>
+
+      {% for taxonomy in page.objects %}
+        <p><a href='/administration/taxonomy/{{ taxonomy.pk }}/'>{{ taxonomy.name }}</a></p>
+      {% endfor %}
+
+      {% url 'components.administration.views.taxonomy' as taxonomy_admin %}
+
+      {% if page.has_other %}
+      {% if page.has_previous %}
+      <a class='btn' href='{{ taxonomy_admin }}?page={{ page.previous }}'>Previous Page</a>
+      {% endif %}
+
+      {% if has_next and has_previous %}&nbsp;{% endif %}
+
+      {% if page.has_next %}
+      <a class='btn' href='{{ taxonomy_admin }}?page={{ page.next }}'>Next Page</a>
+      {% endif %}
+      {% endif %}
+
+    </div>
+
+  </div>
+
+{% endblock %}

--- a/src/dashboard/src/templates/administration/term_detail.html
+++ b/src/dashboard/src/templates/administration/term_detail.html
@@ -1,0 +1,44 @@
+{% extends "layout_fluid.html" %}
+{% load breadcrumb %}
+{% load url from future %}
+
+{% block title %}Administration{% endblock %}
+{% block h1 %}Administration{% endblock %}
+{% block page_id %}Administration{% endblock %}
+
+{% block js %}
+{% endblock %}
+
+{% block css %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="row">
+
+    {% include "administration/sidebar.html" %}
+
+    <div class="span12">
+
+      <ul class="breadcrumb">
+        {% breadcrumb_url 'Taxonomy' 'components.administration.views.taxonomy' %}
+        {% breadcrumb_url taxonomy.name 'components.administration.views.terms' taxonomy.id %}
+        {% breadcrumb term.term %}
+      </ul>
+
+      {% include "_messages.html" %}
+
+      <h3>Term</h3>
+
+      <form method='POST'>
+      {% include "_form.html" %}
+
+      <div style='float: right'>
+        <input type='submit' value='Save' /> <a href='/administration/taxonomy/term/{{ term.pk }}/delete/' class='btn'>Delete</a>
+      </div>
+      </form>
+    </div>
+
+  </div>
+
+{% endblock %}

--- a/src/dashboard/src/templates/administration/terms.html
+++ b/src/dashboard/src/templates/administration/terms.html
@@ -1,0 +1,49 @@
+{% extends "layout_fluid.html" %}
+{% load breadcrumb %}
+{% load url from future %}
+
+{% block title %}Administration{% endblock %}
+{% block h1 %}Administration{% endblock %}
+{% block page_id %}Administration{% endblock %}
+
+{% block js %}
+{% endblock %}
+
+{% block css %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="row">
+
+    {% include "administration/sidebar.html" %}
+
+    <div class="span12">
+
+      <ul class="breadcrumb">
+        {% breadcrumb_url 'Taxonomy' 'components.administration.views.taxonomy' %}
+        {% breadcrumb taxonomy.name %}
+      </ul>
+
+      <h3>Terms</h3>
+
+      {% for term in page.objects %}
+        <p><a href='/administration/taxonomy/term/{{ term.pk }}'>{{ term.term }}</a></p>
+      {% endfor %}
+
+      {% if page.has_other %}
+      {% if page.has_previous %}
+      <a class='btn' href='/administration/taxonomy/terms/{{ taxonomy_uuid }}/?page={{ page.previous }}'>Previous Page</a>
+      {% endif %}
+
+      {% if has_next and has_previous %}&nbsp;{% endif %}
+
+      {% if page.has_next %}
+      <a class='btn' href='/administration/taxonomy/terms/{{ taxonomy_uuid }}/?page={{ page.next }}'>Next Page</a>
+      {% endif %}
+      {% endif %}
+    </div>
+
+  </div>
+
+{% endblock %}

--- a/src/dashboard/src/templates/transfer/component.html
+++ b/src/dashboard/src/templates/transfer/component.html
@@ -1,0 +1,59 @@
+{% extends "layout_fluid.html" %}
+{% load breadcrumb %}
+{% load url from future %}
+{% load keyvalue %}
+
+{% block content %}
+  <div class="row">
+    <div class="span12">
+
+      <ul class="breadcrumb">
+        {% breadcrumb_url 'Transfer' 'components.transfer.views.grid' %}
+        Component metadata
+      </ul>
+
+      <form method='POST'>
+      <input name='path' type='hidden' value='{{ path }}'/>
+      <table>
+      {% for field in fields %}
+        <tr>
+          <td>
+            <label>{{ field.fieldlabel }}</label>
+          </td>
+          <td>
+            {% if field.fieldtype == 'text' %}
+              <input name='{{ field.fieldname }}' value='{{ values|keyvalue:field.fieldname }}' />
+            {% endif %}
+
+            {% if field.fieldtype == 'textarea' %}
+              <textarea name='{{ field.fieldname }}'>{{ values|keyvalue:field.fieldname }}</textarea>
+            {% endif %}
+
+            {% if field.fieldtype == 'select' %}
+              <select name='{{ field.fieldname }}'>
+                {% with values|keyvalue:field.fieldname as select_value %}
+                  {% for optiondata in options %}
+                    {% if optiondata.field == field %}
+                      {% for option in optiondata.options %}
+                        <option {% if option == select_value %}selected{% endif %}>{{ option }}</option>
+                      {% endfor %}
+                    {% endif %}
+                  {% endfor %}
+                {% endwith %}
+              </select>
+
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+        <tr>
+          <td colspan=2>
+            <input type='submit' value='Save' />
+          </td>
+        </tr>
+      </table>
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/src/dashboard/src/templates/transfer/detail.html
+++ b/src/dashboard/src/templates/transfer/detail.html
@@ -33,6 +33,12 @@
         <li><a href="{% url 'components.rights.views.transfer_rights_list' uuid %}">List</a></li>
         <li><a href="{% url 'components.rights.views.transfer_rights_edit' uuid %}">Add</a></li>
       </ul>
+
+      <h5>Transfer Metadata</h5>
+      <ul>
+        <li><a href="{% url 'components.transfer.views.component' set_uuid %}">Edit</a></li>
+      </ul>
+
       <h5>Metadata</h5>
       <ul>
         <li><a href="{% url 'components.transfer.views.transfer_metadata_list' uuid %}">List</a></li>

--- a/src/dashboard/src/templates/transfer/grid.html
+++ b/src/dashboard/src/templates/transfer/grid.html
@@ -180,6 +180,7 @@
               <option value='dspace'>DSpace</option>
               {% endif %}
               <option value='maildir'>Maildir</option>
+              <option value='disk image'>Disk Image</option>
             </select>
             <div class="help-block">Type</div>
           </div>
@@ -212,6 +213,16 @@
       <div class="modal-footer">
         <a href="#" class="btn" data-dismiss="modal" id="transfer-component-select-cancel">Cancel</a>
       </div>
+    </div>
+  </script>
+
+  <script type="text/template" id='transfer-component-path-item'>
+    <div id='transfer-component-path-item-<%= path_counter %>'>
+      <span class="transfer_path"><%= path %></span>
+      <span class="transfer_path_icons">
+        <span class="transfer_path_edit_icon"><img src="/media/images/table_edit.png" /></span>
+        <span class="transfer_path_delete_icon"><img src="/media/images/delete.png" /></span>
+      </span>
     </div>
   </script>
 


### PR DESCRIPTION
This adds a new metadata input form which is provided when creating disk image transfers.

"Disk image" is exposed as a new transfer type, which operates identically to a standard transfer in every way when processing. When "disk image" is selected, a metadata edit button is added for each transfer component which allows a separate form to be filled out for each component. An edit button is also provided next to the "start" button, which lets the user pre-fill out a row to be attached to the next component that is added.

If a transfer metadata form exists for a given transfer, it will be associated with the "objects" directory of the final AIP produced from that transfer. This is accomplished by serializing it to disk, so it should work with SIP arrange as long as the arranged SIP contains contents from only one disk image transfer.

This adds a few forms to view the metadata form field values; there is code to edit them, but at the moment it's disabled by request.
