### PR TITLE
Ingest file browser: improve empty path check

### DIFF
--- a/src/dashboard/src/media/js/ingest/ingest_file_browser.js
+++ b/src/dashboard/src/media/js/ingest/ingest_file_browser.js
@@ -192,7 +192,7 @@ $(document).ready(function() {
   $('#arrange_create_directory_button').click(function() {
     var path = prompt('Name of new directory?');
 
-    if (path != '') {
+    if (path) {
       var path_root = arrange_browser.getPathForCssId(arrange_browser.selectedEntryId) || '/' + Base64.decode(arrange_browser.structure.name)
         , relative_path = path_root + '/' + path;
 


### PR DESCRIPTION
Fixes an issue where hitting "cancel" at the directory creation prompt would create a directory named "null".

`!!path` will filter out both null paths (from hitting "cancel") and empty strings.

Fixes #7766.
