### PR TITLE
sanitize: Don't write events for directory name sanitization

### DIFF
--- a/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
@@ -81,4 +81,12 @@ if __name__ == '__main__':
 
             for f in files:
                 new_path = unicodeToStr(f.currentlocation).replace(oldfile, newfile, 1)
-                updateFileLocation(f.currentlocation, new_path, "name cleanup", date, "prohibited characters removed:" + eventDetail, fileUUID=f.uuid)
+                updateFileLocation(f.currentlocation,
+                                   new_path,
+                                   fileUUID=f.uuid,
+                                   # Don't create sanitization events for each
+                                   # file, since it's only a parent directory
+                                   # somewhere up that changed.
+                                   # Otherwise, extra amdSecs will be generated
+                                   # from the resulting METS.
+                                   createEvent=False)


### PR DESCRIPTION
These events were associated with files (not directories), were repeated several times over in the METS file, and were highly misleading.

We don't currently treat directories as intellectual entities for the sake of PREMIS, but this might change in the future. Meanwhile, the sanitization log file (which is stored in the AIP) has accurate information on the sanitization process and should be preferred for looking up directory names.

Fixes #8033.
