### PR TITLE
launchSubprocess: don't mutate own environment

### DIFF
--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -58,7 +58,7 @@ def launchSubProcess(command, stdIn="", printing=True, arguments=[]):
         else:
             command.extend(arguments)
 
-        my_env = os.environ
+        my_env = os.environ.copy()
         my_env['PYTHONIOENCODING'] = 'utf-8'
         if (not my_env.has_key('LANG')) or (not my_env['LANG']):
              my_env['LANG'] = 'en_US.UTF-8'


### PR DESCRIPTION
Since assigning to a new variable just assigns a new reference to the same object, launchSubprocess has been mutating its own process's environment instead of creating a new environment for the subprocess.

Fixes #5652.
