### PR TITLE
Transfer: Hide transfer metadata link if none

### DIFF
--- a/src/dashboard/src/templates/transfer/detail.html
+++ b/src/dashboard/src/templates/transfer/detail.html
@@ -34,10 +34,12 @@
         <li><a href="{% url 'components.rights.views.transfer_rights_edit' uuid %}">Add</a></li>
       </ul>
 
+      {% if set_uuid %}
       <h5>Transfer Metadata</h5>
       <ul>
         <li><a href="{% url 'components.transfer.views.component' set_uuid %}">Edit</a></li>
       </ul>
+      {% endif %}
 
       <h5>Metadata</h5>
       <ul>


### PR DESCRIPTION
refs #7209

Previously, a TransferMetadataSet was created for every Transfer, even though it was only needed by Disk Image transfer types. It was updated to only create a TransferMetadataSet (and therefore transfermetadatasetrow) when needed, which broke rendering the link to the transfer metadata form. Update to only display the transfer metadata link if it exists.
