### PR TITLE
taskStandard.writeOutputs: encode strings before concatenating

### DIFF
--- a/src/MCPServer/lib/taskStandard.py
+++ b/src/MCPServer/lib/taskStandard.py
@@ -141,9 +141,9 @@ class taskStandard():
             self.outputLock.release()
 
         if a:
-            self.stdError = "Failed to write to file{" + standardOut + "}\r\n" + self.results["stdOut"]
+            self.stdError = "Failed to write to file{" + standardOut.encode('utf-8') + "}\r\n" + self.results["stdOut"]
         if b:
-            self.stdError = "Failed to write to file{" + standardError + "}\r\n" + self.results["stdError"]
+            self.stdError = "Failed to write to file{" + standardError.encode('utf-8') + "}\r\n" + self.results["stdError"]
         if  self.results['exitCode']:
             return self.results['exitCode']
         return a + b


### PR DESCRIPTION
This was presumably broken by the model branch. The `standardOut` and `standardError` strings are now as unicode strings, which can contain unencoded Unicode characters, in which case the string concatenation fails.
