### PR TITLE
Backlog search: run status query as a filter

### DIFF
--- a/src/dashboard/src/components/advanced_search.py
+++ b/src/dashboard/src/components/advanced_search.py
@@ -127,6 +127,7 @@ def paging_related_values_for_template_use(items_per_page, page, start, number_o
 
 def assemble_query(queries, ops, fields, types, **kwargs):
     must_haves     = kwargs.get('must_haves', [])
+    filters        = kwargs.get('filters', {})
     should_haves   = []
     must_not_haves = []
     index          = 0
@@ -145,6 +146,7 @@ def assemble_query(queries, ops, fields, types, **kwargs):
         index = index + 1
 
     return {
+        "filter": filters,
         "query": {
             "bool": {
                 "must": must_haves,

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -468,7 +468,10 @@ def transfer_backlog(request):
             ops,
             fields,
             types,
-            must_haves={'term': {'status': 'backlog'}}
+            # Specify this as a filter, not a must_have, for performance,
+            # and so that it doesn't cause the "should" queries in a
+            # should-only query to be ignored.
+            filters={'term': {'status': 'backlog'}},
         )
 
         results = elasticSearchFunctions.search_raw_wrapper(


### PR DESCRIPTION
When evaluating a bool query, Elasticsearch may ignore "should" values if a "must" or "must not" clause has been specified. Since we were previously specifying "status: backlog" as a "must" clause to the query, this meant that the actual search preferences were being ignored.

Fixes #8292.
