### PR TITLE
Dspace: Add link to parent collection in dmdSec

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -183,7 +183,6 @@ def createDmdSecsFromCSVParsedMetadata(metadata):
 
     for key, value in metadata.iteritems():
         if key.startswith("dc.") or key.startswith("dcterms."):
-            #print "dc item: ", key, value
             if dc is None:
                 globalDmdSecCounter += 1
                 ID = "dmdSec_" + globalDmdSecCounter.__str__()
@@ -193,19 +192,22 @@ def createDmdSecsFromCSVParsedMetadata(metadata):
                 mdWrap = etree.SubElement(dmdSec, ns.metsBNS + "mdWrap")
                 mdWrap.set("MDTYPE", "DC")
                 xmlData = etree.SubElement(mdWrap, ns.metsBNS + "xmlData")
-                dc = etree.Element(ns.dctermsBNS + "dublincore", nsmap={"dc": ns.dctermsNS})
-                dc.set(ns.xsiBNS+"schemaLocation", ns.dctermsNS + " http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd")
+                dc = etree.Element(ns.dctermsBNS + "dublincore", nsmap={"dcterms": ns.dctermsNS, 'dc': ns.dcNS})
+                dc.set(ns.xsiBNS + "schemaLocation", ns.dctermsNS + " http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd")
                 xmlData.append(dc)
+            elem_namespace = ""
             if key.startswith("dc."):
-                key2 = key.replace("dc.", "", 1)
+                key = key.replace("dc.", "", 1)
+                elem_namespace = ns.dcBNS
             elif key.startswith("dcterms."):
-                key2 = key.replace("dcterms.", "", 1)
+                key = key.replace("dcterms.", "", 1)
+                elem_namespace = ns.dctermsBNS
             value = value.decode('utf-8')
-            match = re.match(refinement_regex, key2)
+            match = re.match(refinement_regex, key)
             if match:
-                key2, = match.groups()
+                key, = match.groups()
 
-            el = etree.SubElement(dc, ns.dctermsBNS + key2)
+            el = etree.SubElement(dc, elem_namespace + key)
             el.text = value
         else:  # not a dublin core item
             if other is None:

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -639,7 +639,7 @@ def createFileSec(directoryPath, parentDiv):
             fileId="file-%s" % (myuuid, )
 
             #<fptr FILEID="file-<UUID>" LABEL="filename.ext">
-            label = item if label is None else label
+            label = item if not label else label
             fileDiv = etree.SubElement(structMapDiv, ns.metsBNS + "div", LABEL=label, TYPE='Item')
             etree.SubElement(fileDiv, ns.metsBNS + 'fptr', FILEID=fileId)
             fileNameToFileID[item] = fileId
@@ -682,11 +682,9 @@ def createFileSec(directoryPath, parentDiv):
                 }
                 try:
                     f = File.objects.get(**kwargs)
-                except File.DoesNotExist:
-                    raise ValueError("Original not found for file at path: " + originalLocation)
-                except File.MultipleObjectsReturned:
-                    raise ValueError("More than one original found for file at path: " + originalLocation)
-                    GROUPID = "Group-" + f.uuid
+                    GROUPID = 'Group-' + f.uuid
+                except (File.DoesNotExist, File.MultipleObjectsReturned):
+                    pass
 
 
             elif use == "preservation" or use == "text/ocr":

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRightsDspaceMDRef.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRightsDspaceMDRef.py
@@ -58,15 +58,18 @@ def archivematicaCreateMETSRightsDspaceMDRef(fileUUID, filePath, transferUUID, i
     ret = []
     try:
         print fileUUID, filePath
-        # find the mets file
+        # Find the mets file. May find none.
         path = "%SIPDirectory%{}/mets.xml".format(os.path.dirname(filePath))
-        mets = File.objects.get(currentlocation=path,
-                                transfer_id=transferUUID)
-        metsFileUUID = mets.uuid
-        metsLoc = mets.currentlocation.replace("%SIPDirectory%", "", 1)
-        metsLocation = os.path.join(os.path.dirname(itemdirectoryPath), "mets.xml")
-        LABEL = "mets.xml-%s" % (metsFileUUID)
-        ret.append(createMDRefDMDSec(LABEL, metsLocation, metsLoc))
+        try:
+            mets = File.objects.get(currentlocation=path, transfer_id=transferUUID)
+        except File.DoesNotExist:
+            pass
+        else:
+            metsFileUUID = mets.uuid
+            metsLoc = mets.currentlocation.replace("%SIPDirectory%", "", 1)
+            metsLocation = os.path.join(os.path.dirname(itemdirectoryPath), "mets.xml")
+            LABEL = "mets.xml-%s" % (metsFileUUID)
+            ret.append(createMDRefDMDSec(LABEL, metsLocation, metsLoc))
 
         base = os.path.dirname(os.path.dirname(itemdirectoryPath))
         base2 = os.path.dirname(os.path.dirname(filePath))
@@ -82,14 +85,17 @@ def archivematicaCreateMETSRightsDspaceMDRef(fileUUID, filePath, transferUUID, i
                 continue
 
             path = "%SIPDirectory%{}/mets.xml".format(fullDir2)
-            f = File.objects.get(currentlocation=path,
-                                 transfer_id=transferUUID)
-            metsFileUUID = f.uuid
-            metsLoc = f.currentlocation.replace("%SIPDirectory%", "", 1)
-            metsLocation = os.path.join(fullDir, "mets.xml")
-            print metsLocation
-            LABEL = "mets.xml-" + metsFileUUID
-            ret.append(createMDRefDMDSec(LABEL, metsLocation, metsLoc))
+            try:
+                f = File.objects.get(currentlocation=path, transfer_id=transferUUID)
+            except File.DoesNotExist:
+                pass
+            else:
+                metsFileUUID = f.uuid
+                metsLoc = f.currentlocation.replace("%SIPDirectory%", "", 1)
+                metsLocation = os.path.join(fullDir, "mets.xml")
+                print metsLocation
+                LABEL = "mets.xml-" + metsFileUUID
+                ret.append(createMDRefDMDSec(LABEL, metsLocation, metsLoc))
 
     except Exception as inst:
         print >>sys.stderr, "Error creating mets dspace mdref", fileUUID, filePath

--- a/src/MCPClient/lib/clientScripts/archivematicaXMLNamesSpace.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaXMLNamesSpace.py
@@ -2,6 +2,7 @@
 
 dcNS="http://purl.org/dc/elements/1.1/"
 dctermsNS = "http://purl.org/dc/terms/"
+dspaceNS = "http://www.dspace.org/xmlns/dspace/dim"
 fitsNS = "http://hul.harvard.edu/ois/xml/ns/fits/fits_output"
 metsNS = "http://www.loc.gov/METS/"
 premisNS = "info:lc/xmlns/premis-v2"
@@ -10,6 +11,7 @@ xsiNS = "http://www.w3.org/2001/XMLSchema-instance"
 
 dcBNS = "{" + dcNS + "}"
 dctermsBNS = "{" + dctermsNS + "}"
+dspaceBNS = "{" + dspaceNS + "}"
 fitsBNS = "{" + fitsNS + "}"
 metsBNS = "{" + metsNS + "}"
 premisBNS = "{" + premisNS + "}"
@@ -19,6 +21,7 @@ xsiBNS = "{" + xsiNS + "}"
 NSMAP = {
     'dc': dcNS,
     'dcterms': dctermsNS,
+    'dim': dspaceNS,
     'fits': fitsNS,
     'mets': metsNS,
     'premis': premisNS,


### PR DESCRIPTION
Change dmdSec generated for Dspace METS files to contain DublinCore with the identifier and parent collection (isPartOf) instead of a mdRef to the METS.

refs #6273
