### PR TITLE
submissionDocs: if a submissionDocs already exists in objects, merge instead of nesting

### DIFF
--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -91,6 +91,7 @@ move_v0.0 = sudo mv
 moveDspaceLicenseFilesToDSpaceLicenses_v0.0 = %clientScriptsDirectory%moveDspaceLicenseFilesToDSpaceLicenses.py
 moveDspaceMetsFilesToDSpaceMETS_v0.0 = %clientScriptsDirectory%moveDspaceMetsFilesToDSpaceMETS.py
 moveSIP_v0.0 =  %clientScriptsDirectory%archivematicaMoveSIP.py
+moveOrMerge_v0.0 = %clientScriptsDirectory%moveOrMerge.py
 moveTransfer_v0.0 =  %clientScriptsDirectory%archivematicaMoveTransfer.py
 moveToBacklog_v1.0 = %clientScriptsDirectory%moveToBacklog.py
 normalize_v1.0 = %clientScriptsDirectory%normalize.py

--- a/src/MCPClient/lib/clientScripts/createSIPfromTransferObjects.py
+++ b/src/MCPClient/lib/clientScripts/createSIPfromTransferObjects.py
@@ -62,7 +62,17 @@ if __name__ == '__main__':
 
     #move the objects to the SIPDir
     for item in os.listdir(objectsDirectory):
-        shutil.move(os.path.join(objectsDirectory, item), os.path.join(tmpSIPDir, "objects", item))
+        src_path = os.path.join(objectsDirectory, item)
+        dst_path = os.path.join(tmpSIPDir, "objects", item)
+        # If dst_path already exists and is a directory, shutil.move
+        # will move src_path into it rather than overwriting it;
+        # to avoid incorrectly-nested paths, move src_path's contents
+        # into it instead.
+        if os.path.exists(dst_path):
+            for subitem in os.listdir(src_path):
+                shutil.move(os.path.join(src_path, subitem), dst_path)
+        else:
+            shutil.move(src_path, dst_path)
 
     #get the database list of files in the objects directory
     #for each file, confirm it's in the SIP objects directory, and update the current location/ owning SIP'

--- a/src/MCPClient/lib/clientScripts/moveOrMerge.py
+++ b/src/MCPClient/lib/clientScripts/moveOrMerge.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python -OO
+
+import os
+import sys
+import shutil
+
+def main(src, dst):
+    """
+    Moves a file/directory to a new location, or moves two directories.
+
+    If dst doesn't exist, acts like mv: src is moved to the same path as dst.
+    If dst does exist and is a directory, the two directories are merged by
+    moving src's contents into dst.
+    """
+    if os.path.exists(dst):
+        for item in os.listdir(src):
+            shutil.move(os.path.join(src, item), dst)
+        shutil.rmtree(src)
+    else:
+        shutil.move(src, dst)
+
+    return 0
+
+if __name__ == '__main__':
+    src = sys.argv[1]
+    dst = sys.argv[2]
+    try:
+        sys.exit(main(src, dst))
+    except Exception as e:
+        sys.exit(e)

--- a/src/MCPServer/share/mysql_dev1.sql
+++ b/src/MCPServer/share/mysql_dev1.sql
@@ -786,3 +786,7 @@ UPDATE MicroServiceChainLinks SET microserviceGroup = 'Process submission docume
 UPDATE MicroServiceChainLinks SET microserviceGroup = 'Process metadata directory' WHERE pk IN ('ee438694-815f-4b74-97e1-8e7dde2cc6d5', '75fb5d67-5efa-4232-b00b-d85236de0d3f');
 UPDATE MicroServiceChainLinks SET microserviceGroup = 'Prepare AIP' WHERE pk IN ('f1e286f9-4ec7-4e19-820c-dae7b8ea7d09');
 -- /Issue 6575 Metadata format ID & Characterization
+
+-- Issue 7080 Move submissionDocs into objects
+UPDATE StandardTasksConfigs SET execute='moveOrMerge_v0.0' WHERE pk in ('2f2a9b2b-bcdb-406b-a842-898d4bed02be', 'ce13677c-8ad4-4af0-92c8-ae8763f5094d');
+-- /Issue 7080 Move submissionDocs into objects


### PR DESCRIPTION
When submissionDocumentation was being moved into the AIP before characterization, Archivematica was using mv. This meant that if the SIP already had a directory by that name, submissionDocumentation would end up nested inside the existing directory instead of merged with it.

This adds a new moveOrMerge clientscript that acts like mv if the destination doesn't exist, and merges the contents if it does.

The first commit here was from I was mistaken about the source of this problem. It's not actually _wrong_, but probably unnecessary; I'll probably just remove it.
