### PR TITLE
ATK: Add quotes around parameters to handle whitespace

### DIFF
--- a/src/MCPServer/share/mysql_dev.sh
+++ b/src/MCPServer/share/mysql_dev.sh
@@ -9,4 +9,5 @@ echo 'Running mysql_dev1'
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7464_processing_directory.sql;"
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7478_processing_directory.sql;"
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7603_metadata_identification.sql;"
+mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7606_atk_whitespace.sql;"
 # ...

--- a/src/MCPServer/share/mysql_dev_7606_atk_whitespace.sql
+++ b/src/MCPServer/share/mysql_dev_7606_atk_whitespace.sql
@@ -1,0 +1,3 @@
+-- Add quotes around all the ATK parameters to handle whitespace in names
+
+UPDATE StandardTasksConfigs SET arguments = '--host="%host%" --port="%port%" --dbname="%dbname%" --dbuser="%dbuser%" --dbpass="%dbpass%" --atuser="%atuser%" --dip_location="%SIPDirectory%" --dip_name="%SIPName%" --dip_uuid="%SIPUUID%" --restrictions="%restrictions%" --object_type="%object_type%" --ead_actuate="%ead_actuate%" --ead_show="%ead_show%" --use_statement="%use_statement%" --uri_prefix="%uri_prefix%" --access_conditions="%access_conditions%" --use_conditions="%use_conditions%"' WHERE pk='a650921e-b754-4e61-9713-1457cf52e77d';


### PR DESCRIPTION
This should also get cherry-picked to the 1.3.1 release.  ATK requires extra setup/external system, so have not tested yet.

refs #7606
