### PR TITLE
create new logging directory before running syncdb

### DIFF
--- a/src/dashboard/debian/postinst
+++ b/src/dashboard/debian/postinst
@@ -2,6 +2,12 @@
 
 a2enmod wsgi
 
+
+logdir=/var/log/archivematica/dashboard
+mkdir -p $logdir
+chown -R archivematica:archivematica $logdir
+chmod -R g+s $logdir
+
 #install dashboard requirements
 pip install -r /usr/share/archivematica/dashboard/requirements.txt
 # AM 1.1.0 and earlier did not set charset and collation on db properly
@@ -19,9 +25,4 @@ else
   adduser --uid 334 --group --system --home /var/lib/archivematica-django/ archivematicadashboard
 fi
 
-logdir=/var/log/archivematica/dashboard
-mkdir -p $logdir
-chown -R archivematica:archivematica $logdir
-chmod -R g+s $logdir
-  
 #DEBHELPER#


### PR DESCRIPTION
refs #8267

Create the new logging directory before issuing any manage.py
commands in the debian/postinst script, as django will try to log
to the new logging directory, and it needs to exist for that to work.
