### PR TITLE
Manual Normalization: Misc fixes

### DIFF
--- a/src/MCPClient/lib/clientScripts/manualNormalizationCheckForManualNormalizationDirectory.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationCheckForManualNormalizationDirectory.py
@@ -41,7 +41,7 @@ if os.path.isdir(manualNormalizationPath):
             # made and setting unit variables in client scripts is missed! This
             # should be eliminated (by having another way of setting when DIPs
             # are created) or moved to its own MSCL.
-            UnitVariable.objects.filter(unittype="SIP", unituuid=SIPUUID, variable="returnFromManualNormalized").update(microservicechainlink_id="f060d17f-2376-4c0b-a346-b486446e46ce")
+            UnitVariable.objects.filter(unittype="SIP", unituuid=SIPUUID, variable="returnFromManualNormalized").update(microservicechainlink="f060d17f-2376-4c0b-a346-b486446e46ce")
             exit(179)
     manualNormalizationPreservationPath = os.path.join(manualNormalizationPath, "preservation")
     if os.path.isdir(manualNormalizationPreservationPath):

--- a/src/MCPClient/lib/clientScripts/manualNormalizationMoveAccessFilesToDIP.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationMoveAccessFilesToDIP.py
@@ -88,7 +88,7 @@ except (File.DoesNotExist, File.MultipleObjectsReturned) as e:
         kwargs = {
             "removedtime__isnull": True,
             "filegrpuse": "original",
-            "originallocation": original,
+            "originallocation__endswith": original,
             unitIdentifierType: unitIdentifier
         }
         f = File.objects.get(**kwargs)

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -260,7 +260,7 @@ def ingest_metadata_event_detail(request, uuid):
     # Add path for original and derived files to each form
     for form in formset:
         form.original_file = form.instance.file_uuid.originallocation.replace("%transferDirectory%objects/", "", 1)
-        form.derived_file = form.instance.file_uuid.derived_file_set.get().derived_file.originallocation.replace("%transferDirectory%objects/", "", 1)
+        form.derived_file = form.instance.file_uuid.derived_file_set.filter(derived_file__filegrpuse='preservation').get().derived_file.originallocation.replace("%transferDirectory%objects/", "", 1)
 
     # Get name of SIP from directory name of most recent job
     # Making list and slicing for speed: http://stackoverflow.com/questions/5123839/fastest-way-to-get-the-first-object-from-a-queryset-in-django

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -228,9 +228,9 @@ LOGGING = {
             'propagate': True,
         },
         'django': {
-            'handlers': ['null'],
+            'handlers': ['console', 'logfile'],
             'propagate': True,
-            'level': 'INFO',
+            'level': 'ERROR',
         },
         'archivematica.dashboard': {
             'handlers': ['console', 'logfile'],


### PR DESCRIPTION
Fix typo.

Update the preservation file's path in the DB instead of the original file's path. Minor cleanup.

Generate expected exception when looking for a normalization event, instead of using .filter().update() which always succeeds.
