### PR TITLE
Archival storage: handle items with no 'fields' key

### DIFF
--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -210,7 +210,7 @@ def search_augment_file_results(raw_results):
     modifiedResults = []
 
     for item in raw_results['hits']['hits']:
-        clone = {k: v[0] for k,v in item['fields'].copy().iteritems()}
+        clone = {k: v[0] for k,v in item.get('fields', {}).copy().iteritems()}
 
         # try to find AIP details in database
         try:


### PR DESCRIPTION
This was reported in #8290, where a few items in the aipfile index are empty. Because they have no `fields` key, `search_augment_file_results` raised a KeyError when trying to access their contents.

``` python
{u'_id': u'AUy_JM2bZTVg0eDcbrB9',
 u'_index': u'aips',
 u'_score': 1.0,
 u'_type': u'aipfile'},
```
