### PR TITLE
Duplicate columns in metadata.csv

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 django_find_projects=false
-python_paths=/usr/share/archivematica/dashboard/
+python_paths=/usr/share/archivematica/dashboard/;/usr/lib/archivematica/archivematicaCommon/
 DJANGO_SETTINGS_MODULE=settings.local

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -172,6 +172,12 @@ def createDMDIDsFromCSVMetadata(path):
 
 
 def createDmdSecsFromCSVParsedMetadata(metadata):
+    """
+    Create dmdSec(s) from the provided metadata.
+
+    :param metadata: OrderedDict with the metadata keys and a list of values
+    :return: List of dmdSec Elements created
+    """
     global globalDmdSecCounter
     global dmdSecs
     dc = None
@@ -206,13 +212,13 @@ def createDmdSecsFromCSVParsedMetadata(metadata):
             elif key.startswith("dcterms."):
                 key = key.replace("dcterms.", "", 1)
                 elem_namespace = ns.dctermsBNS
-            value = value.decode('utf-8')
             match = re.match(refinement_regex, key)
             if match:
                 key, = match.groups()
-
-            el = etree.SubElement(dc, elem_namespace + key)
-            el.text = value
+            for v in value:
+                v = v.decode('utf-8')
+                el = etree.SubElement(dc, elem_namespace + key)
+                el.text = v
         else:  # not a dublin core item
             if other is None:
                 globalDmdSecCounter += 1
@@ -224,7 +230,8 @@ def createDmdSecsFromCSVParsedMetadata(metadata):
                 mdWrap.set("MDTYPE", "OTHER")
                 mdWrap.set("OTHERMDTYPE", "CUSTOM")
                 other = etree.SubElement(mdWrap, ns.metsBNS + "xmlData")
-            etree.SubElement(other, normalizeNonDcElementName(key)).text = value
+            for v in value:
+                etree.SubElement(other, normalizeNonDcElementName(key)).text = v
     return ret
 
 

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -216,9 +216,7 @@ def createDmdSecsFromCSVParsedMetadata(metadata):
             if match:
                 key, = match.groups()
             for v in value:
-                v = v.decode('utf-8')
-                el = etree.SubElement(dc, elem_namespace + key)
-                el.text = v
+                etree.SubElement(dc, elem_namespace + key).text = v.decode('utf-8')
         else:  # not a dublin core item
             if other is None:
                 globalDmdSecCounter += 1
@@ -231,7 +229,7 @@ def createDmdSecsFromCSVParsedMetadata(metadata):
                 mdWrap.set("OTHERMDTYPE", "CUSTOM")
                 other = etree.SubElement(mdWrap, ns.metsBNS + "xmlData")
             for v in value:
-                etree.SubElement(other, normalizeNonDcElementName(key)).text = v
+                etree.SubElement(other, normalizeNonDcElementName(key)).text = v.decode('utf-8')
     return ret
 
 

--- a/src/MCPClient/lib/clientScripts/checkForServiceDirectory.py
+++ b/src/MCPClient/lib/clientScripts/checkForServiceDirectory.py
@@ -59,7 +59,7 @@ def something(SIPDirectory, serviceDirectory, objectsDirectory, SIPUUID, date):
             grp_file = File.objects.get(currentlocation__startswith=file2Full,
                                         removedtime__isnull=True,
                                         sip_id=SIPUUID)
-            f.filegrpuuid = grp_file.file_uuid
+            f.filegrpuuid = grp_file.uuid
             f.save()
 
     return exitCode

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -696,7 +696,7 @@ def document_id_from_field_query(conn, index, doc_types, field, value):
     query = {
         "query": {
             "term": {
-                field, value
+                field: value
             }
         }
     }


### PR DESCRIPTION
metadata.csvs may have duplicate columns. Store values in a list to handle this case.  Also, fix some typos.
