### PR TITLE
Extract contents: log any package deletions to disk

### DIFF
--- a/src/MCPClient/lib/clientScripts/extractContents.py
+++ b/src/MCPClient/lib/clientScripts/extractContents.py
@@ -48,6 +48,7 @@ def assign_uuid(filename, package_uuid, transfer_uuid, date, task_uuid, sip_dire
 
 def delete_and_record_package_file(file_path, file_uuid, current_location):
     os.remove(file_path)
+    print("Package removed: " + file_path)
     event_detail_note = "removed from: " + current_location
     fileWasRemoved(file_uuid, eventDetail=event_detail_note)
 

--- a/src/MCPServer/share/mysql_dev.sh
+++ b/src/MCPServer/share/mysql_dev.sh
@@ -22,6 +22,7 @@ mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_8287_siegfried.sql;"
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_7321_dip_processing_xml.sql;"
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_8415_checksum.sql;"
+mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_8423_extract_logging.sql;"
 # ...
 # optional delete unused MCSL's
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_delete_links.sql;"

--- a/src/MCPServer/share/mysql_dev_8423_extract_logging.sql
+++ b/src/MCPServer/share/mysql_dev_8423_extract_logging.sql
@@ -1,0 +1,3 @@
+UPDATE StandardTasksConfigs
+    SET standardOutputFile='%SIPLogsDirectory%extractContents.log'
+    WHERE pk='8fad772e-7d2e-4cdd-89e6-7976152b6696';


### PR DESCRIPTION
Fixes #8423.

This creates a new `extractContents.log`, which will contain both the extraction tool's output and notes on the files being removed, for example:

```
7-Zip [64] 9.20  Copyright (c) 1999-2010 Igor Pavlov  2010-11-18
p7zip Version 9.20 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,2 CPUs)

Processing archive: /var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/extractPackagesChoice/Images-Zipped-1d88c9e4-0cfa-400f-bafb-877baa22f80a/objects/files.7z

Extracting  oakland03.jp2
Extracting  Nemastylis_geminiflora_Flower.PNG
Extracting  799px-Euroleague-LE Roma vs Toulouse IC-27.bmp
Extracting  lion.svg
Extracting  BBhelmet.ai
Extracting  WFPC01.GIF
Extracting  pictures/Landing zone.jpg
Extracting  Vector.NET-Free-Vector-Art-Pack-28-Freedom-Flight.eps
Extracting  pictures/MARBLES.TGA
Extracting  G31DS.TIF
Extracting  pictures

Everything is Ok

Folders: 1
Files: 10
Size:       12017244
Compressed: 7781344

Extracted contents from files.7z
Package removed: /var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/extractPackagesChoice/Images-Zipped-1d88c9e4-0cfa-400f-bafb-877baa22f80a/objects/files.7z
```
