### PR TITLE
Transfer JS: Enable paths that don't start with /

### DIFF
--- a/src/dashboard/src/media/js/file-explorer.js
+++ b/src/dashboard/src/media/js/file-explorer.js
@@ -78,11 +78,12 @@
     // Provides a human-readable version of the path, suitable for display.
     // This is used by path() below.
     displaypath: function() {
-      parent = this.get('parent') || '';
-      parent = Base64.decode(parent);
+      parent = this.get('parent');
       name = this.get('name') || '';
       name = Base64.decode(name);
-      return parent + '/' + name;
+      return (parent !== undefined)
+        ? Base64.decode(parent) + '/' + name
+        : name;
     },
 
     // Decode parent and child elements, concatenate them as plaintext,
@@ -115,7 +116,7 @@
       // Both parent (if present) and child are still base64-encoded at this point
       name = this.get('name') || '';
       name = Base64.decode(name);
-      parent = (parent != undefined)
+      parent = (parent !== undefined)
         ? Base64.decode(parent) + '/' + name
         : name;
       if (parent) {

--- a/src/dashboard/src/media/js/transfer/component_directory_select.js
+++ b/src/dashboard/src/media/js/transfer/component_directory_select.js
@@ -29,9 +29,16 @@ function createDirectoryPicker(locationUUID, baseDirectory, modalCssId, targetCs
     entryTemplate: $('#template-dir-entry').html()
   });
 
+  var path_components = baseDirectory.replace(/\\/g,'/').split('/');
+  var name = Base64.encode(path_components.pop()); // parse out path basename
+  var parent = Base64.encode(path_components.join('/')); // parse out path directory
+  if (path_components.length == 0) {
+    // No leading / in baseDirectory, so parent is undefined to prevent leading /
+    parent = undefined;
+  }
   selector.structure = {
-    'name': Base64.encode(baseDirectory.replace(/\\/g,'/').replace( /.*\//, '' )),      // parse out path basename
-    'parent': Base64.encode(baseDirectory.replace(/\\/g,'/').replace(/\/[^\/]*$/, '')), // parse out path directory
+    'name': name,
+    'parent': parent,
     'children': []
   };
 


### PR DESCRIPTION
refs #7133

Duracloud 'paths' may not start with /. Update JS to not insert /'s at the start of every path.
