### PR TITLE
advanced_search: fix query generation

### DIFF
--- a/src/dashboard/src/components/advanced_search.py
+++ b/src/dashboard/src/components/advanced_search.py
@@ -166,7 +166,7 @@ def query_clause(index, queries, ops, fields, types):
                  term_field = fields[index]
             else:
                 term_field = '_all'
-            return {'term': {term_field, queries[index]}}
+            return {'term': {term_field: queries[index]}}
     else:
         return {'query_string': {'query': queries[index], 'fields': search_fields}}
 

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -393,7 +393,7 @@ def elasticsearch_query_excluding_aips_pending_deletion(uuid_field_name):
     must_not_haves = []
 
     for aip_uuid in aips_pending_deletion():
-        must_not_haves.append({uuid_field_name: aip_uuid})
+        must_not_haves.append({'term': {uuid_field_name: aip_uuid}})
 
     if len(must_not_haves):
         query = {

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -393,7 +393,7 @@ def elasticsearch_query_excluding_aips_pending_deletion(uuid_field_name):
     must_not_haves = []
 
     for aip_uuid in aips_pending_deletion():
-        must_not_haves.append({uuid_field_name, aip_uuid})
+        must_not_haves.append({uuid_field_name: aip_uuid})
 
     if len(must_not_haves):
         query = {


### PR DESCRIPTION
Due to a typo, certain dicts were being created as sets instead.

refs #6273
