### PR TITLE
Advanced search: fix row generation for rows 2+

### DIFF
--- a/src/dashboard/src/components/advanced_search.py
+++ b/src/dashboard/src/components/advanced_search.py
@@ -224,7 +224,7 @@ def query_clause(index, queries, ops, fields, types, search_index=None, doc_type
     if fields[index] == '':
         search_fields = []
     else:
-        search_fields = _fix_object_fields([fields[index]])
+        search_fields = filter_search_fields(_fix_object_fields([fields[index]]), index=search_index, doc_type=doc_type)
 
     if types[index] == 'term':
         # a blank term should be ignored because it prevents any results: you
@@ -235,13 +235,10 @@ def query_clause(index, queries, ops, fields, types, search_index=None, doc_type
         if (queries[index] in ('', '*')):
             return
         else:
-            if (fields[index] != ''):
-                term_field = fields[index]
-            else:
-                term_field = '_all'
-            return {'term': {term_field: queries[index]}}
+            if len(search_fields) == 0:
+                search_fields = ['_all']
+            return {'multi_match': {'query': queries[index], 'fields': search_fields}}
     elif types[index] == 'string':
-        search_fields = filter_search_fields(search_fields, index=search_index, doc_type=doc_type)
         return {'query_string': {'query': queries[index], 'fields': search_fields}}
     elif types[index] == 'range':
         start, end = _parse_date_range(queries[index])

--- a/src/dashboard/src/media/js/advanced-search-query-creator.js
+++ b/src/dashboard/src/media/js/advanced-search-query-creator.js
@@ -3,7 +3,8 @@
   exports.AdvancedSearchView = Backbone.View.extend({
 
     initialize: function() {
-      this.rows = this.options.rows || [];
+      // Default row is a single-length array of a copy of the row template
+      this.rows = [_.extend({}, this.options.rowTemplate)];
       this.fields = [];
       this.optionElements = {};
       this.allowAdd = (this.options.allowAdd != undefined)
@@ -41,14 +42,8 @@
     },
 
     generateBlankRow: function() {
-      var row = {};
-
-      for(var fieldIndex in this.fields) {
-        var fieldName = this.fields[fieldIndex]
-        row[fieldName] = '';
-      }
-
-      return row;
+      // New rows are created as copies of the row template
+      return _.extend({}, this.rowTemplate);
     },
 
     addBlankRow: function() {

--- a/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
+++ b/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
@@ -31,13 +31,13 @@ $(document).ready(function() {
   var search = new advancedSearch.AdvancedSearchView({
     el: $('#search_form_container'),
 //    allowAdd: false,
-    rows: [{
+    rowTemplate: {
       'op': '',
       'query': '',
       'field': '',
       'fieldName': '',
       'type': 'term'
-    }],
+    },
     'deleteHandleHtml': '<img src="/media/images/delete.png" style="margin-left: 5px"/>',
     'addHandleHtml': '<a>Add New</a>'
   });

--- a/src/dashboard/src/media/js/ingest/backlog.js
+++ b/src/dashboard/src/media/js/ingest/backlog.js
@@ -2,12 +2,12 @@ function renderBacklogSearchForm(openInNewTab) {
   // create new form instance, providing a single row of default data
   var search = new advancedSearch.AdvancedSearchView({
     el: $('#search_form_container'),
-    rows: [{
+    rowTemplate: {
       'op': '',
       'query': '',
       'field': '',
       'type': 'term'
-    }],
+    },
     'deleteHandleHtml': '<img src="/media/images/delete.png" style="margin-left: 5px"/>',
     'addHandleHtml': '<a>Add New</a>'
   });


### PR DESCRIPTION
Commit fe101c585d89d9b2182e7eb5e2d6e3f39bd36970 fixed a bug where the initial value for the "keyword" dropdown, "term", would be sent as an empty string. However, the bug recurs for any subsequent rows that are added using the "add new" button. This fixes this issue by adding a row template as a parameter to the advanced search javascript, and creating both initial and subsequent rows from that template rather than naively.

Refs #8292.
