### PR TITLE
AIC: Pass full search results

### DIFF
--- a/src/dashboard/src/components/advanced_search.py
+++ b/src/dashboard/src/components/advanced_search.py
@@ -130,25 +130,6 @@ def assemble_query(queries, ops, fields, types, search_index=None, doc_type=None
                 "should": should_haves,
             }
         },
-        "facets": {
-            "fileExtension": {
-                "terms": {
-                    "field": "fileExtension"
-                }
-            },
-            "sipuuid": {
-                "terms": {
-                    "field": "sipuuid",
-                    "size": 1000000000
-                }
-            },
-            "AIPUUID": {
-                "terms": {
-                    "field": "AIPUUID",
-                    "size": 1000000000
-                }
-            }
-        }
     }
 
 def _fix_object_fields(fields):

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -253,7 +253,7 @@ def create_aic(request, *args, **kwargs):
     aic_form = forms.CreateAICForm(request.POST or None)
     if aic_form.is_valid():
         results = ast.literal_eval(aic_form.cleaned_data['results'])
-        logging.info("AIC AIP info: {}".format(results))
+        logger.info("AIC AIP info: {}".format(results))
 
         # Create files in staging directory with AIP information
         shared_dir = helpers.get_server_config_value('sharedDirectory')
@@ -267,7 +267,7 @@ def create_aic(request, *args, **kwargs):
             os.chmod(destination, 0o770)
         except os.error:
             messages.error(request, "Error creating AIC")
-            logging.exception("Error creating AIC: Error creating directory {}".format(destination))
+            logger.exception("Error creating AIC: Error creating directory {}".format(destination))
             return redirect('archival_storage_index')
 
         # Create SIP in DB
@@ -284,7 +284,7 @@ def create_aic(request, *args, **kwargs):
         return redirect('components.ingest.views.aic_metadata_add', temp_uuid)
     else:
         messages.error(request, "Error creating AIC")
-        logging.error("Error creating AIC: Form not valid: {}".format(aic_form))
+        logger.error("Error creating AIC: Form not valid: {}".format(aic_form))
         return redirect('archival_storage_index')
 
 def delete_context(request, uuid):
@@ -395,7 +395,7 @@ def aips_pending_deletion():
         aips = storage_service.get_file_info(status='DEL_REQ')
     except Exception as e:
         # TODO this should be messages.warning, but we need 'request' here
-        logging.warning("Error retrieving AIPs pending deletion: is the storage server running?  Error: {}".format(e))
+        logger.warning("Error retrieving AIPs pending deletion: is the storage server running?  Error: {}".format(e))
     else:
         for aip in aips:
             aip_uuids.append(aip['uuid'])
@@ -533,7 +533,7 @@ def list_display(request):
             except IndexError:
                 # Storage service does not know about this AIP
                 # TODO what should happen here?
-                logging.info("AIP not found in storage service: {}".format(aip))
+                logger.info("AIP not found in storage service: {}".format(aip))
                 continue
 
             # delete AIP metadata in ElasticSearch if AIP has been deleted from the


### PR DESCRIPTION
AIC creation form needs the whole list of AIP names and UUIDs that match the search, not just this page's results. The search only returned the UUID. Modify search to return the UUID and name. Since we're searching aip/aipfile (not aip/aips), dedupe the results and add a count of the number of files in the AIP.

An alternate implementation is to call `search_augment_aip_results` on the entire results list, but that seemed inefficient, and the aipfiles -> aip conversion still needed to happen.

Also:
- Change to use logger instead of logging
- Add namespacing to create AIC METS
- Remove now-unused facets from assemble_query
