### PR TITLE
Correctly associate transfer metadata with transfer on creation

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -294,7 +294,7 @@ def copy_to_start_transfer(filepath='', type='', accession='', transfer_metadata
             if transfer_metadata_set_row_uuid:
                 try:
                     row = models.TransferMetadataSet.objects.get(
-                        id="transfer_metadata_set_row_uuid"
+                        id=transfer_metadata_set_row_uuid
                     )
                     kwargs["transfermetadatasetrow"] = row
                 except models.TransferMetadataSet.DoesNotExist:


### PR DESCRIPTION
Fixes a pretty silly typo that prevented forensic disk image metadata from being associated with transfers.
