### PR TITLE
Event: linking_agent is an integer, not foreign key

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -460,7 +460,7 @@ def createDigiprovMD(fileUUID):
         if event_record.linking_agent:
             linkingAgentIdentifier = etree.SubElement(event, ns.premisBNS + "linkingAgentIdentifier")
             etree.SubElement(linkingAgentIdentifier, ns.premisBNS + "linkingAgentIdentifierType").text = "Archivematica user pk"
-            etree.SubElement(linkingAgentIdentifier, ns.premisBNS + "linkingAgentIdentifierValue").text = str(event_record.linking_agent_id)
+            etree.SubElement(linkingAgentIdentifier, ns.premisBNS + "linkingAgentIdentifierValue").text = str(event_record.linking_agent)
         
         # linkingAgentIdentifier
         for agent in Agent.objects.all():

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -143,7 +143,7 @@ def insertIntoEvents(fileUUID="", eventIdentifierUUID="", eventType="", eventDat
                          event_type=eventType, event_datetime=eventDateTime,
                          event_detail=eventDetail, event_outcome=eventOutcome,
                          event_outcome_detail=eventOutcomeDetailNote,
-                         linking_agent_id=agent)
+                         linking_agent=agent)
 
 def insertIntoDerivations(sourceFileUUID="", derivedFileUUID="", relatedEventUUID=""):
     """

--- a/src/archivematicaCommon/tests/test_database_functions.py
+++ b/src/archivematicaCommon/tests/test_database_functions.py
@@ -6,7 +6,7 @@ sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 import databaseFunctions
 
 sys.path.append("/usr/share/archivematica/dashboard")
-from main.models import Event, File
+from main.models import Agent, Event, File
 
 from django.test import TestCase
 import pytest
@@ -66,7 +66,8 @@ class TestDatabaseFunctions(TestCase):
     def test_insert_into_event_fetches_correct_agent_from_file(self):
         databaseFunctions.insertIntoEvents(fileUUID="88c8f115-80bc-4da4-a1e6-0158f5df13b9",
                                            eventIdentifierUUID="event_agent_id")
-        assert Event.objects.get(event_id="event_agent_id").linking_agent.name == "Event agent"
+        agent_id = Event.objects.get(event_id="event_agent_id").linking_agent
+        assert Agent.objects.get(id=agent_id).name == "Event agent"
 
     def test_get_accession_number_from_transfer(self):
         accession_id = databaseFunctions.getAccessionNumberFromTransfer("5a8d0539-8e5a-4aa9-98d8-5e5053140398")

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -156,7 +156,7 @@ class Event(models.Model):
     event_detail = models.TextField(db_column='eventDetail', blank=True)
     event_outcome = models.TextField(db_column='eventOutcome', blank=True)
     event_outcome_detail = models.TextField(db_column='eventOutcomeDetailNote', blank=True)  # TODO convert this to a BinaryField with Django >= 1.6
-    linking_agent = models.ForeignKey('Agent', db_column='linkingAgentIdentifier', null=True)
+    linking_agent = models.IntegerField(db_column='linkingAgentIdentifier', null=True)
 
     class Meta:
         db_table = u'Events'


### PR DESCRIPTION
linkingAgentIdentifier is an integer, which can be a reference either to a
value in the Agents table or to a user in the auth_user table. Rather than
enforce the foreign key at the Django level, just return it as an integer.

Fixes #8230.
