### PR TITLE
mysql_dev: touch a file to indicate completion

### DIFF
--- a/src/MCPServer/share/mysql_dev.sh
+++ b/src/MCPServer/share/mysql_dev.sh
@@ -22,3 +22,5 @@ mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_8287_siegfried.sql;"
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7321_dip_processing_xml.sql;"
 # ...
+
+touch $currentDir/mysql_dev.complete


### PR DESCRIPTION
This assists the Ansible deployment scripts in determining if mysql_dev has already been run, since it can't be safely rerun on the same database.
