### PR TITLE
Dashboard: Display Transfer Source descriptions instead of path

### DIFF
--- a/src/dashboard/src/templates/ingest/metadata_add_files.html
+++ b/src/dashboard/src/templates/ingest/metadata_add_files.html
@@ -40,7 +40,7 @@ select {
     $(document).ready(function() {
       var sourceDirectories = {
         {% for dir in source_directories %}
-          '{{ dir.uuid }}': '{{ dir.path }}',
+          '{{ dir.uuid }}': '{{ dir.description }}',
         {% endfor %}
       };
       var form = new MetadataFormView({

--- a/src/dashboard/src/templates/transfer/grid.html
+++ b/src/dashboard/src/templates/transfer/grid.html
@@ -73,7 +73,7 @@
     $(document).ready(function() {
       var sourceDirectories = {
         {% for dir in source_directories %}
-          '{{ dir.uuid }}': '{{ dir.path }}',
+          '{{ dir.uuid }}': '{{ dir.description }}',
         {% endfor %}
       };
 


### PR DESCRIPTION
Instead of always displaying the path, display the user-provided description of transfer source locations. This disambiguates identically named folders on different systems. The description defaults to the path if none provided.
