### PR TITLE
metadata.csv improvements

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -152,24 +152,19 @@ def getDublinCore(unit, id):
     return ret
 
 
-def createDMDIDSFromCSVParsedMetadataFiles(filePath):
-    simpleMetadataCSVkey, simpleMetadataCSV, _, _ = CSVMetadata
-    if filePath in simpleMetadataCSV:
-        # Restructure data
-        # Create OrderedDict with keys from simpleMetadataCSVkey and values for filePath
-        # Drop first element, since that is the filename
-        metadata = collections.OrderedDict(zip(simpleMetadataCSVkey[1:], simpleMetadataCSV[filePath][1:]))
-        dmdsecs = createDmdSecsFromCSVParsedMetadata(metadata)
-        return ' '.join([d.get('ID') for d in dmdsecs])
+def createDMDIDsFromCSVMetadata(path):
+    """
+    Creates dmdSecs with metadata associated with path from the metadata.csv
 
-
-def createDMDIDSFromCSVParsedMetadataDirectories(directory):
-    _, _, compoundMetadataCSVkey, compoundMetadataCSV = CSVMetadata
-    if directory in compoundMetadataCSV:
+    :param path: Path relative to the SIP to find CSV metadata on
+    :return: Space-separated list of DMDIDs or empty string
+    """
+    keys, values = CSVMetadata
+    if path in values:
         # Restructure data
-        # Create OrderedDict with keys from compoundMetadataCSVkey and values for directory
-        # Drop first element, since that is the directory name
-        metadata = collections.OrderedDict(zip(compoundMetadataCSVkey[1:], compoundMetadataCSV[directory][1:]))
+        # Create OrderedDict with keys from keys and values for path
+        # Drop first element, since that is the file/directory name
+        metadata = collections.OrderedDict(zip(keys[1:], values[path][1:]))
         dmdsecs = createDmdSecsFromCSVParsedMetadata(metadata)
         return ' '.join([d.get('ID') for d in dmdsecs])
 
@@ -625,7 +620,7 @@ def createFileSec(directoryPath, parentDiv):
 
     structMapDiv = etree.SubElement(parentDiv, ns.metsBNS + 'div', TYPE='Directory', LABEL=os.path.basename(directoryPath))
 
-    DMDIDS = createDMDIDSFromCSVParsedMetadataDirectories(directoryPath.replace(baseDirectoryPath, "", 1))
+    DMDIDS = createDMDIDsFromCSVMetadata(directoryPath.replace(baseDirectoryPath, "", 1))
     if DMDIDS:
         structMapDiv.set("DMDID", DMDIDS)
 
@@ -706,7 +701,7 @@ def createFileSec(directoryPath, parentDiv):
                 if use == "maildirFile":
                     use = "original"
                 if use == "original":
-                    DMDIDS = createDMDIDSFromCSVParsedMetadataFiles(originalLocation.replace('%transferDirectory%', "", 1))
+                    DMDIDS = createDMDIDsFromCSVMetadata(originalLocation.replace('%transferDirectory%', "", 1))
                     if DMDIDS:
                         fileDiv.set("DMDID", DMDIDS)
                     if typeOfTransfer == "TRIM":

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -21,7 +21,7 @@
 # @package Archivematica
 # @subpackage archivematicaClientScript
 # @author Joseph Perry <joseph@artefactual.com>
-import collections
+
 from glob import glob
 import lxml.etree as etree
 import MySQLdb
@@ -32,7 +32,6 @@ import traceback
 
 import archivematicaXMLNamesSpace as ns
 from archivematicaCreateMETSMetadataCSV import parseMetadata
-from archivematicaCreateMETSMetadataCSV import CSVMetadata
 from archivematicaCreateMETSRights import archivematicaGetRights
 from archivematicaCreateMETSRightsDspaceMDRef import archivematicaCreateMETSRightsDspaceMDRef
 from archivematicaCreateMETSTrim import getTrimDmdSec
@@ -100,6 +99,8 @@ trimStructMapObjects = None
 #GROUPID="G1" -> GROUPID="Group-%object's UUID%"
 ##group of the object and it's related access, license
 
+CSV_METADATA = {}
+
 #move to common
 def newChild(parent, tag, text=None, tailText=None, sets=[]):
     # TODO convert sets to a dict, and use **dict
@@ -159,14 +160,9 @@ def createDMDIDsFromCSVMetadata(path):
     :param path: Path relative to the SIP to find CSV metadata on
     :return: Space-separated list of DMDIDs or empty string
     """
-    keys, values = CSVMetadata
-    if path in values:
-        # Restructure data
-        # Create OrderedDict with keys from keys and values for path
-        # Drop first element, since that is the file/directory name
-        metadata = collections.OrderedDict(zip(keys[1:], values[path][1:]))
-        dmdsecs = createDmdSecsFromCSVParsedMetadata(metadata)
-        return ' '.join([d.get('ID') for d in dmdsecs])
+    metadata = CSV_METADATA.get(path, {})
+    dmdsecs = createDmdSecsFromCSVParsedMetadata(metadata)
+    return ' '.join([d.get('ID') for d in dmdsecs])
 
 
 def createDmdSecsFromCSVParsedMetadata(metadata):
@@ -864,7 +860,7 @@ if __name__ == '__main__':
         import time
         time.sleep(10)
 
-    parseMetadata(baseDirectoryPath)
+    CSV_METADATA = parseMetadata(baseDirectoryPath)
 
     if not baseDirectoryPath.endswith('/'):
         baseDirectoryPath += '/'


### PR DESCRIPTION
metadata.csv can accept both file and directory metadata in the same file.  Also, clean up parsing code and createMETS2 to handle having multiple metadata.csvs better (as a result of SIP arrangement or adding them during ingest).
