### PR TITLE
DublinCore: Namespace properly, update indexing

### DIFF
--- a/src/MCPClient/tests/fixtures/dublincore.json
+++ b/src/MCPClient/tests/fixtures/dublincore.json
@@ -1,0 +1,53 @@
+[
+{
+    "pk": 1,
+    "model": "main.dublincore",
+    "fields": {
+        "rights": "Public Domain",
+        "publisher": "Tortall Press",
+        "format": "parchement",
+        "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
+        "is_part_of": "AIC#42",
+        "creator": "Keladry of Mindelan",
+        "language": "en",
+        "type": "Archival Information Package",
+        "description": "Glaives are cool",
+        "title": "Yamani Weapons",
+        "date": "2015",
+        "relation": "None",
+        "source": "Numair's library",
+        "coverage": "",
+        "contributor": "Yuki",
+        "identifier": "42/1",
+        "metadataappliestoidentifier": "8b891d7c-5bd2-4249-84a1-2f00f725b981",
+        "subject": "Glaives"
+    }
+},
+{
+    "pk": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
+    "model": "main.metadataappliestotype",
+    "fields": {
+        "lastmodified": "2012-10-01T17:25:05",
+        "replaces": null,
+        "description": "SIP"
+    }
+},
+{
+    "pk": "45696327-44c5-4e78-849b-e027a189bf4d",
+    "model": "main.metadataappliestotype",
+    "fields": {
+        "lastmodified": "2012-10-01T17:25:05",
+        "replaces": null,
+        "description": "Transfer"
+    }
+},
+{
+    "pk": "7f04d9d4-92c2-44a5-93dc-b7bfdf0c1f17",
+    "model": "main.metadataappliestotype",
+    "fields": {
+        "lastmodified": "2012-10-01T17:25:05",
+        "replaces": null,
+        "description": "File"
+    }
+}
+]

--- a/src/MCPClient/tests/test_create_aip_mets.py
+++ b/src/MCPClient/tests/test_create_aip_mets.py
@@ -1,0 +1,65 @@
+
+import os
+import sys
+
+from django.test import TestCase
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(THIS_DIR, '../lib/clientScripts')))
+import archivematicaCreateMETS2
+
+from main.models import DublinCore
+
+class TestDublinCore(TestCase):
+
+    fixture_files = ['dublincore.json']
+    fixtures = [os.path.join(THIS_DIR, 'fixtures', p) for p in fixture_files]
+
+    def test_get_dublincore(self):
+        sipuuid = '8b891d7c-5bd2-4249-84a1-2f00f725b981'
+        siptypeuuid = '3e48343d-e2d2-4956-aaa3-b54d26eb9761'
+
+        # Generate DC element from DB
+        dc_elem = archivematicaCreateMETS2.getDublinCore(siptypeuuid, sipuuid)
+
+        # Verify created correctly
+        assert dc_elem
+        assert dc_elem.tag == '{http://purl.org/dc/terms/}dublincore'
+        assert len(dc_elem) == 15
+        assert dc_elem[0].tag == '{http://purl.org/dc/elements/1.1/}title'
+        assert dc_elem[0].text == 'Yamani Weapons'
+        assert dc_elem[1].tag == '{http://purl.org/dc/elements/1.1/}creator'
+        assert dc_elem[1].text == 'Keladry of Mindelan'
+        assert dc_elem[2].tag == '{http://purl.org/dc/elements/1.1/}subject'
+        assert dc_elem[2].text == 'Glaives'
+        assert dc_elem[3].tag == '{http://purl.org/dc/elements/1.1/}description'
+        assert dc_elem[3].text == 'Glaives are cool'
+        assert dc_elem[4].tag == '{http://purl.org/dc/elements/1.1/}publisher'
+        assert dc_elem[4].text == 'Tortall Press'
+        assert dc_elem[5].tag == '{http://purl.org/dc/elements/1.1/}contributor'
+        assert dc_elem[5].text == 'Yuki'
+        assert dc_elem[6].tag == '{http://purl.org/dc/elements/1.1/}date'
+        assert dc_elem[6].text == '2015'
+        assert dc_elem[7].tag == '{http://purl.org/dc/elements/1.1/}type'
+        assert dc_elem[7].text == 'Archival Information Package'
+        assert dc_elem[8].tag == '{http://purl.org/dc/elements/1.1/}format'
+        assert dc_elem[8].text == 'parchement'
+        assert dc_elem[9].tag == '{http://purl.org/dc/elements/1.1/}identifier'
+        assert dc_elem[9].text == '42/1'
+        assert dc_elem[10].tag == '{http://purl.org/dc/elements/1.1/}source'
+        assert dc_elem[10].text == "Numair's library"
+        assert dc_elem[11].tag == '{http://purl.org/dc/elements/1.1/}relation'
+        assert dc_elem[11].text == 'None'
+        assert dc_elem[12].tag == '{http://purl.org/dc/elements/1.1/}language'
+        assert dc_elem[12].text == 'en'
+        assert dc_elem[13].tag == '{http://purl.org/dc/elements/1.1/}rights'
+        assert dc_elem[13].text == 'Public Domain'
+        assert dc_elem[14].tag == '{http://purl.org/dc/terms/}isPartOf'
+        assert dc_elem[14].text == 'AIC#42'
+
+    def test_get_dublincore_none_found(self):
+        sipuuid = 'dnednedn-5bd2-4249-84a1-2f00f725b981'
+        siptypeuuid = '3e48343d-e2d2-4956-aaa3-b54d26eb9761'
+
+        dc_elem = archivematicaCreateMETS2.getDublinCore(siptypeuuid, sipuuid)
+        assert dc_elem is None

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -73,7 +73,6 @@ def remove_tool_output_from_mets(doc):
     """
     root = doc.getroot()
     nsmap = { #TODO use XML namespaces from archivematicaXMLNameSpaces.py
-        'dc': 'http://purl.org/dc/terms/',
         'm': 'http://www.loc.gov/METS/',
         'p': 'info:lc/xmlns/premis-v2',
         'f': 'http://hul.harvard.edu/ois/xml/ns/fits/fits_output',
@@ -302,18 +301,19 @@ def connect_and_index_aip(uuid, name, filePath, pathToMETS, size=None, aips_in_a
 
     root = tree.getroot()
     nsmap = { #TODO use XML namespaces from archivematicaXMLNameSpaces.py
-        'dc': 'http://purl.org/dc/terms/',
+        'dcterms': 'http://purl.org/dc/terms/',
+        'dc': 'http://purl.org/dc/elements/1.1/',
         'm': 'http://www.loc.gov/METS/',
     }
     # Extract AIC identifier, other specially-indexed information
     aic_identifier = None
     is_part_of = None
-    dublincore = root.find('m:dmdSec/m:mdWrap/m:xmlData/dc:dublincore', namespaces=nsmap)
+    dublincore = root.find('m:dmdSec/m:mdWrap/m:xmlData/dcterms:dublincore', namespaces=nsmap)
     if dublincore is not None:
-        aip_type = dublincore.findtext('dc:type', namespaces=nsmap)
+        aip_type = dublincore.findtext('dc:type', namespaces=nsmap) or dublincore.findtext('dcterms:type', namespaces=nsmap)
         if aip_type == "Archival Information Collection":
-            aic_identifier = dublincore.findtext('dc:identifier', namespaces=nsmap)
-        is_part_of = dublincore.findtext('dc:isPartOf', namespaces=nsmap)
+            aic_identifier = dublincore.findtext('dc:identifier', namespaces=nsmap) or dublincore.findtext('dcterms:identifier', namespaces=nsmap)
+        is_part_of = dublincore.findtext('dcterms:isPartOf', namespaces=nsmap)
 
     # convert METS XML to dict
     xml = ElementTree.tostring(root)
@@ -428,7 +428,8 @@ def index_mets_file_metadata(conn, uuid, metsFilePath, index, type, sipName):
     tree = ElementTree.parse(metsFilePath)
     root = tree.getroot()
     nsmap = { #TODO use XML namespaces from archivematicaXMLNameSpaces.py
-        'dc': 'http://purl.org/dc/terms/',
+        'dcterms': 'http://purl.org/dc/terms/',
+        'dc': 'http://purl.org/dc/elements/1.1/',
         'm': 'http://www.loc.gov/METS/',
         'p': 'info:lc/xmlns/premis-v2',
         'f': 'http://hul.harvard.edu/ois/xml/ns/fits/fits_output',
@@ -445,15 +446,15 @@ def index_mets_file_metadata(conn, uuid, metsFilePath, index, type, sipName):
         dmdSecData = xmltodict.parse(xml)
 
     # Extract isPartOf (for AIPs) or identifier (for AICs) from DublinCore
-    dublincore = root.find('m:dmdSec/m:mdWrap/m:xmlData/dc:dublincore', namespaces=nsmap)
+    dublincore = root.find('m:dmdSec/m:mdWrap/m:xmlData/dcterms:dublincore', namespaces=nsmap)
     aic_identifier = None
     is_part_of = None
     if dublincore is not None:
-        aip_type = dublincore.findtext('dc:type', namespaces=nsmap)
+        aip_type = dublincore.findtext('dc:type', namespaces=nsmap) or dublincore.findtext('dcterms:type', namespaces=nsmap)
         if aip_type == "Archival Information Collection":
-            aic_identifier = dublincore.findtext('dc:identifier', namespaces=nsmap)
+            aic_identifier = dublincore.findtext('dc:identifier', namespaces=nsmap) or dublincore.findtext('dcterms:identifier', namespaces=nsmap)
         elif aip_type == "Archival Information Package":
-            is_part_of = dublincore.findtext('dc:isPartOf', namespaces=nsmap)
+            is_part_of = dublincore.findtext('dcterms:isPartOf', namespaces=nsmap)
 
     # establish structure to be indexed for each file item
     fileData = {

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -139,7 +139,7 @@ class MetadataAppliesToType(models.Model):
     """
     id = UUIDPkField()
     description = models.CharField(max_length=50, db_column='description')
-    replaces = models.CharField(max_length=36, db_column='replaces')
+    replaces = models.CharField(max_length=36, db_column='replaces', null=True, blank=True)
     lastmodified = models.DateTimeField(db_column='lastModified')
 
     class Meta:


### PR DESCRIPTION
Namespace DublinCore generated from the DB correctly as dcterms or dc. Fix is_part_of to isPartOf. When indexing, search for both dc and dcterms versions of the DublinCore elements.

Add tests for DC changes.  To support importing createMETS2, cherry-picked commits from #153 
