### PR TITLE
AIP deletion request: fix updating Elasticsearch

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -861,6 +861,20 @@ def connect_and_delete_aip_files(uuid):
     else:
         print 'No AIP files found.'
 
+def connect_and_mark_deletion_requested(uuid):
+    conn = Elasticsearch(hosts=getElasticsearchServerHostAndPort())
+    document_id = document_id_from_field_query(conn, 'aips', ['aip'], 'uuid', uuid)
+    conn.update(
+        body={
+            'doc': {
+                'status': 'DEL_REQ'
+            }
+        },
+        index='aips',
+        doc_type='aip',
+        id=document_id
+    )
+
 def normalize_results_dict(d):
     """
     Given an ElasticSearch response, returns a normalized copy of its fields dict.

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -324,15 +324,7 @@ def aip_delete(request, uuid):
 
         messages.info(request, response['message'])
 
-        # mark AIP as having deletion requested
-        conn = Elasticsearch(hosts=elasticSearchFunctions.getElasticsearchServerHostAndPort())
-        document_id = elasticSearchFunctions.document_id_from_field_query(conn, 'aips', ['aip'], 'uuid', uuid)
-        conn.update(
-            body={'status': 'DEL_REQ'},
-            index='aips',
-            doc_type='aip',
-            id=document_id
-        )
+        elasticSearchFunctions.connect_and_mark_deletion_requested(uuid)
 
     except requests.exceptions.ConnectionError:
         error_message = 'Unable to connect to storage server. Please contact your administrator.'


### PR DESCRIPTION
The structure of the query body in the "update" query was incorrect, causing Elasticsearch to return an error.

Also move this to elasticsearchFunctions at the same time to thin out the logic occurring in the view.

Fixes #8533.
