### PR TITLE
MCPServer: Log all exceptions, use ReplacementDict.replace

### DIFF
--- a/src/MCPServer/lib/jobChainLink.py
+++ b/src/MCPServer/lib/jobChainLink.py
@@ -24,6 +24,7 @@ import logging
 import sys
 import uuid
 
+from utils import log_exceptions
 from linkTaskManagerDirectories import linkTaskManagerDirectories
 from linkTaskManagerFiles import linkTaskManagerFiles
 from linkTaskManagerChoice import linkTaskManagerChoice
@@ -131,6 +132,7 @@ class jobChainLink:
             except (MicroServiceChainLinkExitCode.DoesNotExist, MicroServiceChainLinkExitCode.MultipleObjectsReturned):
                 return self.defaultNextChainLink
 
+    @log_exceptions
     def setExitMessage(self, message):
         Job.objects.filter(jobuuid=self.UUID).update(currentstep=str(message))
 
@@ -146,6 +148,7 @@ class jobChainLink:
         else:
             LOGGER.debug('No exit message')
 
+    @log_exceptions
     def linkProcessingComplete(self, exitCode, passVar=None):
         self.updateExitMessage(exitCode)
         self.jobChain.nextChainLink(self.getNextChainLinkPK(exitCode), passVar=passVar)

--- a/src/MCPServer/lib/linkTaskManagerChoice.py
+++ b/src/MCPServer/lib/linkTaskManagerChoice.py
@@ -32,6 +32,7 @@ import time
 from linkTaskManager import LinkTaskManager
 from executeOrRunSubProcess import executeOrRun
 import jobChain
+from utils import log_exceptions
 import archivematicaMCP
 global choicesAvailableForUnits
 choicesAvailableForUnits = {}
@@ -132,6 +133,7 @@ class linkTaskManagerChoice(LinkTaskManager):
             etree.SubElement(choice, "description").text = description
         return ret
 
+    @log_exceptions
     def proceedWithChoice(self, chain, agent, delayTimerStart=False):
         if agent:
             self.unit.setVariable("activeAgent", agent, None)

--- a/src/MCPServer/lib/linkTaskManagerDirectories.py
+++ b/src/MCPServer/lib/linkTaskManagerDirectories.py
@@ -26,11 +26,10 @@ from taskStandard import taskStandard
 import os
 import sys
 import threading
-import traceback
+
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 import archivematicaFunctions
 import databaseFunctions
-from databaseFunctions import deUnicode
 from dicts import ReplacementDict
 sys.path.append("/usr/share/archivematica/dashboard")
 from main.models import StandardTaskConfig
@@ -41,8 +40,6 @@ class linkTaskManagerDirectories(LinkTaskManager):
         super(linkTaskManagerDirectories, self).__init__(jobChainLink, pk, unit)
         self.tasks = []
         stc = StandardTaskConfig.objects.get(id=str(pk))
-        filterFileEnd = stc.filter_file_end
-        filterFileStart = stc.filter_file_start
         filterSubDir = stc.filter_subdir
         self.requiresOutputLock = stc.requires_output_lock
         standardOutputFile = stc.stdout_file
@@ -55,9 +52,9 @@ class linkTaskManagerDirectories(LinkTaskManager):
             directory = os.path.join(unit.currentPath, filterSubDir)
         else:
             directory = unit.currentPath
-        
+
         # Apply passvar replacement values
-        if self.jobChainLink.passVar != None:
+        if self.jobChainLink.passVar is not None:
             if isinstance(self.jobChainLink.passVar, list):
                 for passVar in self.jobChainLink.passVar:
                     if isinstance(passVar, ReplacementDict):

--- a/src/MCPServer/lib/linkTaskManagerFiles.py
+++ b/src/MCPServer/lib/linkTaskManagerFiles.py
@@ -102,9 +102,9 @@ class linkTaskManagerFiles(LinkTaskManager):
             standardErrorFile = self.standardErrorFile
             execute = self.execute
             arguments = self.arguments
-            
+
             # Apply passvar replacement values
-            if self.jobChainLink.passVar != None:
+            if self.jobChainLink.passVar is not None:
                 if isinstance(self.jobChainLink.passVar, list):
                     for passVar in self.jobChainLink.passVar:
                         if isinstance(passVar, ReplacementDict):
@@ -136,7 +136,7 @@ class linkTaskManagerFiles(LinkTaskManager):
 
         self.clearToNextLink = True
         self.tasksLock.release()
-        if self.tasks == {} :
+        if self.tasks == {}:
             self.jobChainLink.linkProcessingComplete(self.exitCode)
 
     def taskCompletedCallBackFunction(self, task):
@@ -150,7 +150,7 @@ class linkTaskManagerFiles(LinkTaskManager):
             LOGGER.warning('Task UUID %s not in task list %s', task.UUID, self.tasks)
             exit(1)
 
-        if self.clearToNextLink == True and self.tasks == {} :
+        if self.clearToNextLink is True and self.tasks == {} :
             LOGGER.debug('Proceeding to next link %s', self.jobChainLink.UUID)
             self.jobChainLink.linkProcessingComplete(self.exitCode, self.jobChainLink.passVar)
         self.tasksLock.release()

--- a/src/MCPServer/lib/linkTaskManagerGetMicroserviceGeneratedListInStdOut.py
+++ b/src/MCPServer/lib/linkTaskManagerGetMicroserviceGeneratedListInStdOut.py
@@ -31,6 +31,7 @@ import threading
 from linkTaskManager import LinkTaskManager
 from taskStandard import taskStandard
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+import archivematicaFunctions
 import databaseFunctions
 from dicts import ChoicesDict, ReplacementDict
 sys.path.append("/usr/share/archivematica/dashboard")
@@ -58,26 +59,21 @@ class linkTaskManagerGetMicroserviceGeneratedListInStdOut(LinkTaskManager):
         else:
             directory = unit.currentPath
         
+        # Apply passvar replacement values
         if self.jobChainLink.passVar != None:
             if isinstance(self.jobChainLink.passVar, list):
                 for passVar in self.jobChainLink.passVar:
                     if isinstance(passVar, ReplacementDict):
-                        execute, arguments, standardOutputFile, standardErrorFile = passVar.replace(execute, arguments, standardOutputFile, standardErrorFile)
+                        arguments, standardOutputFile, standardErrorFile = passVar.replace(arguments, standardOutputFile, standardErrorFile)
             elif isinstance(self.jobChainLink.passVar, ReplacementDict):
-                execute, arguments, standardOutputFile, standardErrorFile = self.jobChainLink.passVar.replace(execute, arguments, standardOutputFile, standardErrorFile)
-                    
+                arguments, standardOutputFile, standardErrorFile = self.jobChainLink.passVar.replace(arguments, standardOutputFile, standardErrorFile)
+
+        # Apply unit (SIP/Transfer) replacement values
         commandReplacementDic = unit.getReplacementDic(directory)
-        # for each key replace all instances of the key in the command string
-        for key in commandReplacementDic.iterkeys():
-            value = commandReplacementDic[key].replace("\"", ("\\\""))
-            if execute:
-                execute = execute.replace(key, value)
-            if arguments:
-                arguments = arguments.replace(key, value)
-            if standardOutputFile:
-                standardOutputFile = standardOutputFile.replace(key, value)
-            if standardErrorFile:
-                standardErrorFile = standardErrorFile.replace(key, value)
+        # Escape all values for shell
+        for key, value in commandReplacementDic.items():
+                commandReplacementDic[key] = archivematicaFunctions.escapeForCommand(value)
+        arguments, standardOutputFile, standardErrorFile = commandReplacementDic.replace(arguments, standardOutputFile, standardErrorFile)
 
         self.task = taskStandard(self, execute, arguments, standardOutputFile, standardErrorFile, UUID=self.UUID)
         databaseFunctions.logTaskCreatedSQL(self, commandReplacementDic, self.UUID, arguments)

--- a/src/MCPServer/lib/linkTaskManagerGetMicroserviceGeneratedListInStdOut.py
+++ b/src/MCPServer/lib/linkTaskManagerGetMicroserviceGeneratedListInStdOut.py
@@ -44,8 +44,6 @@ class linkTaskManagerGetMicroserviceGeneratedListInStdOut(LinkTaskManager):
         super(linkTaskManagerGetMicroserviceGeneratedListInStdOut, self).__init__(jobChainLink, pk, unit)
         self.tasks = []
         stc = StandardTaskConfig.objects.get(id=str(pk))
-        filterFileEnd = stc.filter_file_end
-        filterFileStart = stc.filter_file_start
         filterSubDir = stc.filter_subdir
         self.requiresOutputLock = stc.requires_output_lock
         standardOutputFile = stc.stdout_file
@@ -58,9 +56,9 @@ class linkTaskManagerGetMicroserviceGeneratedListInStdOut(LinkTaskManager):
             directory = os.path.join(unit.currentPath, filterSubDir)
         else:
             directory = unit.currentPath
-        
+
         # Apply passvar replacement values
-        if self.jobChainLink.passVar != None:
+        if self.jobChainLink.passVar is not None:
             if isinstance(self.jobChainLink.passVar, list):
                 for passVar in self.jobChainLink.passVar:
                     if isinstance(passVar, ReplacementDict):
@@ -95,9 +93,9 @@ class linkTaskManagerGetMicroserviceGeneratedListInStdOut(LinkTaskManager):
                         self.jobChainLink.passVar[index] = choices
                         break
                 else:
-                   self.jobChainLink.passVar.append(choices)
+                    self.jobChainLink.passVar.append(choices)
             else:
-                self.jobChainLink.passVar = [choices, self.jobChainLink.passVar] 
+                self.jobChainLink.passVar = [choices, self.jobChainLink.passVar]
         else:
             self.jobChainLink.passVar = [choices]
 

--- a/src/MCPServer/lib/taskStandard.py
+++ b/src/MCPServer/lib/taskStandard.py
@@ -30,6 +30,7 @@ import time
 import uuid
 
 import archivematicaMCP
+from utils import log_exceptions
 
 from django.utils import timezone
 
@@ -58,7 +59,7 @@ class taskStandard():
         self.standardErrorFile = standardErrorFile
         self.outputLock = outputLock
 
-
+    @log_exceptions
     def performTask(self):
         from archivematicaMCP import limitGearmanConnectionsSemaphore
         limitGearmanConnectionsSemaphore.acquire()

--- a/src/MCPServer/lib/unitFile.py
+++ b/src/MCPServer/lib/unitFile.py
@@ -56,11 +56,11 @@ class unitFile(object):
         # ReplacementDict.frommodel constructor; fall back to the
         # old style of manual construction.
         else:
-            return {
+            return ReplacementDict({
                 "%relativeLocation%": self.currentPath,
                 "%fileUUID%": self.UUID,
                 "%fileGrpUse%": self.fileGrpUse
-            }
+            })
 
     def reload(self):
         pass

--- a/src/MCPServer/lib/utils.py
+++ b/src/MCPServer/lib/utils.py
@@ -1,0 +1,18 @@
+
+import logging
+
+LOGGER = logging.getLogger('archivematica.mcp.server')
+
+def log_exceptions(fn):
+    """
+    Decorator to wrap a function in a try-catch that logs the exception.
+
+    Useful for catching exceptions in threads, which do not normally report back to the parent thread.
+    """
+    def wrapped(*args,  **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except Exception:
+            LOGGER.exception('Uncaught exception')
+            raise
+    return wrapped

--- a/src/MCPServer/lib/watchDirectory.py
+++ b/src/MCPServer/lib/watchDirectory.py
@@ -29,6 +29,7 @@ import sys
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 from archivematicaFunctions import unicodeToStr
 
+from utils import log_exceptions
 from archivematicaMCP import debug
 DEBUG = debug
 
@@ -64,7 +65,8 @@ class archivematicaWatchDirectory:
             t.start()
         else:
             self.start()
-    
+
+    @log_exceptions
     def start(self):
         """Based on polling example: http://timgolden.me.uk/python/win32_how_do_i/watch_directory_for_changes.html"""
         self.run = True


### PR DESCRIPTION
Add a new except handler that logs the exception before continuing with default behavior.

Wrap all functions that are the start of a thread in a decorator that logs any exception raised

Update: Use ReplacementDict.replace for all cases when applying %var%s, since it handles encodings properly.

dev/issue-8509-log-server-exceptions-1.4 is this branch but based on qa/1.4.1
