### PR TITLE
MCPClient: Add dashboard & archivematicaCommon to sys.path

### DIFF
--- a/src/MCPClient/etc/clientConfig.conf
+++ b/src/MCPClient/etc/clientConfig.conf
@@ -37,3 +37,4 @@ disableElasticsearchIndexing = False
 backupElasticSearchDocumentsToMySQL = False
 temp_dir = /var/archivematica/sharedDirectory/tmp
 kioskMode = False
+django_settings_module = settings.common

--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -42,7 +42,10 @@ import sys
 import threading
 import traceback
 
-os.environ['DJANGO_SETTINGS_MODULE'] = "settings.common"
+config = ConfigParser.SafeConfigParser(
+    defaults={'django_settings_module': 'settings.common'})
+config.read("/etc/archivematica/MCPClient/clientConfig.conf")
+os.environ['DJANGO_SETTINGS_MODULE'] = config.get('MCPClient', 'django_settings_module')
 
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 import databaseFunctions
@@ -52,12 +55,10 @@ printOutputLock = threading.Lock()
 sys.path.append("/usr/share/archivematica/dashboard")
 from main.models import Task
 
-config = ConfigParser.SafeConfigParser({'MCPArchivematicaServerInterface': ""})
-config.read("/etc/archivematica/MCPClient/clientConfig.conf")
 
 replacementDic = {
-    "%sharedPath%":config.get('MCPClient', "sharedDirectoryMounted"), \
-    "%clientScriptsDirectory%":config.get('MCPClient', "clientScriptsDirectory")
+    "%sharedPath%": config.get('MCPClient', "sharedDirectoryMounted"),
+    "%clientScriptsDirectory%": config.get('MCPClient', "clientScriptsDirectory")
 }
 supportedModules = {}
 

--- a/src/MCPClient/lib/clientScripts/archivematicaAssignFileUUID.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaAssignFileUUID.py
@@ -23,11 +23,11 @@
 import sys
 import uuid
 from optparse import OptionParser
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from fileOperations import addFileToTransfer
 from fileOperations import addFileToSIP
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
 

--- a/src/MCPClient/lib/clientScripts/archivematicaBagWithEmptyDirectories.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaBagWithEmptyDirectories.py
@@ -23,7 +23,7 @@
 import argparse
 import os
 import sys
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from executeOrRunSubProcess import executeOrRun
 
 

--- a/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
@@ -24,10 +24,10 @@
 import os
 import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import Event
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from executeOrRunSubProcess import executeOrRun
 from databaseFunctions import insertIntoEvents
 

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS.py
@@ -28,10 +28,10 @@ from xml.sax.saxutils import quoteattr
 
 import archivematicaXMLNamesSpace as ns
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from archivematicaFunctions import escape
 
 

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -31,8 +31,7 @@ import traceback
 
 import archivematicaXMLNamesSpace as ns
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from django.contrib.auth.models import User
 from main.models import Agent, Derivation, DublinCore, Event, File, FileID, FPCommandOutput, SIP, Transfer
 
@@ -43,7 +42,7 @@ from archivematicaCreateMETSTrim import getTrimDmdSec
 from archivematicaCreateMETSTrim import getTrimFileDmdSec
 from archivematicaCreateMETSTrim import getTrimAmdSec
 from archivematicaCreateMETSTrim import getTrimFileAmdSec
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from archivematicaFunctions import escape
 from archivematicaFunctions import strToUnicode
 from archivematicaFunctions import normalizeNonDcElementName

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSMetadataCSV.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSMetadataCSV.py
@@ -29,7 +29,7 @@ import csv
 import os
 import sys
 import traceback
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from sharedVariablesAcrossModules import sharedVariablesAcrossModules
 
 

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRights.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRights.py
@@ -27,11 +27,11 @@ import sys
 import uuid
 import lxml.etree as etree
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import RightsStatement
 
 import archivematicaXMLNamesSpace as ns
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from countryCodes import getCodeForCountry
 from sharedVariablesAcrossModules import sharedVariablesAcrossModules
 

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRightsDspaceMDRef.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRightsDspaceMDRef.py
@@ -25,11 +25,11 @@ import os
 import sys
 import lxml.etree as etree
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
 import archivematicaXMLNamesSpace as ns
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from sharedVariablesAcrossModules import sharedVariablesAcrossModules
 
 

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSTrim.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSTrim.py
@@ -26,7 +26,7 @@ import os
 import sys
 import lxml.etree as etree
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
 import archivematicaXMLNamesSpace as ns

--- a/src/MCPClient/lib/clientScripts/archivematicaFITS.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaFITS.py
@@ -27,7 +27,7 @@ import uuid
 import subprocess
 import os
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from archivematicaFunctions import getTagged
 from archivematicaFunctions import escapeForCommand
 from databaseFunctions import insertIntoFPCommandOutput

--- a/src/MCPClient/lib/clientScripts/archivematicaMaildirToMbox.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaMaildirToMbox.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python -OO
 import sys
 import os
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from externals.maildirToMbox import maildir2mailbox2
 
 

--- a/src/MCPClient/lib/clientScripts/archivematicaMoveSIP.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaMoveSIP.py
@@ -23,10 +23,10 @@
 import os
 import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import SIP
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from fileOperations import renameAsSudo
 
 def updateDB(dst, sip_uuid):

--- a/src/MCPClient/lib/clientScripts/archivematicaMoveTransfer.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaMoveTransfer.py
@@ -22,10 +22,10 @@
 # @author Joseph Perry <joseph@artefactual.com>
 import os
 import sys
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from fileOperations import renameAsSudo
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import Transfer
 
 def updateDB(dst, transferUUID):

--- a/src/MCPClient/lib/clientScripts/archivematicaSetTransferType.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaSetTransferType.py
@@ -22,7 +22,7 @@
 # @author Joseph Perry <joseph@artefactual.com>
 import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import Transfer
 
 if __name__ == '__main__':

--- a/src/MCPClient/lib/clientScripts/archivematicaTranscribeFile.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaTranscribeFile.py
@@ -8,18 +8,11 @@ import sys
 from tempfile import gettempdir
 from uuid import uuid4
 
-path = '/usr/share/archivematica/dashboard'
-if path not in sys.path:
-    sys.path.append(path)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
-
+# dashboard
 from main.models import Derivation, File, FileFormatVersion
 from fpr.models import FPRule
 
-path = '/usr/lib/archivematica/archivematicaCommon'
-if path not in sys.path:
-    sys.path.append(path)
-
+# archivematicaCommon
 from dicts import ReplacementDict
 from executeOrRunSubProcess import executeOrRun
 import databaseFunctions

--- a/src/MCPClient/lib/clientScripts/archivematicaTransferMetadata.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaTransferMetadata.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser
 from lxml import etree
 import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import Transfer
 
 

--- a/src/MCPClient/lib/clientScripts/archivematicaUpdateSizeAndChecksum.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaUpdateSizeAndChecksum.py
@@ -22,7 +22,7 @@
 # @author Joseph Perry <joseph@artefactual.com>
 import sys
 from optparse import OptionParser
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from fileOperations import updateSizeAndChecksum
 
 if __name__ == '__main__':

--- a/src/MCPClient/lib/clientScripts/assignFauxFileUUIDs.py
+++ b/src/MCPClient/lib/clientScripts/assignFauxFileUUIDs.py
@@ -25,7 +25,7 @@ import os
 import sys
 import uuid
 from lxml import etree
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from fileOperations import addFileToSIP
 import databaseInterface
 

--- a/src/MCPClient/lib/clientScripts/backlogUpdatingTransferFileIndex.py
+++ b/src/MCPClient/lib/clientScripts/backlogUpdatingTransferFileIndex.py
@@ -22,7 +22,7 @@
 # @author Joseph Perry <joseph@artefactual.com>
 import sys
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import elasticSearchFunctions
 
 if __name__ == '__main__':

--- a/src/MCPClient/lib/clientScripts/characterizeFile.py
+++ b/src/MCPClient/lib/clientScripts/characterizeFile.py
@@ -7,21 +7,16 @@
 # If a tool has no defined characterization commands, then the default
 # will be run instead (currently FITS).
 from __future__ import print_function
-import os
 import sys
 
 from lxml import etree
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from executeOrRunSubProcess import executeOrRun
 from databaseFunctions import insertIntoFPCommandOutput
 from dicts import replace_string_values, ReplacementDict
 
-path = '/usr/share/archivematica/dashboard'
-if path not in sys.path:
-    sys.path.append(path)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
-
+# dashboard
 from main.models import FPCommandOutput
 from fpr.models import FPRule, FormatVersion
 

--- a/src/MCPClient/lib/clientScripts/checkForAccessDirectory.py
+++ b/src/MCPClient/lib/clientScripts/checkForAccessDirectory.py
@@ -25,10 +25,10 @@ import os
 import sys
 from optparse import OptionParser
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from fileOperations import updateFileLocation
 from fileOperations import renameAsSudo
 

--- a/src/MCPClient/lib/clientScripts/checkForServiceDirectory.py
+++ b/src/MCPClient/lib/clientScripts/checkForServiceDirectory.py
@@ -22,16 +22,11 @@
 # @author Joseph Perry <joseph@artefactual.com>
 
 import os
-import sys
-import uuid
 from optparse import OptionParser
 import re
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
-
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
-from databaseFunctions import insertIntoDerivations
 
 
 def something(SIPDirectory, serviceDirectory, objectsDirectory, SIPUUID, date):

--- a/src/MCPClient/lib/clientScripts/compressAIP.py
+++ b/src/MCPClient/lib/clientScripts/compressAIP.py
@@ -4,10 +4,10 @@ import argparse
 import os.path
 import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import SIP
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import databaseFunctions
 from executeOrRunSubProcess import executeOrRun
 

--- a/src/MCPClient/lib/clientScripts/copyTransferSubmissionDocumentation.py
+++ b/src/MCPClient/lib/clientScripts/copyTransferSubmissionDocumentation.py
@@ -25,7 +25,7 @@ import os
 import sys
 import shutil
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
 

--- a/src/MCPClient/lib/clientScripts/copyTransfersMetadataAndLogs.py
+++ b/src/MCPClient/lib/clientScripts/copyTransfersMetadataAndLogs.py
@@ -26,7 +26,7 @@ import shutil
 from optparse import OptionParser
 import traceback
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
 

--- a/src/MCPClient/lib/clientScripts/createAICMETS.py
+++ b/src/MCPClient/lib/clientScripts/createAICMETS.py
@@ -6,17 +6,14 @@ from lxml import etree
 from lxml.builder import ElementMaker
 import os
 import re
-import sys
 import uuid
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import UnitVariable
 
 import archivematicaCreateMETS2
 import archivematicaXMLNamesSpace as namespaces
-PATH = "/usr/lib/archivematica/archivematicaCommon"
-if PATH not in sys.path:
-    sys.path.append(PATH)
+# archivematicaCommon
 import databaseFunctions
 import fileOperations
 import storageService as storage_service

--- a/src/MCPClient/lib/clientScripts/createEvent.py
+++ b/src/MCPClient/lib/clientScripts/createEvent.py
@@ -22,7 +22,7 @@
 # @author Joseph Perry <joseph@artefactual.com>
 from optparse import OptionParser
 import sys
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from databaseFunctions import insertIntoEvents
 
 

--- a/src/MCPClient/lib/clientScripts/createEventsForGroup.py
+++ b/src/MCPClient/lib/clientScripts/createEventsForGroup.py
@@ -21,12 +21,11 @@
 # @subpackage archivematicaClientScript
 # @author Joseph Perry <joseph@artefactual.com>
 from optparse import OptionParser
-import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from databaseFunctions import insertIntoEvents
 
 

--- a/src/MCPClient/lib/clientScripts/createPointerFile.py
+++ b/src/MCPClient/lib/clientScripts/createPointerFile.py
@@ -11,12 +11,10 @@ import uuid
 import archivematicaXMLNamesSpace as namespaces
 import archivematicaCreateMETS2
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import DublinCore
 
-PATH = "/usr/lib/archivematica/archivematicaCommon"
-if PATH not in sys.path:
-    sys.path.append(PATH)
+# archivematicaCommon
 import fileOperations
 from externals import checksummingTools
 

--- a/src/MCPClient/lib/clientScripts/createSIPfromTransferObjects.py
+++ b/src/MCPClient/lib/clientScripts/createSIPfromTransferObjects.py
@@ -24,10 +24,10 @@ import shutil
 import os
 import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File, SIP
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import archivematicaFunctions
 import databaseFunctions
 

--- a/src/MCPClient/lib/clientScripts/createSIPsfromTRIMTransferContainers.py
+++ b/src/MCPClient/lib/clientScripts/createSIPsfromTRIMTransferContainers.py
@@ -25,10 +25,10 @@ import shutil
 import os
 import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import archivematicaFunctions
 import databaseFunctions
 

--- a/src/MCPClient/lib/clientScripts/elasticSearchIndexProcessAIP.py
+++ b/src/MCPClient/lib/clientScripts/elasticSearchIndexProcessAIP.py
@@ -20,10 +20,10 @@
 # @package Archivematica
 # @subpackage archivematicaClientScript
 # @author Mike Cantelon <mike@artefactual.com>
-import sys, os, time, ConfigParser
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
-sys.path.append("/usr/lib/archivematica/archivematicaCommon/externals")
+import ConfigParser
+import sys
+
+# archivematicaCommon
 import elasticSearchFunctions
 
 exitCode = 0

--- a/src/MCPClient/lib/clientScripts/elasticSearchIndexProcessTransfer.py
+++ b/src/MCPClient/lib/clientScripts/elasticSearchIndexProcessTransfer.py
@@ -21,15 +21,9 @@
 # @subpackage archivematicaClientScript
 # @author Mike Cantelon <mike@artefactual.com>
 import ConfigParser
-import os
 import sys
 
-path = '/usr/share/archivematica/dashboard'
-if path not in sys.path:
-    sys.path.append(path)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
-
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import elasticSearchFunctions
 
 exitCode = 0

--- a/src/MCPClient/lib/clientScripts/emailFailReport.py
+++ b/src/MCPClient/lib/clientScripts/emailFailReport.py
@@ -23,17 +23,13 @@
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-import string
 from optparse import OptionParser
-import os
-import sys
 from lxml import etree
 
-sys.path.append("/usr/share/archivematica/dashboard")
-os.environ['DJANGO_SETTINGS_MODULE'] = "settings.common"
+# dashboard
 from django.contrib.auth.models import User
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import databaseInterface
 from externals.HTML import HTML 
 

--- a/src/MCPClient/lib/clientScripts/extractBagTransfer.py
+++ b/src/MCPClient/lib/clientScripts/extractBagTransfer.py
@@ -24,10 +24,10 @@ import shutil
 import os
 import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import Transfer
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from executeOrRunSubProcess import executeOrRun
 
 def extract(target, destinationDirectory):

--- a/src/MCPClient/lib/clientScripts/extractContents.py
+++ b/src/MCPClient/lib/clientScripts/extractContents.py
@@ -5,15 +5,12 @@ import os
 import sys
 import uuid
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from executeOrRunSubProcess import executeOrRun
 from databaseFunctions import fileWasRemoved
 from fileOperations import addFileToTransfer, updateSizeAndChecksum
 
-path = '/usr/share/archivematica/dashboard'
-if path not in sys.path:
-    sys.path.append(path)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+# dashboard
 from fpr.models import FPCommand
 from main.models import FileFormatVersion, File
 

--- a/src/MCPClient/lib/clientScripts/extractMaildirAttachments.py
+++ b/src/MCPClient/lib/clientScripts/extractMaildirAttachments.py
@@ -28,10 +28,10 @@ import sys
 import traceback
 import uuid
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from externals.extractMaildirAttachments import parse
 from fileOperations import addFileToTransfer, updateSizeAndChecksum
 from archivematicaFunctions import unicodeToStr

--- a/src/MCPClient/lib/clientScripts/failedSIPCleanup.py
+++ b/src/MCPClient/lib/clientScripts/failedSIPCleanup.py
@@ -1,13 +1,9 @@
 #!/usr/bin/python2 -OO
 
 import argparse
-import os
 import sys
 
-path = '/usr/share/archivematica/dashboard'
-if path not in sys.path:
-    sys.path.append(path)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+# dashboard
 from main import models
 
 REJECTED = 'reject'

--- a/src/MCPClient/lib/clientScripts/generateDIPFromAIPGenerateDIP.py
+++ b/src/MCPClient/lib/clientScripts/generateDIPFromAIPGenerateDIP.py
@@ -25,10 +25,10 @@ import os
 import sys
 import shutil
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import Job, SIP
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from databaseFunctions import createSIP
 
 if __name__ == '__main__':

--- a/src/MCPClient/lib/clientScripts/getAipStorageLocations.py
+++ b/src/MCPClient/lib/clientScripts/getAipStorageLocations.py
@@ -1,22 +1,13 @@
 #!/usr/bin/python2 -OO
 
 import logging
-import os
 import sys
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(filename="/tmp/archivematica.log",
     level=logging.INFO)
 
-# Set up Django settings
-path = '/usr/share/archivematica/dashboard'
-if path not in sys.path:
-    sys.path.append(path)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
-
-path = "/usr/lib/archivematica/archivematicaCommon"
-if path not in sys.path:
-    sys.path.append(path)
+# archivematicaCommon
 import storageService as storage_service
 
 

--- a/src/MCPClient/lib/clientScripts/hasPackages.py
+++ b/src/MCPClient/lib/clientScripts/hasPackages.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python
 
-import os
 import sys
 
-path = '/usr/share/archivematica/dashboard'
-if path not in sys.path:
-    sys.path.append(path)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+# dashboard
 from fpr.models import FPRule
 from main.models import FileFormatVersion, Transfer
 

--- a/src/MCPClient/lib/clientScripts/identifyDspaceFiles.py
+++ b/src/MCPClient/lib/clientScripts/identifyDspaceFiles.py
@@ -26,7 +26,7 @@ from lxml import etree
 
 import archivematicaXMLNamesSpace
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
 def identify_dspace_files(mets_file, transfer_dir, transfer_uuid, relative_dir="./"):

--- a/src/MCPClient/lib/clientScripts/identifyDspaceMETSFiles.py
+++ b/src/MCPClient/lib/clientScripts/identifyDspaceMETSFiles.py
@@ -22,7 +22,7 @@
 # @author Joseph Perry <joseph@artefactual.com>
 import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
 

--- a/src/MCPClient/lib/clientScripts/identifyFileFormat.py
+++ b/src/MCPClient/lib/clientScripts/identifyFileFormat.py
@@ -1,18 +1,14 @@
 #!/usr/bin/python2
 
 import argparse
-import os
 import sys
 import uuid
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from executeOrRunSubProcess import executeOrRun
 from databaseFunctions import getUTCDate, insertIntoEvents, insertIntoFilesIDs
 
-path = '/usr/share/archivematica/dashboard'
-if path not in sys.path:
-    sys.path.append(path)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+# dashboard
 from fpr.models import IDCommand, IDRule, FormatVersion
 from main.models import FileFormatVersion, File, UnitVariable
 

--- a/src/MCPClient/lib/clientScripts/indexAIP.py
+++ b/src/MCPClient/lib/clientScripts/indexAIP.py
@@ -4,13 +4,10 @@ import ConfigParser
 import os
 import sys
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import UnitVariable
 
-path = "/usr/lib/archivematica/archivematicaCommon"
-if path not in sys.path:
-    sys.path.append(path)
+# archivematicaCommon
 import elasticSearchFunctions
 from executeOrRunSubProcess import executeOrRun
 import storageService as storage_service

--- a/src/MCPClient/lib/clientScripts/loadDublinCore.py
+++ b/src/MCPClient/lib/clientScripts/loadDublinCore.py
@@ -4,10 +4,7 @@ import json
 import os
 import sys
 
-path = '/usr/share/archivematica/dashboard'
-if path not in sys.path:
-    sys.path.append(path)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+# dashboard
 from main import models
 
 # This is the UUID of SIP from the `MetadataAppliesToTypes` table

--- a/src/MCPClient/lib/clientScripts/loadLabelsFromCSV.py
+++ b/src/MCPClient/lib/clientScripts/loadLabelsFromCSV.py
@@ -25,7 +25,7 @@ import sys
 import csv
 import os
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
 if __name__ == '__main__':

--- a/src/MCPClient/lib/clientScripts/manualNormalizationCheckForManualNormalizationDirectory.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationCheckForManualNormalizationDirectory.py
@@ -23,7 +23,7 @@
 import sys
 import os
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import UnitVariable
 
 SIPUUID = sys.argv[1]

--- a/src/MCPClient/lib/clientScripts/manualNormalizationCreateMetadataAndRestructure.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationCreateMetadataAndRestructure.py
@@ -23,12 +23,12 @@
 import os
 import sys
 import uuid
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import databaseFunctions
 import fileOperations
 
 from django.db.models import Q
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import Event, File
 
 #"%SIPUUID%" "%SIPName%" "%SIPDirectory%" "%fileUUID%" "%filePath%"

--- a/src/MCPClient/lib/clientScripts/manualNormalizationIdentifyFilesIncluded.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationIdentifyFilesIncluded.py
@@ -22,7 +22,7 @@
 # @author Joseph Perry <joseph@artefactual.com>
 import sys
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from fileOperations import updateFileGrpUse
 
 fileUUID = sys.argv[1]

--- a/src/MCPClient/lib/clientScripts/manualNormalizationMoveAccessFilesToDIP.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationMoveAccessFilesToDIP.py
@@ -22,11 +22,11 @@
 # @author Joseph Perry <joseph@artefactual.com>
 import os
 import sys
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import fileOperations
 
 from django.db.models import Q
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
 #--sipUUID "%SIPUUID%" --sipDirectory "%SIPDirectory%" --filePath "%relativeLocation%"

--- a/src/MCPClient/lib/clientScripts/manualNormalizationRemoveMNDirectories.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationRemoveMNDirectories.py
@@ -23,10 +23,10 @@
 import os
 import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import databaseFunctions
 
 SIPDirectory = sys.argv[1]

--- a/src/MCPClient/lib/clientScripts/moveDspaceLicenseFilesToDSpaceLicenses.py
+++ b/src/MCPClient/lib/clientScripts/moveDspaceLicenseFilesToDSpaceLicenses.py
@@ -23,7 +23,7 @@
 import os
 import sys
 import lxml.etree as etree
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from fileOperations import updateFileLocation
 from fileOperations import renameAsSudo
 

--- a/src/MCPClient/lib/clientScripts/moveDspaceMetsFilesToDSpaceMETS.py
+++ b/src/MCPClient/lib/clientScripts/moveDspaceMetsFilesToDSpaceMETS.py
@@ -23,7 +23,7 @@
 import os
 import sys
 import lxml.etree as etree
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from fileOperations import updateFileLocation
 from fileOperations import renameAsSudo
 

--- a/src/MCPClient/lib/clientScripts/moveToBacklog.py
+++ b/src/MCPClient/lib/clientScripts/moveToBacklog.py
@@ -5,9 +5,7 @@ import os
 import shutil
 import sys
 
-path = "/usr/lib/archivematica/archivematicaCommon"
-if path not in sys.path:
-    sys.path.append(path)
+# archivematicaCommon
 import storageService as storage_service
 
 logger = logging.getLogger(__name__)

--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -13,15 +13,12 @@ import uuid
 
 import transcoder
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import databaseFunctions
 import fileOperations
 from dicts import ReplacementDict
 
-path = '/usr/share/archivematica/dashboard'
-if path not in sys.path:
-    sys.path.append(path)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+# dashboard
 from fpr.models import FPRule
 from main.models import Derivation, FileFormatVersion, File, FileID
 from annoying.functions import get_object_or_None

--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -1,15 +1,13 @@
 #!/usr/bin/python2 -OO
 
 import argparse
-import os
 import sys
 
-sys.path.append('/usr/lib/archivematica/archivematicaCommon')
+# archivematicaCommon
 import elasticSearchFunctions
 import storageService as storage_service
 
-sys.path.append('/usr/share/archivematica/dashboard')
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+# dashboard
 from main import models
 
 def post_store_hook(sip_uuid):

--- a/src/MCPClient/lib/clientScripts/removeAIPFilesFromIndex.py
+++ b/src/MCPClient/lib/clientScripts/removeAIPFilesFromIndex.py
@@ -22,7 +22,7 @@
 # @author Joseph Perry <joseph@artefactual.com>
 import sys
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import elasticSearchFunctions
 
 if __name__ == '__main__':

--- a/src/MCPClient/lib/clientScripts/removeUnneededFiles.py
+++ b/src/MCPClient/lib/clientScripts/removeUnneededFiles.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from databaseFunctions import fileWasRemoved
 
 REMOVEABLE_FILES = ["Thumbs.db", "Icon", u"Icon\u000D"]

--- a/src/MCPClient/lib/clientScripts/renameDIPFauxToOrigUUIDs.py
+++ b/src/MCPClient/lib/clientScripts/renameDIPFauxToOrigUUIDs.py
@@ -25,7 +25,7 @@ import os
 import sys
 import uuid
 import shutil
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import databaseInterface
 
 if __name__ == '__main__':

--- a/src/MCPClient/lib/clientScripts/restructureBagAIPToSIP.py
+++ b/src/MCPClient/lib/clientScripts/restructureBagAIPToSIP.py
@@ -24,7 +24,7 @@
 import os
 import sys
 import shutil
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import archivematicaFunctions
 
 if __name__ == '__main__':

--- a/src/MCPClient/lib/clientScripts/restructureDIPForContentDMUpload.py
+++ b/src/MCPClient/lib/clientScripts/restructureDIPForContentDMUpload.py
@@ -34,7 +34,7 @@ import zipfile
 import re
 from xml.dom.minidom import parse, parseString
 from lxml import etree
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from archivematicaFunctions import normalizeNonDcElementName
 from executeOrRunSubProcess import executeOrRun
 

--- a/src/MCPClient/lib/clientScripts/restructureForCompliance.py
+++ b/src/MCPClient/lib/clientScripts/restructureForCompliance.py
@@ -24,7 +24,7 @@ import os
 import sys
 import shutil
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import archivematicaFunctions
 from archivematicaFunctions import REQUIRED_DIRECTORIES, OPTIONAL_FILES
 

--- a/src/MCPClient/lib/clientScripts/restructureForComplianceSIP.py
+++ b/src/MCPClient/lib/clientScripts/restructureForComplianceSIP.py
@@ -3,9 +3,8 @@
 import argparse
 import os
 import shutil
-import sys
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import archivematicaFunctions
 from archivematicaFunctions import REQUIRED_DIRECTORIES, OPTIONAL_FILES
 import fileOperations

--- a/src/MCPClient/lib/clientScripts/retryNormalizeRemoveNormalized.py
+++ b/src/MCPClient/lib/clientScripts/retryNormalizeRemoveNormalized.py
@@ -28,7 +28,7 @@ import shutil
 import traceback
 from optparse import OptionParser
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import Derivation, Event, File
 
 

--- a/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
@@ -25,13 +25,12 @@ import subprocess
 import os
 import uuid
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
-from databaseFunctions import insertIntoEvents
+# archivematicaCommon
 from fileOperations import updateFileLocation
 from archivematicaFunctions import unicodeToStr
 import sanitizeNames
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
 if __name__ == '__main__':

--- a/src/MCPClient/lib/clientScripts/sanitizeSIPName.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeSIPName.py
@@ -24,7 +24,7 @@
 from archivematicaMoveSIP import moveSIP
 import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import SIP, Transfer
 
 from sanitizeNames import sanitizePath

--- a/src/MCPClient/lib/clientScripts/saveDublinCore.py
+++ b/src/MCPClient/lib/clientScripts/saveDublinCore.py
@@ -1,13 +1,9 @@
 #!/usr/bin/python2
 
 import json
-import os
 import sys
 
-path = '/usr/share/archivematica/dashboard'
-if path not in sys.path:
-    sys.path.append(path)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+# dashboard
 from main import models
 
 FIELDS = [

--- a/src/MCPClient/lib/clientScripts/setMaildirFileGrpUseAndFileIDs.py
+++ b/src/MCPClient/lib/clientScripts/setMaildirFileGrpUseAndFileIDs.py
@@ -24,7 +24,7 @@
 import os
 import sys
 exitCode = 0
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from externals.extractMaildirAttachments import parse
 import databaseInterface
 

--- a/src/MCPClient/lib/clientScripts/storeAIP.py
+++ b/src/MCPClient/lib/clientScripts/storeAIP.py
@@ -26,9 +26,7 @@ import os
 import sys
 from uuid import uuid4
 
-path = "/usr/lib/archivematica/archivematicaCommon"
-if path not in sys.path:
-    sys.path.append(path)
+# archivematicaCommon
 import storageService as storage_service
 
 logger = logging.getLogger(__name__)

--- a/src/MCPClient/lib/clientScripts/transcoder.py
+++ b/src/MCPClient/lib/clientScripts/transcoder.py
@@ -18,16 +18,12 @@
 
 # @package Archivematica
 # @subpackage archivematicaClient
-import os
 import sys
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from executeOrRunSubProcess import executeOrRun
 
-path = '/usr/share/archivematica/dashboard'
-if path not in sys.path:
-    sys.path.append(path)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+# dashboard
 from django.db.models import F
 
 

--- a/src/MCPClient/lib/clientScripts/trimCreateRightsEntries.py
+++ b/src/MCPClient/lib/clientScripts/trimCreateRightsEntries.py
@@ -31,10 +31,10 @@ from datetime import datetime
 from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import RightsStatement, RightsStatementOtherRightsInformation, RightsStatementOtherRightsDocumentationIdentifier, RightsStatementRightsGranted, RightsStatementRightsGrantedNote, RightsStatementRightsGrantedRestriction
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from externals.checksummingTools import md5_for_file
 from fileOperations import getFileUUIDLike
 import databaseFunctions

--- a/src/MCPClient/lib/clientScripts/trimRestructureForCompliance.py
+++ b/src/MCPClient/lib/clientScripts/trimRestructureForCompliance.py
@@ -24,7 +24,7 @@
 import os
 import sys
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import archivematicaFunctions
 from archivematicaFunctions import REQUIRED_DIRECTORIES
 import fileOperations

--- a/src/MCPClient/lib/clientScripts/trimVerifyChecksums.py
+++ b/src/MCPClient/lib/clientScripts/trimVerifyChecksums.py
@@ -26,7 +26,7 @@ from lxml import etree as etree
 import sys
 import traceback
 import uuid
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from externals.checksummingTools import md5_for_file
 from fileOperations import getFileUUIDLike
 import databaseFunctions

--- a/src/MCPClient/lib/clientScripts/trimVerifyManifest.py
+++ b/src/MCPClient/lib/clientScripts/trimVerifyManifest.py
@@ -35,7 +35,7 @@ transferPath = sys.argv[3]
 date = sys.argv[4]
  
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from fileOperations import getFileUUIDLike
 import databaseFunctions
 topDirectory = None

--- a/src/MCPClient/lib/clientScripts/upload-archivistsToolkit-fcd.py
+++ b/src/MCPClient/lib/clientScripts/upload-archivistsToolkit-fcd.py
@@ -22,7 +22,7 @@ import MySQLdb
 from time import localtime, strftime
 import argparse
 import logging
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import archivistsToolkit.atk as atk
 import mets
 from xml2obj import mets_file

--- a/src/MCPClient/lib/clientScripts/upload-archivistsToolkit.py
+++ b/src/MCPClient/lib/clientScripts/upload-archivistsToolkit.py
@@ -17,12 +17,11 @@
 #
 
 import os
-import sys
 import MySQLdb
 from time import localtime, strftime
 import argparse
 import logging
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import archivistsToolkit.atk as atk
 import mets
 from xml2obj import mets_file

--- a/src/MCPClient/lib/clientScripts/upload-qubit.py
+++ b/src/MCPClient/lib/clientScripts/upload-qubit.py
@@ -34,11 +34,10 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 logger.addHandler(logging.FileHandler('/tmp/atom_upload.log', mode='a'))
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon/externals")
+# externals
 import requests
 
-sys.path.append("/usr/share/archivematica/dashboard")
-os.environ['DJANGO_SETTINGS_MODULE'] = "settings.common"
+# dashboard
 import main.models as models
 
 PREFIX = "[uploadDIP]"

--- a/src/MCPClient/lib/clientScripts/validateFile.py
+++ b/src/MCPClient/lib/clientScripts/validateFile.py
@@ -7,16 +7,14 @@ If a format has no defined validation commands, no command is run.
 """
 from __future__ import print_function
 import ast
-import os
 import sys
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from executeOrRunSubProcess import executeOrRun
 import databaseFunctions
 from dicts import replace_string_values
 
-sys.path.append('/usr/share/archivematica/dashboard')
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
+# dashboard
 from fpr.models import FPRule, FormatVersion
 
 

--- a/src/MCPClient/lib/clientScripts/verifyAIP.py
+++ b/src/MCPClient/lib/clientScripts/verifyAIP.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import sys
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from executeOrRunSubProcess import executeOrRun
 
 

--- a/src/MCPClient/lib/clientScripts/verifyAndRestructureTransferBag.py
+++ b/src/MCPClient/lib/clientScripts/verifyAndRestructureTransferBag.py
@@ -23,10 +23,10 @@
 import os
 import sys
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from archivematicaFunctions import REQUIRED_DIRECTORIES, OPTIONAL_FILES
 import fileOperations
 from executeOrRunSubProcess import executeOrRun

--- a/src/MCPClient/lib/clientScripts/verifyBAG.py
+++ b/src/MCPClient/lib/clientScripts/verifyBAG.py
@@ -22,7 +22,7 @@
 # @author Joseph Perry <joseph@artefactual.com>
 import os
 import sys
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from executeOrRunSubProcess import executeOrRun
 
 printSubProcessOutput=True

--- a/src/MCPClient/lib/clientScripts/verifyChecksumsInFileSecOfDspaceMETSFiles.py
+++ b/src/MCPClient/lib/clientScripts/verifyChecksumsInFileSecOfDspaceMETSFiles.py
@@ -23,7 +23,7 @@
 import os
 import sys
 import lxml.etree as etree
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 from externals.checksummingTools import sha_for_file
 from externals.checksummingTools import md5_for_file
 

--- a/src/MCPClient/lib/clientScripts/verifyPREMISChecksums.py
+++ b/src/MCPClient/lib/clientScripts/verifyPREMISChecksums.py
@@ -21,13 +21,12 @@
 # @subpackage archivematicaClientScript
 # @author Joseph Perry <joseph@artefactual.com>
 import sys
-import os
 from optparse import OptionParser
 
-sys.path.append("/usr/share/archivematica/dashboard")
+# dashboard
 from main.models import File
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+# archivematicaCommon
 import databaseFunctions
 from externals.checksummingTools import sha_for_file
 

--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -64,7 +64,7 @@ from main.models import Job, SIP, Task, WatchedDirectory
 global countOfCreateUnitAndJobChainThreaded
 countOfCreateUnitAndJobChainThreaded = 0
 
-config = ConfigParser.SafeConfigParser({'MCPArchivematicaServerInterface': ""})
+config = ConfigParser.SafeConfigParser()
 config.read("/etc/archivematica/MCPServer/serverConfig.conf")
 
 #time to sleep to allow db to be updated with the new location of a SIP

--- a/src/archivematicaCommon/lib/dicts.py
+++ b/src/archivematicaCommon/lib/dicts.py
@@ -245,5 +245,5 @@ else:
 
     # TODO This probably shouldn't be directly read here, but this file can't
     #      safely import archivematicaMCP because it has too many side effects.
-    config = ConfigParser.SafeConfigParser({'MCPArchivematicaServerInterface': ""})
+    config = ConfigParser.SafeConfigParser()
     config.read("/etc/archivematica/MCPServer/serverConfig.conf")


### PR DESCRIPTION
MCPClient adds the dashboard and archivematicaCommon to the sys.path for all client scripts.  Remove all changes to sys.path from client scripts.

Feedback on this both as a feature and implementation approach welcome.
