### PR TITLE
MCPClient control: specify libavcodec-extra-56 dependency

### DIFF
--- a/src/MCPClient/debian/control
+++ b/src/MCPClient/debian/control
@@ -9,7 +9,7 @@ Homepage: http://archivematica.org
 Package: archivematica-mcp-client
 Architecture: i386 amd64 
 Depends: ${shlibs:Depends}, ${misc:Depends}, archivematica-common,
- atool, bagit, bulk-extractor, clamav, clamav-daemon, ffmpeg (>= 7:2.1.0), fits (>= 0.8.0-3),
+ atool, bagit, bulk-extractor, clamav, clamav-daemon, ffmpeg (>= 7:2.1.0), libavcodec-extra-56, fits (>= 0.8.0-3),
  gearman, imagemagick, inkscape, jhove, libimage-exiftool-perl, libxml2-utils, logapp,
  md5deep, mediainfo, nailgun-client, nfs-common, openjdk-7-jre-headless, p7zip-full,
  pbzip2, postfix, python-fido, python-gearman, python-lxml,


### PR DESCRIPTION
libvo_aacenc requires ffmpeg to be built as GPL3, and won't be available in the default libavcodec build. Since faac and libfdk_aac are both nonfree, this means that ffmpeg isn't installed with any AAC encoder other than the experimental internal one by default.
