### PR TITLE
Replace Python 2.5-style exception syntax with 2.6-style

### DIFF
--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -150,7 +150,7 @@ Unable to determine if it completed successfully."""
         exitCode, stdOut, stdError = executeOrRun("command", command, sInput, printing=False)
         return cPickle.dumps({"exitCode" : exitCode, "stdOut": stdOut, "stdError": stdError})
     #catch OS errors
-    except OSError, ose:
+    except OSError as ose:
         traceback.print_exc(file=sys.stdout)
         printOutputLock.acquire()
         print >>sys.stderr, "Execution failed:", ose

--- a/src/MCPClient/lib/clientScripts/archivematicaFITS.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaFITS.py
@@ -173,7 +173,7 @@ if __name__ == '__main__':
         insertIntoFPCommandOutput(fileUUID, etree.tostring(fits, pretty_print=False), '3a19de70-0e42-4145-976b-3a248d43b462')
         includeFits(fits, XMLfile, date, eventUUID, fileUUID)
 
-    except OSError, ose:
+    except OSError as ose:
         print >>sys.stderr, "Execution failed:", ose
         exit(1)
     exit(exitCode)

--- a/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
             print output[1]# sError
             quit(retcode)
         version = output[0].replace("\n", "")
-    except OSError, ose:
+    except OSError as ose:
         print >>sys.stderr, "Execution failed:", ose
         quit(2)
 

--- a/src/archivematicaCommon/lib/archivematicaMCPFileUUID.py
+++ b/src/archivematicaCommon/lib/archivematicaMCPFileUUID.py
@@ -115,7 +115,7 @@ def findUUIDFromFileUUIDxml(sipUUIDfile, filename, fileUUIDxmlFilesDirectory, up
                                 f = open(sipUUIDfile, 'a')
                                 f.write(uuid.text + " -> " + filename + "\n")
                                 f.close()
-                        except OSError, ose:
+                        except OSError as ose:
                             print >>sys.stderr, "output Error", ose
                             return -2
                         except IOError as (errno, strerror):

--- a/src/archivematicaCommon/lib/databaseInterface.py
+++ b/src/archivematicaCommon/lib/databaseInterface.py
@@ -48,8 +48,8 @@ def reconnect():
             database.autocommit(True)
             warnings.filterwarnings('error', category=MySQLdb.Warning)
             break
-        except MySQLdb.OperationalError, message:
-            if message[0] == 1045 and message[1].startswith('Access denied for user'):
+        except MySQLdb.OperationalError as inst:
+            if inst[0] == 1045 and inst[1].startswith('Access denied for user'):
                 raise
             else:
                 print >>sys.stderr, "Error connecting to database:"
@@ -109,7 +109,7 @@ def runSQL(sql):
         c.execute(sql)
         database.commit()
         rows = c.fetchall()
-    except MySQLdb.OperationalError, message:
+    except MySQLdb.OperationalError as message:
         #errorMessage = "Error %d:\n%s" % (message[ 0 ], message[ 1 ] )
         if message[0] == 2006 and message[1] == 'MySQL server has gone away':
             reconnect()
@@ -151,7 +151,7 @@ def insertAndReturnID(sql):
         c.execute(sql)
         database.commit()
         ret = c.lastrowid
-    except MySQLdb.OperationalError, message:
+    except MySQLdb.OperationalError as message:
         #errorMessage = "Error %d:\n%s" % (message[ 0 ], message[ 1 ] )
         if message[0] == 2006 and message[1] == 'MySQL server has gone away':
             reconnect()
@@ -185,7 +185,7 @@ def querySQL(sql):
     try:
         c=database.cursor()
         c.execute(sql)
-    except MySQLdb.OperationalError, message:
+    except MySQLdb.OperationalError as message:
         #errorMessage = "Error %d:\n%s" % (message[ 0 ], message[ 1 ] )
         if message[0] == 2006 and message[1] == 'MySQL server has gone away':
             reconnect()
@@ -228,7 +228,7 @@ def queryAllSQL(sql):
         c.execute(sql)
         rows = c.fetchall()
         sqlLock.release()
-    except MySQLdb.OperationalError, message:
+    except MySQLdb.OperationalError as message:
         #errorMessage = "Error %d:\n%s" % (message[ 0 ], message[ 1 ] )
         if message[0] == 2006 and message[1] == 'MySQL server has gone away':
             reconnect()

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -81,10 +81,10 @@ def launchSubProcess(command, stdIn="", printing=True, arguments=[]):
             print stdOut
             print  >>sys.stderr, stdError
         retcode = p.returncode
-    except OSError, ose:
+    except OSError as ose:
         print >>sys.stderr, "Execution failed:", ose
         return -1, "Config Error!", ose.__str__()
-    except Exception  as inst:
+    except Exception as inst:
         print  >>sys.stderr, "Execution failed:", command
         print >>sys.stderr, type(inst)     # the exception instance
         print >>sys.stderr, inst.args

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -104,7 +104,7 @@ def writeToFile(output, fileName, writeWhite=False):
             f.write(output.__str__())
             f.close()
             os.chmod(fileName, 488)
-        except OSError, ose:
+        except OSError as ose:
             print >>sys.stderr, "output Error", ose
             return -2
         except IOError as (errno, strerror):


### PR DESCRIPTION
Also fixes up an exception handling block which captured an exception under one name and then tried to use the object under a different name.

That exception handling block was the original inspiration, but decided to touch up the syntax everwhere. Came across it here: https://github.com/artefactual/archivematica/blob/qa/1.x/src/archivematicaCommon/lib/databaseInterface.py#L52-L56 When a MySQL exception was raised but wasn't handled by the first case, and so blew up.

This should also help us with a hypothetical Python 3.x migration, since the old style of exception catching no longer exists there.
