### PR TITLE
Search: Handle empty searches better

### DIFF
--- a/src/dashboard/src/components/advanced_search.py
+++ b/src/dashboard/src/components/advanced_search.py
@@ -215,7 +215,7 @@ def query_clause(index, queries, ops, fields, types):
         #
         # TODO: add condition to deal with a query with no clauses because all have
         #       been ignored
-        if (queries[index] == ''):
+        if (queries[index] in ('', '*')):
             return
         else:
             if (fields[index] != ''):

--- a/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
+++ b/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
@@ -36,7 +36,7 @@ $(document).ready(function() {
       'query': '',
       'field': '',
       'fieldName': '',
-      'type': ''
+      'type': 'term'
     }],
     'deleteHandleHtml': '<img src="/media/images/delete.png" style="margin-left: 5px"/>',
     'addHandleHtml': '<a>Add New</a>'

--- a/src/dashboard/src/media/js/ingest/backlog.js
+++ b/src/dashboard/src/media/js/ingest/backlog.js
@@ -6,7 +6,7 @@ function renderBacklogSearchForm(openInNewTab) {
       'op': '',
       'query': '',
       'field': '',
-      'type': ''
+      'type': 'term'
     }],
     'deleteHandleHtml': '<img src="/media/images/delete.png" style="margin-left: 5px"/>',
     'addHandleHtml': '<a>Add New</a>'


### PR DESCRIPTION
Set a default value for 'type' in search queries to match what's displayed, and handle '' and '*' as empty search queries for type=term.
