### PR TITLE
Archival storage: avoid searching nested date fields as strings

### DIFF
--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -100,7 +100,7 @@ def search(request):
     conn = Elasticsearch(hosts=elasticSearchFunctions.getElasticsearchServerHostAndPort())
 
     results = None
-    query = advanced_search.assemble_query(queries, ops, fields, types)
+    query = advanced_search.assemble_query(queries, ops, fields, types, search_index='aips', doc_type='aipfile')
     try:
         # use all results to pull transfer facets if not in file mode
         # pulling only one field (we don't need field data as we augment


### PR DESCRIPTION
Searching nested documents using wildcard field names and the query_string query type can fail in unexpected ways when the nested document contains mixed types. For example, if the nested document contains both strings and dates, a search for "foo" will fail because Elasticsearch will attempt to parse it into a date for use with the date fields.

Since the "phrase" search in archival storage is only meant to search string fields, this adds a check to query_string generation to search only string-type nested document fields.

Fixes #8338.
