### PR TITLE
createMETSMetadataCSV: use universal newlines

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSMetadataCSV.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSMetadataCSV.py
@@ -61,7 +61,8 @@ def parseMetadata(SIPPath):
 
 
 def parseMetadtaCSV(metadataCSVFilePath):
-    with open(metadataCSVFilePath, 'rb') as f:
+    # use universal newline mode to support unusual newlines, like \r
+    with open(metadataCSVFilePath, 'rbU') as f:
         reader = csv.reader(f)
         firstRow = True
         type = ""

--- a/src/MCPClient/lib/clientScripts/loadLabelsFromCSV.py
+++ b/src/MCPClient/lib/clientScripts/loadLabelsFromCSV.py
@@ -37,7 +37,8 @@ if __name__ == '__main__':
         print "No such file:", fileLabels
         exit(0)
     
-    with open(fileLabels, 'rb') as f:
+    # use universal newline mode to support unusual newlines, like \r
+    with open(fileLabels, 'rbU') as f:
         reader = csv.reader(f)
         for row in reader:
             if labelFirst:

--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -88,7 +88,8 @@ def check_manual_normalization(opts):
     bname = opts.file_path.replace(objects_dir, '', 1)
     if os.path.isfile(normalization_csv):
         found = False
-        with open(normalization_csv, 'rb') as csv_file:
+        # use universal newline mode to support unusual newlines, like \r
+        with open(normalization_csv, 'rbU') as csv_file:
             reader = csv.reader(csv_file)
             # Search the file for an original filename that matches the one provided
             try:

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -228,7 +228,8 @@ def findFileInNormalizatonCSV(csv_path, commandClassification, target_file):
 
     TODO handle sanitized filenames
     """
-    with open(csv_path, 'rb') as csv_file:
+    # use universal newline mode to support unusual newlines, like \r
+    with open(csv_path, 'rbU') as csv_file:
         reader = csv.reader(csv_file)
         # Search CSV for an access/preservation filename that matches target_file
 


### PR DESCRIPTION
This fixes reading CSVs with unusual newlines, like \r.

Fixes #7015.
