### PR TITLE
Improve Elasticsearch error handling in try_to_index

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -287,18 +287,15 @@ def connect_and_index_aip(uuid, name, filePath, pathToMETS, size=None, aips_in_a
     try_to_index(conn, aipData, 'aips', 'aip')
 
 def try_to_index(conn, data, index, doc_type, wait_between_tries=10, max_tries=10):
-    tries = 0
+    if max_tries < 1:
+        raise ValueError("max_tries must be 1 or greater")
 
-    while tries < max_tries:
-        tries = tries + 1
-
+    for _ in xrange(0, max_tries):
         try:
             return conn.index(data, index, doc_type)
         except:
             print "ERROR: error trying to index."
             time.sleep(wait_between_tries)
-            pass
-        tries = tries + 1
 
 def connect_and_get_aip_data(uuid):
     conn = connect_and_create_index('aips')

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -493,9 +493,9 @@ def index_mets_file_metadata(conn, uuid, metsFilePath, index, type, sipName, bac
 def rename_dict_keys_with_child_dicts(data):
     new = {}
     for key in data:
-        if type(data[key]) is dict:
+        if isinstance(data[key], dict):
             new[key + '_data'] = rename_dict_keys_with_child_dicts(data[key])
-        elif type(data[key]) is list:
+        elif isinstance(data[key], list):
             # Elasticsearch's lists are typed; a list of strings and
             # a list of objects are not the same type. Check the type
             # of the first object in the list and use that as the tag,
@@ -508,9 +508,9 @@ def rename_dict_keys_with_child_dicts(data):
 
 def rename_list_elements_if_they_are_dicts(data):
     for index, value in enumerate(data):
-        if type(value) is list:
+        if isinstance(value, list):
             data[index] = rename_list_elements_if_they_are_dicts(value)
-        elif type(value) is dict:
+        elif isinstance(value, dict):
             data[index] = rename_dict_keys_with_child_dicts(value)
     return data
 
@@ -523,17 +523,17 @@ def rename_list_elements_if_they_are_dicts(data):
 #
 def normalize_dict_values(data):
     for key in data:
-        if type(data[key]) is dict:
+        if isinstance(data[key], dict):
             data[key] = [normalize_dict_values(data[key])]
-        elif type(data[key]) is list:
+        elif isinstance(data[key], list):
             data[key] = normalize_list_dict_elements(data[key])
     return data
 
 def normalize_list_dict_elements(data):
     for index, value in enumerate(data):
-        if type(value) is list:
+        if isinstance(value, list):
             data[index] = normalize_list_dict_elements(value)
-        elif type(value) is dict:
+        elif isinstance(value, dict):
             data[index] =  normalize_dict_values(value)
     return data
 

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -501,13 +501,13 @@ def rename_dict_keys_with_child_dicts(data):
             new[key] = data[key]
     return new
 
-def rename_list_elements_if_they_are_dicts(list):
-    for index, value in enumerate(list):
+def rename_list_elements_if_they_are_dicts(data):
+    for index, value in enumerate(data):
         if type(value) is list:
-            list[index] = rename_list_elements_if_they_are_dicts(value)
+            data[index] = rename_list_elements_if_they_are_dicts(value)
         elif type(value) is dict:
-            list[index] = rename_dict_keys_with_child_dicts(value)
-    return list
+            data[index] = rename_dict_keys_with_child_dicts(value)
+    return data
 
 # Because an XML document node may include one or more children, conversion
 # to a dict can result in the converted child being one of two types.
@@ -524,13 +524,13 @@ def normalize_dict_values(data):
             data[key] = normalize_list_dict_elements(data[key])
     return data
 
-def normalize_list_dict_elements(list):
-    for index, value in enumerate(list):
+def normalize_list_dict_elements(data):
+    for index, value in enumerate(data):
         if type(value) is list:
-            list[index] = normalize_list_dict_elements(value)
+            data[index] = normalize_list_dict_elements(value)
         elif type(value) is dict:
-            list[index] =  normalize_dict_values(value)
-    return list
+            data[index] =  normalize_dict_values(value)
+    return data
 
 def index_transfer_files(conn, uuid, pathToTransfer, index, type):
     """

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -496,7 +496,12 @@ def rename_dict_keys_with_child_dicts(data):
         if type(data[key]) is dict:
             new[key + '_data'] = rename_dict_keys_with_child_dicts(data[key])
         elif type(data[key]) is list:
-            new[key + '_list'] = rename_list_elements_if_they_are_dicts(data[key])
+            # Elasticsearch's lists are typed; a list of strings and
+            # a list of objects are not the same type. Check the type
+            # of the first object in the list and use that as the tag,
+            # rather than just tagging this "_list"
+            type_of_list = type(data[key][0]).__name__
+            new[key + '_' + type_of_list + '_list'] = rename_list_elements_if_they_are_dicts(data[key])
         else:
             new[key] = data[key]
     return new

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -293,9 +293,14 @@ def try_to_index(conn, data, index, doc_type, wait_between_tries=10, max_tries=1
     for _ in xrange(0, max_tries):
         try:
             return conn.index(data, index, doc_type)
-        except:
+        except Exception as e:
             print "ERROR: error trying to index."
+            print e
             time.sleep(wait_between_tries)
+
+    # If indexing did not succeed after max_tries is already complete,
+    # reraise the Elasticsearch exception to aid in debugging.
+    raise e
 
 def connect_and_get_aip_data(uuid):
     conn = connect_and_create_index('aips')


### PR DESCRIPTION
- Iterate the correct number of times, instead of half the number of specified times
- If indexing fails at the end, reraise the exception instead of silently swallowing it
