### PR TITLE
Fix up encoding issues in ReplacementDict

### DIFF
--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -56,18 +56,17 @@ def get_replacement_dict(opts):
 
     # Populates the standard set of unit variables, so,
     # e.g., %fileUUID% is available
-    standard_values = ReplacementDict.frommodel(type_='file',
-                                                file_=opts.file_uuid)
+    replacement_dict = ReplacementDict.frommodel(type_='file',
+                                                 file_=opts.file_uuid)
 
     output_filename = ''.join([prefix, filename, postfix])
-    replacement_dict = {
+    replacement_dict.update({
         "%outputDirectory%": output_dir,
         "%prefix%": prefix,
         "%postfix%": postfix,
         "%outputFileName%": output_filename, # does not include extension
         "%outputFilePath%": os.path.join(output_dir, output_filename) # does not include extension
-    }
-    replacement_dict.update(standard_values)
+    })
     return replacement_dict
 
 

--- a/src/archivematicaCommon/lib/dicts.py
+++ b/src/archivematicaCommon/lib/dicts.py
@@ -27,6 +27,10 @@ import os
 import re
 import sys
 
+path = '/usr/lib/archivematica/archivematicaCommon/'
+if not path in sys.path:
+    sys.path.append(path)
+from archivematicaFunctions import unicodeToStr
 
 def replace_string_values(string, **kwargs):
     """
@@ -172,12 +176,26 @@ class ReplacementDict(dict):
         >>> rd = ReplacementDict({"$foo": "bar"})
         >>> rd.replace('The value of the foo variable is: $foo')
         ['The value of the foo variable is: bar']
+
+        IMPORTANT NOTE: Any unicode strings present as dictionary values will
+        be converted into bytestrings. All returned strings will also be
+        bytestrings, regardless of the type of the original strings.
+        Returned strings may or may not be valid Unicode, depending on the
+        contents of data fetched from the database. (%originalLocation%,
+        for instance, may contain arbitrary non-Unicode characters of
+        nonspecific encoding.)
+
+        Note that, within, Archivematica, the only value that typically
+        contains Unicode characters is "%originalLocation%", and Archivematica
+        does not use this variable in any place where precise fidelity of the
+        original string is required.
         """
         ret = []
         for orig in strings:
             if orig is not None:
+                orig = unicodeToStr(orig)
                 for key, value in self.iteritems():
-                    orig = orig.replace(key, value)
+                    orig = orig.replace(key, unicodeToStr(value))
             ret.append(orig)
         return ret
 

--- a/src/archivematicaCommon/lib/dicts.py
+++ b/src/archivematicaCommon/lib/dicts.py
@@ -135,7 +135,9 @@ class ReplacementDict(dict):
 
             if expand_path:
                 base_location = base_location.replace('%sharedPath%', shared_path)
-                origin = file_.originallocation.replace('%transferDirectory%', base_location)
+                # If the original location contains non-unicode characters,
+                # using base_location as retrieved from the DB will raise.
+                origin = file_.originallocation.replace('%transferDirectory%', base_location.encode("utf-8"))
                 current_location = file_.currentlocation.replace('%transferDirectory%', base_location)
                 current_location = current_location.replace('%SIPDirectory%', sipdir)
             else:

--- a/src/archivematicaCommon/tests/test_dicts.py
+++ b/src/archivematicaCommon/tests/test_dicts.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 import os
 import sys
 
@@ -107,3 +108,12 @@ def test_replacementdict_model_constructor_file_only():
 def test_replacementdict_options():
     d = ReplacementDict({'%relativeLocation%': 'bar'})
     assert d.to_gnu_options() == ['--relative-location=bar']
+
+
+def test_replacementdict_replace_returns_bytestring():
+    in_str = u"%originalLocation%/location/การแปล"
+    assert type(in_str) == unicode
+
+    d = ReplacementDict({'%originalLocation%': '\x82\xdb\x82\xc1\x82\xd5\x82\xe9\x83\x81\x83C\x83\x8b'})
+    out_str = d.replace(in_str)[0]
+    assert type(out_str) == str

--- a/src/archivematicaCommon/tests/test_dicts.py
+++ b/src/archivematicaCommon/tests/test_dicts.py
@@ -96,8 +96,6 @@ def test_replacementdict_model_constructor_sip():
 def test_replacementdict_model_constructor_file_only():
     rd = ReplacementDict.frommodel(file_=FILE, type_='file')
 
-    assert not '%SIPUUID%' in rd
-
     assert rd['%fileUUID%'] == FILE.uuid
     assert rd['%originalLocation%'] == FILE.originallocation
     assert rd['%currentLocation%'] == FILE.currentlocation


### PR DESCRIPTION
One field in the replacement dicts can possibly contain non-Unicode values: originallocation. This causes an issue when interpolating in the value of the shared directory, which _is_ a unistring (and could, theoretically, contain Unicode values).

This updates ReplacementDict.replace() to always use and return str objects instead of unistrings, to preserve all characters in both the original string and values in the dict and to avoid interpolating different string types.

This also updates the normalize.py client script and the transcoder to use ReplacementDict's methods, instead of its own implementations of them.
