### PR TITLE
Fix issue causing slow archival storage pageload.

### DIFF
--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -389,7 +389,7 @@ def aip_file_count():
 def total_size_of_aips(conn):
     query = elasticsearch_query_excluding_aips_pending_deletion('uuid')
 
-    query = query.search()
+    query = query.search(fields='size')
     query.facet.add(pyes.facets.StatisticalFacet('total', field='size'))
 
     aipResults = conn.search(query, doc_types=['aip'], indices=['aips'])


### PR DESCRIPTION
Fixed a minor issue causing the archival storage page to
load slowly when there are AIPs with extensive METS data.
