### PR TITLE
Reduce DB queries

### DIFF
--- a/src/MCPServer/lib/unit.py
+++ b/src/MCPServer/lib/unit.py
@@ -85,10 +85,7 @@ class unit:
                                            variable=variable)
         if variables:
             LOGGER.info('Existing UnitVariables for %s updated to %s (MSCL %s)', variable, variableValue, microServiceChainLink)
-            for var in variables:
-                var.variablevalue = variableValue
-                var.microservicechainlink_id = microServiceChainLink
-                var.save()
+            variables.update(variablevalue=variableValue, microservicechainlink_id=microServiceChainLink)
         else:
             LOGGER.info('New UnitVariable created for %s: %s (MSCL: %s)', variable, variableValue, microServiceChainLink)
             var = UnitVariable(
@@ -102,9 +99,10 @@ class unit:
     def getmicroServiceChainLink(self, variable, variableValue, defaultMicroServiceChainLink):
         LOGGER.debug('Fetching MicroServiceChainLink for %s (default %s)', variable, defaultMicroServiceChainLink)
         try:
-            var = UnitVariable.objects.get(unittype=self.unitType,
-                                           unituuid=self.UUID,
-                                           variable=variable)
-            return var.microservicechainlink
-        except UnitVariable.DoesNotExist:
+            return UnitVariable.objects.filter(
+                unittype=self.unitType,
+                unituuid=self.UUID,
+                variable=variable
+            ).values_list('microservicechainlink_id', flat=True)[0]
+        except IndexError:
             return defaultMicroServiceChainLink

--- a/src/MCPServer/lib/unitFile.py
+++ b/src/MCPServer/lib/unitFile.py
@@ -50,7 +50,8 @@ class unitFile(object):
         elif self.UUID != "None":
             return ReplacementDict.frommodel(
                 type_='file',
-                file_=self.UUID
+                file_=self.UUID,
+                sip=self.owningUnit.getModel(),
             )
         # If no UUID has been assigned yet, we can't use the
         # ReplacementDict.frommodel constructor; fall back to the

--- a/src/MCPServer/lib/unitSIP.py
+++ b/src/MCPServer/lib/unitSIP.py
@@ -45,6 +45,10 @@ class unitSIP(unit):
         self.owningUnit = None
         self.unitType = "SIP"
         self.aipFilename = ""
+        self.query = SIP.objects.filter(uuid=self.UUID)
+
+    def getModel(self):
+        return self.query[0]
 
     def __str__(self):
         return 'unitSIP: <UUID: {u.UUID}, path: {u.currentPath}>'.format(u=self)
@@ -57,13 +61,13 @@ class unitSIP(unit):
         }
         if exitStatus:
             updates['magiclinkexitmessage'] = exitStatus
-        SIP.objects.filter(uuid=self.UUID).update(**updates)
+        self.query.update(**updates)
 
     def getMagicLink(self):
         """Load a link from the unit to process.
         Deprecated! Replaced with Set/Load Unit Variable"""
         try:
-            return SIP.objects.filter(uuid=self.UUID).values_list("magiclink", "magiclinkexitmessage")[0]
+            return self.query.values_list("magiclink", "magiclinkexitmessage")[0]
         except IndexError:
             return
 
@@ -78,7 +82,7 @@ class unitSIP(unit):
         """ Return a dict with all of the replacement strings for this unit and the value to replace with. """
         ret = ReplacementDict.frommodel(
             type_='sip',
-            sip=self.UUID
+            sip=self.getModel()
         )
         ret["%AIPFilename%"] = self.aipFilename
         ret["%unitType%"] = self.unitType

--- a/src/MCPServer/lib/unitSIP.py
+++ b/src/MCPServer/lib/unitSIP.py
@@ -52,20 +52,20 @@ class unitSIP(unit):
     def setMagicLink(self, link, exitStatus=""):
         """Assign a link to the unit to process when loaded.
         Deprecated! Replaced with Set/Load Unit Variable"""
-        sip = SIP.objects.get(uuid=self.UUID)
-        sip.magiclink = link
+        updates = {
+            'magiclink': link
+        }
         if exitStatus:
-            sip.magiclinkexitmessage = exitStatus
-        sip.save()
+            updates['magiclinkexitmessage'] = exitStatus
+        SIP.objects.filter(uuid=self.UUID).update(**updates)
 
     def getMagicLink(self):
         """Load a link from the unit to process.
         Deprecated! Replaced with Set/Load Unit Variable"""
         try:
-            sip = SIP.objects.get(uuid=self.UUID)
-        except SIP.DoesNotExist:
+            return SIP.objects.filter(uuid=self.UUID).values_list("magiclink", "magiclinkexitmessage")[0]
+        except IndexError:
             return
-        return (sip.magiclink, sip.magiclinkexitmessage)
 
     def reload(self):
         sip = SIP.objects.get(uuid=self.UUID)

--- a/src/MCPServer/lib/unitTransfer.py
+++ b/src/MCPServer/lib/unitTransfer.py
@@ -64,6 +64,10 @@ class unitTransfer(unit):
         self.currentPath = currentPath2
         self.UUID = UUID
         self.fileList = {}
+        self.query = Transfer.objects.filter(uuid=self.UUID)
+
+    def getModel(self):
+        return self.query[0]
 
     def __str__(self):
         return 'unitTransfer: <UUID: {u.UUID}, path: {u.currentPath}>'.format(u=self)
@@ -76,23 +80,23 @@ class unitTransfer(unit):
         }
         if exitStatus:
             updates["magiclinkexitmessage"] = exitStatus
-        Transfer.objects.filter(uuid=self.UUID).update(**updates)
+        self.query.update(**updates)
 
     def getMagicLink(self):
         """Load a link from the unit to process.
         Deprecated! Replaced with Set/Load Unit Variable"""
         try:
-            return Transfer.objects.filter(uuid=self.UUID).values_list("magiclink", "magiclinkexitmessage")[0]
+            return self.query.values_list("magiclink", "magiclinkexitmessage")[0]
         except IndexError:
             return
 
     def reload(self):
-        self.currentPath = Transfer.objects.filter(uuid=self.UUID).values_list("currentlocation")[0][0]
+        self.currentPath = self.query.values_list("currentlocation")[0][0]
 
     def getReplacementDic(self, target):
         ret = ReplacementDict.frommodel(
             type_='transfer',
-            sip=self.UUID
+            sip=self.getModel(),
         )
         ret["%unitType%"] = self.unitType
         return ret

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -179,12 +179,12 @@ def insertIntoFilesIDs(fileUUID="", formatName="", formatVersion="", formatRegis
     Creates a new entry in the FilesIDs table using the provided data.
     This function, and its associated table, may be removed in the future.
     """
-    f = FileID(file_id=fileUUID,
-               format_name=formatName,
-               format_version=formatVersion,
-               format_registry_name=formatRegistryName,
-               format_registry_key=formatRegistryKey)
-    f.save()
+    FileID.objects.create(
+        file_id=fileUUID,
+        format_name=formatName,
+        format_version=formatVersion,
+        format_registry_name=formatRegistryName,
+        format_registry_key=formatRegistryKey)
 
 
 #user approved?
@@ -228,12 +228,12 @@ def logTaskCompletedSQL(task):
     stdOut = task.results["stdOut"]
     stdError = task.results["stdError"]
 
-    task = Task.objects.get(taskuuid=taskUUID)
-    task.endtime = getUTCDate()
-    task.exitcode = exitCode
-    task.stdout = stdOut
-    task.stderror = stdError
-    task.save()
+    Task.objects.filter(taskuuid=taskUUID).update(
+        endtime=getUTCDate(),
+        exitcode=exitCode,
+        stdout=stdOut,
+        stderror=stdError,
+    )
 
 def logJobCreatedSQL(job):
     """
@@ -285,10 +285,7 @@ def fileWasRemoved(fileUUID, utcDate=None, eventDetail = "", eventOutcomeDetailN
                        eventOutcome=eventOutcome, \
                        eventOutcomeDetailNote=eventOutcomeDetailNote)
 
-    f = File.objects.get(uuid=fileUUID)
-    f.removedtime = utcDate
-    f.currentlocation = None
-    f.save()
+    File.objects.filter(uuid=fileUUID).update(removedtime=utcDate, currentlocation=None)
 
 def createSIP(path, UUID=None, sip_type='SIP'):
     """
@@ -303,10 +300,10 @@ def createSIP(path, UUID=None, sip_type='SIP'):
     if UUID is None:
         UUID = str(uuid.uuid4())
     print "Creating SIP:", UUID, "-", path
-    sip = SIP(uuid=UUID,
-              currentpath=path,
-              sip_type=sip_type)
-    sip.save()
+    SIP.objects.create(
+        uuid=UUID,
+        currentpath=path,
+        sip_type=sip_type)
 
     return UUID
 

--- a/src/archivematicaCommon/lib/dicts.py
+++ b/src/archivematicaCommon/lib/dicts.py
@@ -132,16 +132,17 @@ class ReplacementDict(dict):
 
         if file_:
             rd['%fileUUID%'] = file_.uuid
-            try:
-                base_location = file_.sip.currentpath
-            except:
-                base_location = file_.transfer.currentlocation
 
             if expand_path and sipdir is not None:
-                base_location = base_location.replace('%sharedPath%', shared_path)
-                # If the original location contains non-unicode characters,
+                try:
+                    base_location = sip.currentpath
+                except:
+                    base_location = sip.currentlocation
+                # If the location contains non-unicode characters,
                 # using base_location as retrieved from the DB will raise.
-                origin = file_.originallocation.replace('%transferDirectory%', base_location.encode("utf-8"))
+                base_location = base_location.replace('%sharedPath%', shared_path).encode('utf-8')
+                sipdir = sipdir.encode('utf-8')
+                origin = file_.originallocation.replace('%transferDirectory%', base_location)
                 current_location = file_.currentlocation.replace('%transferDirectory%', base_location)
                 current_location = current_location.replace('%SIPDirectory%', sipdir)
             else:


### PR DESCRIPTION
Convert several places that fetch and object, update and save it to use filter, which generates better SQL.

Try to ensure that unitFile replacement dicts only query the parent object once.  Unsure why this required changes in ReplacementDict for unicode.
