### PR TITLE
Tests: Update tests to run from root

### DIFF
--- a/src/MCPClient/tests/test_json_conversion.py
+++ b/src/MCPClient/tests/test_json_conversion.py
@@ -7,13 +7,14 @@ CSV = 'filename,dc.title\r\nobjects/test.txt,This is a test item\r\n'
 JSON_MULTICOLUMN = '[{"filename": "objects/test.txt", "dc.subject": ["foo", "bar", "baz"], "dc.title": "This is a test item"}]'
 CSV_MULTICOLUMN = 'filename,dc.subject,dc.subject,dc.subject,dc.title\r\nobjects/test.txt,foo,bar,baz,This is a test item\r\n'
 
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 
 def test_json_csv_conversion(tmpdir):
     json_path = os.path.join(str(tmpdir), 'metadata.json')
     csv_path = os.path.join(str(tmpdir), 'metadata.csv')
     with open(json_path, 'w') as jsonfile:
         jsonfile.write(JSON)
-    subprocess.call(['lib/clientScripts/jsonMetadataToCSV.py', '', json_path])
+    subprocess.call([THIS_DIR + '/../lib/clientScripts/jsonMetadataToCSV.py', '', json_path])
     with open(csv_path) as csvfile:
         csvdata = csvfile.read()
 
@@ -25,7 +26,7 @@ def test_json_csv_conversion_with_repeated_columns(tmpdir):
     csv_path = os.path.join(str(tmpdir), 'metadata.csv')
     with open(json_path, 'w') as jsonfile:
         jsonfile.write(JSON_MULTICOLUMN)
-    subprocess.call(['lib/clientScripts/jsonMetadataToCSV.py', '', json_path])
+    subprocess.call([THIS_DIR + '/../lib/clientScripts/jsonMetadataToCSV.py', '', json_path])
     with open(csv_path) as csvfile:
         csvdata = csvfile.read()
 

--- a/src/archivematicaCommon/requirements/local.txt
+++ b/src/archivematicaCommon/requirements/local.txt
@@ -1,2 +1,5 @@
-pytest==2.5.2
-vcrpy==1.0.0
+-r base.txt
+
+pytest>=2,<3
+pytest-django>=2,<3
+vcrpy>=1,<2

--- a/src/archivematicaCommon/tests/test_database_functions.py
+++ b/src/archivematicaCommon/tests/test_database_functions.py
@@ -1,4 +1,5 @@
 # -*- coding: UTF-8 -*-
+import os
 import sys
 
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
@@ -10,10 +11,12 @@ from main.models import Event, File
 from django.test import TestCase
 import pytest
 
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 class TestDatabaseFunctions(TestCase):
 
-    fixtures = ['test_database_functions.json']
+    fixture_files = ['test_database_functions.json']
+    fixtures = [os.path.join(THIS_DIR, 'fixtures', p) for p in fixture_files]
 
     def test_insert_into_files_with_sip(self):
         path = "%sharedDirectory%/no_such_file"

--- a/src/dashboard/src/requirements/local.txt
+++ b/src/dashboard/src/requirements/local.txt
@@ -1,5 +1,6 @@
 -r base.txt
 
-ipython==1.1.0
-pytest==2.5.1
-pytest-django==2.4
+ipython
+pytest>=2,<3
+pytest-django>=2,<3
+vcrpy>=1,<2

--- a/src/dashboard/tests/test_filesystem_ajax.py
+++ b/src/dashboard/tests/test_filesystem_ajax.py
@@ -1,11 +1,8 @@
 #! /usr/bin/python2
 
-# Run from src/dashboard with:
-# bash: PYTHONPATH='./src' py.test --ds 'settings.local' -v
-# fish: env PYTHONPATH='./src' py.test --ds 'settings.local' -v
-
 import base64
 import json
+import os
 
 from django.core.urlresolvers import reverse
 from django.test import TestCase
@@ -13,12 +10,12 @@ from django.test.client import Client
 
 from main import models
 
-# Run from src/dashboard:
-# env PYTHONPATH='./src' py.test --ds 'settings.local'
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 class TestSIPArrange(TestCase):
 
-    fixtures = ['test_user.json', 'sip_arrange.json']
+    fixture_files = ['test_user.json', 'sip_arrange.json']
+    fixtures = [os.path.join(THIS_DIR, 'fixtures', p) for p in fixture_files]
 
     def setUp(self):
         self.client = Client()


### PR DESCRIPTION
Several tests only run from certain directories - update to use absolute paths instead of relative paths.  Also, updated versions of pytest etc to be a range rather than a specific version (especially since we already specified different specific versions!)

All of the FPRClient tests fail, because they're trying to query a non-existent server.  They need to be updated to use VCR.py

Tests can be run with `~/archivematica$ py.test` after setting `$PYTHONPATH` to  `archivematica/src/dashboard/src/` and `$DJANGO_SETTINGS_MODULE` to  `settings.local`
