### PR TITLE
Start transfer calls storage service

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/urls.py
+++ b/src/dashboard/src/components/filesystem_ajax/urls.py
@@ -29,7 +29,6 @@ urlpatterns = patterns('components.filesystem_ajax.views',
     (r'^move_within_arrange/$', 'move_within_arrange'),
     (r'^create_directory_within_arrange/$', 'create_directory_within_arrange'),
     (r'^copy_to_arrange/$', 'copy_to_arrange'),
-    (r'^get_temp_directory/$', 'get_temp_directory'),
     (r'^ransfer/$', 'start_transfer'),
     (r'^copy_from_arrange/$', 'copy_from_arrange_to_completed')
 )

--- a/src/dashboard/src/media/js/transfer/component_directory_select.js
+++ b/src/dashboard/src/media/js/transfer/component_directory_select.js
@@ -71,19 +71,20 @@ function createDirectoryPicker(locationUUID, baseDirectory, modalCssId, targetCs
       }
 
       // render path component
-      trailing_slash = decoded_path + (result.type == 'directory' ? '/' : '');
+      var trailing_slash = decoded_path + (result.type == 'directory' ? '/' : '');
+      var location_path = locationUUID+':'+trailing_slash;
       $('#' + targetCssId).append(selector.pathTemplateRender({
         'path_counter': transferDirectoryPickerPathCounter,
         'path': decoded_path,
-        'location_path': locationUUID+':'+trailing_slash,
+        'location_path': location_path,
         'edit_icon': '1',
         'delete_icon': '2'
       }));
 
       if (!active_component) { active_component = createMetadataSetID(); }
       var component = active_component;
-      component.path = decoded_path;
-      components[decoded_path] = component;
+      component.path = location_path;
+      components[location_path] = component;
 
       // enable editing of transfer component metadata
       if ($('#transfer-type').val() == 'disk image') {
@@ -107,7 +108,7 @@ function createDirectoryPicker(locationUUID, baseDirectory, modalCssId, targetCs
       .children('.transfer_path_delete_icon')
       .click(function() {
         if (confirm('Are you sure you want to remove this transfer component?')) {
-          var path = $(this).parent().parent().text().trim();
+          var path = $(this).parent().parent().prop("id").trim();
           var component = components[path];
 
           removeMetadataForms(component.uuid);

--- a/src/dashboard/src/media/js/transfer/component_directory_select.js
+++ b/src/dashboard/src/media/js/transfer/component_directory_select.js
@@ -71,9 +71,11 @@ function createDirectoryPicker(locationUUID, baseDirectory, modalCssId, targetCs
       }
 
       // render path component
+      trailing_slash = decoded_path + (result.type == 'directory' ? '/' : '');
       $('#' + targetCssId).append(selector.pathTemplateRender({
         'path_counter': transferDirectoryPickerPathCounter,
         'path': decoded_path,
+        'location_path': locationUUID+':'+trailing_slash,
         'edit_icon': '1',
         'delete_icon': '2'
       }));

--- a/src/dashboard/src/media/js/transfer/component_form.js
+++ b/src/dashboard/src/media/js/transfer/component_form.js
@@ -132,6 +132,7 @@ var TransferComponentFormView = Backbone.View.extend({
       success: function(results) {
         if (results['error']) {
           alert(results.message);
+          return;
         }
 
         $('#transfer-name').val('');
@@ -139,11 +140,11 @@ var TransferComponentFormView = Backbone.View.extend({
         $('#transfer-name-container').show();
         $('#transfer-type').val('standard');
         $('#path_container').html('');
-        $('.transfer-component-activity-indicator').hide();
 
         components = {};
       }
     });
+    $('.transfer-component-activity-indicator').hide();
   },
 
   render: function() {

--- a/src/dashboard/src/templates/transfer/grid.html
+++ b/src/dashboard/src/templates/transfer/grid.html
@@ -220,7 +220,7 @@
 
   <script type="text/template" id='transfer-component-path-item'>
     <div id='transfer-component-path-item-<%= path_counter %>'>
-      <span class="transfer_path"><%= path %></span>
+      <span class="transfer_path" id="<%= location_path %>"><%= path %></span>
       <span class="transfer_path_icons">
         <span class="transfer_path_edit_icon"><img src="/media/images/table_edit.png" /></span>
         <span class="transfer_path_delete_icon"><img src="/media/images/delete.png" /></span>


### PR DESCRIPTION
Updated Archivematica to call the storage service to move files when starting a transfer, instead of assuming all files are locally available.

Part of this work cherry-picked from dev/issue-6488-aip-reingest, specifically the work to upload metadata files from a transfer source.  This will need to be cleaned up if it is merged before AIP reingest is.

JS browser now tracks the UUID of the Location a path was selected from, and POSTs that to the dashboard in the form `<UUID>:<full path>`.  Note the UUID is not displayed to the user - it is the 'id' of the element containing the path displayed to the user.

The dashboard POSTs to the storage service to move these to the pipeline's temp directory, then moves them to the correct watched directory when complete.

Some cleanup of dead code as well.
