### PR TITLE
Unify Unit ReplacementDict creation code

### DIFF
--- a/src/MCPServer/lib/unitDIP.py
+++ b/src/MCPServer/lib/unitDIP.py
@@ -22,15 +22,11 @@
 # @author Joseph Perry <joseph@artefactual.com>
 
 from unit import unit
-from unitFile import unitFile
 import archivematicaMCP
 import os
 import sys
 
 import lxml.etree as etree
-
-sys.path.append("/usr/share/archivematica/dashboard")
-from main.models import File
 
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 from dicts import ReplacementDict
@@ -39,8 +35,8 @@ from dicts import ReplacementDict
 class UnitDIPError(Exception):
     pass
 
-class unitDIP(unit):
 
+class unitDIP(unit):
     def __init__(self, currentPath, UUID):
         self.currentPath = currentPath.__str__()
         self.UUID = UUID
@@ -50,19 +46,7 @@ class unitDIP(unit):
         self.unitType = "DIP"
 
     def reload(self):
-        #sql = """SELECT * FROM SIPs WHERE sipUUID =  '""" + self.UUID + "'"
-        #c, sqlLock = databaseInterface.querySQL(sql)
-        #row = c.fetchone()
-        #while row != None:
-        #    print row
-        #    #self.UUID = row[0]
-        #    self.createdTime = row[1]
-        #    self.currentPath = row[2]
-        #    row = c.fetchone()
-        #sqlLock.release()
-
-        #no-op for reload on DIP
-        return
+        pass
 
     def getReplacementDic(self, target):
         ret = ReplacementDict.frommodel(

--- a/src/MCPServer/lib/unitFile.py
+++ b/src/MCPServer/lib/unitFile.py
@@ -34,7 +34,7 @@ class unitFile(object):
         self.UUID = UUID
         self.owningUnit = owningUnit
         self.fileGrpUse = 'None'
-        self.fileList={currentPath:self}
+        self.fileList = {currentPath: self}
         self.pathString = ""
         if owningUnit:
             self.pathString = owningUnit.pathString
@@ -58,7 +58,7 @@ class unitFile(object):
             }
 
     def reload(self):
-        return
+        pass
 
     def reloadFileList(self):
-        return
+        pass

--- a/src/MCPServer/lib/unitFile.py
+++ b/src/MCPServer/lib/unitFile.py
@@ -21,6 +21,12 @@
 # @subpackage MCPServer
 # @author Joseph Perry <joseph@artefactual.com>
 
+import sys
+
+sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+from dicts import ReplacementDict
+
+
 class unitFile(object):
     """For objects representing a File"""
     def __init__(self, currentPath, UUID="None", owningUnit=None):
@@ -34,21 +40,25 @@ class unitFile(object):
             self.pathString = owningUnit.pathString
 
     def getReplacementDic(self, target=None):
-        if target != None and self.owningUnit:
+        if target is not None and self.owningUnit:
             return self.owningUnit.getReplacementDic(self.owningUnit.currentPath)
-        # self.currentPath = currentPath.__str__()
-        # self.UUID = uuid.uuid4().__str__()
-        #Pre do some variables, that other variables rely on, because dictionaries don't maintain order
+        elif self.UUID != "None":
+            return ReplacementDict.frommodel(
+                type_='file',
+                file_=self.UUID
+            )
+        # If no UUID has been assigned yet, we can't use the
+        # ReplacementDict.frommodel constructor; fall back to the
+        # old style of manual construction.
         else:
-            ret = {\
-                   "%relativeLocation%": self.currentPath, \
-                   "%fileUUID%": self.UUID, \
-                   "%fileGrpUse%": self.fileGrpUse
+            return {
+                "%relativeLocation%": self.currentPath,
+                "%fileUUID%": self.UUID,
+                "%fileGrpUse%": self.fileGrpUse
             }
-            return ret
-    
+
     def reload(self):
-        return 
-    
+        return
+
     def reloadFileList(self):
         return

--- a/src/MCPServer/lib/unitSIP.py
+++ b/src/MCPServer/lib/unitSIP.py
@@ -23,7 +23,6 @@
 
 from unit import unit
 import archivematicaMCP
-import os
 import sys
 import lxml.etree as etree
 
@@ -35,7 +34,6 @@ from dicts import ReplacementDict
 
 
 class unitSIP(unit):
-
     def __init__(self, currentPath, UUID):
         self.currentPath = currentPath.__str__()
         self.UUID = UUID
@@ -45,7 +43,7 @@ class unitSIP(unit):
         self.unitType = "SIP"
         self.aipFilename = ""
 
-    def setMagicLink(self,link, exitStatus=""):
+    def setMagicLink(self, link, exitStatus=""):
         """Assign a link to the unit to process when loaded.
         Deprecated! Replaced with Set/Load Unit Variable"""
         sip = SIP.objects.get(uuid=self.UUID)
@@ -62,7 +60,6 @@ class unitSIP(unit):
         except SIP.DoesNotExist:
             return
         return (sip.magiclink, sip.magiclinkexitmessage)
-
 
     def reload(self):
         sip = SIP.objects.get(uuid=self.UUID)

--- a/src/MCPServer/lib/unitSIP.py
+++ b/src/MCPServer/lib/unitSIP.py
@@ -30,6 +30,10 @@ import lxml.etree as etree
 sys.path.append("/usr/share/archivematica/dashboard")
 from main.models import SIP
 
+sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+from dicts import ReplacementDict
+
+
 class unitSIP(unit):
 
     def __init__(self, currentPath, UUID):
@@ -69,38 +73,13 @@ class unitSIP(unit):
 
     def getReplacementDic(self, target):
         """ Return a dict with all of the replacement strings for this unit and the value to replace with. """
-        # Pre-do some variables that other variables rely on because dicts
-        # don't maintain order
-        SIPUUID = self.UUID
-        if self.currentPath.endswith("/"):
-            SIPName = os.path.basename(self.currentPath[:-1]).replace("-" + SIPUUID, "")
-        else:
-            SIPName = os.path.basename(self.currentPath).replace("-" + SIPUUID, "")
-        SIPDirectory = self.currentPath.replace(archivematicaMCP.config.get('MCPServer', "sharedDirectory"), "%sharedPath%")
-        relativeDirectoryLocation = target.replace(archivematicaMCP.config.get('MCPServer', "sharedDirectory"), "%sharedPath%")
-
-        ret = {
-            "%SIPLogsDirectory%": SIPDirectory + "logs/",
-            "%SIPObjectsDirectory%": SIPDirectory + "objects/",
-            "%SIPDirectory%": SIPDirectory,
-            "%SIPDirectoryBasename%":
-                os.path.basename(os.path.abspath(SIPDirectory)),
-            "%relativeLocation%":
-                target.replace(self.currentPath, relativeDirectoryLocation, 1),
-            "%processingDirectory%":
-                archivematicaMCP.config.get('MCPServer', "processingDirectory"),
-            "%checksumsNoExtention%":
-                archivematicaMCP.config.get('MCPServer', "checksumsNoExtention"),
-            "%watchDirectoryPath%":
-                archivematicaMCP.config.get('MCPServer', "watchDirectoryPath"),
-            "%rejectedDirectory%":
-                archivematicaMCP.config.get('MCPServer', "rejectedDirectory"),
-            "%AIPFilename%": self.aipFilename,
-            "%SIPUUID%": SIPUUID,
-            "%SIPName%": SIPName,
-            "%unitType%": self.unitType,
-            "%SIPType%": self.sipType,
-        }
+        ret = ReplacementDict.frommodel(
+            type_='sip',
+            sip=self.UUID
+        )
+        ret["%AIPFilename%"] = self.aipFilename
+        ret["%unitType%"] = self.unitType
+        ret["%SIPType%"] = self.sipType
         return ret
 
     def xmlify(self):

--- a/src/MCPServer/lib/unitTransfer.py
+++ b/src/MCPServer/lib/unitTransfer.py
@@ -24,7 +24,6 @@
 from unit import unit
 import uuid
 import archivematicaMCP
-import os
 import sys
 
 import lxml.etree as etree
@@ -40,10 +39,9 @@ class unitTransfer(unit):
     def __init__(self, currentPath, UUID=""):
         self.owningUnit = None
         self.unitType = "Transfer"
-        #Just Use the end of the directory name
+        # Just use the end of the directory name
         self.pathString = "%transferDirectory%"
-        currentPath2 = currentPath.replace(archivematicaMCP.config.get('MCPServer', "sharedDirectory"), \
-                       "%sharedPath%", 1)
+        currentPath2 = currentPath.replace(archivematicaMCP.config.get('MCPServer', "sharedDirectory"), "%sharedPath%", 1)
 
         if not UUID:
             try:
@@ -55,8 +53,8 @@ class unitTransfer(unit):
 
         if not UUID:
             uuidLen = -36
-            if archivematicaMCP.isUUID(currentPath[uuidLen-1:-1]):
-                UUID = currentPath[uuidLen-1:-1]
+            if archivematicaMCP.isUUID(currentPath[uuidLen - 1:-1]):
+                UUID = currentPath[uuidLen - 1:-1]
             else:
                 UUID = str(uuid.uuid4())
                 self.UUID = UUID
@@ -109,6 +107,5 @@ class unitTransfer(unit):
         etree.SubElement(unitXML, "UUID").text = self.UUID
         tempPath = self.currentPath.replace(archivematicaMCP.config.get('MCPServer', "sharedDirectory"), "%sharedPath%").decode("utf-8")
         etree.SubElement(unitXML, "currentPath").text = tempPath
-        
-        return ret
 
+        return ret

--- a/src/MCPServer/lib/unitTransfer.py
+++ b/src/MCPServer/lib/unitTransfer.py
@@ -32,6 +32,10 @@ import lxml.etree as etree
 sys.path.append("/usr/share/archivematica/dashboard")
 from main.models import Transfer
 
+sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+from dicts import ReplacementDict
+
+
 class unitTransfer(unit):
     def __init__(self, currentPath, UUID=""):
         self.owningUnit = None
@@ -91,33 +95,11 @@ class unitTransfer(unit):
         self.currentPath = transfer.currentlocation
 
     def getReplacementDic(self, target):
-        # self.currentPath = currentPath.__str__()
-        # self.UUID = uuid.uuid4().__str__()
-        #Pre do some variables, that other variables rely on, because dictionaries don't maintain order
-        SIPUUID = self.UUID
-        if self.currentPath.endswith("/"):
-            SIPName = os.path.basename(self.currentPath[:-1]).replace("-" + SIPUUID, "")
-        else:
-            SIPName = os.path.basename(self.currentPath).replace("-" + SIPUUID, "")
-        SIPDirectory = self.currentPath.replace(archivematicaMCP.config.get('MCPServer', "sharedDirectory"), "%sharedPath%")
-        relativeDirectoryLocation = target.replace(archivematicaMCP.config.get('MCPServer', "sharedDirectory"), "%sharedPath%")
-
-
-        ret = { \
-        "%SIPLogsDirectory%": SIPDirectory + "logs/", \
-        "%SIPObjectsDirectory%": SIPDirectory + "objects/", \
-        "%SIPDirectory%": SIPDirectory, \
-        "%transferDirectory%": SIPDirectory, \
-        "%SIPDirectoryBasename%": os.path.basename(os.path.abspath(SIPDirectory)), \
-        "%relativeLocation%": target.replace(self.currentPath, relativeDirectoryLocation, 1), \
-        "%processingDirectory%": archivematicaMCP.config.get('MCPServer', "processingDirectory"), \
-        "%checksumsNoExtention%":archivematicaMCP.config.get('MCPServer', "checksumsNoExtention"), \
-        "%watchDirectoryPath%":archivematicaMCP.config.get('MCPServer', "watchDirectoryPath"), \
-        "%rejectedDirectory%":archivematicaMCP.config.get('MCPServer', "rejectedDirectory"), \
-        "%SIPUUID%":SIPUUID, \
-        "%SIPName%":SIPName, \
-        "%unitType%":self.unitType \
-        }
+        ret = ReplacementDict.frommodel(
+            type_='transfer',
+            sip=self.UUID
+        )
+        ret["%unitType%"] = self.unitType
         return ret
 
     def xmlify(self):


### PR DESCRIPTION
In the past, each Unit class had its own logic for creating replacementDicts. This meant that the available unit variables for a given job was dependent on the type of unit class that was spawning the job, and introduced the possibility of other inconsistencies.

For Archivematica 1.2, a new constructor for ReplacementDict had already been created which used the database to populate a common set of fields; this is used by every other place in Archivematica that creates and consumes ReplacementDicts for this kind of task, including every client script (normalization, identification, etc.)

The File unit is the only unit which retains its original constructor, and only as a backup. The new constructor depends on the database, but the File unit has to spawn several jobs before files are ever added to the database. The old minimalistic ReplacementDict is kept as a fallback for this case only; as soon as every file is assigned a UUID, the new ReplacementDict can be used.

refs #6451
