### PR TITLE
MCPClient: remove unused rfc6266 dependency

### DIFF
--- a/src/MCPClient/debian/control
+++ b/src/MCPClient/debian/control
@@ -13,7 +13,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, archivematica-common,
  gearman, imagemagick, inkscape, jhove, libimage-exiftool-perl, libxml2-utils, logapp,
  md5deep, mediainfo, nfs-common, openjdk-7-jre-headless, p7zip-full,
  pbzip2, postfix, python-fido, python-gearman, python-lxml,
- python-mysqldb, python-pyicu, python-rfc6266, python-unidecode, readpst,
+ python-mysqldb, python-pyicu, python-unidecode, readpst,
  rsync, sleuthkit, tesseract-ocr, tika, tree, ufraw, unrar-free, uuid
 Description: MCP Client for Archivematica
   

--- a/src/archivematicaCommon/lib/externals/extractMaildirAttachments.py
+++ b/src/archivematicaCommon/lib/externals/extractMaildirAttachments.py
@@ -8,7 +8,6 @@
 # Modification
 # Author Joseph Perry
 # date Aug 10 2010
-# Using rfc6266 library
 
 import email
 import sys


### PR DESCRIPTION
This was once used in Archivematica's email code, but was removed in 6d86d6add9fe516e8a806eeaf4eef2cb389e9447 and never used anywhere else in the code.

I noticed this when setting up a 14.04 AM install. dev-helper complained about being unable to find the package, which we haven't packaged for 14.04. Since we're not using it, I'd rather delete it than rebuild it. ;)

We can probably remove the 12.04 package, too.
