### PR TITLE
xml2obj: not every amdSec contains a techMD

### DIFF
--- a/src/archivematicaCommon/lib/xml2obj.py
+++ b/src/archivematicaCommon/lib/xml2obj.py
@@ -13,6 +13,11 @@ def mets_file(src):
     
     file_uuid = None
     for amd in raw.mets_amdSec:
+        # Some amdSecs are other types of metadata (for instance sourceMD),
+        # and we don't care about those; skip them.
+        if amd.mets_techMD is None:
+            continue
+
         file_uuid = amd.mets_techMD.mets_mdWrap.mets_xmlData.premis_object.premis_objectIdentifier.premis_objectIdentifierValue
         if amd.mets_rightsMD:
             for rights in amd.mets_rightsMD:


### PR DESCRIPTION
Fixes #8431.
