### PR TITLE
Index identifiers in ElasticSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@ dev (1.4.0)
 
 * Remove unused Elasticsearch backup code (#8076)
 * Improve performance of indexing AIP by saving uncompressed METS (#7424)
+* Index MODS identifiers in Elasticsearch (#7424)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@ dev (1.4.0)
 ===========
 
 * Remove unused Elasticsearch backup code (#8076)
+* Improve performance of indexing AIP by saving uncompressed METS (#7424)

--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -49,6 +49,7 @@ checkTransferDirectoryForObjects_v0.0 = %clientScriptsDirectory%checkTransferDir
 compressAIP_v0.0 = %clientScriptsDirectory%compressAIP.py
 copy_v0.0 = cp
 copyRecursive_v0.0 = %clientScriptsDirectory%copyRecursiveIfExists.sh
+copySubmissionDocs_v0.0 = %clientScriptsDirectory%copySubmissionDocs.sh
 copyTransfersMetadataAndLogs_v0.0 = %clientScriptsDirectory%copyTransfersMetadataAndLogs.py
 copyTransferSubmissionDocumentation_v0.0 = %clientScriptsDirectory%copyTransferSubmissionDocumentation.py
 createAIC_METS_v1.0 =  %clientScriptsDirectory%createAICMETS.py

--- a/src/MCPClient/lib/clientScripts/copySubmissionDocs.sh
+++ b/src/MCPClient/lib/clientScripts/copySubmissionDocs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Arguments:
+# $1 - %SIPDirectory%
+# $2 - %SIPName%-%SIPUUID%
+
+# Copy submission documentation from the AIP back into the SIP
+subdir="$1/submissionDocumentation"
+mkdir -p $subdir
+cp -R "$1/$2/data/objects/submissionDocumentation" $subdir

--- a/src/MCPClient/lib/clientScripts/indexAIP.py
+++ b/src/MCPClient/lib/clientScripts/indexAIP.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python2 -OO
 
 import ConfigParser
+from glob import glob
 import os
 import sys
 
@@ -11,6 +12,11 @@ from main.models import UnitVariable
 import elasticSearchFunctions
 from executeOrRunSubProcess import executeOrRun
 import storageService as storage_service
+from identifer_functions import extract_identifiers_from_mods
+
+
+def list_mods(sip_path):
+    return glob('{}/submissionDocumentation/**/mods/*.xml'.format(sip_path))
 
 
 def index_aip():
@@ -42,6 +48,11 @@ def index_aip():
     mets_name = 'METS.{}.xml'.format(sip_uuid)
     mets_path = os.path.join(sip_path, mets_name)
 
+    mods_paths = list_mods(sip_path)
+    identifiers = []
+    for mods in mods_paths:
+        identifiers.extend(extract_identifiers_from_mods(mods))
+
     # If this is an AIC, find the number of AIP stored in it and index that
     aips_in_aic = None
     if sip_type == "AIC":
@@ -59,7 +70,8 @@ def index_aip():
         aip_info['current_full_path'],
         mets_path,
         size=aip_info['size'],
-        aips_in_aic=aips_in_aic)
+        aips_in_aic=aips_in_aic,
+        identifiers=identifiers)
 
     return 0
 

--- a/src/MCPClient/lib/clientScripts/indexAIP.py
+++ b/src/MCPClient/lib/clientScripts/indexAIP.py
@@ -13,30 +13,12 @@ from executeOrRunSubProcess import executeOrRun
 import storageService as storage_service
 
 
-def extract_mets(mets_path, aip_path):
-    """
-    Extract a METS file from an AIP, given the relative METS path
-    and the path to the compressed AIP.
-    """
-    output_mets_path = os.path.join('/tmp', os.path.basename(mets_path))
-    command = 'atool --cat {aip_path} {mets_path} > {output}'.format(
-        aip_path=aip_path, mets_path=mets_path, output=output_mets_path)
-    print 'Extracting METS file with:', command
-    exit_code, _, _ = executeOrRun("bashScript", command, printing=True)
-    if exit_code != 0:
-        raise Exception("Error extracting")
-
-    return output_mets_path
-
-
 def index_aip():
     """ Write AIP information to ElasticSearch. """
     sip_uuid = sys.argv[1]  # %SIPUUID%
     sip_name = sys.argv[2]  # %SIPName%
-    aip_path = sys.argv[3]  # %SIPDirectory%%SIPName%-%SIPUUID%.7z
+    sip_path = sys.argv[3]  # %SIPDirectory%
     sip_type = sys.argv[4]  # %SIPType%
-
-    is_uncompressed_aip = os.path.isdir(aip_path)
 
     # Check if ElasticSearch is enabled
     client_config_path = '/etc/archivematica/MCPClient/clientConfig.conf'
@@ -57,26 +39,8 @@ def index_aip():
     print 'aip_info', aip_info
     aip_info = aip_info[0]
 
-    relative_mets_path = os.path.join(
-        "data",
-        'METS.{}.xml'.format(sip_uuid)
-    )
-
-    if is_uncompressed_aip:
-        mets_path = os.path.join(aip_path, relative_mets_path)
-    else:
-        try:
-            # The package contains a top-level directory which is named
-            # after the SIP; need to check in there for the METS if
-            # the AIP path is a compressed file instead of a directory.
-            package_mets_path = os.path.join(
-                "{}-{}".format(sip_name, sip_uuid),
-                relative_mets_path
-            )
-            mets_path = extract_mets(package_mets_path, aip_path)
-        except:
-            print >> sys.stderr, "Unable to extract AIP METS from AIP {} (located at {})".format(sip_uuid, aip_path)
-            return 1
+    mets_name = 'METS.{}.xml'.format(sip_uuid)
+    mets_path = os.path.join(sip_path, mets_name)
 
     # If this is an AIC, find the number of AIP stored in it and index that
     aips_in_aic = None
@@ -96,9 +60,6 @@ def index_aip():
         mets_path,
         size=aip_info['size'],
         aips_in_aic=aips_in_aic)
-
-    if not is_uncompressed_aip:
-        os.remove(mets_path)
 
     return 0
 

--- a/src/MCPServer/share/mysql_dev.sh
+++ b/src/MCPServer/share/mysql_dev.sh
@@ -12,4 +12,5 @@ mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7606_atk_whitespace.sql;"
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_6488_aip_reingest.sql;"
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7137_models.sql;"
+mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7424_identifiers_in_es.sql;"
 # ...

--- a/src/MCPServer/share/mysql_dev_7424_identifiers_in_es.sql
+++ b/src/MCPServer/share/mysql_dev_7424_identifiers_in_es.sql
@@ -1,0 +1,8 @@
+-- Compressed AIP path no longer needed in indexAIP;
+-- instead pass the SIP directory, which contains the metadata files
+UPDATE StandardTasksConfigs SET arguments='"%SIPUUID%" "%SIPName%" "%SIPDirectory%" "%SIPType%"' WHERE pk='81f36881-9e54-4c75-a5b2-838cfb2ca228';
+
+-- Don't delete the AIP METS, to avoid needing to re-extract it from the AIP
+-- during indexAIP.
+UPDATE StandardTasksConfigs SET arguments='-R "%SIPDirectory%%SIPName%-%SIPUUID%" "%SIPLogsDirectory%" "%SIPObjectsDirectory%" "%SIPDirectory%thumbnails/"' WHERE pk='d12b6b59-1f1c-47c2-b1a3-2bf898740eae';
+UPDATE StandardTasksConfigs SET arguments='-R "%SIPLogsDirectory%" "%SIPObjectsDirectory%" "%SIPDirectory%thumbnails/"' WHERE pk='d17b25c7-f83c-4862-904b-8074150b1395';

--- a/src/MCPServer/share/mysql_dev_7424_identifiers_in_es.sql
+++ b/src/MCPServer/share/mysql_dev_7424_identifiers_in_es.sql
@@ -6,3 +6,13 @@ UPDATE StandardTasksConfigs SET arguments='"%SIPUUID%" "%SIPName%" "%SIPDirector
 -- during indexAIP.
 UPDATE StandardTasksConfigs SET arguments='-R "%SIPDirectory%%SIPName%-%SIPUUID%" "%SIPLogsDirectory%" "%SIPObjectsDirectory%" "%SIPDirectory%thumbnails/"' WHERE pk='d12b6b59-1f1c-47c2-b1a3-2bf898740eae';
 UPDATE StandardTasksConfigs SET arguments='-R "%SIPLogsDirectory%" "%SIPObjectsDirectory%" "%SIPDirectory%thumbnails/"' WHERE pk='d17b25c7-f83c-4862-904b-8074150b1395';
+
+-- Copies submission documentation back into the root of the SIP directory,
+-- so it's available to be used by indexAIP without extraction from
+-- a compressed AIP.
+INSERT INTO StandardTasksConfigs (pk, requiresOutputLock, execute, arguments) VALUES ('919dfbcd-b328-4a7e-9340-569a9d8859df', 0, 'copySubmissionDocs_v0.0', '"%SIPDirectory%" "%SIPName%-%SIPUUID%"');
+INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES ('2894f4ea-0d11-431f-a7de-c2f765bd55a6', '36b2e239-4a57-4aa5-8ebc-7a29139baca6', '919dfbcd-b328-4a7e-9340-569a9d8859df', 'Copy submission documentation');
+INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, currentTask, defaultNextChainLink) values ('0a63befa-327d-4655-a021-341b639ee9ed', 'Prepare AIP', 'Failed', '2894f4ea-0d11-431f-a7de-c2f765bd55a6', '7d728c39-395f-4892-8193-92f086c0546f');
+INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('264fdc03-9102-4eb6-b671-09e48b136d27', '0a63befa-327d-4655-a021-341b639ee9ed', 0, '0915f727-0bc3-47c8-b9b2-25dc2ecef2bb', 'Completed successfully');
+UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink='0a63befa-327d-4655-a021-341b639ee9ed' WHERE microServiceChainLink='d55b42c8-c7c5-4a40-b626-d248d2bd883f';
+

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -292,7 +292,7 @@ def set_up_mapping(conn, index):
         )
         print 'AIP file mapping created.'
 
-def connect_and_index_aip(uuid, name, filePath, pathToMETS, size=None, aips_in_aic=None):
+def connect_and_index_aip(uuid, name, filePath, pathToMETS, size=None, aips_in_aic=None, identifiers=[]):
     conn = connect_and_create_index('aips')
 
     tree = ElementTree.parse(pathToMETS)
@@ -330,6 +330,7 @@ def connect_and_index_aip(uuid, name, filePath, pathToMETS, size=None, aips_in_a
         'AICID': aic_identifier,
         'isPartOf': is_part_of,
         'countAIPsinAIC': aips_in_aic,
+        'identifiers': identifiers
     }
     wait_for_cluster_yellow_status(conn)
     try_to_index(conn, aipData, 'aips', 'aip')

--- a/src/archivematicaCommon/lib/identifier_functions.py
+++ b/src/archivematicaCommon/lib/identifier_functions.py
@@ -1,0 +1,6 @@
+from lxml import etree
+
+def extract_identifiers_from_mods(mods_path):
+    doc = etree.parse(mods_path)
+    elements = doc.findall('//{http://www.loc.gov/mods/v3}identifier')
+    return [e.text for e in elements]


### PR DESCRIPTION
This adds support for indexing document identifiers in ES, in addition to METS content. Document identifiers refer to identifiers used to reference the content in other systems. For example, if content originated in an Islandora system, the identifiers would contain the Islandora IDs of each item within the AIP.

A new `'identifiers'` key has been added to the ES document that is indexed, containing an array of zero or more strings. These can be returned via the "any" search in archival storage.

This adds support for retrieving these from one source, currently: identifiers will be extracted from MODS XML files located in the submissionDocumentation directory of each transfer contained in an AIP. This supports the Islandora workflow.

This also improves the existing indexing workflow by removing the need to extract the AIP's METS from the compressed AIP; the file was already contained at the root of the SIP and was being deleted unnecessarily. This leaves it in the SIP root and uses that copy. This should speed up indexing a bit. (Potentially a lot, for large solid archives.)
