### PR TITLE
Manual Normalization: normalization.csv, non-Unicode

### DIFF
--- a/src/MCPClient/debian/control
+++ b/src/MCPClient/debian/control
@@ -13,7 +13,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, archivematica-common,
  gearman, imagemagick, inkscape, jhove, libimage-exiftool-perl, libxml2-utils, logapp,
  md5deep, mediainfo, nailgun-client, nfs-common, openjdk-7-jre-headless, p7zip-full,
  pbzip2, postfix, python-fido, python-gearman, python-lxml,
- python-mysqldb, python-pyicu, python-unidecode, readpst,
+ python-mysqldb, python-unidecode, readpst,
  rsync, sleuthkit, tesseract-ocr, tika, tree, ufraw, unrar-free, uuid
 Description: MCP Client for Archivematica
   

--- a/src/MCPClient/lib/clientScripts/manualNormalizationCreateMetadataAndRestructure.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationCreateMetadataAndRestructure.py
@@ -67,7 +67,7 @@ if len(rows) != 1:
             print >>sys.stderr, "{0} not in manualNormalization directory".format(filePath)
             exit(4)
         original = fileOperations.findFileInNormalizatonCSV(csv_path,
-            "preservation", preservation_file)
+            "preservation", preservation_file, SIPUUID)
         if original is None:
             if len(rows) < 1:
                 print >>sys.stderr, "No matching file for: {0}".format(
@@ -82,7 +82,7 @@ if len(rows) != 1:
                  FROM Files 
                  WHERE removedTime = 0 AND 
                     fileGrpUse='original' AND 
-                    Files.currentLocation LIKE '%{filename}' AND 
+                    Files.originalLocation LIKE '%{filename}' AND
                     {unitIdentifierType} = '{unitIdentifier}';""".format(
                 filename=original, unitIdentifierType=unitIdentifierType,
                 unitIdentifier=unitIdentifier)
@@ -98,7 +98,7 @@ if len(rows) != 1:
 for row in rows:
     originalFileUUID, originalFilePath = row
 
-print "matched: {%s}%s" % (originalFileUUID, originalFilePath)
+print "matched: (%s) %s to (%s) %s" % (originalFileUUID, originalFilePath, fileUUID, filePath)
 basename = os.path.basename(filePath)
 i = basename.rfind(".")
 dstFile = basename[:i] + "-" + fileUUID + basename[i:] 

--- a/src/MCPClient/lib/clientScripts/manualNormalizationMoveAccessFilesToDIP.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationMoveAccessFilesToDIP.py
@@ -66,7 +66,7 @@ if len(rows) != 1:
             print >>sys.stderr, "{0} not in manualNormalization directory".format(opts.filePath)
             exit(4)
         original = fileOperations.findFileInNormalizatonCSV(csv_path,
-            "access", access_file)
+            "access", access_file, unitIdentifier)
         if original == None:
             if len(rows) < 1:
                 print >>sys.stderr, "No matching file for: {0}".format(
@@ -81,7 +81,7 @@ if len(rows) != 1:
                  FROM Files 
                  WHERE removedTime = 0 AND 
                     fileGrpUse='original' AND 
-                    Files.currentLocation LIKE '%{filename}' AND 
+                    Files.originalLocation LIKE '%{filename}' AND
                     {unitIdentifierType} = '{unitIdentifier}';""".format(
                 filename=original, unitIdentifierType=unitIdentifierType,
                 unitIdentifier=unitIdentifier)


### PR DESCRIPTION
Fix normalization.csv parsing to match on the unsanitized name in all cases, instead of the sanitized name.

Fix createMETS2 trying to sort files and folders in the fileSec (and structMap?) that broke on non-Unicode filenames. Since the sort is unecessary, removed that and the outdated PyICU dependency.

Diff may be easier to understand if done with -w (ignore whitespace changes), since I increased the identation in `createFileSec` without really making other changes.

Quick testing shows that all the expected files/directories are the fileSec and structMap, and the METS passes validation.
