### PR TITLE
Fixes for verifyMD5

### DIFF
--- a/src/MCPClient/lib/clientScripts/verifyMD5.sh
+++ b/src/MCPClient/lib/clientScripts/verifyMD5.sh
@@ -25,10 +25,9 @@
 checkMD5NoGui="`dirname $0`/archivematicaCheckMD5NoGUI.sh"
 
 target="$1"
-checksums="$2"
-date="$3"
-eventID="$4"
-transferUUID="$5"
+date="$2"
+eventID="$3"
+transferUUID="$4"
 
 
 #       md5deep - Compute and compare MD5 message digests
@@ -39,7 +38,7 @@ transferUUID="$5"
 
 ret=0
 
-MD5FILE="${target}metadata/${checksums}.md5"
+MD5FILE="${target}metadata/checksum.md5"
 if [ -f "${MD5FILE}" ]; then
     "${checkMD5NoGui}" "${target}objects/" "${MD5FILE}" "${target}logs/`basename "${MD5FILE}"`-Check-`date`" "md5deep" && \
     "`dirname $0`/createEventsForGroup.py" --groupUUID "${transferUUID}" --groupType "transfer_id" --eventType "fixity" --eventDateTime "$date" --eventOutcome "Pass" --eventDetail "`md5deep -v` md5deep ${target}"   
@@ -48,7 +47,7 @@ else
     echo "File Does not exist:" "${MD5FILE}"
 fi
 
-SHA1FILE="${target}metadata/${checksums}.sha1"
+SHA1FILE="${target}metadata/checksum.sha1"
 if [ -f "${SHA1FILE}" ]; then
     "${checkMD5NoGui}" "${target}objects/" "${SHA1FILE}" "${target}logs/`basename "${SHA1FILE}"`-Check-`date`" "sha1deep" && \
     "`dirname $0`/createEventsForGroup.py" --groupUUID "${transferUUID}" --groupType "transfer_id" --eventType "fixity" --eventDateTime "$date" --eventOutcome "Pass" --eventDetail "`sha1deep -v` sha1deep ${target}"  
@@ -57,7 +56,7 @@ else
     echo "File Does not exist:" "${SHA1FILE}"
 fi
 
-SHA256FILE="${target}metadata/${checksums}.sha256"
+SHA256FILE="${target}metadata/checksum.sha256"
 if [ -f "${SHA256FILE}" ]; then
     "${checkMD5NoGui}" "${target}objects/" "${SHA256FILE}" "${target}logs/`basename "${SHA256FILE}"`-Check-`date`" "sha256deep" && \
     "`dirname $0`/createEventsForGroup.py" --groupUUID "${transferUUID}" --groupType "transfer_id" --eventType "fixity" --eventDateTime "$date" --eventOutcome "Pass" --eventDetail "`sha256deep -v` sha256deep ${target}"  

--- a/src/MCPClient/lib/clientScripts/verifyMD5.sh
+++ b/src/MCPClient/lib/clientScripts/verifyMD5.sh
@@ -42,7 +42,7 @@ ret=0
 MD5FILE="${target}metadata/${checksums}.md5"
 if [ -f "${MD5FILE}" ]; then
     "${checkMD5NoGui}" "${target}objects/" "${MD5FILE}" "${target}logs/`basename "${MD5FILE}"`-Check-`date`" "md5deep" && \
-    "`dirname $0`/createEventsForGroup.py" --groupUUID "${transferUUID}" --groupType "transferUUID" --eventType "fixity" --eventDateTime "$date" --eventOutcome "Pass" --eventDetail "`md5deep -v` md5deep ${target}"   
+    "`dirname $0`/createEventsForGroup.py" --groupUUID "${transferUUID}" --groupType "transfer_id" --eventType "fixity" --eventDateTime "$date" --eventOutcome "Pass" --eventDetail "`md5deep -v` md5deep ${target}"   
     ret+="$?"
 else
     echo "File Does not exist:" "${MD5FILE}"
@@ -51,7 +51,7 @@ fi
 SHA1FILE="${target}metadata/${checksums}.sha1"
 if [ -f "${SHA1FILE}" ]; then
     "${checkMD5NoGui}" "${target}objects/" "${SHA1FILE}" "${target}logs/`basename "${SHA1FILE}"`-Check-`date`" "sha1deep" && \
-    "`dirname $0`/createEventsForGroup.py" --groupUUID "${transferUUID}" --groupType "transferUUID" --eventType "fixity" --eventDateTime "$date" --eventOutcome "Pass" --eventDetail "`sha1deep -v` sha1deep ${target}"  
+    "`dirname $0`/createEventsForGroup.py" --groupUUID "${transferUUID}" --groupType "transfer_id" --eventType "fixity" --eventDateTime "$date" --eventOutcome "Pass" --eventDetail "`sha1deep -v` sha1deep ${target}"  
     ret+="$?"
 else
     echo "File Does not exist:" "${SHA1FILE}"
@@ -60,7 +60,7 @@ fi
 SHA256FILE="${target}metadata/${checksums}.sha256"
 if [ -f "${SHA256FILE}" ]; then
     "${checkMD5NoGui}" "${target}objects/" "${SHA256FILE}" "${target}logs/`basename "${SHA256FILE}"`-Check-`date`" "sha256deep" && \
-    "`dirname $0`/createEventsForGroup.py" --groupUUID "${transferUUID}" --groupType "transferUUID" --eventType "fixity" --eventDateTime "$date" --eventOutcome "Pass" --eventDetail "`sha256deep -v` sha256deep ${target}"  
+    "`dirname $0`/createEventsForGroup.py" --groupUUID "${transferUUID}" --groupType "transfer_id" --eventType "fixity" --eventDateTime "$date" --eventOutcome "Pass" --eventDetail "`sha256deep -v` sha256deep ${target}"  
     ret+="$?"
 else
     echo "File Does not exist:" "${SHA256FILE}"

--- a/src/MCPServer/etc/serverConfig.conf
+++ b/src/MCPServer/etc/serverConfig.conf
@@ -26,7 +26,6 @@
 [MCPServer]
 AIPCompressionAlgorithm = lzma
 AIPCompressionLevel = 1 
-checksumsNoExtention  =  checksum
 fileUUIDSHumanReadable  =  FileUUIDs.log
 moduleConfigDir  =  /etc/archivematica/MCPServer/mcpModulesConfig
 #to listen on localhost only, uncomment the following line 

--- a/src/MCPServer/share/mysql_dev.sh
+++ b/src/MCPServer/share/mysql_dev.sh
@@ -21,6 +21,7 @@ mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7922_index_aips.sql;"
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_8287_siegfried.sql;"
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7321_dip_processing_xml.sql;"
+mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_8415_checksum.sql;"
 # ...
 # optional delete unused MCSL's
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_delete_links.sql;"

--- a/src/MCPServer/share/mysql_dev_8415_checksum.sql
+++ b/src/MCPServer/share/mysql_dev_8415_checksum.sql
@@ -1,0 +1,4 @@
+-- Remove unused "checksumNoExtention" argument
+UPDATE StandardTasksConfigs
+    SET arguments='"%relativeLocation%" "%date%" "%taskUUID%" "%SIPUUID%"'
+    WHERE execute='verifyMD5_v0.0';

--- a/src/archivematicaCommon/lib/dicts.py
+++ b/src/archivematicaCommon/lib/dicts.py
@@ -163,7 +163,6 @@ class ReplacementDict(dict):
             rd['%fileExtensionWithDot%'] = ext
 
         rd['%processingDirectory%'] = config.get('MCPServer', "processingDirectory")
-        rd['%checksumsNoExtension%'] = config.get('MCPServer', "checksumsNoExtention")
         rd['%watchDirectoryPath%'] = config.get('MCPServer', "watchDirectoryPath")
         rd['%rejectedDirectory%'] = config.get('MCPServer', "rejectedDirectory")
 


### PR DESCRIPTION
- Hardcode "checksum" as the filename; this was technically customizeable, but it was never used, and that feature was broken.
- Fix the `groupType` passed to the Django ORM
