### PR TITLE
Remove disabled 'Create SIP manually' option

### DIFF
--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -702,3 +702,9 @@ UPDATE MicroServiceChainLinks SET defaultNextChainLink=@MoveSIPToFailedLink WHER
 -- of moving to the next link in normalization.
 UPDATE MicroServiceChainLinks SET defaultNextChainLink='83484326-7be7-4f9f-b252-94553cd42370' WHERE pk='2dd53959-8106-457d-a385-fee57fc93aa9';
 -- /Issue 7012 - Normalization ID failure
+
+-- Issue 6965 - remove 'create sip manually'
+SET @manualSIPMSC = '9634868c-b183-4d65-8587-2f53f7ff5a0a' COLLATE utf8_unicode_ci;
+DELETE FROM MicroServiceChainChoice WHERE chainAvailable=@manualSIPMSC;
+DELETE FROM MicroServiceChains WHERE pk=@manualSIPMSC;
+-- /Issue 6965 - remove 'create sip manually'

--- a/src/dashboard/src/components/administration/views_processing.py
+++ b/src/dashboard/src/components/administration/views_processing.py
@@ -367,7 +367,6 @@ def populate_select_field_options_with_chain_choices(field):
 
     if field['label'] == 'Create SIP(s)':
         remove_option_by_value(options, 'Reject transfer')
-        remove_option_by_value(options, 'Create SIP(s) manually')
 
     if field['label'] == 'Normalize':
         remove_option_by_value(options, 'Reject SIP')

--- a/src/dashboard/src/media/js/transfer.js
+++ b/src/dashboard/src/media/js/transfer.js
@@ -167,7 +167,7 @@ $(function()
 
           choices = this.model.get('choices');
 
-         if (choices)
+          if (choices)
           {
             var $select = $('<select />').append('<option>Actions</option>')
               , numberOfChoices = Object.keys(choices).length
@@ -182,9 +182,7 @@ $(function()
 
             for (var code in choices)
             {
-              optionHtml = (choices[code] == 'Create SIP(s) manually')
-                ? '<option value="' + code + '" disabled="disabled" style="color: #aaa">- ' + choices[code] + '</option>'
-                : '<option value="' + code + '">- ' + choices[code] + '</option>';
+              optionHtml = '<option value="' + code + '">- ' + choices[code] + '</option>';
               $select.append(optionHtml);
             }
 


### PR DESCRIPTION
Workflow for SIP arrangement requires sending the transfer to backlog, so disabled 'Create SIP(s) manually' option is inaccurate and misleading.

refs #6965
