### PR TITLE
taskStandard: stdout/stderr values are already normalized

### DIFF
--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -94,8 +94,6 @@ def writeToFile(output, fileName, writeWhite=False):
         return 0
     if fileName and output:
         #print "writing to: " + fileName
-        if fileName.startswith("<^Not allowed to write to file^> "):
-            return -1
         try:
             f = open(fileName, 'a')
             f.write(output.__str__())


### PR DESCRIPTION
Due to the changes to ReplacementDict, the stdout/stderr values are now being expanded before being passed to taskStandard.

Fortunately, this allows for a general simplification/cleanup of the validation code in taskStandard; it can now perform a straightforward check whether the files are writable, instead of relying on heuristics based on the presence of a variable string in the text.

Fixes #8404.
