### PR TITLE
PREMIS Rights: month and day optional

### DIFF
--- a/src/dashboard/src/media/js/rights_edit.js
+++ b/src/dashboard/src/media/js/rights_edit.js
@@ -280,16 +280,26 @@ $(document).ready(function() {
 
   // apply input mask to date fields
   $.extend($.inputmask.defaults.definitions, {
-    'y': {
-      'validator': '[012]\\d\\d\\d',
-      'cardinality': 4,
-      'prevalidator': [
-        { 'validator': '[012]', 'cardinality': 1 }
-      ]
+    'd': { //basic day - from jquery.inputmask.date.extensions
+        validator: "0[1-9]|[12][0-9]|3[01]",
+        cardinality: 2,
+        prevalidator: [{ validator: "[0-3]", cardinality: 1 }],
+        placeholder: 'd'
+    },
+    'm': { //basic month - from jquery.inputmask.date.extensions
+        validator: "0[1-9]|1[012]",
+        cardinality: 2,
+        prevalidator: [{ validator: "[01]", cardinality: 1 }],
+        placeholder: 'm'
+    },
+    'y': { // modified year - to allow dates beyond 19xx and 20xx
+      validator: '\\d\\d\\d\\d',
+      cardinality: 4,
+      placeholder: 'y'
     }
   });
 
-  $('input[type="text"][name*="date"]').inputmask('y/m/d');
+  $('input[type="text"][name*="date"]').inputmask('y[-m[-d]]');
 
   // active formset changer
   $('#id_rightsbasis').change(revealSelectedBasis);

--- a/src/dashboard/src/media/vendor/jquery.inputmask.js
+++ b/src/dashboard/src/media/vendor/jquery.inputmask.js
@@ -1,731 +1,1722 @@
-/*
-Input Mask plugin for jquery
-http://github.com/RobinHerbots/jquery.inputmask
-Copyright (c) 2010 Robin Herbots
-Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php)
-Version: 0.4.5e
- 
-This plugin is based on the masked input plugin written by Josh Bush (digitalbush.com)
+/**
+* @license Input Mask plugin for jquery
+* http://github.com/RobinHerbots/jquery.inputmask
+* Copyright (c) 2010 - 2014 Robin Herbots
+* Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php)
+* Version: 3.0.55
 */
 
-(function($) {
-    if ($.fn.inputmask == undefined) {
+(function ($) {
+    if ($.fn.inputmask === undefined) {
+
+        //helper functions
+        function isInputEventSupported(eventName) {
+            var el = document.createElement('input'),
+                eventName = 'on' + eventName,
+                isSupported = (eventName in el);
+            if (!isSupported) {
+                el.setAttribute(eventName, 'return;');
+                isSupported = typeof el[eventName] == 'function';
+            }
+            el = null;
+            return isSupported;
+        }
+
+        function resolveAlias(aliasStr, options, opts) {
+            var aliasDefinition = opts.aliases[aliasStr];
+            if (aliasDefinition) {
+                if (aliasDefinition.alias) resolveAlias(aliasDefinition.alias, undefined, opts); //alias is another alias
+                $.extend(true, opts, aliasDefinition); //merge alias definition in the options
+                $.extend(true, opts, options); //reapply extra given options
+                return true;
+            }
+            return false;
+        }
+
+        function generateMaskSet(opts) {
+            var ms = [];
+
+            function analyseMask(mask) {
+                var tokenizer = /(?:[?*+]|\{[0-9\+\*]+(?:,[0-9\+\*]*)?\})\??|[^.?*+^${[]()|\\]+|./g,
+                    escaped = false;
+
+                function maskToken(isGroup, isOptional, isQuantifier, isAlternator) {
+                    this.matches = [];
+                    this.isGroup = isGroup || false;
+                    this.isOptional = isOptional || false;
+                    this.isQuantifier = isQuantifier || false;
+                    this.isAlternator = isAlternator || false;
+                    this.quantifier = { min: 1, max: 1 };
+                };
+
+                //test definition => {fn: RegExp/function, cardinality: int, optionality: bool, newBlockMarker: bool, offset: int, casing: null/upper/lower, def: definitionSymbol, placeholder: placeholder}
+                function insertTestDefinition(mtoken, element, position) {
+                    var maskdef = opts.definitions[element];
+                    var newBlockMarker = mtoken.matches.length == 0;
+                    position = position != undefined ? position : mtoken.matches.length;
+                    if (maskdef && !escaped) {
+                        var prevalidators = maskdef["prevalidator"], prevalidatorsL = prevalidators ? prevalidators.length : 0;
+                        for (var i = 1; i < maskdef.cardinality; i++) {
+                            var prevalidator = prevalidatorsL >= i ? prevalidators[i - 1] : [], validator = prevalidator["validator"], cardinality = prevalidator["cardinality"];
+                            mtoken.matches.splice(position++, 0, { fn: validator ? typeof validator == 'string' ? new RegExp(validator) : new function () { this.test = validator; } : new RegExp("."), cardinality: cardinality ? cardinality : 1, optionality: mtoken.isOptional, newBlockMarker: newBlockMarker, casing: maskdef["casing"], def: maskdef["definitionSymbol"] || element, placeholder: maskdef["placeholder"] });
+                        }
+                        mtoken.matches.splice(position++, 0, { fn: maskdef.validator ? typeof maskdef.validator == 'string' ? new RegExp(maskdef.validator) : new function () { this.test = maskdef.validator; } : new RegExp("."), cardinality: maskdef.cardinality, optionality: mtoken.isOptional, newBlockMarker: newBlockMarker, casing: maskdef["casing"], def: maskdef["definitionSymbol"] || element, placeholder: maskdef["placeholder"] });
+                    } else {
+                        mtoken.matches.splice(position++, 0, { fn: null, cardinality: 0, optionality: mtoken.isOptional, newBlockMarker: newBlockMarker, casing: null, def: element, placeholder: undefined });
+                        escaped = false;
+                    }
+                }
+
+                var currentToken = new maskToken(),
+                    match,
+                    m,
+                    openenings = [],
+                    maskTokens = [];
+
+                while (match = tokenizer.exec(mask)) {
+                    m = match[0];
+                    switch (m.charAt(0)) {
+                        case opts.optionalmarker.end:
+                            // optional closing
+                        case opts.groupmarker.end:
+                            // Group closing
+                            var openingToken = openenings.pop();
+                            if (openenings.length > 0) {
+                                openenings[openenings.length - 1]["matches"].push(openingToken);
+                            } else {
+                                currentToken.matches.push(openingToken);
+                            }
+                            break;
+                        case opts.optionalmarker.start:
+                            // optional opening
+                            openenings.push(new maskToken(false, true));
+                            break;
+                        case opts.groupmarker.start:
+                            // Group opening
+                            openenings.push(new maskToken(true));
+                            break;
+                        case opts.quantifiermarker.start:
+                            //Quantifier
+                            var quantifier = new maskToken(false, false, true);
+
+                            m = m.replace(/[{}]/g, "");
+                            var mq = m.split(","),
+                                mq0 = isNaN(mq[0]) ? mq[0] : parseInt(mq[0]),
+                                mq1 = mq.length == 1 ? mq0 : (isNaN(mq[1]) ? mq[1] : parseInt(mq[1]));
+                            if (mq1 == "*" || mq1 == "+") {
+                                mq0 = mq1 == "*" ? 0 : 1;
+                            }
+                            quantifier.quantifier = { min: mq0, max: mq1 };
+                            if (openenings.length > 0) {
+                                var matches = openenings[openenings.length - 1]["matches"];
+                                var match = matches.pop();
+                                if (!match["isGroup"]) {
+                                    var groupToken = new maskToken(true);
+                                    groupToken.matches.push(match);
+                                    match = groupToken;
+                                }
+                                matches.push(match);
+                                matches.push(quantifier);
+                            } else {
+                                var match = currentToken.matches.pop();
+                                if (!match["isGroup"]) {
+                                    var groupToken = new maskToken(true);
+                                    groupToken.matches.push(match);
+                                    match = groupToken;
+                                }
+                                currentToken.matches.push(match);
+                                currentToken.matches.push(quantifier);
+                            }
+                            break;
+                        case opts.escapeChar:
+                            escaped = true;
+                            break;
+                        case opts.alternatormarker:
+
+                            break;
+                        default:
+                            if (openenings.length > 0) {
+                                insertTestDefinition(openenings[openenings.length - 1], m);
+                            } else {
+                                if (currentToken.matches.length > 0) {
+                                    var lastMatch = currentToken.matches[currentToken.matches.length - 1];
+                                    if (lastMatch["isGroup"]) { //this is not a group but a normal mask => convert
+                                        lastMatch.isGroup = false;
+                                        insertTestDefinition(lastMatch, opts.groupmarker.start, 0);
+                                        insertTestDefinition(lastMatch, opts.groupmarker.end);
+                                    }
+                                }
+                                insertTestDefinition(currentToken, m);
+                            }
+                    }
+                }
+
+                if (currentToken.matches.length > 0) {
+                    var lastMatch = currentToken.matches[currentToken.matches.length - 1];
+                    if (lastMatch["isGroup"]) { //this is not a group but a normal mask => convert
+                        lastMatch.isGroup = false;
+                        insertTestDefinition(lastMatch, opts.groupmarker.start, 0);
+                        insertTestDefinition(lastMatch, opts.groupmarker.end);
+                    }
+                    maskTokens.push(currentToken);
+                }
+
+                //console.log(JSON.stringify(maskTokens));
+                return maskTokens;
+            }
+
+            function generateMask(mask, metadata) {
+                if (opts.numericInput && opts.multi !== true) { //TODO FIX FOR DYNAMIC MASKS WITH QUANTIFIERS
+                    mask = mask.split('').reverse();
+                    for (var ndx = 0; ndx < mask.length; ndx++) {
+                        if (mask[ndx] == opts.optionalmarker.start)
+                            mask[ndx] = opts.optionalmarker.end;
+                        else if (mask[ndx] == opts.optionalmarker.end)
+                            mask[ndx] = opts.optionalmarker.start;
+                        else if (mask[ndx] == opts.groupmarker.start)
+                            mask[ndx] = opts.groupmarker.end;
+                        else if (mask[ndx] == opts.groupmarker.end)
+                            mask[ndx] = opts.groupmarker.start;
+                    }
+                    mask = mask.join('');
+                }
+                if (mask == undefined || mask == "")
+                    return undefined;
+                else {
+                    if (opts.repeat > 0 || opts.repeat == "*" || opts.repeat == "+") {
+                        var repeatStart = opts.repeat == "*" ? 0 : (opts.repeat == "+" ? 1 : opts.repeat);
+                        mask = opts.groupmarker.start + mask + opts.groupmarker.end + opts.quantifiermarker.start + repeatStart + "," + opts.repeat + opts.quantifiermarker.end;
+                    }
+                    if ($.inputmask.masksCache[mask] == undefined) {
+                        $.inputmask.masksCache[mask] = {
+                            "mask": mask,
+                            "maskToken": analyseMask(mask),
+                            "validPositions": {},
+                            "_buffer": undefined,
+                            "buffer": undefined,
+                            "tests": {},
+                            "metadata": metadata
+                        };
+                    }
+
+                    return $.extend(true, {}, $.inputmask.masksCache[mask]);
+                }
+            }
+
+            if ($.isFunction(opts.mask)) { //allow mask to be a preprocessing fn - should return a valid mask
+                opts.mask = opts.mask.call(this, opts);
+            }
+            if ($.isArray(opts.mask)) {
+                $.each(opts.mask, function (ndx, msk) {
+                    if (msk["mask"] != undefined) {
+                        ms.push(generateMask(msk["mask"].toString(), msk));
+                    } else {
+                        ms.push(generateMask(msk.toString()));
+                    }
+                });
+            } else {
+                if (opts.mask.length == 1 && opts.greedy == false && opts.repeat != 0) {
+                    opts.placeholder = "";
+                } //hide placeholder with single non-greedy mask
+                if (opts.mask["mask"] != undefined) {
+                    ms = generateMask(opts.mask["mask"].toString(), opts.mask);
+                } else {
+                    ms = generateMask(opts.mask.toString());
+                }
+            }
+            return ms;
+        }
+
+        var msie1x = typeof ScriptEngineMajorVersion === "function"
+                ? ScriptEngineMajorVersion() //IE11 detection
+                : new Function("/*@cc_on return @_jscript_version; @*/")() >= 10, //conditional compilation from mickeysoft trick
+            ua = navigator.userAgent,
+            iphone = ua.match(new RegExp("iphone", "i")) !== null,
+            android = ua.match(new RegExp("android.*safari.*", "i")) !== null,
+            androidchrome = ua.match(new RegExp("android.*chrome.*", "i")) !== null,
+            androidfirefox = ua.match(new RegExp("android.*firefox.*", "i")) !== null,
+            kindle = /Kindle/i.test(ua) || /Silk/i.test(ua) || /KFTT/i.test(ua) || /KFOT/i.test(ua) || /KFJWA/i.test(ua) || /KFJWI/i.test(ua) || /KFSOWI/i.test(ua) || /KFTHWA/i.test(ua) || /KFTHWI/i.test(ua) || /KFAPWA/i.test(ua) || /KFAPWI/i.test(ua),
+            PasteEventType = isInputEventSupported('paste') ? 'paste' : isInputEventSupported('input') ? 'input' : "propertychange";
+
+        //if (androidchrome) {
+        //    var browser = navigator.userAgent.match(new RegExp("chrome.*", "i")),
+        //        version = parseInt(new RegExp(/[0-9]+/).exec(browser));
+        //    androidchrome32 = (version == 32);
+        //}
+
+        //masking scope
+        //actionObj definition see below
+        function maskScope(actionObj, maskset, opts) {
+            var isRTL = false,
+                valueOnFocus,
+                $el,
+                skipKeyPressEvent = false, //Safari 5.1.x - modal dialog fires keypress twice workaround
+                skipInputEvent = false, //skip when triggered from within inputmask
+                ignorable = false,
+                maxLength;
+
+            //maskset helperfunctions
+
+
+            function getMaskTemplate(baseOnInput, minimalPos, includeInput) {
+                minimalPos = minimalPos || 0;
+                var maskTemplate = [], ndxIntlzr, pos = 0, test, testPos;
+                do {
+                    if (baseOnInput === true && getMaskSet()['validPositions'][pos]) {
+                        var validPos = getMaskSet()['validPositions'][pos];
+                        test = validPos["match"];
+                        ndxIntlzr = validPos["locator"].slice();
+                        maskTemplate.push(test["fn"] == null ? test["def"] : (includeInput === true ? validPos["input"] : test["placeholder"] || opts.placeholder.charAt(pos % opts.placeholder.length)));
+                    } else {
+                        if (minimalPos > pos) {
+                            var testPositions = getTests(pos, ndxIntlzr, pos - 1);
+                            testPos = testPositions[0];
+                        } else {
+                            testPos = getTestTemplate(pos, ndxIntlzr, pos - 1);
+                        }
+                        test = testPos["match"];
+                        ndxIntlzr = testPos["locator"].slice();
+                        maskTemplate.push(test["fn"] == null ? test["def"] : test["placeholder"] || opts.placeholder.charAt(pos % opts.placeholder.length));
+                    }
+                    pos++;
+                } while ((maxLength == undefined || pos - 1 < maxLength) && test["fn"] != null || (test["fn"] == null && test["def"] != "") || minimalPos >= pos);
+                maskTemplate.pop(); //drop the last one which is empty
+                return maskTemplate;
+            }
+
+            function getMaskSet() {
+                return maskset;
+            }
+
+            function resetMaskSet(soft) {
+                var maskset = getMaskSet();
+                maskset["buffer"] = undefined;
+                maskset["tests"] = {};
+                if (soft !== true) {
+                    maskset["_buffer"] = undefined;
+                    maskset["validPositions"] = {};
+                    maskset["p"] = -1;
+                }
+            }
+
+            function getLastValidPosition(closestTo) {
+                var maskset = getMaskSet(), lastValidPosition = -1, valids = maskset["validPositions"];
+                if (closestTo == undefined) closestTo = -1;
+                var before = lastValidPosition, after = lastValidPosition;
+                for (var posNdx in valids) {
+                    var psNdx = parseInt(posNdx);
+                    if (closestTo == -1 || valids[psNdx]["match"].fn != null) {
+                        if (psNdx < closestTo) before = psNdx;
+                        if (psNdx >= closestTo) after = psNdx;
+                    }
+                }
+                lastValidPosition = (closestTo - before) > 1 || after < closestTo ? before : after;
+                return lastValidPosition;
+            }
+
+            function setValidPosition(pos, validTest, fromSetValid) {
+                if (opts.insertMode && getMaskSet()["validPositions"][pos] != undefined && fromSetValid == undefined) {
+                    //reposition & revalidate others
+                    var positionsClone = $.extend(true, {}, getMaskSet()["validPositions"]), lvp = getLastValidPosition(), i;
+                    for (i = pos; i <= lvp; i++) { //clear selection
+                        delete getMaskSet()["validPositions"][i];
+                    }
+                    getMaskSet()["validPositions"][pos] = validTest;
+                    var valid = true;
+                    for (i = pos; i <= lvp ; i++) {
+                        var t = positionsClone[i];
+                        if (t != undefined) {
+                            var j = t["match"].fn == null ? i + 1 : seekNext(i);
+                            if (positionCanMatchDefinition(j, t["match"].def)) {
+                                valid = valid && isValid(j, t["input"], true, true) !== false;
+                            } else valid = false;
+                        }
+                        if (!valid) break;
+                    }
+
+                    if (!valid) {
+                        getMaskSet()["validPositions"] = $.extend(true, {}, positionsClone);
+                        return false;
+                    }
+                } else
+                    getMaskSet()["validPositions"][pos] = validTest;
+
+                return true;
+            }
+
+            function stripValidPositions(start, end) {
+                var i, startPos = start, lvp;
+                for (i = start; i < end; i++) { //clear selection
+                    //TODO FIXME BETTER CHECK
+                    delete getMaskSet()["validPositions"][i];
+                }
+
+                for (i = end ; i <= getLastValidPosition() ;) {
+                    var t = getMaskSet()["validPositions"][i];
+                    var s = getMaskSet()["validPositions"][startPos];
+                    if (t != undefined && s == undefined) {
+                        if (positionCanMatchDefinition(startPos, t.match.def) && isValid(startPos, t["input"], true) !== false) {
+                            delete getMaskSet()["validPositions"][i];
+                            i++;
+                        }
+                        startPos++;
+                    } else i++;
+                }
+                lvp = getLastValidPosition();
+                //catchup
+                while (lvp > 0 && (getMaskSet()["validPositions"][lvp] == undefined || getMaskSet()["validPositions"][lvp].match.fn == null)) {
+                    delete getMaskSet()["validPositions"][lvp];
+                    lvp--;
+                }
+                resetMaskSet(true);
+            }
+
+            function getTestTemplate(pos, ndxIntlzr, tstPs) {
+                var testPositions = getTests(pos, ndxIntlzr, tstPs), testPos;
+                for (var ndx = 0; ndx < testPositions.length; ndx++) {
+                    testPos = testPositions[ndx];
+                    if (opts.greedy || (testPos["match"] && (testPos["match"].optionality === false || testPos["match"].newBlockMarker === false) && testPos["match"].optionalQuantifier !== true)) {
+                        break;
+                    }
+                }
+
+                return testPos;
+            }
+            function getTest(pos) {
+                if (getMaskSet()['validPositions'][pos]) {
+                    return getMaskSet()['validPositions'][pos]["match"];
+                }
+                return getTests(pos)[0]["match"];
+            }
+            function positionCanMatchDefinition(pos, def) {
+                var valid = false, tests = getTests(pos);
+                for (var tndx = 0; tndx < tests.length; tndx++) {
+                    if (tests[tndx]["match"] && tests[tndx]["match"].def == def) {
+                        valid = true;
+                        break;
+                    }
+                }
+                return valid;
+            };
+            function getTests(pos, ndxIntlzr, tstPs) {
+                var maskTokens = getMaskSet()["maskToken"], testPos = ndxIntlzr ? tstPs : 0, ndxInitializer = ndxIntlzr || [0], matches = [], insertStop = false;
+                function ResolveTestFromToken(maskToken, ndxInitializer, loopNdx, quantifierRecurse) { //ndxInitilizer contains a set of indexes to speedup searches in the mtokens
+
+                    function handleMatch(match, loopNdx, quantifierRecurse) {
+                        if (testPos == pos && match.matches == undefined) {
+                            matches.push({ "match": match, "locator": loopNdx.reverse() });
+                            return true;
+                        } else if (match.matches != undefined) {
+                            if (match.isGroup && quantifierRecurse !== true) { //when a group pass along to the quantifier
+                                match = handleMatch(maskToken.matches[tndx + 1], loopNdx);
+                                if (match) return true;
+                            } else if (match.isOptional) {
+                                var optionalToken = match;
+                                match = ResolveTestFromToken(match, ndxInitializer, loopNdx, quantifierRecurse);
+                                if (match) {
+                                    var latestMatch = matches[matches.length - 1]["match"];
+                                    var isFirstMatch = $.inArray(latestMatch, optionalToken.matches) == 0;
+                                    if (isFirstMatch) {
+                                        insertStop = true; //insert a stop for non greedy
+                                    }
+                                    testPos = pos; //match the position after the group
+                                }
+                            } else if (match.isAlternator) {
+                                //TODO
+                            } else if (match.isQuantifier && quantifierRecurse !== true) {
+                                var qt = match;
+                                opts.greedy = opts.greedy && isFinite(qt.quantifier.max); //greedy must be off when * or + is used (always!!)
+                                for (var qndx = (ndxInitializer.length > 0 && quantifierRecurse !== true) ? ndxInitializer.shift() : 0; (qndx < (isNaN(qt.quantifier.max) ? qndx + 1 : qt.quantifier.max)) && testPos <= pos; qndx++) {
+                                    var tokenGroup = maskToken.matches[$.inArray(qt, maskToken.matches) - 1];
+                                    match = handleMatch(tokenGroup, [qndx].concat(loopNdx), true);
+                                    if (match) {
+                                        //get latest match
+                                        var latestMatch = matches[matches.length - 1]["match"];
+                                        latestMatch.optionalQuantifier = qndx > qt.quantifier.min - 1;
+                                        var isFirstMatch = $.inArray(latestMatch, tokenGroup.matches) == 0;
+
+                                        if (isFirstMatch) { //search for next possible match
+                                            if (qndx > qt.quantifier.min - 1) {
+                                                insertStop = true;
+                                                testPos = pos; //match the position after the group
+                                                break; //stop quantifierloop
+                                            } else return true;
+                                        } else {
+                                            return true;
+                                        }
+                                    }
+                                }
+                            } else {
+                                match = ResolveTestFromToken(match, ndxInitializer, loopNdx, quantifierRecurse);
+                                if (match)
+                                    return true;
+                            }
+                        } else testPos++;
+                    }
+
+                    for (var tndx = (ndxInitializer.length > 0 ? ndxInitializer.shift() : 0) ; tndx < maskToken.matches.length; tndx++) {
+                        if (maskToken.matches[tndx]["isQuantifier"] !== true) {
+                            var match = handleMatch(maskToken.matches[tndx], [tndx].concat(loopNdx), quantifierRecurse);
+                            if (match && testPos == pos) {
+                                return match;
+                            } else if (testPos > pos) {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                //if (disableCache !== true && getMaskSet()['tests'][pos] && !getMaskSet()['validPositions'][pos]) {
+                //    return getMaskSet()['tests'][pos];
+                //}
+                if (ndxIntlzr == undefined) {
+                    var previousPos = pos - 1, test;
+                    while ((test = getMaskSet()['validPositions'][previousPos]) == undefined && previousPos > -1) {
+                        previousPos--;
+                    }
+                    if (test != undefined && previousPos > -1) {
+                        testPos = previousPos;
+                        ndxInitializer = test["locator"].slice();
+                    } else {
+                        previousPos = pos - 1;
+                        while ((test = getMaskSet()['tests'][previousPos]) == undefined && previousPos > -1) {
+                            previousPos--;
+                        }
+                        if (test != undefined && previousPos > -1) {
+                            testPos = previousPos;
+                            ndxInitializer = test[0]["locator"].slice();
+                        }
+                    }
+                }
+                for (var mtndx = ndxInitializer.shift() ; mtndx < maskTokens.length; mtndx++) {
+                    var match = ResolveTestFromToken(maskTokens[mtndx], ndxInitializer, [mtndx]);
+                    if ((match && testPos == pos) || testPos > pos) {
+                        break;
+                    }
+                }
+                if (matches.length == 0 || insertStop)
+                    matches.push({ "match": { fn: null, cardinality: 0, optionality: true, casing: null, def: "" }, "locator": [] });
+
+                getMaskSet()['tests'][pos] = matches;
+                //console.log(pos + " - " + JSON.stringify(matches));
+                return matches;
+            }
+
+            function getBufferTemplate() {
+                if (getMaskSet()['_buffer'] == undefined) {
+                    //generate template
+                    getMaskSet()["_buffer"] = getMaskTemplate(false, 1);
+                }
+                return getMaskSet()['_buffer'];
+            }
+
+            function getBuffer() {
+                if (getMaskSet()['buffer'] == undefined) {
+                    getMaskSet()['buffer'] = getMaskTemplate(true, getLastValidPosition(), true);
+                }
+                return getMaskSet()['buffer'];
+            }
+
+            function refreshFromBuffer(start, end) {
+                var buffer = getBuffer().slice(); //work on clone
+                if (start === true) {
+                    resetMaskSet();
+                    start = 0;
+                    end = buffer.length;
+                } else {
+                    for (var i = start; i < end; i++) {
+                        delete getMaskSet()["validPositions"][i];
+                        delete getMaskSet()["tests"][i];
+                    }
+                }
+
+                for (var i = start; i < end; i++) {
+                    if (buffer[i] != opts.skipOptionalPartCharacter) {
+                        isValid(i, buffer[i], true, true);
+                    }
+                }
+            }
+
+            function casing(elem, test) {
+                switch (test.casing) {
+                    case "upper":
+                        elem = elem.toUpperCase();
+                        break;
+                    case "lower":
+                        elem = elem.toLowerCase();
+                        break;
+                }
+
+                return elem;
+            }
+
+            function isValid(pos, c, strict, fromSetValid) { //strict true ~ no correction or autofill
+                strict = strict === true; //always set a value to strict to prevent possible strange behavior in the extensions 
+
+                function _isValid(position, c, strict, fromSetValid) {
+                    var rslt = false;
+                    $.each(getTests(position), function (ndx, tst) {
+                        var test = tst["match"];
+                        var loopend = c ? 1 : 0, chrs = '', buffer = getBuffer();
+                        for (var i = test.cardinality; i > loopend; i--) {
+                            chrs += getBufferElement(position - (i - 1));
+                        }
+                        if (c) {
+                            chrs += c;
+                        }
+
+                        //return is false or a json object => { pos: ??, c: ??} or true
+                        rslt = test.fn != null ?
+                            test.fn.test(chrs, getMaskSet(), position, strict, opts)
+                            : (c == test["def"] || c == opts.skipOptionalPartCharacter) && test["def"] != "" ? //non mask
+                            { c: test["def"], pos: position }
+                            : false;
+
+                        if (rslt !== false) {
+                            var elem = rslt.c != undefined ? rslt.c : c;
+                            elem = (elem == opts.skipOptionalPartCharacter && test["fn"] === null) ? test["def"] : elem;
+
+                            var validatedPos = position;
+                            if (rslt["remove"] != undefined) { //remove position
+                                stripValidPositions(rslt["remove"], rslt["remove"] + 1);
+                            }
+
+                            if (rslt["refreshFromBuffer"]) {
+                                var refresh = rslt["refreshFromBuffer"];
+                                strict = true;
+                                refreshFromBuffer(refresh === true ? refresh : refresh["start"], refresh["end"]);
+                                if (rslt.pos == undefined && rslt.c == undefined) {
+                                    rslt.pos = getLastValidPosition();
+                                    return false;//breakout if refreshFromBuffer && nothing to insert
+                                }
+                                validatedPos = rslt.pos != undefined ? rslt.pos : position;
+                                if (validatedPos != position) {
+                                    rslt = $.extend(rslt, isValid(validatedPos, elem, true)); //revalidate new position strict
+                                    return false;
+                                }
+
+                            } else if (rslt !== true && rslt.pos != undefined && rslt["pos"] != position) { //their is a position offset
+                                validatedPos = rslt["pos"];
+                                refreshFromBuffer(position, validatedPos);
+                                if (validatedPos != position) {
+                                    rslt = $.extend(rslt, isValid(validatedPos, elem, true)); //revalidate new position strict
+                                    return false;
+                                }
+                            }
+
+                            if (rslt != true && rslt.pos == undefined && rslt.c == undefined) {
+                                return false; //breakout if nothing to insert
+                            }
+
+                            if (ndx > 0) {
+                                resetMaskSet(true);
+                            }
+
+                            if (!setValidPosition(validatedPos, $.extend({}, tst, { "input": casing(elem, test) }), fromSetValid))
+                                rslt = false;
+                            return false; //break from $.each
+                        }
+                    });
+
+                    return rslt;
+                }
+
+                //Check for a nonmask before the pos
+                var buffer = getBuffer();
+                for (var pndx = pos - 1; pndx > -1; pndx--) {
+                    if (getMaskSet()["validPositions"][pndx] && getMaskSet()["validPositions"][pndx].fn == null)
+                        break;
+                    else if ((!isMask(pndx) || buffer[pndx] != getPlaceholder(pndx)) && getTests(pndx).length > 1) {
+                        _isValid(pndx, buffer[pndx], true);
+                        break;
+                    }
+                }
+
+                var maskPos = pos;
+                if (maskPos >= getMaskLength()) return false;
+                var result = _isValid(maskPos, c, strict, fromSetValid);
+                if (!strict && result === false) {
+                    var currentPosValid = getMaskSet()["validPositions"][maskPos];
+                    if (currentPosValid && currentPosValid["match"].fn == null && (currentPosValid["match"].def == c || c == opts.skipOptionalPartCharacter)) {
+                        result = { "caret": seekNext(maskPos) };
+                    } else if ((opts.insertMode || getMaskSet()["validPositions"][seekNext(maskPos)] == undefined) && !isMask(maskPos)) { //does the input match on a further position?
+                        for (var nPos = maskPos + 1, snPos = seekNext(maskPos) ; nPos <= snPos; nPos++) {
+                            result = _isValid(nPos, c, strict, fromSetValid);
+                            if (result !== false) {
+                                maskPos = nPos;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if (result === true) result = { "pos": maskPos };
+                return result;
+            }
+
+            function isMask(pos) {
+                var test = getTest(pos);
+                return test.fn != null ? test.fn : false;
+            }
+
+            function getMaskLength() {
+                var maskLength;
+                maxLength = $el.prop('maxLength');
+                if (maxLength == -1) maxLength = undefined; /* FF sets no defined max length to -1 */
+                if (opts.greedy == false) {
+                    var pos, lvp = getLastValidPosition(), testPos = getMaskSet()["validPositions"][lvp],
+                        ndxIntlzr = testPos != undefined ? testPos["locator"].slice() : undefined;
+                    for (pos = lvp + 1; testPos == undefined || (testPos["match"]["fn"] != null || (testPos["match"]["fn"] == null && testPos["match"]["def"] != "")) ; pos++) {
+                        testPos = getTestTemplate(pos, ndxIntlzr, pos - 1);
+                        ndxIntlzr = testPos["locator"].slice();
+                    }
+                    maskLength = pos;
+                } else
+                    maskLength = getBuffer().length;
+
+                return (maxLength == undefined || maskLength < maxLength) ? maskLength : maxLength;
+            }
+
+            function seekNext(pos) {
+                var maskL = getMaskLength();
+                if (pos >= maskL) return maskL;
+                var position = pos;
+                while (++position < maskL && !isMask(position) && (opts.nojumps !== true || opts.nojumpsThreshold > position)) {
+                }
+                return position;
+            }
+
+            function seekPrevious(pos) {
+                var position = pos;
+                if (position <= 0) return 0;
+
+                while (--position > 0 && !isMask(position)) {
+                };
+                return position;
+            }
+
+            function getBufferElement(position) {
+                return getMaskSet()["validPositions"][position] == undefined ? getPlaceholder(position) : getMaskSet()["validPositions"][position]["input"];
+            }
+
+            function writeBuffer(input, buffer, caretPos) {
+                input._valueSet(buffer.join(''));
+                if (caretPos != undefined) {
+                    caret(input, caretPos);
+                }
+            }
+
+            function getPlaceholder(pos, test) {
+                test = test || getTest(pos);
+                return test["placeholder"] || (test["fn"] == null ? test["def"] : opts.placeholder.charAt(pos % opts.placeholder.length));
+            }
+
+            function checkVal(input, writeOut, strict, nptvl, intelliCheck) {
+                var inputValue = nptvl != undefined ? nptvl.slice() : truncateInput(input._valueGet()).split('');
+                resetMaskSet();
+                if (writeOut) input._valueSet(""); //initial clear
+                $.each(inputValue, function (ndx, charCode) {
+                    if (intelliCheck === true) {
+                        var p = getMaskSet()["p"],
+                            lvp = p == -1 ? p : seekPrevious(p),
+                            pos = lvp == -1 ? ndx : seekNext(lvp);
+                        if ($.inArray(charCode, getBufferTemplate().slice(lvp + 1, pos)) == -1) {
+                            keypressEvent.call(input, undefined, true, charCode.charCodeAt(0), false, strict, ndx);
+                        }
+                    } else {
+                        keypressEvent.call(input, undefined, true, charCode.charCodeAt(0), false, strict, ndx);
+                        strict = strict || (ndx > 0 && ndx > getMaskSet()["p"]);
+                    }
+                });
+                if (writeOut) {
+                    var keypressResult = opts.onKeyPress.call(this, undefined, getBuffer(), 0, opts);
+                    handleOnKeyResult(input, keypressResult);
+                    writeBuffer(input, getBuffer(), $(input).is(":focus") ? seekNext(getLastValidPosition(0)) : undefined);
+                }
+            }
+
+            function escapeRegex(str) {
+                return $.inputmask.escapeRegex.call(this, str);
+            }
+
+            function truncateInput(inputValue) {
+                return inputValue.replace(new RegExp("(" + escapeRegex(getBufferTemplate().join('')) + ")*$"), "");
+            }
+            function unmaskedvalue($input) {
+                if ($input.data('_inputmask') && !$input.hasClass('hasDatepicker')) {
+                    var umValue = [], vps = getMaskSet()["validPositions"];
+                    for (var pndx in vps) {
+                        if (vps[pndx]["match"] && vps[pndx]["match"].fn != null) {
+                            umValue.push(vps[pndx]["input"]);
+                        }
+                    }
+                    var unmaskedValue = (isRTL ? umValue.reverse() : umValue).join('');
+                    var bufferValue = (isRTL ? getBuffer().reverse() : getBuffer()).join('');
+                    if ($.isFunction(opts.onUnMask)) {
+                        unmaskedValue = opts.onUnMask.call($input, bufferValue, unmaskedValue, opts);
+                    }
+                    return unmaskedValue;
+                } else {
+                    return $input[0]._valueGet();
+                }
+            }
+            function TranslatePosition(pos) {
+                if (isRTL && typeof pos == 'number' && (!opts.greedy || opts.placeholder != "")) {
+                    var bffrLght = getBuffer().length;
+                    pos = bffrLght - pos;
+                }
+                return pos;
+            }
+            function caret(input, begin, end) {
+                var npt = input.jquery && input.length > 0 ? input[0] : input, range;
+                if (typeof begin == 'number') {
+                    begin = TranslatePosition(begin);
+                    end = TranslatePosition(end);
+                    end = (typeof end == 'number') ? end : begin;
+
+                    //store caret for multi scope
+                    var data = $(npt).data('_inputmask') || {};
+                    data["caret"] = { "begin": begin, "end": end };
+                    $(npt).data('_inputmask', data);
+
+                    if (!$(npt).is(":visible")) {
+                        return;
+                    }
+
+                    npt.scrollLeft = npt.scrollWidth;
+                    if (opts.insertMode == false && begin == end) end++; //set visualization for insert/overwrite mode
+                    if (npt.setSelectionRange) {
+                        npt.selectionStart = begin;
+                        npt.selectionEnd = end;
+
+                    } else if (npt.createTextRange) {
+                        range = npt.createTextRange();
+                        range.collapse(true);
+                        range.moveEnd('character', end);
+                        range.moveStart('character', begin);
+                        range.select();
+                    }
+                } else {
+                    var data = $(npt).data('_inputmask');
+                    if (!$(npt).is(":visible") && data && data["caret"] != undefined) {
+                        begin = data["caret"]["begin"];
+                        end = data["caret"]["end"];
+                    } else if (npt.setSelectionRange) {
+                        begin = npt.selectionStart;
+                        end = npt.selectionEnd;
+                    } else if (document.selection && document.selection.createRange) {
+                        range = document.selection.createRange();
+                        begin = 0 - range.duplicate().moveStart('character', -100000);
+                        end = begin + range.text.length;
+                    }
+                    begin = TranslatePosition(begin);
+                    end = TranslatePosition(end);
+                    return { "begin": begin, "end": end };
+                }
+            }
+            function determineLastRequiredPosition(returnDefinition) {
+                var buffer = getBuffer(), bl = buffer.length,
+                   pos, lvp = getLastValidPosition(), positions = {},
+                   ndxIntlzr = getMaskSet()["validPositions"][lvp] != undefined ? getMaskSet()["validPositions"][lvp]["locator"].slice() : undefined, testPos;
+                for (pos = lvp + 1; pos < buffer.length; pos++) {
+                    testPos = getTestTemplate(pos, ndxIntlzr, pos - 1);
+                    ndxIntlzr = testPos["locator"].slice();
+                    positions[pos] = $.extend(true, {}, testPos);
+                }
+
+                for (pos = bl - 1; pos > lvp; pos--) {
+                    testPos = positions[pos]["match"];
+                    if ((testPos.optionality || testPos.optionalQuantifier) && buffer[pos] == getPlaceholder(pos, testPos)) {
+                        bl--;
+                    } else break;
+                }
+                return returnDefinition ? { "l": bl, "def": positions[bl] ? positions[bl]["match"] : undefined } : bl;
+            }
+            function clearOptionalTail(input) {
+                var buffer = getBuffer(), tmpBuffer = buffer.slice();
+                var rl = determineLastRequiredPosition();
+                tmpBuffer.length = rl;
+                writeBuffer(input, tmpBuffer);
+            }
+            function isComplete(buffer) { //return true / false / undefined (repeat *)
+                if ($.isFunction(opts.isComplete)) return opts.isComplete.call($el, buffer, opts);
+                if (opts.repeat == "*") return undefined;
+                var complete = false, lrp = determineLastRequiredPosition(true), aml = seekPrevious(lrp["l"]), lvp = getLastValidPosition();
+
+                if (lvp == aml) {
+                    if (lrp["def"] == undefined || lrp["def"].newBlockMarker || lrp["def"].optionalQuantifier) {
+                        complete = true;
+                        for (var i = 0; i <= aml; i++) {
+                            var mask = isMask(i);
+                            if ((mask && (buffer[i] == undefined || buffer[i] == getPlaceholder(i))) || (!mask && buffer[i] != getPlaceholder(i))) {
+                                complete = false;
+                                break;
+                            }
+                        }
+                    }
+                }
+                return complete;
+            }
+
+            function isSelection(begin, end) {
+                return isRTL ? (begin - end) > 1 || ((begin - end) == 1 && opts.insertMode) :
+                (end - begin) > 1 || ((end - begin) == 1 && opts.insertMode);
+            }
+
+            function installEventRuler(npt) {
+                var events = $._data(npt).events;
+
+                $.each(events, function (eventType, eventHandlers) {
+                    $.each(eventHandlers, function (ndx, eventHandler) {
+                        if (eventHandler.namespace == "inputmask") {
+                            if (eventHandler.type != "setvalue") {
+                                var handler = eventHandler.handler;
+                                eventHandler.handler = function (e) {
+                                    if (this.readOnly || this.disabled)
+                                        e.preventDefault;
+                                    else
+                                        return handler.apply(this, arguments);
+                                };
+                            }
+                        }
+                    });
+                });
+            }
+
+            function patchValueProperty(npt) {
+
+                function PatchValhook(type) {
+                    if ($.valHooks[type] == undefined || $.valHooks[type].inputmaskpatch != true) {
+                        var valueGet = $.valHooks[type] && $.valHooks[type].get ? $.valHooks[type].get : function (elem) { return elem.value; };
+                        var valueSet = $.valHooks[type] && $.valHooks[type].set ? $.valHooks[type].set : function (elem, value) {
+                            elem.value = value;
+                            return elem;
+                        };
+
+                        $.valHooks[type] = {
+                            get: function (elem) {
+                                var $elem = $(elem);
+                                if ($elem.data('_inputmask')) {
+                                    if ($elem.data('_inputmask')['opts'].autoUnmask)
+                                        return $elem.inputmask('unmaskedvalue');
+                                    else {
+                                        var result = valueGet(elem),
+                                            inputData = $elem.data('_inputmask'),
+                                            maskset = inputData['maskset'],
+                                            bufferTemplate = maskset['_buffer'];
+                                        bufferTemplate = bufferTemplate ? bufferTemplate.join('') : '';
+                                        return result != bufferTemplate ? result : '';
+                                    }
+                                } else return valueGet(elem);
+                            },
+                            set: function (elem, value) {
+                                var $elem = $(elem), inputData = $elem.data('_inputmask'), result;
+                                if (inputData) {
+                                    result = valueSet(elem, $.isFunction(inputData['opts'].onBeforeMask) ? inputData['opts'].onBeforeMask.call(el, value, inputData['opts']) : value);
+                                    $elem.triggerHandler('setvalue.inputmask');
+                                } else {
+                                    result = valueSet(elem, value);
+                                }
+                                return result;
+                            },
+                            inputmaskpatch: true
+                        };
+                    }
+                }
+
+                var valueProperty;
+                if (Object.getOwnPropertyDescriptor)
+                    valueProperty = Object.getOwnPropertyDescriptor(npt, "value");
+                if (valueProperty && valueProperty.get) {
+                    if (!npt._valueGet) {
+                        var valueGet = valueProperty.get;
+                        var valueSet = valueProperty.set;
+                        npt._valueGet = function () {
+                            return isRTL ? valueGet.call(this).split('').reverse().join('') : valueGet.call(this);
+                        };
+                        npt._valueSet = function (value) {
+                            valueSet.call(this, isRTL ? value.split('').reverse().join('') : value);
+                        };
+
+                        Object.defineProperty(npt, "value", {
+                            get: function () {
+                                var $self = $(this), inputData = $(this).data('_inputmask');
+                                if (inputData) {
+                                    return inputData['opts'].autoUnmask ? $self.inputmask('unmaskedvalue') : (valueGet.call(this) != getBufferTemplate().join('') ? valueGet.call(this) : '');
+                                } else return valueGet.call(this);
+                            },
+                            set: function (value) {
+                                var inputData = $(this).data('_inputmask');
+                                if (inputData) {
+                                    valueSet.call(this, $.isFunction(inputData['opts'].onBeforeMask) ? inputData['opts'].onBeforeMask.call(el, value, inputData['opts']) : value);
+                                    $(this).triggerHandler('setvalue.inputmask');
+                                } else {
+                                    valueSet.call(this, value);
+                                }
+                            }
+                        });
+                    }
+                } else if (document.__lookupGetter__ && npt.__lookupGetter__("value")) {
+                    if (!npt._valueGet) {
+                        var valueGet = npt.__lookupGetter__("value");
+                        var valueSet = npt.__lookupSetter__("value");
+                        npt._valueGet = function () {
+                            return isRTL ? valueGet.call(this).split('').reverse().join('') : valueGet.call(this);
+                        };
+                        npt._valueSet = function (value) {
+                            valueSet.call(this, isRTL ? value.split('').reverse().join('') : value);
+                        };
+
+                        npt.__defineGetter__("value", function () {
+                            var $self = $(this), inputData = $(this).data('_inputmask');
+                            if (inputData) {
+                                return inputData['opts'].autoUnmask ? $self.inputmask('unmaskedvalue') : (valueGet.call(this) != getBufferTemplate().join('') ? valueGet.call(this) : '');
+                            } else return valueGet.call(this);
+                        });
+                        npt.__defineSetter__("value", function (value) {
+                            var inputData = $(this).data('_inputmask');
+                            if (inputData) {
+                                valueSet.call(this, $.isFunction(inputData['opts'].onBeforeMask) ? inputData['opts'].onBeforeMask.call(el, value, inputData['opts']) : value);
+                                $(this).triggerHandler('setvalue.inputmask');
+                            } else {
+                                valueSet.call(this, value);
+                            }
+                        });
+                    }
+                } else {
+                    if (!npt._valueGet) {
+                        npt._valueGet = function () { return isRTL ? this.value.split('').reverse().join('') : this.value; };
+                        npt._valueSet = function (value) { this.value = isRTL ? value.split('').reverse().join('') : value; };
+                    }
+                    PatchValhook(npt.type);
+                }
+            }
+
+            function handleRemove(input, k, pos) {
+                if (opts.numericInput || isRTL) {
+                    if (k == opts.keyCode.BACKSPACE)
+                        k = opts.keyCode.DELETE;
+                    else if (k == opts.keyCode.DELETE)
+                        k = opts.keyCode.BACKSPACE;
+
+                    if (isRTL) {
+                        var pend = pos.end;
+                        pos.end = pos.begin;
+                        pos.begin = pend;
+                    }
+                }
+
+                if (k == opts.keyCode.BACKSPACE && pos.end - pos.begin <= 1)
+                    pos.begin = seekPrevious(pos.begin);
+                else if (k == opts.keyCode.DELETE && pos.begin == pos.end)
+                    pos.end++;
+
+                stripValidPositions(pos.begin, pos.end);
+                var firstMaskedPos = getLastValidPosition(pos.begin);
+                if (firstMaskedPos < pos.begin) {
+                    getMaskSet()["p"] = seekNext(firstMaskedPos);
+                } else {
+                    getMaskSet()["p"] = pos.begin;
+                }
+            }
+
+            function handleOnKeyResult(input, keyResult, caretPos) {
+                if (keyResult && keyResult["refreshFromBuffer"]) {
+                    var refresh = keyResult["refreshFromBuffer"];
+                    refreshFromBuffer(refresh === true ? refresh : refresh["start"], refresh["end"]);
+
+                    resetMaskSet(true);
+                    if (caretPos != undefined) {
+                        writeBuffer(input, getBuffer());
+                        caret(input, keyResult.caret || caretPos.begin, keyResult.caret || caretPos.end);
+                    }
+                }
+            }
+
+            function keydownEvent(e) {
+                //Safari 5.1.x - modal dialog fires keypress twice workaround
+                skipKeyPressEvent = false;
+                var input = this, $input = $(input), k = e.keyCode, pos = caret(input);
+
+                //backspace, delete, and escape get special treatment
+                if (k == opts.keyCode.BACKSPACE || k == opts.keyCode.DELETE || (iphone && k == 127) || e.ctrlKey && k == 88) { //backspace/delete
+                    e.preventDefault(); //stop default action but allow propagation
+                    if (k == 88) valueOnFocus = getBuffer().join('');
+                    handleRemove(input, k, pos);
+                    writeBuffer(input, getBuffer(), getMaskSet()["p"]);
+                    if (input._valueGet() == getBufferTemplate().join(''))
+                        $input.trigger('cleared');
+
+                    if (opts.showTooltip) { //update tooltip
+                        $input.prop("title", getMaskSet()["mask"]);
+                    }
+                } else if (k == opts.keyCode.END || k == opts.keyCode.PAGE_DOWN) { //when END or PAGE_DOWN pressed set position at lastmatch
+                    setTimeout(function () {
+                        var caretPos = seekNext(getLastValidPosition());
+                        if (!opts.insertMode && caretPos == getMaskLength() && !e.shiftKey) caretPos--;
+                        caret(input, e.shiftKey ? pos.begin : caretPos, caretPos);
+                    }, 0);
+                } else if ((k == opts.keyCode.HOME && !e.shiftKey) || k == opts.keyCode.PAGE_UP) { //Home or page_up
+                    caret(input, 0, e.shiftKey ? pos.begin : 0);
+                } else if (k == opts.keyCode.ESCAPE || (k == 90 && e.ctrlKey)) { //escape && undo
+                    checkVal(input, true, false, valueOnFocus.split(''));
+                    $input.click();
+                } else if (k == opts.keyCode.INSERT && !(e.shiftKey || e.ctrlKey)) { //insert
+                    opts.insertMode = !opts.insertMode;
+                    caret(input, !opts.insertMode && pos.begin == getMaskLength() ? pos.begin - 1 : pos.begin);
+                } else if (opts.insertMode == false && !e.shiftKey) {
+                    if (k == opts.keyCode.RIGHT) {
+                        setTimeout(function () {
+                            var caretPos = caret(input);
+                            caret(input, caretPos.begin);
+                        }, 0);
+                    } else if (k == opts.keyCode.LEFT) {
+                        setTimeout(function () {
+                            var caretPos = caret(input);
+                            caret(input, isRTL ? caretPos.begin + 1 : caretPos.begin - 1);
+                        }, 0);
+                    }
+                }
+
+                var currentCaretPos = caret(input);
+                var keydownResult = opts.onKeyDown.call(this, e, getBuffer(), currentCaretPos.begin, opts);
+                handleOnKeyResult(input, keydownResult, currentCaretPos);
+                ignorable = $.inArray(k, opts.ignorables) != -1;
+            }
+
+            function keypressEvent(e, checkval, k, writeOut, strict, ndx) {
+                //Safari 5.1.x - modal dialog fires keypress twice workaround
+                if (k == undefined && skipKeyPressEvent) return false;
+                skipKeyPressEvent = true;
+
+                var input = this, $input = $(input);
+
+                e = e || window.event;
+                var k = checkval ? k : (e.which || e.charCode || e.keyCode);
+
+                if (checkval !== true && (!(e.ctrlKey && e.altKey) && (e.ctrlKey || e.metaKey || ignorable))) {
+                    return true;
+                } else {
+                    if (k) {
+                        //special treat the decimal separator
+                        if (checkval !== true && k == 46 && e.shiftKey == false && opts.radixPoint == ",") k = 44;
+
+                        var pos, forwardPosition, c = String.fromCharCode(k);
+                        if (checkval) {
+                            var pcaret = strict ? ndx : getLastValidPosition() + 1;
+                            pos = { begin: pcaret, end: pcaret };
+                        } else {
+                            pos = caret(input);
+                        }
+
+                        //should we clear a possible selection??
+                        var isSlctn = isSelection(pos.begin, pos.end);
+                        if (isSlctn) {
+                            getMaskSet()["undoPositions"] = $.extend(true, {}, getMaskSet()["validPositions"]); //init undobuffer for recovery when not valid
+                            handleRemove(input, opts.keyCode.DELETE, pos);
+                            if (!opts.insertMode) { //preserve some space
+                                opts.insertMode = !opts.insertMode;
+                                setValidPosition(pos.begin, strict);
+                                opts.insertMode = !opts.insertMode;
+                            }
+                            isSlctn = !opts.multi;
+                        }
+
+                        getMaskSet()["writeOutBuffer"] = true;
+                        var p = isRTL && !isSlctn ? pos.end : pos.begin;
+                        var valResult = isValid(p, c, strict);
+                        if (valResult !== false) {
+                            if (valResult !== true) {
+                                p = valResult.pos != undefined ? valResult.pos : p; //set new position from isValid
+                                c = valResult.c != undefined ? valResult.c : c; //set new char from isValid
+                            }
+                            resetMaskSet(true);
+                            if (valResult.caret != undefined)
+                                forwardPosition = valResult.caret;
+                            else {
+                                var vps = getMaskSet()["validPositions"];
+                                if (vps[p + 1] != undefined && getTests(p + 1, vps[p].locator.slice(), p).length > 1)
+                                    forwardPosition = p + 1;
+                                else
+                                    forwardPosition = seekNext(p);
+                            }
+                            getMaskSet()["p"] = forwardPosition; //needed for checkval
+                        }
+
+                        if (writeOut !== false) {
+                            var self = this;
+                            setTimeout(function () { opts.onKeyValidation.call(self, valResult, opts); }, 0);
+                            if (getMaskSet()["writeOutBuffer"] && valResult !== false) {
+                                var buffer = getBuffer();
+                                writeBuffer(input, buffer, checkval ? undefined : opts.numericInput ? seekPrevious(forwardPosition) : forwardPosition);
+                                if (checkval !== true) {
+                                    setTimeout(function () { //timeout needed for IE
+                                        if (isComplete(buffer) === true)
+                                            $input.trigger("complete");
+                                        skipInputEvent = true;
+                                        $input.trigger("input");
+                                    }, 0);
+                                }
+                            } else if (isSlctn) {
+                                getMaskSet()["buffer"] = undefined;
+                                getMaskSet()["validPositions"] = getMaskSet()["undoPositions"];
+                            }
+                        } else if (isSlctn) {
+                            getMaskSet()["buffer"] = undefined;
+                            getMaskSet()["validPositions"] = getMaskSet()["undoPositions"];
+                        }
+
+
+                        if (opts.showTooltip) { //update tooltip
+                            $input.prop("title", getMaskSet()["mask"]);
+                        }
+
+                        //needed for IE8 and below
+                        if (e && checkval != true) {
+                            e.preventDefault ? e.preventDefault() : e.returnValue = false;
+
+                            var currentCaretPos = caret(input);
+                            var keypressResult = opts.onKeyPress.call(this, e, getBuffer(), currentCaretPos.begin, opts);
+                            handleOnKeyResult(input, keypressResult, currentCaretPos);
+                        }
+                        var temp;
+                        for (var i in getMaskSet().validPositions) {
+                            temp += " " + i;
+                        }
+                    }
+                }
+            }
+            function keyupEvent(e) {
+                var $input = $(this), input = this, k = e.keyCode, buffer = getBuffer();
+
+                var currentCaretPos = caret(input);
+                var keyupResult = opts.onKeyUp.call(this, e, buffer, currentCaretPos.begin, opts);
+                handleOnKeyResult(input, keyupResult, currentCaretPos);
+                if (k == opts.keyCode.TAB && opts.showMaskOnFocus) {
+                    if ($input.hasClass('focus-inputmask') && input._valueGet().length == 0) {
+                        resetMaskSet();
+                        buffer = getBuffer();
+                        writeBuffer(input, buffer);
+                        caret(input, 0);
+                        valueOnFocus = getBuffer().join('');
+                    } else {
+                        writeBuffer(input, buffer);
+                        caret(input, TranslatePosition(0), TranslatePosition(getMaskLength()));
+                    }
+                }
+            }
+            function pasteEvent(e) {
+                if (skipInputEvent === true && e.type == "input") {
+                    skipInputEvent = false;
+                    return true;
+                }
+
+                var input = this, $input = $(input), inputValue = input._valueGet();
+                //paste event for IE8 and lower I guess ;-)
+                if (e.type == "propertychange" && input._valueGet().length <= getMaskLength()) {
+                    return true;
+                } else if (e.type == "paste") {
+                    if (window.clipboardData && window.clipboardData.getData) { // IE
+                        inputValue = window.clipboardData.getData('Text');
+                    } else if (e.originalEvent && e.originalEvent.clipboardData && e.originalEvent.clipboardData.getData) {
+                        inputValue = e.originalEvent.clipboardData.getData('text/plain');
+                    }
+                }
+
+                var pasteValue = $.isFunction(opts.onBeforePaste) ? opts.onBeforePaste.call(input, inputValue, opts) : inputValue;
+                checkVal(input, true, false, pasteValue.split(''), true);
+                $input.click();
+                if (isComplete(getBuffer()) === true)
+                    $input.trigger("complete");
+
+                return false;
+            }
+            function mobileInputEvent(e) {
+                if (skipInputEvent === true && e.type == "input") {
+                    skipInputEvent = false;
+                    return true;
+                }
+                var input = this;
+
+                //backspace in chrome32 only fires input event - detect & treat
+                var caretPos = caret(input),
+                    currentValue = input._valueGet();
+
+                currentValue = currentValue.replace(new RegExp("(" + escapeRegex(getBufferTemplate().join('')) + ")*"), "");
+                //correct caretposition for chrome
+                if (caretPos.begin > currentValue.length) {
+                    caret(input, currentValue.length);
+                    caretPos = caret(input);
+                }
+                if ((getBuffer().length - currentValue.length) == 1 && currentValue.charAt(caretPos.begin) != getBuffer()[caretPos.begin]
+                    && currentValue.charAt(caretPos.begin + 1) != getBuffer()[caretPos.begin]
+                    && !isMask(caretPos.begin)) {
+                    e.keyCode = opts.keyCode.BACKSPACE;
+                    keydownEvent.call(input, e);
+                }
+                e.preventDefault();
+            }
+
+            function mask(el) {
+                $el = $(el);
+                if ($el.is(":input") && $el.attr("type") != "number") {
+                    //store tests & original buffer in the input element - used to get the unmasked value
+                    $el.data('_inputmask', {
+                        'maskset': maskset,
+                        'opts': opts,
+                        'isRTL': false
+                    });
+
+                    //show tooltip
+                    if (opts.showTooltip) {
+                        $el.prop("title", getMaskSet()["mask"]);
+                    }
+
+                    patchValueProperty(el);
+
+                    if (el.dir == "rtl" || opts.rightAlign)
+                        $el.css("text-align", "right");
+
+                    if (el.dir == "rtl" || opts.numericInput) {
+                        el.dir = "ltr";
+                        $el.removeAttr("dir");
+                        var inputData = $el.data('_inputmask');
+                        inputData['isRTL'] = true;
+                        $el.data('_inputmask', inputData);
+                        isRTL = true;
+                    }
+
+                    //unbind all events - to make sure that no other mask will interfere when re-masking
+                    $el.unbind(".inputmask");
+                    $el.removeClass('focus-inputmask');
+                    //bind events
+                    $el.closest('form').bind("submit", function () { //trigger change on submit if any
+                        if (valueOnFocus != getBuffer().join('')) {
+                            $el.change();
+                        }
+                        if (opts.autoUnmask && opts.removeMaskOnSubmit) {
+                            $el.inputmask("remove");
+                        }
+                    }).bind('reset', function () {
+                        setTimeout(function () {
+                            $el.trigger("setvalue");
+                        }, 0);
+                    });
+                    $el.bind("mouseenter.inputmask", function () {
+                        var $input = $(this), input = this;
+                        if (!$input.hasClass('focus-inputmask') && opts.showMaskOnHover) {
+                            if (input._valueGet() != getBuffer().join('')) {
+                                writeBuffer(input, getBuffer());
+                            }
+                        }
+                    }).bind("blur.inputmask", function () {
+                        var $input = $(this), input = this;
+                        if ($input.data('_inputmask')) {
+                            var nptValue = input._valueGet(), buffer = getBuffer();
+                            $input.removeClass('focus-inputmask');
+                            if (valueOnFocus != getBuffer().join('')) {
+                                $input.change();
+                            }
+                            if (opts.clearMaskOnLostFocus && nptValue != '') {
+                                if (nptValue == getBufferTemplate().join(''))
+                                    input._valueSet('');
+                                else { //clearout optional tail of the mask
+                                    clearOptionalTail(input);
+                                }
+                            }
+                            if (isComplete(buffer) === false) {
+                                $input.trigger("incomplete");
+                                if (opts.clearIncomplete) {
+                                    resetMaskSet();
+                                    if (opts.clearMaskOnLostFocus)
+                                        input._valueSet('');
+                                    else {
+                                        buffer = getBufferTemplate().slice();
+                                        writeBuffer(input, buffer);
+                                    }
+                                }
+                            }
+                        }
+                    }).bind("focus.inputmask", function () {
+                        var $input = $(this), input = this, nptValue = input._valueGet();
+                        if (opts.showMaskOnFocus && !$input.hasClass('focus-inputmask') && (!opts.showMaskOnHover || (opts.showMaskOnHover && nptValue == ''))) {
+                            if (input._valueGet() != getBuffer().join('')) {
+                                writeBuffer(input, getBuffer(), seekNext(getLastValidPosition()));
+                            }
+                        }
+                        $input.addClass('focus-inputmask');
+                        valueOnFocus = getBuffer().join('');
+                    }).bind("mouseleave.inputmask", function () {
+                        var $input = $(this), input = this;
+                        if (opts.clearMaskOnLostFocus) {
+                            if (!$input.hasClass('focus-inputmask') && input._valueGet() != $input.attr("placeholder")) {
+                                if (input._valueGet() == getBufferTemplate().join('') || input._valueGet() == '')
+                                    input._valueSet('');
+                                else { //clearout optional tail of the mask
+                                    clearOptionalTail(input);
+                                }
+                            }
+                        }
+                    }).bind("click.inputmask", function () {
+                        var input = this;
+                        if ($(input).is(":focus")) {
+                            setTimeout(function () {
+                                var selectedCaret = caret(input);
+                                if (selectedCaret.begin == selectedCaret.end) {
+                                    var clickPosition = isRTL ? TranslatePosition(selectedCaret.begin) : selectedCaret.begin,
+                                        lvp = getLastValidPosition(clickPosition),
+                                        lastPosition = seekNext(lvp);
+                                    if (clickPosition < lastPosition) {
+                                        if (isMask(clickPosition))
+                                            caret(input, clickPosition);
+                                        else caret(input, seekNext(clickPosition));
+                                    } else
+                                        caret(input, lastPosition);
+                                }
+                            }, 0);
+                        }
+                    }).bind('dblclick.inputmask', function () {
+                        var input = this;
+                        setTimeout(function () {
+                            caret(input, 0, seekNext(getLastValidPosition()));
+                        }, 0);
+                    }).bind(PasteEventType + ".inputmask dragdrop.inputmask drop.inputmask", pasteEvent
+                    ).bind('setvalue.inputmask', function () {
+                        var input = this;
+                        checkVal(input, true);
+                        valueOnFocus = getBuffer().join('');
+                        if (input._valueGet() == getBufferTemplate().join(''))
+                            input._valueSet('');
+                    }).bind('complete.inputmask', opts.oncomplete
+                    ).bind('incomplete.inputmask', opts.onincomplete
+                    ).bind('cleared.inputmask', opts.oncleared);
+
+                    $el.bind("keydown.inputmask", keydownEvent
+                    ).bind("keypress.inputmask", keypressEvent
+                    ).bind("keyup.inputmask", keyupEvent);
+
+                    if (android || androidfirefox || androidchrome || kindle) {
+                        if (PasteEventType == "input") {
+                            $el.unbind(PasteEventType + ".inputmask");
+                        }
+                        $el.bind("input.inputmask", mobileInputEvent);
+                    }
+
+                    if (msie1x)
+                        $el.bind("input.inputmask", pasteEvent);
+
+                    //apply mask
+                    var initialValue = $.isFunction(opts.onBeforeMask) ? opts.onBeforeMask.call(el, el._valueGet(), opts) : el._valueGet();
+                    checkVal(el, true, false, initialValue.split(''), true);
+                    valueOnFocus = getBuffer().join('');
+                    // Wrap document.activeElement in a try/catch block since IE9 throw "Unspecified error" if document.activeElement is undefined when we are in an IFrame.
+                    var activeElement;
+                    try {
+                        activeElement = document.activeElement;
+                    } catch (e) {
+                    }
+                    if (activeElement === el) { //position the caret when in focus
+                        $el.addClass('focus-inputmask');
+                        caret(el, seekNext(getLastValidPosition()));
+                    } else {
+                        if (isComplete(getBuffer()) === false) {
+                            if (opts.clearIncomplete)
+                                resetMaskSet();
+                        }
+                        if (opts.clearMaskOnLostFocus) {
+                            if (getBuffer().join('') == getBufferTemplate().join('')) {
+                                el._valueSet('');
+                            } else {
+                                clearOptionalTail(el);
+                            }
+                        } else {
+                            writeBuffer(el, getBuffer());
+                        }
+                    }
+
+                    installEventRuler(el);
+                }
+            }
+
+            //action object
+            if (actionObj != undefined) {
+                switch (actionObj["action"]) {
+                    case "isComplete":
+                        $el = $(actionObj["el"]);
+                        maskset = $el.data('_inputmask')['maskset'];
+                        opts = $el.data('_inputmask')['opts'];
+                        return isComplete(actionObj["buffer"]);
+                    case "unmaskedvalue":
+                        $el = actionObj["$input"];
+                        maskset = $el.data('_inputmask')['maskset'];
+                        opts = $el.data('_inputmask')['opts'];
+                        isRTL = actionObj["$input"].data('_inputmask')['isRTL'];
+                        return unmaskedvalue(actionObj["$input"]);
+                    case "mask":
+                        valueOnFocus = getBuffer().join('');
+                        mask(actionObj["el"]);
+                        break;
+                    case "format":
+                        $el = $({});
+                        $el.data('_inputmask', {
+                            'maskset': maskset,
+                            'opts': opts,
+                            'isRTL': opts.numericInput
+                        });
+                        if (opts.numericInput) {
+                            isRTL = true;
+                        }
+                        var valueBuffer = actionObj["value"].split('');
+                        checkVal($el, false, false, isRTL ? valueBuffer.reverse() : valueBuffer, true);
+                        return isRTL ? getBuffer().reverse().join('') : getBuffer().join('');
+                    case "isValid":
+                        $el = $({});
+                        $el.data('_inputmask', {
+                            'maskset': maskset,
+                            'opts': opts,
+                            'isRTL': opts.numericInput
+                        });
+                        if (opts.numericInput) {
+                            isRTL = true;
+                        }
+                        var valueBuffer = actionObj["value"].split('');
+                        checkVal($el, false, true, isRTL ? valueBuffer.reverse() : valueBuffer);
+                        var buffer = getBuffer();
+                        var rl = determineLastRequiredPosition();
+                        buffer.length = rl;
+
+                        return isComplete(buffer) && actionObj["value"] == buffer.join('');
+                    case "getemptymask":
+                        $el = $(actionObj["el"]);
+                        maskset = $el.data('_inputmask')['maskset'];
+                        opts = $el.data('_inputmask')['opts'];
+                        return getBufferTemplate();
+                    case "remove":
+                        var el = actionObj["el"];
+                        $el = $(el);
+                        maskset = $el.data('_inputmask')['maskset'];
+                        opts = $el.data('_inputmask')['opts'];
+                        //writeout the unmaskedvalue
+                        el._valueSet(unmaskedvalue($el));
+                        //unbind all events
+                        $el.unbind(".inputmask");
+                        $el.removeClass('focus-inputmask');
+                        //clear data
+                        $el.removeData('_inputmask');
+                        //restore the value property
+                        var valueProperty;
+                        if (Object.getOwnPropertyDescriptor)
+                            valueProperty = Object.getOwnPropertyDescriptor(el, "value");
+                        if (valueProperty && valueProperty.get) {
+                            if (el._valueGet) {
+                                Object.defineProperty(el, "value", {
+                                    get: el._valueGet,
+                                    set: el._valueSet
+                                });
+                            }
+                        } else if (document.__lookupGetter__ && el.__lookupGetter__("value")) {
+                            if (el._valueGet) {
+                                el.__defineGetter__("value", el._valueGet);
+                                el.__defineSetter__("value", el._valueSet);
+                            }
+                        }
+                        try { //try catch needed for IE7 as it does not supports deleting fns
+                            delete el._valueGet;
+                            delete el._valueSet;
+                        } catch (e) {
+                            el._valueGet = undefined;
+                            el._valueSet = undefined;
+
+                        }
+                        break;
+                }
+            }
+        };
+
         $.inputmask = {
             //options default
             defaults: {
                 placeholder: "_",
-                optionalmarker: {
-                    start: "[",
-                    end: "]"
-                },
+                optionalmarker: { start: "[", end: "]" },
+                quantifiermarker: { start: "{", end: "}" },
+                groupmarker: { start: "(", end: ")" },
+                alternatormarker: "|",
                 escapeChar: "\\",
                 mask: null,
-                oncomplete: null, //executes when the mask is complete
-                oncleared: null, //executes when the mask is cleared
-                repeat: 0, //repetitions of the mask
+                oncomplete: $.noop, //executes when the mask is complete
+                onincomplete: $.noop, //executes when the mask is incomplete and focus is lost
+                oncleared: $.noop, //executes when the mask is cleared
+                repeat: 0, //repetitions of the mask: * ~ forever, otherwise specify an integer
                 greedy: true, //true: allocated buffer for the mask and repetitions - false: allocate only if needed
-                patch_val: true, //override the jquery.val fn to detect changed in the inputmask by setting val(value)
-                autoUnmask: false, //in combination with patch_val: true => automatically unmask when retrieving the value with $.fn.val
-                numericInput: false, //numericInput input direction style (input shifts to the left while holding the caret position)
+                autoUnmask: false, //automatically unmask when retrieving the value with $.fn.val or value if the browser supports __lookupGetter__ or getOwnPropertyDescriptor
+                removeMaskOnSubmit: true, //remove the mask before submitting the form.  Use in combination with autoUnmask: true
                 clearMaskOnLostFocus: true,
                 insertMode: true, //insert the input or overwrite the input
                 clearIncomplete: false, //clear the incomplete input on blur
-                aliases: {}, //aliases definitions => see jquery.inputmask.extentions.js
+                aliases: {}, //aliases definitions => see jquery.inputmask.extensions.js
+                alias: null,
+                onKeyUp: $.noop, //callback to implement autocomplete on certain keys for example
+                onKeyPress: $.noop, //callback to implement autocomplete on certain keys for example
+                onKeyDown: $.noop, //callback to implement autocomplete on certain keys for example
+                onBeforeMask: undefined, //executes before masking the initial value to allow preprocessing of the initial value.  args => initialValue, opts => return processedValue
+                onBeforePaste: undefined, //executes before masking the pasted value to allow preprocessing of the pasted value.  args => pastedValue, opts => return processedValue
+                onUnMask: undefined, //executes after unmasking to allow postprocessing of the unmaskedvalue.  args => maskedValue, unmaskedValue, opts
+                showMaskOnFocus: true, //show the mask-placeholder when the input has focus
+                showMaskOnHover: true, //show the mask-placeholder when hovering the empty input
+                onKeyValidation: $.noop, //executes on every key-press with the result of isValid. Params: result, opts
+                skipOptionalPartCharacter: " ", //a character which can be used to skip an optional part of a mask
+                showTooltip: false, //show the activemask as tooltip
+                numericInput: false, //numericInput input direction style (input shifts to the left while holding the caret position)
+                rightAlign: false, //align to the right
+                //numeric basic properties
+                radixPoint: "", //".", // | ","
+                //numeric basic properties
+                nojumps: false, //do not jump over fixed parts in the mask
+                nojumpsThreshold: 0, //start nojumps as of
                 definitions: {
                     '9': {
-                        "validator": "[0-9]",
-                        "cardinality": 1,
-                        'prevalidator': null
+                        validator: "[0-9]",
+                        cardinality: 1,
+                        definitionSymbol: "*"
                     },
                     'a': {
-                        "validator": "[A-Za-z]",
-                        "cardinality": 1,
-                        "prevalidator": null
+                        validator: "[A-Za-z\u0410-\u044F\u0401\u0451]",
+                        cardinality: 1,
+                        definitionSymbol: "*"
                     },
                     '*': {
-                        "validator": "[A-Za-z0-9]",
-                        "cardinality": 1,
-                        "prevalidator": null
-                    },
-                    'd': { //day
-                        "validator": "0[1-9]|[12][0-9]|3[01]",
-                        "cardinality": 2,
-                        "prevalidator": [{ "validator": "[0-3]", "cardinality": 1}]
-                    },
-                    'm': { //month
-                        "validator": "0[1-9]|1[012]",
-                        "cardinality": 2,
-                        "prevalidator": [{ "validator": "[01]", "cardinality": 1}]
-                    },
-                    'y': { //year
-                        "validator": "(19|20)\\d\\d",
-                        "cardinality": 4,
-                        "prevalidator": [
-                        { "validator": "[12]", "cardinality": 1 },
-                        { "validator": "(19|20)", "cardinality": 2 },
-                        { "validator": "(19|20)\\d", "cardinality": 3 }
-                        ]
+                        validator: "[A-Za-z\u0410-\u044F\u0401\u04510-9]",
+                        cardinality: 1
                     }
                 },
-                keyCode: { ALT: 18, BACKSPACE: 8, CAPS_LOCK: 20, COMMA: 188, COMMAND: 91, COMMAND_LEFT: 91, COMMAND_RIGHT: 93, CONTROL: 17, DELETE: 46, DOWN: 40, END: 35, ENTER: 13, ESCAPE: 27, HOME: 36, INSERT: 45, LEFT: 37, MENU: 93, NUMPAD_ADD: 107, NUMPAD_DECIMAL: 110, NUMPAD_DIVIDE: 111, NUMPAD_ENTER: 108,
+                keyCode: {
+                    ALT: 18, BACKSPACE: 8, CAPS_LOCK: 20, COMMA: 188, COMMAND: 91, COMMAND_LEFT: 91, COMMAND_RIGHT: 93, CONTROL: 17, DELETE: 46, DOWN: 40, END: 35, ENTER: 13, ESCAPE: 27, HOME: 36, INSERT: 45, LEFT: 37, MENU: 93, NUMPAD_ADD: 107, NUMPAD_DECIMAL: 110, NUMPAD_DIVIDE: 111, NUMPAD_ENTER: 108,
                     NUMPAD_MULTIPLY: 106, NUMPAD_SUBTRACT: 109, PAGE_DOWN: 34, PAGE_UP: 33, PERIOD: 190, RIGHT: 39, SHIFT: 16, SPACE: 32, TAB: 9, UP: 38, WINDOWS: 91
-                }
+                },
+                //specify keycodes which should not be considered in the keypress event, otherwise the preventDefault will stop their default behavior especially in FF
+                ignorables: [8, 9, 13, 19, 27, 33, 34, 35, 36, 37, 38, 39, 40, 45, 46, 93, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123],
+                isComplete: undefined //override for isComplete - args => buffer, opts - return true || false
             },
-            val: $.fn.val //store the original jquery val function
+            masksCache: {},
+            escapeRegex: function (str) {
+                var specials = ['/', '.', '*', '+', '?', '|', '(', ')', '[', ']', '{', '}', '\\'];
+                return str.replace(new RegExp('(\\' + specials.join('|\\') + ')', 'gim'), '\\$1');
+            },
+            format: function (value, options) {
+                var opts = $.extend(true, {}, $.inputmask.defaults, options);
+                resolveAlias(opts.alias, options, opts);
+                return maskScope({ "action": "format", "value": value }, generateMaskSet(opts), opts);
+            },
+            isValid: function (value, options) {
+                var opts = $.extend(true, {}, $.inputmask.defaults, options);
+                resolveAlias(opts.alias, options, opts);
+                return maskScope({ "action": "isValid", "value": value }, generateMaskSet(opts), opts);
+            }
         };
 
-        $.fn.inputmask = function(fn, options) {
-            var opts = $.extend(true, {}, $.inputmask.defaults, options);
-            var pasteEventName = $.browser.msie ? 'paste.inputmask' : 'input.inputmask';
-            var iPhone = (window.orientation != undefined);
-
-            var _val = $.inputmask.val;
-            if (opts.patch_val && $.fn.val.inputmaskpatch != true) {
-                $.fn.val = function() {
-                    if (this.data('inputmask')) {
-                        if (this.data('inputmask')['autoUnmask'] && arguments.length == 0) {
-                            return this.inputmask('unmaskedvalue');
-                        }
-                        else {
-                            var result = _val.apply(this, arguments);
-                            if (arguments.length > 0) {
-                                this.triggerHandler('setvalue.inputmask');
-                            }
-                            return result;
-                        }
-                    }
-                    else {
-                        return _val.apply(this, arguments);
-                    }
-                };
-                $.extend($.fn.val, {
-                    inputmaskpatch: true
-                });
+        $.fn.inputmask = function (fn, options, targetScope, targetData, msk) {
+            targetScope = targetScope || maskScope;
+            targetData = targetData || "_inputmask";
+            function importAttributeOptions(npt, opts) {
+                var $npt = $(npt);
+                for (var option in opts) {
+                    var optionData = $npt.data("inputmask-" + option.toLowerCase());
+                    if (optionData != undefined)
+                        opts[option] = optionData;
+                }
+                return opts;
             }
+            var opts = $.extend(true, {}, $.inputmask.defaults, options),
+                maskset;
 
-            if (typeof fn == "string") {
+            if (typeof fn === "string") {
                 switch (fn) {
                     case "mask":
-                        //init buffer
-                        var _buffer = getMaskTemplate();
-                        var tests = getTestingChain();
+                        //resolve possible aliases given by options
+                        resolveAlias(opts.alias, options, opts);
+                        maskset = generateMaskSet(opts);
+                        if (maskset.length == 0) { return this; }
 
-                        return this.each(function() {
-                            mask(this);
+                        return this.each(function () {
+                            targetScope({ "action": "mask", "el": this }, $.extend(true, {}, $.isArray(maskset) && targetScope === maskScope ? maskset[0] : maskset), importAttributeOptions(this, opts));
                         });
-                        break;
                     case "unmaskedvalue":
-                        var tests = this.data('inputmask')['tests'];
-                        var _buffer = this.data('inputmask')['_buffer'];
-                        opts.greedy = this.data('inputmask')['greedy'];
-                        opts.repeat = this.data('inputmask')['repeat'];
-                        opts.definitions = this.data('inputmask')['definitions'];
-                        return unmaskedvalue(this);
-                        break;
-                    case "setvalue":
-                        setvalue(this, options); //options in this case the value
-                        break;
+                        var $input = $(this);
+                        if ($input.data(targetData)) {
+                            return targetScope({ "action": "unmaskedvalue", "$input": $input });
+                        } else return $input.val();
                     case "remove":
-                        var tests, _buffer;
-                        return this.each(function() {
-                            var input = $(this);
-                            if (input.data('inputmask')) {
-                                tests = input.data('inputmask')['tests'];
-                                _buffer = input.data('inputmask')['_buffer'];
-                                opts.greedy = input.data('inputmask')['greedy'];
-                                opts.repeat = input.data('inputmask')['repeat'];
-                                opts.definitions = input.data('inputmask')['definitions'];
-                                //writeout the unmaskedvalue
-                                _val.call(input, unmaskedvalue(input, true));
-                                //clear data
-                                input.removeData('inputmask');
-                                //unbind all events
-                                input.unbind(".inputmask");
-                                input.removeClass('focus.inputmask');
+                        return this.each(function () {
+                            var $input = $(this);
+                            if ($input.data(targetData)) {
+                                targetScope({ "action": "remove", "el": this });
                             }
                         });
-                        break;
+                    case "getemptymask": //return the default (empty) mask value, usefull for setting the default value in validation
+                        if (this.data(targetData)) {
+                            return targetScope({ "action": "getemptymask", "el": this });
+                        }
+                        else return "";
+                    case "hasMaskedValue": //check wheter the returned value is masked or not; currently only works reliable when using jquery.val fn to retrieve the value 
+                        return this.data(targetData) ? !this.data(targetData)['opts'].autoUnmask : false;
+                    case "isComplete":
+                        if (this.data(targetData)) {
+                            return targetScope({ "action": "isComplete", "buffer": this[0]._valueGet().split(''), "el": this });
+                        } else return true;
+                    case "getmetadata": //return mask metadata if exists
+                        if (this.data(targetData)) {
+                            maskset = this.data(targetData)['maskset'];
+                            return maskset['metadata'];
+                        }
+                        else return undefined;
+                    case "_detectScope":
+                        resolveAlias(opts.alias, options, opts);
+                        if (msk != undefined && !resolveAlias(msk, options, opts) && $.inArray(msk, ["mask", "unmaskedvalue", "remove", "getemptymask", "hasMaskedValue", "isComplete", "getmetadata", "_detectScope"]) == -1) {
+                            opts.mask = msk;
+                        }
+                        if ($.isFunction(opts.mask)) {
+                            opts.mask = opts.mask.call(this, opts);
+                        }
+                        return $.isArray(opts.mask);
                     default:
+                        resolveAlias(opts.alias, options, opts);
                         //check if the fn is an alias
-                        if (!ResolveAlias(fn)) {
+                        if (!resolveAlias(fn, options, opts)) {
                             //maybe fn is a mask so we try
                             //set mask
                             opts.mask = fn;
                         }
-                        //init buffer
-                        var _buffer = getMaskTemplate();
-                        var tests = getTestingChain();
-
-                        return this.each(function() {
-                            mask(this);
+                        maskset = generateMaskSet(opts);
+                        if (maskset == undefined) { return this; }
+                        return this.each(function () {
+                            targetScope({ "action": "mask", "el": this }, $.extend(true, {}, $.isArray(maskset) && targetScope === maskScope ? maskset[0] : maskset), importAttributeOptions(this, opts));
                         });
-
-                        break;
                 }
-            } if (typeof fn == "object") {
+            } else if (typeof fn == "object") {
                 opts = $.extend(true, {}, $.inputmask.defaults, fn);
 
-                //init buffer
-                var _buffer = getMaskTemplate();
-                var tests = getTestingChain();
-
-                return this.each(function() {
-                    mask(this);
+                resolveAlias(opts.alias, fn, opts); //resolve aliases
+                maskset = generateMaskSet(opts);
+                if (maskset == undefined) { return this; }
+                return this.each(function () {
+                    targetScope({ "action": "mask", "el": this }, $.extend(true, {}, $.isArray(maskset) && targetScope === maskScope ? maskset[0] : maskset), importAttributeOptions(this, opts));
                 });
-            }
-
-            //helper functions
-            function ResolveAlias(aliasStr) {
-                var aliasDefinition = opts.aliases[aliasStr];
-                if (aliasDefinition)
-                    if (!aliasDefinition.alias) {
-                    $.extend(true, opts, aliasDefinition);  //merge alias definition in the options
-                    return true;
-                } else return ResolveAlias(aliasDefinition.alias); //alias is another alias
-                return false;
-            }
-
-            function getMaskTemplate() {
-                var escaped = false, outCount = 0;
-                if (opts.mask.length == 1 && opts.greedy == false) { opts.placeholder = ""; } //hide placeholder with single non-greedy mask
-                var singleMask = $.map(opts.mask.split(""), function(element, index) {
-                    var outElem = [];
-                    if (element == opts.escapeChar) {
-                        escaped = true;
-                    }
-                    else if ((element != opts.optionalmarker.start && element != opts.optionalmarker.end) || escaped) {
-                        var maskdef = opts.definitions[element];
-                        if (maskdef && !escaped) {
-                            for (i = 0; i < maskdef.cardinality; i++) {
-                                outElem.push(getPlaceHolder(outCount + i));
-                            }
-                        } else {
-                            outElem.push(element);
-                            escaped = false;
-                        }
-                        outCount += outElem.length;
-                        return outElem;
+            } else if (fn == undefined) {
+                //look for data-inputmask atribute - the attribute should only contain optipns
+                return this.each(function () {
+                    var attrOptions = $(this).attr("data-inputmask");
+                    if (attrOptions && attrOptions != "") {
+                        try {
+                            attrOptions = attrOptions.replace(new RegExp("'", "g"), '"');
+                            var dataoptions = $.parseJSON("{" + attrOptions + "}");
+                            $.extend(true, dataoptions, options);
+                            opts = $.extend(true, {}, $.inputmask.defaults, dataoptions);
+                            resolveAlias(opts.alias, dataoptions, opts);
+                            opts.alias = undefined;
+                            $(this).inputmask("mask", opts, targetScope);
+                        } catch (ex) { } //need a more relax parseJSON
                     }
                 });
-
-                //allocate repetitions
-                var repeatedMask = singleMask.slice();
-                for (var i = 1; i < opts.repeat && opts.greedy; i++) {
-                    repeatedMask = repeatedMask.concat(singleMask.slice());
-                }
-                return repeatedMask;
-            }
-
-            //test definition => {fn: RegExp/function, cardinality: int, optionality: bool, newBlockMarker: bool, offset: int}
-            function getTestingChain() {
-                var isOptional = false, escaped = false;
-                var newBlockMarker = false; //indicates wheter the begin/ending of a block should be indicated
-
-                return $.map(opts.mask.split(""), function(element, index) {
-                    var outElem = [];
-
-                    if (element == opts.escapeChar) {
-                        escaped = true;
-                    } else if (element == opts.optionalmarker.start && !escaped) {
-                        isOptional = true;
-                        newBlockMarker = true;
-                    }
-                    else if (element == opts.optionalmarker.end && !escaped) {
-                        isOptional = false;
-                        newBlockMarker = true;
-                    }
-                    else {
-                        var maskdef = opts.definitions[element];
-                        if (maskdef && !escaped) {
-                            var prevalidators = maskdef["prevalidator"], prevalidatorsL = prevalidators ? prevalidators.length : 0;
-                            for (i = 1; i < maskdef.cardinality; i++) {
-                                var prevalidator = prevalidatorsL >= i ? prevalidators[i - 1] : [], validator = prevalidator["validator"], cardinality = prevalidator["cardinality"];
-                                outElem.push({ fn: validator ? typeof validator == 'string' ? new RegExp(validator) : new function() { this.test = validator; } : new RegExp("."), cardinality: cardinality ? cardinality : 1, optionality: isOptional, newBlockMarker: isOptional == true ? newBlockMarker : false, offset: 0 });
-                                if (isOptional == true) //reset newBlockMarker
-                                    newBlockMarker = false;
-                            }
-                            outElem.push({ fn: maskdef.validator ? typeof maskdef.validator == 'string' ? new RegExp(maskdef.validator) : new function() { this.test = maskdef.validator; } : new RegExp("."), cardinality: maskdef.cardinality, optionality: isOptional, newBlockMarker: newBlockMarker, offset: 0 });
-                        } else {
-                            outElem.push({ fn: null, cardinality: 0, optionality: isOptional, newBlockMarker: newBlockMarker, offset: 0 });
-                            escaped = false;
-                        }
-                        //reset newBlockMarker
-                        newBlockMarker = false;
-                        return outElem;
-                    }
-                });
-            }
-
-            function isValid(pos, c, buffer) {
-                if (pos < 0 || pos >= getMaskLength()) return false;
-                var testPos = determineTestPosition(pos), loopend = c ? 1 : 0, chrs = '';
-                for (var i = tests[testPos].cardinality; i > loopend; i--) {
-                    chrs += getBufferElement(buffer, testPos - (i - 1));
-                }
-
-                if (c) { chrs += c; }
-                return tests[testPos].fn != null ? tests[testPos].fn.test(chrs, buffer) : false;
-            }
-
-            function isMask(pos) {
-                var testPos = determineTestPosition(pos);
-                var test = tests[testPos];
-
-                return test != undefined ? test.fn : false;
-            }
-
-            function determineTestPosition(pos) {
-                return pos % tests.length;
-            }
-
-            function getPlaceHolder(pos) {
-                return opts.placeholder.charAt(pos % opts.placeholder.length);
-            }
-
-            function getMaskLength() {
-                var calculatedLength = _buffer.length;
-                if (!opts.greedy && opts.repeat > 1) {
-                    calculatedLength += (_buffer.length * (opts.repeat - 1))
-                }
-                return calculatedLength;
-            }
-
-            //pos: from position
-            function seekNext(buffer, pos) {
-                var maskL = getMaskLength();
-                if (pos >= maskL) return maskL;
-                var position = pos;
-                while (++position < maskL && !isMask(position)) { };
-                return position;
-            }
-            //pos: from position
-            function seekPrevious(buffer, pos) {
-                if (pos <= 0) return 0;
-                var position = pos;
-                while (--position > 0 && !isMask(position)) { };
-                return position;
-            }
-            //these are needed to handle the non-greedy mask repetitions
-            function setBufferElement(buffer, position, element) {
-                prepareBuffer(buffer, position);
-                buffer[position] = element;
-            }
-            function getBufferElement(buffer, position) {
-                prepareBuffer(buffer, position);
-                return buffer[position];
-            }
-
-            function prepareBuffer(buffer, position) {
-                while ((buffer.length <= position || position < 0) && buffer.length < getMaskLength()) {
-                    var j = 0;
-                    if (opts.numericInput) {
-                        j = determineTestPosition(position);
-                        buffer.unshift(_buffer[j]);
-                    } else while (_buffer[j] !== undefined) {
-                        buffer.push(_buffer[j++]);
-                    }
-                }
-            }
-
-            function writeBuffer(input, buffer, caretPos) {
-                _val.call(input, buffer.join(''));
-                if (caretPos != undefined)
-                    caret(input, caretPos);
-            };
-            function clearBuffer(buffer, start, end) {
-                for (var i = start, maskL = getMaskLength(); i < end && i < maskL; i++) {
-                    setBufferElement(buffer, i, getBufferElement(_buffer.slice(), i));
-                }
-            };
-
-            function SetReTargetPlaceHolder(buffer, pos) {
-                var testPos = determineTestPosition(pos);
-                setBufferElement(buffer, pos, getBufferElement(_buffer, testPos));
-            }
-
-            function checkVal(input, buffer, clearInvalid) {
-                var inputValue = TruncateInput(_val.call(input));
-                clearBuffer(buffer, 0, buffer.length);
-                buffer.length = _buffer.length;
-                var lastMatch = -1, checkPosition = -1, maskL = getMaskLength(), ivl = inputValue.length;
-                if (opts.numericInput) {
-                    lastMatch += maskL;
-                    var p = seekPrevious(buffer, ivl);
-                    for (var ivp = 0; ivp < ivl; ivp++) {
-                        var c = inputValue.charAt(ivp);
-                        if (isValid(p, c, buffer)) {
-                            for (var i = 0; i < maskL; i++) {
-                                if (isMask(i)) {
-                                    SetReTargetPlaceHolder(buffer, i);
-
-                                    var j = seekNext(buffer, i);
-                                    var el = getBufferElement(buffer, j);
-                                    if (el != getPlaceHolder(j)) {
-                                        if (j < getMaskLength() && isValid(i, el, buffer) !== false) {
-                                            setBufferElement(buffer, i, getBufferElement(buffer, j));
-                                        } else {
-                                            if (isMask(i))
-                                                break;
-                                        }
-                                    }
-                                } else
-                                    SetReTargetPlaceHolder(buffer, i);
-                            }
-                            lastMatch = seekPrevious(buffer, maskL);
-                            setBufferElement(buffer, lastMatch, c);
-                        }
-                    }
-                } else {
-                    for (var i = 0; i < ivl; i++) {
-                        for (var pos = checkPosition + 1; pos < maskL; pos++) {
-                            if (isMask(pos)) {
-                                if (isValid(pos, inputValue.charAt(i), buffer) !== false) {
-                                    setBufferElement(buffer, pos, inputValue.charAt(i));
-                                    lastMatch = checkPosition = pos;
-                                } else {
-                                    SetReTargetPlaceHolder(buffer, pos);
-                                    if (isMask(i) && inputValue.charAt(i) == getPlaceHolder(i))
-                                        checkPosition = pos;
-                                }
-                                break;
-                            } else {   //nonmask
-                                SetReTargetPlaceHolder(buffer, pos);
-                                if (lastMatch == checkPosition) //once outsync the nonmask cannot be the lastmatch
-                                    lastMatch = pos;
-                                checkPosition = pos;
-                            }
-                        }
-                    }
-                }
-                if (clearInvalid) {
-                    writeBuffer(input, buffer);
-                }
-                return seekNext(buffer, lastMatch);
-            }
-
-            function EscapeRegex(str) {
-                var specials = ['/', '.', '*', '+', '?', '|', '(', ')', '[', ']', '{', '}', '\\'];
-                return str.replace(new RegExp('(\\' + specials.join('|\\') + ')', 'gim'), '\\$1');
-            }
-            function TruncateInput(input) {
-                return input.replace(new RegExp("(" + EscapeRegex(_buffer.join('')) + ")*$"), "");
-            }
-
-
-            //functionality fn
-            function setvalue(el, value) {
-                _val.call(el, value);
-                el.triggerHandler('setvalue.inputmask');
-            }
-
-            function unmaskedvalue(el, skipDatepickerCheck) {
-
-                if (tests && (skipDatepickerCheck === true || !el.hasClass('hasDatepicker'))) {
-                    var buffer = _buffer.slice();
-                    checkVal(el, buffer);
-                    return $.map(buffer, function(element, index) {
-                        return isMask(index) && element != getBufferElement(_buffer.slice(), index) ? element : null;
-                    }).join('');
-                }
-                else {
-                    return _val.call(el);
-                }
-            }
-
-            function caret(input, begin, end) {
-                if (input.length == 0) return;
-                if (typeof begin == 'number') {
-                    end = (typeof end == 'number') ? end : begin;
-                    if (opts.insertMode == false && begin == end) end++; //set visualization for insert/overwrite mode
-                    return input.each(function() {
-                        if (this.setSelectionRange) {
-                            this.focus();
-                            this.setSelectionRange(begin, end);
-                        } else if (this.createTextRange) {
-                            var range = this.createTextRange();
-                            range.collapse(true);
-                            range.moveEnd('character', end);
-                            range.moveStart('character', begin);
-                            range.select();
-                        }
-                    });
-                } else {
-                    if (input[0].setSelectionRange) {
-                        begin = input[0].selectionStart;
-                        end = input[0].selectionEnd;
-                    } else if (document.selection && document.selection.createRange) {
-                        var range = document.selection.createRange();
-                        begin = 0 - range.duplicate().moveStart('character', -100000);
-                        end = begin + range.text.length;
-                    }
-                    return { begin: begin, end: end };
-                }
-            };
-
-            function mask(el) {
-                var input = $(el);
-                //store tests & original buffer in the input element - used to get the unmasked value
-                input.data('inputmask', {
-                    'tests': tests,
-                    '_buffer': _buffer,
-                    'greedy': opts.greedy,
-                    'repeat': opts.repeat,
-                    'autoUnmask': opts.autoUnmask,
-                    'definitions': opts.definitions
-                });
-
-                //init buffer
-                var buffer = _buffer.slice();
-                var undoBuffer = _val.call(input);
-                var ignore = false;              //Variable for ignoring control keys
-                var lastPosition = -1;
-                var firstMaskPos = seekNext(buffer, -1);
-
-                //unbind all events - to make sure that no other mask will interfere when re-masking
-                input.unbind(".inputmask");
-                input.removeClass('focus.inputmask');
-                //bind events
-                if (!input.attr("readonly")) {
-                    input.bind("mouseenter.inputmask", function() {
-                        var input = $(this);
-                        if (!input.hasClass('focus.inputmask') && _val.call(input).length == 0) {
-                            buffer = _buffer.slice();
-                            writeBuffer(input, buffer);
-                        }
-                    }).bind("blur.inputmask", function() {
-                        var input = $(this);
-                        input.removeClass('focus.inputmask');
-                        if (_val.call(input) != undoBuffer) {
-                            input.change();
-                        }
-                        if (opts.clearMaskOnLostFocus && _val.call(input) == _buffer.join(''))
-                            _val.call(input, '');
-                        if (opts.clearIncomplete && checkVal(input, buffer, true) != getMaskLength()) {
-                            if (opts.clearMaskOnLostFocus)
-                                _val.call(input, '');
-                            else {
-                                buffer = _buffer.slice();
-                                writeBuffer(input, buffer);
-                            }
-                        }
-                    }).bind("focus.inputmask", function() {
-                        var input = $(this);
-                        input.addClass('focus.inputmask');
-                        undoBuffer = _val.call(input);
-                    }).bind("mouseleave.inputmask", function() {
-                        var input = $(this);
-                        if (opts.clearMaskOnLostFocus && !input.hasClass('focus.inputmask') && _val.call(input) == _buffer.join(''))
-                            _val.call(input, '');
-                    }).bind("click.inputmask", function() {
-                        var input = $(this);
-                        setTimeout(function() {
-                            var selectedCaret = caret(input);
-                            if (selectedCaret.begin == selectedCaret.end) {
-                                var clickPosition = selectedCaret.begin;
-                                lastPosition = checkVal(input, buffer, false);
-                                caret(input, clickPosition < lastPosition && (isValid(clickPosition, buffer[clickPosition], buffer) || !isMask(clickPosition)) ? clickPosition : lastPosition);
-                            }
-                        }, 0);
-                    }).bind('dblclick.inputmask', function() {
-                        var input = $(this);
-                        setTimeout(function() {
-                            caret(input, 0, lastPosition);
-                        }, 0);
-                    }).bind("keydown.inputmask", keydownEvent
-                ).bind("keypress.inputmask", keypressEvent
-                ).bind("keyup.inputmask", function(e) {
-                    var input = $(this);
-                    var k = e.keyCode;
-                    if (k == opts.keyCode.TAB && input.hasClass('focus.inputmask') && _val.call(input).length == 0) {
-                        buffer = _buffer.slice();
-                        writeBuffer(input, buffer);
-                        if (!opts.numericInput) caret(input, 0);
-                    }
-                }).bind(pasteEventName, function() {
-                    var input = $(this);
-                    setTimeout(function() {
-                        caret(input, checkVal(input, buffer, true));
-                    }, 0);
-                }).bind('setvalue.inputmask', function() {
-                    var input = $(this);
-                    setTimeout(function() {
-                        undoBuffer = _val.call(input);
-                        checkVal(input, buffer, true);
-                        if (_val.call(input) == _buffer.join(''))
-                            _val.call(input, '');
-                    }, 0);
-                });
-                }
-
-                setTimeout(function() {
-                    lastPosition = checkVal(input, buffer, true);
-                    if (document.activeElement === input[0]) { //position the caret when in focus
-                        input.addClass('focus.inputmask');
-                        caret(input, lastPosition);
-                    } else if (opts.clearMaskOnLostFocus && _val.call(input) == _buffer.join(''))
-                        _val.call(input, '');
-                }, 0);
-
-                //private functions
-                //shift chars to left from start to end and put c at end position if defined
-                function shiftL(start, end, c) {
-                    while (!isMask(start) && start - 1 >= 0) start--;
-                    for (var i = start; i <= end && i < getMaskLength(); i++) {
-                        if (isMask(i)) {
-                            SetReTargetPlaceHolder(buffer, i);
-                            var j = seekNext(buffer, i);
-                            var p = getBufferElement(buffer, j);
-                            if (p != getPlaceHolder(j)) {
-                                if (j < getMaskLength() && isValid(i, p, buffer) !== false) {
-                                    setBufferElement(buffer, i, getBufferElement(buffer, j));
-                                } else {
-                                    if (isMask(i))
-                                        break;
-                                }
-                            } else if (c == undefined) break;
-                        } else {
-                            SetReTargetPlaceHolder(buffer, i);
-                        }
-                    }
-                    if (c != undefined)
-                        setBufferElement(buffer, seekPrevious(buffer, end), c);
-
-                    buffer = TruncateInput(buffer.join('')).split('');
-                    if (buffer.length == 0) buffer = _buffer.slice();
-
-                    return start; //return the used start position
-                }
-                function shiftR(pos, c, full) { //full => behave like a push right ~ do not stop on placeholders
-                    for (var i = pos; i < getMaskLength(); i++) {
-                        if (isMask(i)) {
-                            var t = getBufferElement(buffer, i);
-                            setBufferElement(buffer, i, c);
-                            if (t != getPlaceHolder(i)) {
-                                var j = seekNext(buffer, i);
-                                if (j < getMaskLength()) {
-                                    if (isValid(j, t, buffer) !== false)
-                                        c = t;
-                                    else {
-                                        if (isMask(j))
-                                            break;
-                                        else c = t;
-                                    }
-                                } else break;
-                            } else if (full !== true) break;
-                        } else
-                            SetReTargetPlaceHolder(buffer, i);
-                    }
-                };
-
-                function keydownEvent(e) {
-                    var input = $(this);
-                    var pos = caret(input);
-                    var k = e.keyCode;
-                    ignore = (k < 16 || (k > 16 && k < 32) || (k > 32 && k < 41));
-
-                    //delete selection before proceeding
-                    if ((pos.begin - pos.end) != 0 && (!ignore || k == opts.keyCode.BACKSPACE || k == opts.keyCode.DELETE))
-                        clearBuffer(buffer, pos.begin, pos.end);
-
-                    //backspace, delete, and escape get special treatment
-                    if (k == opts.keyCode.BACKSPACE || k == opts.keyCode.DELETE || (iPhone && k == 127)) {//backspace/delete
-                        var maskL = getMaskLength();
-                        if (pos.begin == 0 && pos.end == maskL) {
-                            buffer = _buffer.slice();
-                            writeBuffer(input, buffer);
-                            if (!opts.numericInput) caret(input, 0);
-                        } else {
-                            var beginPos = pos.begin - (k == opts.keyCode.DELETE || pos.begin < pos.end ? 0 : 1);
-                            beginPos = shiftL(beginPos < 0 ? 0 : beginPos, maskL);
-                            if (opts.numericInput) {
-                                shiftR(0, getPlaceHolder(0), true);
-                                beginPos = seekNext(buffer, beginPos);
-                            }
-                            writeBuffer(input, buffer, beginPos);
-                            if (!opts.insertMode && k == opts.keyCode.BACKSPACE) {
-                                caret(input, seekPrevious(buffer, beginPos));
-                            }
-                        }
-                        if (opts.oncleared && _val.call(input) == _buffer.join(''))
-                            opts.oncleared.call(input);
-
-                        return false;
-                    } else if (k == opts.keyCode.END || k == opts.keyCode.PAGE_DOWN) { //when END or PAGE_DOWN pressed set position at lastmatch
-                        setTimeout(function() {
-                            var caretPos = checkVal(input, buffer, false);
-                            if (!opts.insertMode && caretPos == getMaskLength() && !e.shiftKey) caretPos--;
-                            caret(input, e.shiftKey ? pos.begin : caretPos, caretPos);
-                        }, 0);
-                        return false;
-                    } else if (k == opts.keyCode.HOME || k == opts.keyCode.PAGE_UP) {//Home or page_up
-                        caret(input, 0, e.shiftKey ? pos.begin : 0);
-                        return false;
-                    }
-                    else if (k == opts.keyCode.ESCAPE) {//escape
-                        _val.call(input, undoBuffer);
-                        caret(input, 0, checkVal(input, buffer));
-                        return false;
-                    } else if (k == opts.keyCode.INSERT) {//insert
-                        opts.insertMode = !opts.insertMode;
-                        caret(input, !opts.insertMode && pos.begin == getMaskLength() ? pos.begin - 1 : pos.begin);
-                        return false;
-                    }
-                    else if (!opts.insertMode) { //overwritemode
-                        if (k == opts.keyCode.RIGHT) {//right
-                            var caretPos = pos.begin == pos.end ? pos.end + 1 : pos.end;
-                            caretPos = caretPos < getMaskLength() ? caretPos : pos.end;
-                            caret(input, e.shiftKey ? pos.begin : caretPos, e.shiftKey ? caretPos + 1 : caretPos);
-                            return false;
-                        } else if (k == opts.keyCode.LEFT) {//left
-                            var caretPos = pos.begin - 1;
-                            caretPos = caretPos > 0 ? caretPos : 0;
-                            caret(input, caretPos, e.shiftKey ? pos.end : caretPos);
-                            return false;
-                        }
-                    }
-                }
-
-                function keypressEvent(e) {
-                    var input = $(this);
-                    if (ignore) {
-                        ignore = false;
-                        //Fixes Mac FF bug on backspace
-                        return (e.keyCode == opts.keyCode.BACKSPACE) ? false : null;
-                    }
-                    e = e || window.event;
-                    var k = e.charCode || e.keyCode || e.which;
-                    var pos = caret($(this));
-                    if (e.ctrlKey || e.altKey || e.metaKey) {//Ignore
-                        return true;
-                    } else if ((k >= 32 && k <= 125) || k > 186) {//typeable characters
-                        var c = String.fromCharCode(k);
-                        if (opts.numericInput) {
-                            var posEnd = opts.greedy ? pos.end : (pos.end + 1);
-                            var p = seekPrevious(buffer, posEnd);
-                            if (isValid(p, c, buffer)) {
-                                if (isValid(firstMaskPos, buffer[firstMaskPos], buffer) == false || (opts.greedy === false && buffer.length < getMaskLength())) {
-                                    shiftL(firstMaskPos, posEnd, c);
-                                    writeBuffer(input, buffer, posEnd);
-                                } else if (opts.oncomplete)
-                                    opts.oncomplete.call(input);
-                            }
-                        }
-                        else {
-                            var p = seekNext(buffer, pos.begin - 1);
-                            if (isValid(p, c, buffer)) {
-                                if (opts.insertMode == true) shiftR(p, c); else setBufferElement(buffer, p, c);
-                                var next = seekNext(buffer, p);
-                                writeBuffer(input, buffer, next);
-
-                                if (opts.oncomplete && next == getMaskLength())
-                                    opts.oncomplete.call(input);
-                            }
-                        }
-                    }
-                    return false;
-                }
-
-
             }
         };
     }

--- a/src/dashboard/src/templates/rights/rights_edit.html
+++ b/src/dashboard/src/templates/rights/rights_edit.html
@@ -3,6 +3,7 @@
 {% load url from future %}
 
 {% block js %}
+  <script src="{{ STATIC_URL }}vendor/jquery.js" type="text/javascript"></script>
   <script src="{{ STATIC_URL }}vendor/jquery.inputmask.js" type="text/javascript"></script>
   <script src="{{ STATIC_URL }}js/repeating-ajax-data.js" type="text/javascript"></script>
   <script src="{{ STATIC_URL }}js/rights_edit.js" type="text/javascript"></script>

--- a/src/dashboard/src/templates/rights/rights_grants_edit.html
+++ b/src/dashboard/src/templates/rights/rights_grants_edit.html
@@ -3,6 +3,7 @@
 {% load url from future %}
 
 {% block js %}
+  <script src="{{ STATIC_URL }}vendor/jquery.js" type="text/javascript"></script>
   <script src="{{ STATIC_URL }}vendor/jquery.inputmask.js" type="text/javascript"></script>
   <script src="{{ STATIC_URL }}js/repeating-ajax-data.js" type="text/javascript"></script>
   <script src="{{ STATIC_URL }}js/rights_edit.js" type="text/javascript"></script>


### PR DESCRIPTION
refs #7099

PREMIS Rights dates should accept year, year-month or year-month-day. Update matching to make month and day optional. Update year regex to allow any 4 digit year, instead of just ones starting with 0, 1 or 2.

Update vendored library from 2011 version to version at 3.0.55 tag in https://github.com/RobinHerbots/jquery.inputmask  This allows optional segments in the regex.
