### PR TITLE
Allow MySQLdb to take parameter placeholders

### DIFF
--- a/src/MCPClient/lib/clientScripts/emailFailReport.py
+++ b/src/MCPClient/lib/clientScripts/emailFailReport.py
@@ -63,8 +63,8 @@ def sendEmail(subject, to, from_, content, server):
 
 def getUnitStatisticalDataHTML(unitIdentifier):
     fields = ["unitType", "Total time processing", "total file size", "number of files", "average file size KB", "average file size MB"]
-    sql = """SELECT `%s` FROM PDI_by_unit WHERE SIP_OR_TRANSFER_UUID = '%s';""" % ("`, `".join(fields), unitIdentifier)
-    rows = databaseInterface.queryAllSQL(sql)
+    sql = """SELECT `{fields}` FROM PDI_by_unit WHERE SIP_OR_TRANSFER_UUID = %s;""".format(fields="`, `".join(fields))
+    rows = databaseInterface.queryAllSQL(sql, (unitIdentifier,))
     return HTML.table(rows, header_row=fields)
 
 def getUnitJobLogHTML(unitIdentifier):
@@ -72,12 +72,12 @@ def getUnitJobLogHTML(unitIdentifier):
 
     sql = """SELECT Jobs.jobType, Jobs.currentStep, Jobs.createdTime, jobUUID
     FROM Jobs 
-    WHERE Jobs.SIPUUID = '%s' 
+    WHERE Jobs.SIPUUID = %s
     AND Jobs.jobType != 'Email fail report'
     AND subJobOf = ''
-    ORDER BY Jobs.createdTime DESC, Jobs.createdTimeDec DESC;""" % (unitIdentifier)
+    ORDER BY Jobs.createdTime DESC, Jobs.createdTimeDec DESC;"""
     
-    rows2Temp = databaseInterface.queryAllSQL(sql)
+    rows2Temp = databaseInterface.queryAllSQL(sql, (unitIdentifier,))
 
     rows2=[]
     for row in rows2Temp:
@@ -90,8 +90,8 @@ def getUnitJobLogHTML(unitIdentifier):
         if False:
             try:
                 databaseInterface.printErrors = False
-                sql = """SELECT SEC_TO_TIME(jobDurationsView.time_from_job_created_till_end_of_processing_in_seconds) FROM  jobDurationsView WHERE jobUUID = '%s';""" % (row[3])
-                duration = databaseInterface.queryAllSQL(sql)
+                sql = """SELECT SEC_TO_TIME(jobDurationsView.time_from_job_created_till_end_of_processing_in_seconds) FROM  jobDurationsView WHERE jobUUID = %s;"""
+                duration = databaseInterface.queryAllSQL(sql, (row[3],))
                 if duration and duration[0] and duration[0][0]:
                     newRow.append(duration[0][0])
                 else:
@@ -159,8 +159,8 @@ def getContentFor(unitType, unitName, unitIdentifier, as_html_page=True):
     return etree.tostring(root, pretty_print=True)
 
 def storeReport(content, type, name, UUID):
-    sql = """INSERT INTO Reports (content, unitType, unitName, unitIdentifier) VALUES ('%s', '%s', '%s', '%s')""" % (content, type, name, UUID)
-    databaseInterface.queryAllSQL(sql)
+    sql = """INSERT INTO Reports (content, unitType, unitName, unitIdentifier) VALUES (%s, %s, %s, %s)"""
+    databaseInterface.queryAllSQL(sql, (content, type, name, UUID))
 
 if __name__ == '__main__':
     parser = OptionParser()

--- a/src/archivematicaCommon/lib/databaseInterface.py
+++ b/src/archivematicaCommon/lib/databaseInterface.py
@@ -93,7 +93,7 @@ global database
 reconnect()
 sqlLock.release()
 
-def runSQL(sql):
+def runSQL(sql, arguments=None):
     global database
     if printSQL:
         print sql
@@ -106,7 +106,7 @@ def runSQL(sql):
     try:
         #db.query(sql)
         c=database.cursor()
-        c.execute(sql)
+        c.execute(sql, arguments)
         database.commit()
         rows = c.fetchall()
     except MySQLdb.OperationalError as message:
@@ -134,7 +134,7 @@ def runSQL(sql):
     return
 
 
-def insertAndReturnID(sql):
+def insertAndReturnID(sql, arguments=None):
     global database
     ret = None
     if printSQL:
@@ -148,7 +148,7 @@ def insertAndReturnID(sql):
     try:
         #db.query(sql)
         c=database.cursor()
-        c.execute(sql)
+        c.execute(sql, arguments)
         database.commit()
         ret = c.lastrowid
     except MySQLdb.OperationalError as message:
@@ -175,7 +175,7 @@ def insertAndReturnID(sql):
 
 
 
-def querySQL(sql):
+def querySQL(sql, arguments=None):
     global database
     if printSQL:
         print sql
@@ -184,7 +184,7 @@ def querySQL(sql):
     sqlLock.acquire()
     try:
         c=database.cursor()
-        c.execute(sql)
+        c.execute(sql, arguments)
     except MySQLdb.OperationalError as message:
         #errorMessage = "Error %d:\n%s" % (message[ 0 ], message[ 1 ] )
         if message[0] == 2006 and message[1] == 'MySQL server has gone away':
@@ -192,7 +192,7 @@ def querySQL(sql):
             import time
             time.sleep(10)
             c=database.cursor()
-            c.execute(sql)
+            c.execute(sql, arguments)
         else:
             if printErrors:
                 print >>sys.stderr, "Error with query: ", sql
@@ -213,7 +213,7 @@ def querySQL(sql):
 #            row = c.fetchone()
 
 
-def queryAllSQL(sql):
+def queryAllSQL(sql, arguments=None):
     global database
     if isinstance(sql, unicode):
         sql = sql.encode('utf-8')
@@ -225,7 +225,7 @@ def queryAllSQL(sql):
     rows = []
     try:
         c=database.cursor()
-        c.execute(sql)
+        c.execute(sql, arguments)
         rows = c.fetchall()
         sqlLock.release()
     except MySQLdb.OperationalError as message:
@@ -235,7 +235,7 @@ def queryAllSQL(sql):
             import time
             time.sleep(10)
             c=database.cursor()
-            c.execute(sql)
+            c.execute(sql, arguments)
             rows = c.fetchall()
             sqlLock.release()
         else:


### PR DESCRIPTION
These allow values to be passed into SQL statements without interpolating them into the string, preventing possible SQL injection issues. For example:

``` python
sql = """SELECT * FROM fpr_formatversion WHERE uuid='%s'""".format(uuid)
databaseInterface.queryAllSQL(sql)
```

Could be run as:

``` python
sql = """SELECT * FROM fpr_formatversion WHERE uuid=%s"""
databaseInterface.queryAllSQL(sql, (uuid,))
```

Since the values are inserted here without string interpolation, there is no risk of quoting issues or SQL injection regardless of the contents of the values.
