### PR TITLE
AIC: Continue if submission docs don't exist to be copied

### DIFF
--- a/src/MCPClient/lib/clientScripts/copySubmissionDocs.sh
+++ b/src/MCPClient/lib/clientScripts/copySubmissionDocs.sh
@@ -7,4 +7,4 @@
 # Copy submission documentation from the AIP back into the SIP
 subdir="$1/submissionDocumentation"
 mkdir -p $subdir
-cp -R "$1/$2/data/objects/submissionDocumentation" $subdir
+cp -R "$1/$2/data/objects/submissionDocumentation" $subdir || true


### PR DESCRIPTION
In an AIC, submission docs don't exist, so if that microservice fails it shouldn't fail the SIP.

I have two implementations here: copySubmissionDocs always returns success (which silences all failures), and continue if that MSCL fails (which shows as a fail for AICs even though that's expected). Thoughts on which is better, or if I should continue to do both?

refs #8258
