### PR TITLE
Dashboard: Accession IDs associate with Transfers again

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -227,7 +227,8 @@ def copy_to_start_transfer(filepath='', type='', accession='', transfer_metadata
         # supplementary info from
         if accession != '' or transfer_metadata_set_row_uuid != '':
             temp_uuid = uuid.uuid4().__str__()
-            mcp_destination = destination.replace(SHARED_DIRECTORY_ROOT + '/', '%sharedPath%') + '/'
+            mcp_destination = destination.replace(os.path.join(SHARED_DIRECTORY_ROOT, ''), '%sharedPath%')
+            mcp_destination = os.path.join(mcp_destination, '')  # Add trailing /
             kwargs = {
                 "uuid": temp_uuid,
                 "accessionid": accession,


### PR DESCRIPTION
Use os.path.join to add / to the end of SHARED_DIRECTORY_ROOT if needed before replacing it with %sharedPath%.

SHARED_DIRECTORY_ROOT was updated to read the shared directory path from a config file instead of being hardcoded in an earlier commit. The previous hardcoded value was not / terminated, but the config file path is / terminated.

When creating a new Transfer, a replace is done on the path to convert it from absolute to relative to %sharedPath%. The replace always added / to the end of SHARED_DIRECTORY_ROOT, which caused the replace to fail when SHARED_DIRECTORY_ROOT was already / terminated.

This caused the MCPServer to create a duplicate Transfer (without an accession ID) when it found the files on disk, as it could not find an associated Transfer by path in the DB.

refs #7442
