### PR TITLE
DSpace transfers from files, automation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ dev (1.4.0)
 * Handle linking_agent as an integer, not a foreign key, in Django models (#8230)
 * Index MODS identifiers in the aips/aipfile index (#8266)
 * Fix bag transfer names (#8229)
+* DSpace transfer type accepts either files or folders

--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -70,6 +70,7 @@ extractBagTransfer_v0.0 = %clientScriptsDirectory%extractBagTransfer.py
 extractContents_v0.0 = %clientScriptsDirectory%extractContents.py
 extractMaildirAttachments_v0.0 = %clientScriptsDirectory%extractMaildirAttachments.py
 failedSIPCleanup_v1.0 = %clientScriptsDirectory%failedSIPCleanup.py
+fileToFolder_v1.0 = %clientScriptsDirectory%file_to_folder.py
 FITS_v0.0 = %clientScriptsDirectory%archivematicaFITS.py
 generateDIPFromAIPGenerateDIP_v0.0 = %clientScriptsDirectory%generateDIPFromAIPGenerateDIP.py
 getAipStorageLocations_v0.0 = %clientScriptsDirectory%getAipStorageLocations.py

--- a/src/MCPClient/lib/clientScripts/archivematicaMoveTransfer.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaMoveTransfer.py
@@ -42,7 +42,10 @@ def moveSIP(src, dst, transferUUID, sharedDirectoryPath):
         dest = os.path.join(dest, os.path.basename(src))
     if dest.endswith("/."):
         dest = os.path.join(dest[:-1], os.path.basename(src))
-    updateDB(dest + "/", transferUUID)
+
+    if os.path.isdir(src):
+        dest += "/"
+    updateDB(dest, transferUUID)
 
     renameAsSudo(src, dst)
 

--- a/src/MCPClient/lib/clientScripts/file_to_folder.py
+++ b/src/MCPClient/lib/clientScripts/file_to_folder.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import os
+import sys
+
+# dashboard
+from main.models import Transfer
+
+def main(transfer_path, transfer_uuid, shared_path):
+    """
+    Move a Transfer that is a file into a directory.
+
+    Given a transfer that is one file, move the file into a directory with the same basename and updated the DB for the new path.
+    No action taken if the transfer is already a directory.
+
+    WARNING This should not be run inside a watched directory - may result in duplicated transfers.
+
+    :param transfer_path: Path to the current transfer, file or folder
+    :param transfer_uuid: UUID of the transfer to update
+    :param shared_path: Value of the %sharedPath% variable
+    """
+    # If directory, return unchanged
+    if os.path.isdir(transfer_path):
+        print(transfer_path, 'is a folder, no action needed. Exiting.')
+        return 0
+    # If file, move into directory and update transfer
+    dirpath = os.path.splitext(transfer_path)[0]
+    basename = os.path.basename(transfer_path)
+    if os.path.exists(dirpath):
+        print('Cannot move file', transfer_path, 'to folder', dirpath, 'because it already exists', file=sys.stderr)
+        return 1
+    os.mkdir(dirpath)
+    new_path = os.path.join(dirpath, basename)
+    print('Moving', transfer_path, 'to', new_path)
+    os.rename(transfer_path, new_path)
+
+    db_path = os.path.join(dirpath.replace(shared_path, '%sharedPath%', 1), '')
+    print('Updating transfer', transfer_uuid, 'path to', db_path)
+    Transfer.objects.filter(uuid=transfer_uuid).update(currentlocation=db_path)
+    return 0
+
+if __name__ == '__main__':
+    transfer_path = sys.argv[1]
+    transfer_uuid = sys.argv[2]
+    shared_path = sys.argv[3]
+    sys.exit(main(transfer_path, transfer_uuid, shared_path))

--- a/src/MCPServer/share/mysql_dev.sh
+++ b/src/MCPServer/share/mysql_dev.sh
@@ -17,4 +17,5 @@ mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7690_recursive_extraction.sql;"
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7239_contentdm.sql;"
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_8825_checksum_failure.sql;"
+mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_8019_dspace_at_fixes.sql;"
 # ...

--- a/src/MCPServer/share/mysql_dev_8019_dspace_at_fixes.sql
+++ b/src/MCPServer/share/mysql_dev_8019_dspace_at_fixes.sql
@@ -1,0 +1,10 @@
+
+-- DSpace AT sees files
+UPDATE WatchedDirectories SET onlyActOnDirectories=0 WHERE pk='e3b15e28-6370-42bf-a0e1-f61e4837a2a7';
+
+-- Add client script to extract DSpace zipped files into a dir
+INSERT INTO StandardTasksConfigs (pk, requiresOutputLock, execute, arguments) VALUES ('21f89353-30ba-4601-8690-7c235630736f', 0, 'fileToFolder_v1.0', '"%SIPDirectory%" "%SIPUUID%" "%sharedPath%"');
+INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES ('d9ebceed-2cfb-462b-b130-48fecdf55bbf', '36b2e239-4a57-4aa5-8ebc-7a29139baca6', '21f89353-30ba-4601-8690-7c235630736f', 'Check if file or folder');
+INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, currentTask, defaultNextChainLink) VALUES ('bda96b35-48c7-44fc-9c9e-d7c5a05016c1', 'Verify transfer compliance', 'Failed', 'd9ebceed-2cfb-462b-b130-48fecdf55bbf', '61c316a6-0a50-4f65-8767-1f44b1eeb6dd');
+INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('c5c68ced-17d5-4b7d-b955-a56080d5b9bb', 'bda96b35-48c7-44fc-9c9e-d7c5a05016c1', 0, '26bf24c9-9139-4923-bf99-aa8648b1692b', 'Completed successfully');
+UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink='bda96b35-48c7-44fc-9c9e-d7c5a05016c1' WHERE microServiceChainLink='0e1a8a6b-abcc-4ed6-b4fb-cbccfdc23ef5';

--- a/src/MCPServer/share/mysql_dev_8019_dspace_at_fixes.sql
+++ b/src/MCPServer/share/mysql_dev_8019_dspace_at_fixes.sql
@@ -8,3 +8,29 @@ INSERT INTO TasksConfigs (pk, taskType, taskTypePKReference, description) VALUES
 INSERT INTO MicroServiceChainLinks(pk, microserviceGroup, defaultExitMessage, currentTask, defaultNextChainLink) VALUES ('bda96b35-48c7-44fc-9c9e-d7c5a05016c1', 'Verify transfer compliance', 'Failed', 'd9ebceed-2cfb-462b-b130-48fecdf55bbf', '61c316a6-0a50-4f65-8767-1f44b1eeb6dd');
 INSERT INTO MicroServiceChainLinksExitCodes (pk, microServiceChainLink, exitCode, nextMicroServiceChainLink, exitMessage) VALUES ('c5c68ced-17d5-4b7d-b955-a56080d5b9bb', 'bda96b35-48c7-44fc-9c9e-d7c5a05016c1', 0, '26bf24c9-9139-4923-bf99-aa8648b1692b', 'Completed successfully');
 UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink='bda96b35-48c7-44fc-9c9e-d7c5a05016c1' WHERE microServiceChainLink='0e1a8a6b-abcc-4ed6-b4fb-cbccfdc23ef5';
+
+-- Delete unused MSCLs
+SET @d1='663a11f6-91cb-4fef-9aa7-2594b3752e4c' COLLATE utf8_unicode_ci;
+SET @d2='a132193a-2e79-4221-a092-c51839d566fb' COLLATE utf8_unicode_ci;
+SET @d3='9e4e39be-0dad-41bc-bee0-35cb71e693df' COLLATE utf8_unicode_ci;
+SET @d4='e888269d-460a-4cdf-9bc7-241c92734402' COLLATE utf8_unicode_ci;
+-- Transfer backup
+SET @d5='9fa0a0d1-25bb-4507-a5f7-f177d7fa920d' COLLATE utf8_unicode_ci;
+SET @d6='c1339015-e15b-4303-8f37-a2516669ac4e' COLLATE utf8_unicode_ci;
+SET @d7='a72afc44-fa28-4de7-b35f-c79b9f01aa5c' COLLATE utf8_unicode_ci;
+SET @d8='478512a6-10e4-410a-847d-ce1e25d8d31c' COLLATE utf8_unicode_ci;
+
+DELETE FROM TasksConfigsAssignMagicLink WHERE execute = @d5;
+DELETE FROM MicroServiceChainChoice WHERE choiceAvailableAtLink IN (@d1, @d2, @d3, @d4, @d5, @d6, @d7, @d8);
+DELETE FROM MicroServiceChains WHERE pk IN ('a7f8f67f-401f-4665-b7b3-35496fd5017c', '2884ed7c-8c4c-4fa9-a6eb-e27bcaf9ab92');
+DELETE FROM MicroServiceChainLinksExitCodes WHERE microServiceChainLink IN (@d1, @d2, @d3, @d4, @d5, @d6, @d7, @d8);
+DELETE FROM MicroServiceChainLinks WHERE pk IN (@d1, @d2, @d3, @d4, @d5, @d6, @d7, @d8);
+
+-- Zipped bags should also be moved to procesing directory
+UPDATE MicroServiceChainLinksExitCodes SET nextMicroServiceChainLink='288b739d-40a1-4454-971b-812127a5e03d' WHERE microServiceChainLink='3229e01f-adf3-4294-85f7-4acb01b3fbcf';
+
+
+-- Delete all TasksConfigs that don't have MicroServiceChainLinks pointing at them
+DELETE FROM TasksConfigs USING TasksConfigs LEFT OUTER JOIN MicroServiceChainLinks ON currentTask=TasksConfigs.pk WHERE MicroServiceChainLinks.pk is NULL;
+-- Delete all StandardTasksConfigs that don't have TasksConfigs pointing at them
+DELETE FROM StandardTasksConfigs USING StandardTasksConfigs LEFT OUTER JOIN TasksConfigs ON taskTypePKReference=StandardTasksConfigs.pk WHERE TasksConfigs.pk is NULL;

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -86,7 +86,7 @@ def get_unit_status(unit_uuid, unit_type):
     elif models.Job.objects.filter(sipuuid=unit_uuid).filter(jobtype='Create SIP from transfer objects').exists():
         ret['status'] = 'COMPLETE'
         # Get SIP UUID
-        sips = models.File.objects.filter(transfer_id=unit_uuid).values('sip').distinct()
+        sips = models.File.objects.filter(transfer_id=unit_uuid, sip__isnull=False).values('sip').distinct()
         if sips:
             ret['sip_uuid'] = sips[0]['sip']
     elif models.Job.objects.filter(sipuuid=unit_uuid).filter(jobtype='Move transfer to backlog').exists():

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -344,8 +344,7 @@ def get_modified_standard_transfer_path(transfer_type=None):
         except:
             return None
 
-    shared_directory_path = helpers.get_server_config_value('sharedDirectory')
-    return path.replace(shared_directory_path, '%sharedPath%', 1)
+    return path.replace(SHARED_DIRECTORY_ROOT, '%sharedPath%', 1)
 
 
 def approve_transfer_via_mcp(directory, transfer_type, user_id):
@@ -358,13 +357,14 @@ def approve_transfer_via_mcp(directory, transfer_type, user_id):
         if modified_transfer_path is None:
             error = 'Invalid transfer type.'
         else:
-            if transfer_type == 'zipped bag':
-                transfer_path = os.path.join(modified_transfer_path, directory)
-            else:
-                transfer_path = os.path.join(modified_transfer_path, directory, '')
+            db_transfer_path = os.path.join(modified_transfer_path, directory)
+            transfer_path = db_transfer_path.replace('%sharedPath%', SHARED_DIRECTORY_ROOT, 1)
+            # Ensure directories end with /
+            if os.path.isdir(transfer_path):
+                db_transfer_path = os.path.join(db_transfer_path, '')
             # look up job UUID using transfer path
             try:
-                job = models.Job.objects.filter(directory=transfer_path, currentstep='Awaiting decision')[0]
+                job = models.Job.objects.filter(directory=db_transfer_path, currentstep='Awaiting decision')[0]
                 unit_uuid = job.sipuuid
 
                 type_task_config_descriptions = {

--- a/src/dashboard/src/media/js/transfer/component_form.js
+++ b/src/dashboard/src/media/js/transfer/component_form.js
@@ -88,13 +88,18 @@ var TransferComponentFormView = Backbone.View.extend({
       return true;
     };
 
+    display_filter = undefined;
+    if (this.transfer_type == 'zipped bag' || this.transfer_type == 'dspace') {
+      display_filter = zip_filter;
+    }
+
     createDirectoryPicker(
       locationUUID,
       sourceDir,
       'transfer-component-select-modal',
       'path_container',
       'transfer-component-path-item',
-      this.transfer_type == 'zipped bag' ? zip_filter : undefined
+      display_filter
     );
   },
 


### PR DESCRIPTION
Updates to support automation of DSpace transfers
- Handle folders & deleted files in get status
- DSpace transfer type handles files or folders when creating a transfer

Works with artefactual/automation-tools#2 and artefactual/archivematica-storage-service#73
