### PR TITLE
Config fixes for Ubuntu 14.04

### DIFF
--- a/dev-helper
+++ b/dev-helper
@@ -213,25 +213,6 @@ function export-sampledata() {
   fi
 }
 
-function update-atom() {
-  part="update AtoM and restart its atom-worker service"
-  echo -n "\"Would you like to ${part}?\" (y/N) "
-  read a
-  if [[ $a == "Y" || $a == "y" ]]; then
-          cd atom-git
-          sudo -u www-data git fetch origin
-          sudo -u www-data git reset --hard origin/stable/1.3.x
-          sudo -u www-data sed -i "s/'qbAclPlugin',/      'qbAclPlugin',\n'qtSwordPlugin',/g" config/ProjectConfiguration.class.php
-          sudo -u www-data rm -rf cache/*
-          sudo -u www-data php symfony cc
-          cd -
-          colour sudo stop atom-worker
-          colour sudo start atom-worker
-  else
-          echo "Not going to ${part}."
-  fi
-}
-
 function example() {
   part="example"
   echo -n "\"Would you like to ${part}?\" (y/N) "
@@ -257,4 +238,3 @@ clear-storage
 restart
 update-sampledata
 export-sampledata
-update-atom

--- a/dev-installer
+++ b/dev-installer
@@ -97,46 +97,6 @@ else
         echo "Not going to ${part}"
 fi
 
-part="install AtoM (branch stable/1.3.x)"
-echo -n "\"Would you like to ${part}?\" (y/N) "
-read a
-if [[ $a == "Y" || $a == "y" ]]; then
-
-        # Working directory
-        WDIR=$(pwd)
-
-        # Install git
-        sudo apt-get --quiet --quiet --yes install git-core
-
-        # Clone
-        git clone -b stable/1.3.x git://github.com/artefactual/atom.git ${WDIR}/atom-git
-
-        # Cleanups
-        # sudo rm -rf /var/www/ica-atom  ${WDIR}/qubit-git ${WDIR}/ica-atom-svn
-        # mysql -u root --execute="DROP DATABASE IF EXISTS qubit;"
-
-        sudo ln --no-dereference --force --symbolic ${WDIR}/atom-git /var/www/ica-atom
-
-        # Enable SWORD plugin
-        sed -i "s/'qbAclPlugin',/      'qbAclPlugin',\n'qtSwordPlugin',/g" /var/www/ica-atom/config/ProjectConfiguration.class.php
-
-        # Permissions
-        sudo chown -R www-data:www-data ${WDIR}/atom-git
-
-        # Restart database
-        echo "Enter mysql root password (hit enter if blank)"
-        mysql -u root --execute="DROP DATABASE IF EXISTS atom; CREATE DATABASE atom CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
-
-        # Workaround for #3188
-        sudo rm -rf ${WDIR}/atom-git/cache/*
-        sudo -u www-data php ${WDIR}/atom-git/symfony cc
-
-        # Restart Apache (not really needed)
-        sudo apache2ctl restart
-
-else
-        echo "Not going to ${part}."
-fi
 
 part="reinstall archivematica upstart services - requires restart"
 echo -n "\"Would you like to ${part}?\" (y/N) "
@@ -146,17 +106,12 @@ if [[ $a == "Y" || $a == "y" ]]; then
         sudo stop archivematica-mcp-client
         sleep 1
         sudo stop archivematica-mcp-server
-        sleep 3
-        sudo stop atom-worker
         sudo rm \
           /etc/init/archivematica-mcp-server.conf \
           /etc/init/archivematica-mcp-client.conf \
-          /etc/init/atom-worker.conf \
           /etc/init/openoffice-service.conf
         sudo ln src/MCPServer/init/archivematica-mcp-server.conf /etc/init/
         sudo ln src/MCPClient/init/archivematica-mcp-client.conf /etc/init/
-        #sudo ln src/MCPClient/init/openoffice-service.conf /etc/init/
-        sudo ln atom-git/init/atom-worker.conf /etc/init/
 else
         echo "Not going to ${part}."
 fi

--- a/localDevSetup/apache/apache.default
+++ b/localDevSetup/apache/apache.default
@@ -18,14 +18,6 @@
   CustomLog /var/log/apache2/access.log combined
   ServerSignature On
 
-  Alias /ica-atom "/var/www/atom/"
-  <Directory "/var/www/atom/">
-    Options Indexes FollowSymLinks MultiViews
-    AllowOverride All
-    Order allow,deny
-    Allow from all
-  </Directory>
-
   # Serve static files from Dashboard
   Alias /media "/usr/share/archivematica/dashboard/media/"
   <Directory "/usr/share/archivematica/dashboard/media/">

--- a/localDevSetup/cleanup.sh
+++ b/localDevSetup/cleanup.sh
@@ -37,4 +37,4 @@ do
     fi
 done
 
-sudo rm /etc/apache2/sites-enabled/000-default
+sudo rm /etc/apache2/sites-enabled/000-default.conf

--- a/localDevSetup/createDatabases/postBuildRun.sh
+++ b/localDevSetup/createDatabases/postBuildRun.sh
@@ -10,7 +10,6 @@ fi
 
 cd postBuildRunAssistScripts
 ./preMCPLogging.sh "$dpPassword"
-sudo mysqladmin create ica-atom $dpPassword
 sudo mysqladmin create dcb $dpPassword
 sudo mysqladmin create qubit $dpPassword
 sudo mysqladmin create dashboard $dpPassword

--- a/localDevSetup/createLocalDevDirectories.sh
+++ b/localDevSetup/createLocalDevDirectories.sh
@@ -52,16 +52,10 @@ if [ -e  /etc/init/openoffice-service.conf ] ; then
     sudo stop openoffice-service
 	sudo rm "/etc/init/openoffice-service.conf"
 fi
-if [ ! -e  /etc/init/qubit-sword.conf ] ; then
-        sudo ln "${svnDir}qubit-git/init/qubit-sword.conf" "/etc/init/"
-fi
 
 sudo ln "${svnDir}localDevSetup/apache/apache.default" "/etc/apache2/sites-enabled/000-default.conf" -f
 sudo ln "${svnDir}localDevSetup/apache/apache.default" "/etc/apache2/sites-available/000-default.conf" -f
 sudo ln -sf "${svnDir}localDevSetup/apache/httpd.conf" "/etc/apache2/httpd.conf"
-
-sudo ln -sf "${svnDir}qubit-git" /var/www/ica-atom
-sudo chown -R www-data:www-data "${svnDir}qubit-git"
 
 sudo mkdir /var/archivematica/
 sudo ln -s "${svnDir}src/MCPServer/share/sharedDirectoryStructure" "/var/archivematica/sharedDirectory"

--- a/localDevSetup/createLocalDevDirectories.sh
+++ b/localDevSetup/createLocalDevDirectories.sh
@@ -56,8 +56,8 @@ if [ ! -e  /etc/init/qubit-sword.conf ] ; then
         sudo ln "${svnDir}qubit-git/init/qubit-sword.conf" "/etc/init/"
 fi
 
-sudo ln "${svnDir}localDevSetup/apache/apache.default" "/etc/apache2/sites-enabled/000-default" -f
-sudo ln "${svnDir}localDevSetup/apache/apache.default" "/etc/apache2/sites-available/default" -f
+sudo ln "${svnDir}localDevSetup/apache/apache.default" "/etc/apache2/sites-enabled/000-default.conf" -f
+sudo ln "${svnDir}localDevSetup/apache/apache.default" "/etc/apache2/sites-available/000-default.conf" -f
 sudo ln -sf "${svnDir}localDevSetup/apache/httpd.conf" "/etc/apache2/httpd.conf"
 
 sudo ln -sf "${svnDir}qubit-git" /var/www/ica-atom

--- a/src/MCPClient/init/archivematica-mcp-client.conf
+++ b/src/MCPClient/init/archivematica-mcp-client.conf
@@ -34,11 +34,14 @@ pre-start script
     # Check that $CONF directory exists
     [ -d $CONF ]
 
-    # Wait for Gearman service
-    while [[ "`gearadmin --getpid`" == '' ]]
+    # Wait for Gearman to start - timeout eventually
+    for i in $(seq 1 10)
     do
-        sleep 20
+        gearadmin --getpid && break
+        sleep 3
     done
+    gearadmin --getpid || exit 1
+    exit 0
 
 end script
 

--- a/src/MCPClient/init/archivematica-mcp-client.conf
+++ b/src/MCPClient/init/archivematica-mcp-client.conf
@@ -35,7 +35,7 @@ pre-start script
     [ -d $CONF ]
 
     # Wait for Gearman service
-    while [ ! -f /var/run/gearman/gearmand.pid ]
+    while [[ "`gearadmin --getpid`" == '' ]]
     do
         sleep 20
     done
@@ -49,6 +49,7 @@ script
     LOGFILE=/tmp/archivematicaMCPClient-${HOSTNAME}.log
     test -f /etc/default/locale && . /etc/default/locale || true 
     test -f /etc/environment && . /etc/environment || true
+
     # Run
     LANG=$LANG $LOCATION 2>>$LOGFILE 1>&2
 

--- a/src/MCPServer/init/archivematica-mcp-server.conf
+++ b/src/MCPServer/init/archivematica-mcp-server.conf
@@ -32,11 +32,14 @@ pre-start script
     # Check that $CONF directory exists
     [ -d $CONF ]
 
-    # Wait for Gearman service
-    while [[ "`gearadmin --getpid`" == '' ]]
+    # Wait for Gearman to start - timeout eventually
+    for i in $(seq 1 10)
     do
+        gearadmin --getpid && break
         sleep 3
     done
+    gearadmin --getpid || exit 1
+    exit 0
 
 end script
 

--- a/src/MCPServer/init/archivematica-mcp-server.conf
+++ b/src/MCPServer/init/archivematica-mcp-server.conf
@@ -33,7 +33,7 @@ pre-start script
     [ -d $CONF ]
 
     # Wait for Gearman service
-    while [ ! -f /var/run/gearman/gearmand.pid ]
+    while [[ "`gearadmin --getpid`" == '' ]]
     do
         sleep 3
     done


### PR DESCRIPTION
Apache now expects sites-[available|enabled] to end in .conf, so update dev creation to create 000-default.conf instead of [000-]default.

Gearman no longer creates a PID file that can be checked for. Instead, check the status directly by asking gearadmin for the PID.

refs #7293
