### PR TITLE
AIC: misc fixes

### DIFF
--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -174,6 +174,7 @@ def search_augment_aip_results(conn, aips):
         }
         documents = conn.search(body=query,
             fields='name,size,created,status,AICID,isPartOf,countAIPsinAIC')
+        aip = {}
         if documents['hits']['hits']:
             aip_info = documents['hits']['hits'][0]
 
@@ -263,7 +264,7 @@ def create_aic(request, *args, **kwargs):
 
         # Create files with filename = AIP UUID, and contents = AIP name
         for aip in results:
-            filepath = os.path.join(destination, aip['term'])
+            filepath = os.path.join(destination, aip['uuid'])
             with open(filepath, 'w') as f:
                 os.chmod(filepath, 0o660)
                 f.write(str(aip['name']))

--- a/src/dashboard/src/components/ingest/forms.py
+++ b/src/dashboard/src/components/ingest/forms.py
@@ -60,6 +60,7 @@ class AICDublinCoreMetadataForm(DublinCoreMetadataForm):
     class Meta:
         model = models.DublinCore
         fields = ('title', 'identifier', 'creator', 'subject', 'description', 'publisher', 'contributor', 'date', 'format', 'source', 'relation', 'language', 'coverage', 'rights')  # Removed 'is_part_of'
+        widgets = DublinCoreMetadataForm.Meta.widgets.copy()
 
     def __init__(self, *args, **kwargs):
         super(AICDublinCoreMetadataForm, self).__init__(*args, **kwargs)

--- a/src/dashboard/src/templates/archival_storage/archival_storage_search.html
+++ b/src/dashboard/src/templates/archival_storage/archival_storage_search.html
@@ -83,7 +83,7 @@
           {% if show_aics %}
           <td>
             {% if term_usage.type == 'AIC' %}
-              {{ term_usage.AICID }} ({{ term_usage.aips_in_aic }} AIP{{ term_usage.aips_in_aic|pluralize }} in AIC)
+              {{ term_usage.AICID }} ({{ term_usage.countAIPsinAIC }} AIP{{ term_usage.countAIPsinAIC|pluralize }} in AIC)
             {% elif term_usage.isPartOf %}
               Part of {{ term_usage.isPartOf }}
             {% else %}


### PR DESCRIPTION
DublinCore elements are namespaced correctly now, but in older versions the 'title' element may be dc or dcterms.  Update parsing to handle either.

AIC METS structMap LABEL will fall back to AIP name if no title is found.

AIC metadata form doesn't inherit widget info, so copy that.

Fix template reading of # of AIPs in an AIC.
