### PR TITLE
Transfer backlog deletion: remove all files from ES

### DIFF
--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -40,7 +40,7 @@ def post_store_hook(sip_uuid):
                 user_email='archivematica system',
                 reason_for_deletion='All files in Transfer are now in AIPs.'
             )
-            elasticSearchFunctions.connect_and_remove_sip_transfer_files(transfer_uuid)
+            elasticSearchFunctions.connect_and_remove_transfer_files(transfer_uuid)
 
 
 if __name__ == '__main__':

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -748,20 +748,25 @@ def connect_and_remove_backlog_transfer_files(uuid):
 def connect_and_remove_sip_transfer_files(uuid):
     return connect_and_remove_transfer_files(uuid, 'sip')
 
-def connect_and_remove_transfer_files(uuid, unit_type):
-    # get file UUIDs for each file in the SIP
-    sql = "SELECT fileUUID from Files WHERE " + unit_type + "UUID='" + MySQLdb.escape_string(uuid) + "'"
+def connect_and_remove_transfer_files(uuid, unit_type=None):
+    if unit_type == 'transfer':
+        transfers = {uuid}
+    else:
+        sql = "SELECT transferUUID FROM Files WHERE transferUUID=%s OR sipUUID=%s"
+        transfers = {f[0] for f in databaseInterface.queryAllSQL(sql, (uuid, uuid))}
 
-    rows = databaseInterface.queryAllSQL(sql)
-
-    if len(rows) > 0:
+    if len(transfers) > 0:
         conn = connect_and_create_index('transfers')
 
-        # cycle through file UUIDs and delete files from transfer backlog
-        for row in rows:
-            document_id = _document_ids_from_field_query(conn, 'transfers', ['transferfile'],  'fileuuid', row[0])
-            if document_id:
-                conn.delete('transfers', 'transferfile', document_id[0])
+        for transfer in transfers:
+            files = _document_ids_from_field_query(conn, 'transfers', ['transferfile'], 'sipuuid', transfer)
+            if len(files) > 0:
+                for f in files:
+                    conn.delete('transfers', 'transferfile', f)
+    else:
+        if not unit_type:
+            unit_type = 'transfer or SIP'
+        logging.warning("No transfers found for %s %s", unit_type, uuid)
 
 def delete_aip(uuid):
     return delete_matching_documents('aips', 'aip', 'uuid', uuid)


### PR DESCRIPTION
When files are removed from transfer backlog after an AIP is stored, the current version of Archivematica will leave certain files dangling - any file that's not tracked in the Archivematica DB (such as logs or metadata) will be kept in the index even though they're gone from the disk.

This updates the function to avoid querying the database for files, and instead queries the database for transfers and asks ES for its list of files in those transfers.
