### PR TITLE
Dashboard: Remove transfer components

### DIFF
--- a/src/dashboard/src/media/js/transfer/component_directory_select.js
+++ b/src/dashboard/src/media/js/transfer/component_directory_select.js
@@ -99,8 +99,8 @@ function createDirectoryPicker(locationUUID, baseDirectory, modalCssId, targetCs
       .children('.transfer_path_icons')
       .children('.transfer_path_delete_icon')
       .click(function() {
-        if (confirm('Are you sure you want to remove this transfer component?')) {
-          var path = $(this).parent().parent().prop("id").trim();
+        if (confirm('Are you sure you want to remove this transfer component (' + $(this).parent().prev().text() + ')?')) {
+          var path = $(this).parent().prev().prop("id").trim();
           var component = components[path];
 
           removeMetadataForms(component.uuid);


### PR DESCRIPTION
Fix finding the ID of the transfer component to delete. Display path of to-be-removed transfer component in popup. Fixes #7482
