### PR TITLE
Maildir: Temporarily disable transfer type

### DIFF
--- a/src/dashboard/src/templates/transfer/grid.html
+++ b/src/dashboard/src/templates/transfer/grid.html
@@ -179,7 +179,9 @@
               {% if not hide_features.dspace %}
               <option value='dspace'>DSpace</option>
               {% endif %}
+              {% comment 'Disabled until maildir is better supported' %}
               <option value='maildir'>Maildir</option>
+              {% endcomment %}
               <option value='disk image'>Disk Image</option>
             </select>
             <div class="help-block">Type</div>


### PR DESCRIPTION
refs #7228

Remove maildir as a transfer type until it is better supported and doesn't always break.
