### PR TITLE
SIP arrange: fix fetching results from relative_path

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -244,7 +244,10 @@ def set_up_mapping(conn, index):
     if index == 'transfers':
         mapping = {
             'filename'     : {'type': 'string'},
-            'relative_path': {'type': 'string'},
+            # Analyzed copy allows the stirng to be found via free-text search,
+            # but a raw unanalyzed copy is required for exact string matches.
+            'relative_path': {'type': 'string',
+                              'fields': {'raw': machine_readable_field_spec}},
             'fileuuid'     : machine_readable_field_spec,
             'sipuuid'      : machine_readable_field_spec,
             'accessionid'  : machine_readable_field_spec,

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -479,7 +479,7 @@ def _get_arrange_directory_tree(backlog_uuid, original_path, arrange_path):
             path = os.path.join(original_path, entry)
             relative_path = path.replace(DEFAULT_BACKLOG_PATH, '', 1)
             file_info = elasticSearchFunctions.get_transfer_file_info(
-                'relative_path', relative_path)
+                'relative_path.raw', relative_path)
             try:
                 file_uuid = file_info['fileuuid']
                 transfer_uuid = file_info['sipuuid']
@@ -566,7 +566,7 @@ def copy_to_arrange(request):
         else:
             arrange_path = os.path.join(destination, os.path.basename(sourcepath))
             file_info = elasticSearchFunctions.get_transfer_file_info(
-                'relative_path', sourcepath.replace(DEFAULT_BACKLOG_PATH, '', 1))
+                'relative_path.raw', sourcepath.replace(DEFAULT_BACKLOG_PATH, '', 1))
             file_uuid = file_info.get('fileuuid')
             transfer_uuid = file_info.get('sipuuid')
             to_add.append({'original_path': sourcepath,


### PR DESCRIPTION
The `relative_path` field in the `transferfile` document type is indexed with analysis to allow for free-text searching; however, this can result in exact string matching failing. This PR adds a second, raw copy of that field, and uses that where an exact match is required.
