### PR TITLE
Ingest, index bag-info metadata

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -328,7 +328,8 @@ def connect_and_index_aip(uuid, name, filePath, pathToMETS, size=None, aips_in_a
         'AICID': aic_identifier,
         'isPartOf': is_part_of,
         'countAIPsinAIC': aips_in_aic,
-        'identifiers': identifiers
+        'identifiers': identifiers,
+        'transferMetadata': _extract_transfer_metadata(root, nsmap),
     }
     wait_for_cluster_yellow_status(conn)
     try_to_index(conn, aipData, 'aips', 'aip')
@@ -421,6 +422,10 @@ def connect_and_index_files(index, type, uuid, pathToArchive, identifiers=[], si
 
     return exitCode
 
+def _extract_transfer_metadata(doc, nsmap):
+    return [xmltodict.parse(ElementTree.tostring(el))['transfer_metadata']
+            for el in doc.findall("m:amdSec/m:sourceMD/m:mdWrap/m:xmlData/transfer_metadata", namespaces=nsmap)]
+
 def index_mets_file_metadata(conn, uuid, metsFilePath, index, type, sipName, identifiers=[]):
 
     # parse XML
@@ -472,6 +477,7 @@ def index_mets_file_metadata(conn, uuid, metsFilePath, index, type, sipName, ide
         },
         'origin': getDashboardUUID(),
         'identifiers': identifiers,
+        'transferMetadata': _extract_transfer_metadata(root, nsmap),
     }
 
     # Index all files in a fileGrup with USE='original' or USE='metadata'

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -257,7 +257,7 @@ def set_up_mapping(conn, index):
 
     if index == 'aips':
         print 'Creating AIP mapping...'
-        conn.indices.put_mapping(doc_type='aip', body={'aip': {'date_detection': False}}, index='aips')
+        conn.indices.put_mapping(doc_type='aip', body={'aip': {'date_detection': True}}, index='aips')
         print 'AIP mapping created.'
 
         mapping = {
@@ -269,7 +269,7 @@ def set_up_mapping(conn, index):
         print 'Creating AIP mapping...'
         conn.indices.put_mapping(
             doc_type='aip',
-            body={'aip': {'date_detection': False, 'properties': mapping}},
+            body={'aip': {'date_detection': True, 'properties': mapping}},
             index='aips'
         )
         print 'AIP mapping created.'
@@ -284,7 +284,7 @@ def set_up_mapping(conn, index):
         print 'Creating AIP file mapping...'
         conn.indices.put_mapping(
             doc_type='aipfile',
-            body={'aipfile': {'date_detection': False, 'properties': mapping}},
+            body={'aipfile': {'date_detection': True, 'properties': mapping}},
             index='aips'
         )
         print 'AIP file mapping created.'

--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -1,2 +1,3 @@
+bagit==1.5.2
 Django==1.5.4
 elasticsearch>=1.0.0,<2.0.0

--- a/src/dashboard/debian/control
+++ b/src/dashboard/debian/control
@@ -14,6 +14,7 @@ Depends:
 	apache2-mpm-prefork,
 	libapache2-mod-wsgi,
 	python-pip,
+	python-dateutil,
 	python-gearman,
 	python-simplejson
 Description: Web Dashboard for Archivematica

--- a/src/dashboard/src/media/css/archival_storage.css
+++ b/src/dashboard/src/media/css/archival_storage.css
@@ -34,6 +34,11 @@
   margin-left: 20px;
 }
 
+#aip-search-query-other-field-name {
+  margin-left: 5px;
+  display: none;
+}
+
 div.search-summary p {
   font-weight: bold;
 }

--- a/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
+++ b/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
@@ -17,6 +17,14 @@ You should have received a copy of the GNU General Public License
 along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+function selectField(name) {
+  if (name == 'transferMetadataOther') {
+    $('#aip-search-query-other-field-name').show('fade', {}, 250);
+  } else {
+    $('#aip-search-query-other-field-name').hide('fade', {}, 250);
+  }
+}
+
 $(document).ready(function() {
 
   // create new form instance, providing a single row of default data
@@ -27,6 +35,7 @@ $(document).ready(function() {
       'op': '',
       'query': '',
       'field': '',
+      'fieldName': '',
       'type': ''
     }],
     'deleteHandleHtml': '<img src="/media/images/delete.png" style="margin-left: 5px"/>',
@@ -48,7 +57,7 @@ $(document).ready(function() {
   search.addInput('query', {title: 'search query', 'class': 'aip-search-query-input'});
 
   // default field name field
-  search.addSelect('field', {title: 'field name'}, {
+  search.addSelect('field', {title: 'field name', onchange: 'selectField(this.value)'}, {
     '': 'Any',
     'FILEUUID': 'File UUID',
     'filePath': 'File path',
@@ -58,12 +67,17 @@ $(document).ready(function() {
     'isPartOf': 'Part of AIC',
     'AICID': 'AIC Identifier',
     'transferMetadata': 'Transfer metadata',
+    'transferMetadataOther': 'Transfer metadata (other)',
   });
+
+  // "Other" field name, when selecting "transfer metadata (other)"
+  search.addInput('fieldName', {title: 'other field name', 'class': 'aip-search-query-input', 'id': 'aip-search-query-other-field-name'});
 
   // default field name field
   search.addSelect('type', {title: 'query type'}, {
     'term': 'Keyword',
-    'string': 'Phrase'
+    'string': 'Phrase',
+    'range': 'Date range'
   });
 
   // don't show first op field
@@ -77,6 +91,9 @@ $(document).ready(function() {
   }
 
   search.render();
+
+  // Ensure the select field name field is hidden/displayed as appropriate
+  selectField($('.advanced_search_form_field_field > select')[0].value);
 
   function aipSearchSubmit() {
     var destination = '/archival-storage/search/' + '?' + search.toUrlParams();

--- a/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
+++ b/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
@@ -49,14 +49,15 @@ $(document).ready(function() {
 
   // default field name field
   search.addSelect('field', {title: 'field name'}, {
-    ''             : 'Any',
-    'FILEUUID'     : 'File UUID',
-    'filePath'     : 'File path',
+    '': 'Any',
+    'FILEUUID': 'File UUID',
+    'filePath': 'File path',
     'fileExtension': 'File extension',
-    'AIPUUID'      : 'AIP UUID',
-    'sipName'      : 'AIP name',
-    'isPartOf'     : 'Part of AIC',
-    'AICID'        : 'AIC Identifier',
+    'AIPUUID': 'AIP UUID',
+    'sipName': 'AIP name',
+    'isPartOf': 'Part of AIC',
+    'AICID': 'AIC Identifier',
+    'transferMetadata': 'Transfer metadata',
   });
 
   // default field name field


### PR DESCRIPTION
This adds support for ingesting transfer metadata from bags using the data contained within the `bag_info.txt`. `bag-info.txt` contains [simple key-value pairs](https://tools.ietf.org/html/draft-kunze-bagit-10#section-2.2.2).

Changes in this branch:
- createMETS2 now uses python-bagit to parse each originating transfer's bag-info.txt. Each key/value pair is translated into XML tags containing the value as text, within a `mets:sourceMD/xmlData/transfer_metadata` element; the overall structure is essentially identical to disk image transfer metadata. Any key/value pairs whose keys are not XML tag-compatible are skipped.
- All `transfer_metadata` elements are now indexed in Elasticsearch.
- "Transfer metadata" has been added as a searchable value in archival storage, and the values of any BagIt tags can be searched on.
