### PR TITLE
Add automation endpoints

### DIFF
--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -15,10 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import patterns
+from django.conf.urls import patterns, url
+from django.conf import settings
 
 urlpatterns = patterns('components.api.views',
     (r'transfer/approve', 'approve_transfer'), 
     (r'transfer/unapproved', 'unapproved_transfers'),
+    url(r'transfer/status/(?P<unit_uuid>' + settings.UUID_REGEX + ')', 'status', {'unit_type': 'unitTransfer'}),
+    url(r'ingest/status/(?P<unit_uuid>' + settings.UUID_REGEX + ')', 'status', {'unit_type': 'unitSIP'}),
     (r'ingest/waiting', 'waiting_for_user_input'),
 )

--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -22,6 +22,7 @@ urlpatterns = patterns('components.api.views',
     (r'transfer/approve', 'approve_transfer'), 
     (r'transfer/unapproved', 'unapproved_transfers'),
     url(r'transfer/status/(?P<unit_uuid>' + settings.UUID_REGEX + ')', 'status', {'unit_type': 'unitTransfer'}),
+    url(r'transfer/start_transfer/', 'start_transfer_api'),
     url(r'ingest/status/(?P<unit_uuid>' + settings.UUID_REGEX + ')', 'status', {'unit_type': 'unitSIP'}),
     (r'ingest/waiting', 'waiting_for_user_input'),
 )

--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -19,5 +19,6 @@ from django.conf.urls import patterns
 
 urlpatterns = patterns('components.api.views',
     (r'transfer/approve', 'approve_transfer'), 
-    (r'transfer/unapproved', 'unapproved_transfers')
+    (r'transfer/unapproved', 'unapproved_transfers'),
+    (r'ingest/waiting', 'waiting_for_user_input'),
 )

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -21,7 +21,7 @@ import os
 
 # Core Django, alphabetical
 from django.db.models import Q
-from django.http import Http404, HttpResponseForbidden, HttpResponseServerError
+import django.http
 
 # External dependencies, alphabetical
 from tastypie.authentication import ApiKeyAuthentication
@@ -115,7 +115,7 @@ def unapproved_transfers(request):
                 response['message'] = 'Fetched unapproved transfers successfully.'
 
                 if error is not None:
-                    return HttpResponseServerError(
+                    return django.http.HttpResponseServerError(
                         json.dumps(response),
                         mimetype='application/json'
                     )
@@ -124,12 +124,12 @@ def unapproved_transfers(request):
         else:
             response['message'] = auth_error
             response['error'] = True
-            return HttpResponseForbidden(
+            return django.http.HttpResponseForbidden(
                 json.dumps(response),
                 mimetype='application/json'
             )
     else:
-        return Http404
+        return django.http.HttpResponseNotAllowed(['GET'])
 
 
 def approve_transfer(request):
@@ -155,7 +155,7 @@ def approve_transfer(request):
                 response['message'] = 'Approval successful.'
 
             if error is not None:
-                return HttpResponseServerError(
+                return django.http.HttpResponseServerError(
                     json.dumps(response),
                     mimetype='application/json'
                 )
@@ -164,12 +164,12 @@ def approve_transfer(request):
         else:
             response['message'] = auth_error
             response['error'] = True
-            return HttpResponseForbidden(
+            return django.http.HttpResponseForbidden(
                 json.dumps(response),
                 mimetype='application/json'
             )
     else:
-        raise Http404
+        return django.http.HttpResponseNotAllowed(['POST'])
 
 
 def get_modified_standard_transfer_path(transfer_type=None):

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -32,6 +32,16 @@ from components import helpers
 from main import models
 
 
+TRANSFER_TYPE_DIRECTORIES = {
+    'standard': 'standardTransfer',
+    'unzipped bag': 'baggitDirectory',
+    'zipped bag': 'baggitZippedDirectory',
+    'dspace': 'Dspace',
+    'maildir': 'maildir',
+    'TRIM': 'TRIM'
+}
+
+
 def authenticate_request(request):
     error = None
 
@@ -83,7 +93,9 @@ def unapproved_transfers(request):
                     type_and_directory = type_and_directory[:-1]
 
                 transfer_watch_directory = type_and_directory.split('/')[0]
-                transfer_type = helpers.transfer_type_by_directory(transfer_watch_directory)
+                # Get transfer type from transfer directory
+                transfer_type_directories_reversed = {v: k for k, v in TRANSFER_TYPE_DIRECTORIES.iteritems()}
+                transfer_type = transfer_type_directories_reversed[transfer_watch_directory]
 
                 job_directory = type_and_directory.replace(transfer_watch_directory + '/', '', 1)
 
@@ -168,7 +180,7 @@ def get_modified_standard_transfer_path(transfer_type=None):
 
     if transfer_type is not None:
         try:
-            path = os.path.join(path, helpers.transfer_directory_by_type(transfer_type))
+            path = os.path.join(path, TRANSFER_TYPE_DIRECTORIES[transfer_type])
         except:
             return None
 

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -29,18 +29,10 @@ from tastypie.authentication import ApiKeyAuthentication
 
 # This project, alphabetical
 from contrib.mcp.client import MCPClient
+from components.filesystem_ajax import views as filesystem_ajax_views
 from components import helpers
 from main import models
 
-
-TRANSFER_TYPE_DIRECTORIES = {
-    'standard': 'standardTransfer',
-    'unzipped bag': 'baggitDirectory',
-    'zipped bag': 'baggitZippedDirectory',
-    'dspace': 'Dspace',
-    'maildir': 'maildir',
-    'TRIM': 'TRIM'
-}
 
 SHARED_DIRECTORY_ROOT = helpers.get_server_config_value('sharedDirectory')
 
@@ -233,7 +225,7 @@ def unapproved_transfers(request):
 
                 transfer_watch_directory = type_and_directory.split('/')[0]
                 # Get transfer type from transfer directory
-                transfer_type_directories_reversed = {v: k for k, v in TRANSFER_TYPE_DIRECTORIES.iteritems()}
+                transfer_type_directories_reversed = {v: k for k, v in filesystem_ajax_views.TRANSFER_TYPE_DIRECTORIES.iteritems()}
                 transfer_type = transfer_type_directories_reversed[transfer_watch_directory]
 
                 job_directory = type_and_directory.replace(transfer_watch_directory + '/', '', 1)
@@ -318,7 +310,7 @@ def get_modified_standard_transfer_path(transfer_type=None):
 
     if transfer_type is not None:
         try:
-            path = os.path.join(path, TRANSFER_TYPE_DIRECTORIES[transfer_type])
+            path = os.path.join(path, filesystem_ajax_views.TRANSFER_TYPE_DIRECTORIES[transfer_type])
         except:
             return None
 

--- a/src/dashboard/src/components/filesystem_ajax/urls.py
+++ b/src/dashboard/src/components/filesystem_ajax/urls.py
@@ -29,7 +29,7 @@ urlpatterns = patterns('components.filesystem_ajax.views',
     (r'^move_within_arrange/$', 'move_within_arrange'),
     (r'^create_directory_within_arrange/$', 'create_directory_within_arrange'),
     (r'^copy_to_arrange/$', 'copy_to_arrange'),
-    (r'^ransfer/$', 'start_transfer'),
+    (r'^ransfer/$', 'start_transfer_logged_in'),
     (r'^copy_from_arrange/$', 'copy_from_arrange_to_completed'),
     (r'^copy_metadata_files/$', 'copy_metadata_files'),
 )

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -53,6 +53,15 @@ ORIGINAL_DIR = os.path.join(SHARED_DIRECTORY_ROOT, 'www', 'AIPsStore', 'transfer
 DEFAULT_BACKLOG_PATH = 'originals/'
 DEFAULT_ARRANGE_PATH = '/arrange/'
 
+TRANSFER_TYPE_DIRECTORIES = {
+    'standard': 'standardTransfer',
+    'unzipped bag': 'baggitDirectory',
+    'zipped bag': 'baggitZippedDirectory',
+    'dspace': 'Dspace',
+    'maildir': 'maildir',
+    'TRIM': 'TRIM'
+}
+
 
 def directory_children_proxy_to_storage_server(request, location_uuid, basePath=False):
     path = ''
@@ -205,16 +214,7 @@ def copy_to_start_transfer(filepath='', type='', accession='', transfer_metadata
         basename = os.path.basename(filepath)
 
         # default to standard transfer
-        type_paths = {
-            'standard': 'standardTransfer',
-            'unzipped bag': 'baggitDirectory',
-            'zipped bag': 'baggitZippedDirectory',
-            'dspace': 'Dspace',
-            'maildir': 'maildir',
-            'TRIM': 'TRIM'
-        }
-
-        type_subdir = type_paths.get(type, 'standardTransfer')
+        type_subdir = TRANSFER_TYPE_DIRECTORIES.get(type, 'standardTransfer')
         destination = os.path.join(ACTIVE_TRANSFER_DIR, type_subdir)
 
         # if transfer compontent path leads to a ZIP file, treat as zipped

--- a/src/dashboard/src/components/helpers.py
+++ b/src/dashboard/src/components/helpers.py
@@ -199,35 +199,6 @@ def get_metadata_type_id_by_description(description):
     types = models.MetadataAppliesToType.objects.filter(description=description)
     return types[0]
 
-def transfer_type_directories():
-    return {
-      'standard':     'standardTransfer',
-      'unzipped bag': 'baggitDirectory',
-      'zipped bag':   'baggitZippedDirectory',
-      'dspace':       'Dspace',
-      'maildir':      'maildir',
-      'TRIM':         'TRIM'
-    }
-
-def transfer_directory_by_type(type):
-    type_paths = {
-      'standard':     'standardTransfer',
-      'unzipped bag': 'baggitDirectory',
-      'zipped bag':   'baggitZippedDirectory',
-      'dspace':       'Dspace',
-      'maildir':      'maildir',
-      'TRIM':         'TRIM'
-    }
-
-    return transfer_type_directories()[type]
-
-def transfer_type_by_directory(directory):
-    type_directories = transfer_type_directories()
-
-    # flip keys and values in dictionary
-    directory_types = dict((value, key) for key, value in type_directories.iteritems())
-
-    return directory_types[directory]
 
 def get_setting(setting, default=''):
     try:


### PR DESCRIPTION
Supports automating transfers in automation-tools.
- Add endpoint to return status of a SIP or transfer, one of `FAILED`, `REJECTED`, `USER_INPUT`, `COMPLETE` or `PROCESSING`.  Attention to how these statuses are generated appreciated
- Add endpoint to start a transfer that takes API key instead of requiring the caller to be logged in
- Commit: "Dashboard API: Endpoint for all waiting units" may be dropped, as nothing currently uses that endpoint (it was part of an earlier implementation).
- PEP8 and restructuring cleanup
