### PR TITLE
databaseFunctions: remove debug print

### DIFF
--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -63,7 +63,6 @@ def getAgentForFileUUID(fileUUID):
         raise Exception(error_message)
     else:
         rows = databaseInterface.queryAllSQL("""SELECT sipUUID, transferUUID FROM Files WHERE fileUUID = '%s';""" % (fileUUID))
-        print """SELECT sipUUID, transferUUID FROM Files WHERE fileUUID = '%s';""" % (fileUUID)
         sipUUID, transferUUID = rows[0]
         if sipUUID:
             rows = databaseInterface.queryAllSQL("""SELECT variableValue FROM UnitVariables WHERE unitType = '%s' AND unitUUID = '%s' AND variable = '%s';""" % ('SIP', sipUUID, "activeAgent"))


### PR DESCRIPTION
Looks like this got committed by accident. It's been causing SQL statements to be printed into the stdout of microservice jobs by accident, which makes debugging a little noisier.
