### PR TITLE
Extract: skip prompts unless relevant

### DIFF
--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -77,6 +77,7 @@ identifyDspaceMETSFiles_v0.0 = %clientScriptsDirectory%identifyDspaceMETSFiles.p
 identifyDspaceFiles_v0.0 = %clientScriptsDirectory%identifyDspaceFiles.py
 identifyFileFormat_v0.0 = %clientScriptsDirectory%identifyFileFormat.py
 isMaildirAIP_v0.0 = %clientScriptsDirectory%isMaildirAIP.py
+hasPackages_v0.0 = %clientScriptsDirectory%hasPackages.py
 indexAIP_v0.0 = %clientScriptsDirectory%indexAIP.py
 jsonMetadataToCSV_v0.0 = %clientScriptsDirectory%jsonMetadataToCSV.py
 loadDublinCore_v0.0 = %clientScriptsDirectory%loadDublinCore.py

--- a/src/MCPClient/lib/clientScripts/hasPackages.py
+++ b/src/MCPClient/lib/clientScripts/hasPackages.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+path = '/usr/share/archivematica/dashboard'
+if path not in sys.path:
+    sys.path.append(path)
+os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+from fpr.models import FPRule
+from main.models import FileFormatVersion, Transfer
+
+
+def is_extractable(f):
+    try:
+        format = f.fileformatversion_set.get().format_version
+    except FileFormatVersion.DoesNotExist:
+        return False
+
+    extract_rules = FPRule.active.filter(purpose="extract", format=format)
+    if extract_rules:
+        return True
+    else:
+        return False
+
+
+def main(sip_uuid):
+    transfer = Transfer.objects.get(uuid=sip_uuid)
+    for f in transfer.file_set.iterator():
+        if is_extractable(f):
+            return 0
+
+    return 1
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1]))

--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -666,3 +666,13 @@ UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink='db99ab43-0
 UPDATE MicroServiceChains SET description='Yes' WHERE pk='01d80b27-4ad1-4bd1-8f8d-f819f18bf685';
 UPDATE MicroServiceChains SET description='No' WHERE pk='79f1f5af-7694-48a4-b645-e42790bbf870';
 -- /Issue 6539 Extract package chain naming
+
+-- Issue 6350 Extract package prompt
+INSERT INTO StandardTasksConfigs (pk, requiresOutputLock, execute, arguments) VALUES ('93039c6d-5ef7-4a95-bf07-5f89c8886808', 0, 'hasPackages_v0.0', '%SIPUUID%');
+INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES ('d9ce0690-a8f9-40dc-a8b5-b021f578f8ff', '36b2e239-4a57-4aa5-8ebc-7a29139baca6', '93039c6d-5ef7-4a95-bf07-5f89c8886808', 'Determine if transfer contains packages');
+INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, currentTask, defaultNextChainLink) values ('b944ec7f-7f99-491f-986d-58914c9bb4fa', 'Extract packages', 'Failed', 'd9ce0690-a8f9-40dc-a8b5-b021f578f8ff', NULL);
+INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('4ba2d89a-d741-4868-98a7-6202d0c57163', 'b944ec7f-7f99-491f-986d-58914c9bb4fa', 0, 'dec97e3c-5598-4b99-b26e-f87a435a6b7f', 'Completed successfully');
+INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('2b3f01ca-7101-4801-96a9-ede85dba319c', 'b944ec7f-7f99-491f-986d-58914c9bb4fa', 1, '303a65f6-a16f-4a06-807b-cb3425a30201', 'Completed successfully');
+
+UPDATE MicroServiceChains SET startingLink='b944ec7f-7f99-491f-986d-58914c9bb4fa' WHERE pk='c868840c-cf0b-49db-a684-af4248702954';
+-- /Issue 6350 Extract package prompt


### PR DESCRIPTION
This adds a new microservice which checks to see if the transfer contains any compressed packages. If no extractable packages are present, then the prompts to extract and delete will be skipped.

Fixes #6350.
