### PR TITLE
Remove popup metadata reminder

### DIFF
--- a/src/dashboard/src/media/js/ingest.js
+++ b/src/dashboard/src/media/js/ingest.js
@@ -217,37 +217,6 @@ $(function()
         {
           var jobData = this.model.toJSON();
 
-//console.log(jobData.microservicegroup); Normalize
-// console.log(jobData.currentstep); Awaiting decision
-
-          if (
-            jobData.microservicegroup == 'Normalize'
-            && jobData.type == 'Normalize'
-            && jobData.currentstep == 'Awaiting decision'
-          ) {
-            // use global variable to note whether dialog has been displayed
-            if (typeof normalizationWarningShown === 'undefined') {
- 
-              var dialog = $('<div>Reminder: Add descriptive and/or rights metadata prior to normalization if desired</div>');
- 
-              setTimeout(function() {
-                $(dialog).dialog('close');
-              }, 5000);
- 
-              dialog.dialog({
-                title: 'Warning',
-                width: 640,
-                height: 200,
-                buttons: [{
-                  text: 'Dismiss',
-                  click: function() { $(this).dialog('close'); }
-                }]
-              });
-
-              normalizationWarningShown = true;
-            }
-          }
-
           if (
             jobData.type == 'Access normalization failed - copying'
             || jobData.type == 'Preservation normalization failed - copying'


### PR DESCRIPTION
This is no longer needed now that there are ways to ensure that there's an opportunity to input metadata before it's finalized.

Fixes #7013.
