### PR TITLE
bagit: shorten argument list

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaBagWithEmptyDirectories.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaBagWithEmptyDirectories.py
@@ -71,10 +71,15 @@ def bag_with_empty_directories(args):
     """ Run bagit create bag command, and create any empty directories from the SIP. """
     # Get list of directories in SIP
     sip_dir = os.path.dirname(args.destination)
-    dir_list = get_sip_directories(sip_dir)
+    dir_list = get_sip_directories(args.sip_directory)
 
+    # These are passed to this script as paths relative to their location in
+    # the SIP; passing the full SIP location each time has the potential to
+    # overflow the 1000-character limit the job's command has in the database,
+    # especially with long SIP names.
+    full_paths = [os.path.join(args.sip_directory, p) for p in args.payload_entries]
     # Ensure all payload items actually exist
-    payload_entries = [e for e in args.payload_entries if os.path.exists(e)]
+    payload_entries = [e for e in full_paths if os.path.exists(e)]
 
     # Reconstruct bagit arguments
     # Goal: bagit <operation> <destination> <flattened payload list> <optional args>
@@ -91,6 +96,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Convert folder into a bag.')
     parser.add_argument('operation')
     parser.add_argument('destination')
+    parser.add_argument('sip_directory')
     parser.add_argument('payload_entries', metavar='Payload', nargs='+',
                    help='All the files/folders that should go in the bag.')
     parser.add_argument('--writer', dest='writer')

--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -758,3 +758,10 @@ INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, cu
 INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('c3c8e23c-1c8a-4c24-b8a1-3d6e8a8c3a7b', @postStoreMSCL, 0, 'd5a2ef60-a757-483c-a71a-ccbffe6b80da', 'Completed successfully');
 UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink=@postStoreMSCL WHERE microServiceChainLink='48703fad-dc44-4c8e-8f47-933df3ef6179';
 -- /Issue 6788 - Add post store AIP hook
+
+-- Issue 6624 - Bagit arguments
+-- Update the arguments field to not repeatedly expand the value of
+-- %SIPDirectory% - which is so verbose it causes this to frequently
+-- overflow the 1000-character limit on this field in the database.
+UPDATE StandardTasksConfigs SET arguments='create "%SIPDirectory%%SIPName%-%SIPUUID%" "%SIPDirectory" "logs/" "objects/" "METS.%SIPUUID%.xml" "thumbnails/" "metadata/" --writer filesystem --payloadmanifestalgorithm "sha512"' WHERE pk='045f84de-2669-4dbc-a31b-43a4954d0481';
+-- /Issue 6624 - Bagit arguments


### PR DESCRIPTION
This prevents issues like #6624, where a long SIP name would cause the argument list to easily overflow the 1000-character limit in the job command column.
