### PR TITLE
templatetags: fix active tag when unhandled exception raised

### DIFF
--- a/src/dashboard/src/main/templatetags/active.py
+++ b/src/dashboard/src/main/templatetags/active.py
@@ -22,7 +22,9 @@ register = Library()
 
 @register.simple_tag
 def active(request, pattern):
-    if request.path.startswith(pattern) and pattern != '/':
+    if not request:
+        return ''
+    elif request.path.startswith(pattern) and pattern != '/':
         return 'active'
     elif request.path == pattern == '/':
         return 'active'


### PR DESCRIPTION
If Django calls handle_uncaught_exception, the passed "request" object will be an empty string instead of a Request object.

This is the cause of the "AttributeError: 'str' object has no attribute 'path'" exception that happens when a generic Apache 500 page is seen.
