### PR TITLE
Archival storage: skip empty items

### DIFF
--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -210,7 +210,10 @@ def search_augment_file_results(raw_results):
     modifiedResults = []
 
     for item in raw_results['hits']['hits']:
-        clone = {k: v[0] for k,v in item.get('fields', {}).copy().iteritems()}
+        if 'fields' not in item:
+            continue
+
+        clone = {k: v[0] for k,v in item['fields'].copy().iteritems()}
 
         # try to find AIP details in database
         try:


### PR DESCRIPTION
After further testing of #203, I realized that archival storage couldn't properly operate on empty items - so it's better just to skip them.
