### PR TITLE
Ingest: Normalization report links visible as links

### DIFF
--- a/src/dashboard/src/media/js/ingest/normalization_report.js
+++ b/src/dashboard/src/media/js/ingest/normalization_report.js
@@ -37,12 +37,4 @@ $(function() {
     .click(function(event) {
       event.preventDefault();
     });
-
-  // make it so clicking on job shows details
-  $('.normalization-report-task').each(function() {
-    var taskUUID = $(this).attr('id').replace('normalization-report-task-', '');
-    $(this).click(function() {
-      window.open('/task/' + taskUUID + '/', '_blank');
-    });
-  });
 });

--- a/src/dashboard/src/templates/ingest/normalization_report.html
+++ b/src/dashboard/src/templates/ingest/normalization_report.html
@@ -32,7 +32,7 @@
           <!-- Never red -->
           <td>
             {% if item.preservation_normalization_task_uuid %}
-              <span id='normalization-report-task-{{ item.preservation_normalization_task_uuid }}' class='normalization-report-task'>{{ item.preservation_normalization_attempted|yesno:"Yes,No" }}</span>
+              <a href="{% url 'main.views.task' item.preservation_normalization_task_uuid %}" target="_blank">{{ item.preservation_normalization_attempted|yesno:"Yes,No" }}</a>
             {% else %}
               {{ item.preservation_normalization_attempted|yesno:"Yes,No" }}
             {% endif %}
@@ -40,26 +40,18 @@
 
           <!-- Red when yes -->
           <td class="{{ item.preservation_normalization_failed|yesno:"error,ok" }}">
-            {% if item.preservation_normalization_task_uuid %}
-              <span id='normalization-report-task-{{ item.preservation_normalization_task_uuid }}' class='normalization-report-task'>{{ item.preservation_normalization_failed|yesno:"Yes,No" }}</span>
-            {% else %}
-              {{ item.preservation_normalization_failed|yesno:"Yes,No" }}
-            {% endif %}
+            {{ item.preservation_normalization_failed|yesno:"Yes,No" }}
           </td>
 
-          <!-- Red is reservation_normalization_attempted is No and already_in_preservation_format is No -->
+          <!-- Red if reservation_normalization_attempted is No and already_in_preservation_format is No -->
           <td{% if not item.preservation_normalization_attempted and not item.already_in_preservation_format %} class="error"{% endif %}>
-            {% if item.preservation_normalization_task_uuid %}
-              <span id='normalization-report-task-{{ item.preservation_normalization_task_uuid }}' class='normalization-report-task'>{{ item.already_in_preservation_format|yesno:"Yes,No" }}</span>
-            {% else %}
-              {{ item.already_in_preservation_format|yesno:"Yes,No" }}
-            {% endif %}
+            {{ item.already_in_preservation_format|yesno:"Yes,No" }}
           </td>
 
           <!-- Never red -->
           <td>
             {% if item.access_normalization_task_uuid %}
-              <span id='normalization-report-task-{{ item.access_normalization_task_uuid }}' class='normalization-report-task'>{{ item.access_normalization_attempted|yesno:"Yes,No" }}</span>
+              <a href="{% url 'main.views.task' item.access_normalization_task_uuid %}" target="_blank">{{ item.access_normalization_attempted|yesno:"Yes,No" }}</a>
             {% else %}
               {{ item.access_normalization_attempted|yesno:"Yes,No" }}
             {% endif %}
@@ -67,20 +59,12 @@
 
           <!-- Red when yes -->
           <td class="{{ item.access_normalization_failed|yesno:"error,ok" }}">
-            {% if item.access_normalization_task_uuid %}
-              <span id='normalization-report-task-{{ item.access_normalization_task_uuid }}' class='normalization-report-task'>{{ item.access_normalization_failed|yesno:"Yes,No" }}</span>
-            {% else %}
-              {{ item.access_normalization_failed|yesno:"Yes,No" }}
-            {% endif %}
+            {{ item.access_normalization_failed|yesno:"Yes,No" }}
           </td>
 
-          <!-- Red is [already_in_preservation_format is No and access_normalization_failed is No -->
+          <!-- Red if already_in_preservation_format is No and access_normalization_failed is No -->
           <td{% if not item.access_normalization_attempted and not item.already_in_access_format %} class="error"{% endif %}>
-            {% if item.access_normalization_task_uuid %}
-              <span id='normalization-report-task-{{ item.access_normalization_task_uuid }}' class='normalization-report-task'>{{ item.already_in_access_format|yesno:"Yes,No" }}</span>
-            {% else %}
-              {{ item.already_in_access_format|yesno:"Yes,No" }}
-            {% endif %}
+            {{ item.already_in_access_format|yesno:"Yes,No" }}
           </td>
         </tr>
       {% endfor %}


### PR DESCRIPTION
refs #7217

Use normal HTML to make links, instead of JS, so the links are visibly styled as links.  Remove duplicate links so that only the normalization attempted column is a link to reduce confusion.
