### PR TITLE
Fix archival storage display of deletion requests

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -820,14 +820,14 @@ def delete_matching_documents(index, type, field, value, **kwargs):
     query = {
         "query": {
             "term": {
-                field, value
+                field: value
             }
         }
     }
-    documents = conn.search_raw(
-        indices=[index],
-        doc_types=[type],
-        query=query
+    documents = conn.search(
+        body=query,
+        index=index,
+        doc_type=type,
     )
 
     count = 0

--- a/src/archivematicaCommon/tests/fixtures/test_delete_aip.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_delete_aip.yaml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: '{"query": {"term": {"uuid": "a1ee611a-a4f5-4ba9-b7ce-b92695746514"}}}'
+    headers: {}
+    method: GET
+    uri: http://127.0.0.1:9200/aips/aip/_search?fields=uuid
+  response:
+    body: {string: !!python/unicode '{"took":6,"timed_out":false,"_shards":{"total":1,"successful":1,"failed":0},"hits":{"total":1,"max_score":2.7917593,"hits":[{"_index":"aips","_type":"aip","_id":"sh6hMT1JScefY87-VJLjiw","_score":2.7917593,"fields":{"uuid":["a1ee611a-a4f5-4ba9-b7ce-b92695746514"]}}]}}'}
+    headers:
+      content-length: ['267']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: PUT
+    uri: http://localhost:9200/aips
+  response:
+    body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[aips]
+        already exists]","status":400}'}
+    headers:
+      content-length: ['75']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: '{"query": {"term": {"uuid": "a1ee611a-a4f5-4ba9-b7ce-b92695746514"}}}'
+    headers: {}
+    method: DELETE
+    uri: http://localhost:9200/aips/aip/_query
+  response:
+    body: {string: !!python/unicode '{"_indices":{"aips":{"_shards":{"total":1,"successful":1,"failed":0}}}}'}
+    headers:
+      content-length: ['71']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"query": {"term": {"uuid": "a1ee611a-a4f5-4ba9-b7ce-b92695746514"}}}'
+    headers: {}
+    method: GET
+    uri: http://127.0.0.1:9200/aips/aip/_search?fields=uuid
+  response:
+    body: {string: !!python/unicode '{"took":2,"timed_out":false,"_shards":{"total":1,"successful":1,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'}
+    headers:
+      content-length: ['122']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 200, message: OK}
+version: 1

--- a/src/archivematicaCommon/tests/fixtures/test_delete_aip_files.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_delete_aip_files.yaml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: '{"query": {"term": {"AIPUUID": "a1ee611a-a4f5-4ba9-b7ce-b92695746514"}}}'
+    headers: {}
+    method: GET
+    uri: http://127.0.0.1:9200/aips/aipfile/_search?sort=FILEUUID%3Adesc&fields=AIPUUID%2CFILEUUID
+  response:
+    body: {string: !!python/unicode '{"took":3,"timed_out":false,"_shards":{"total":1,"successful":1,"failed":0},"hits":{"total":3,"max_score":null,"hits":[{"_index":"aips","_type":"aipfile","_id":"83MSFM3_TWWgcbRIKhA3KA","_score":null,"fields":{"FILEUUID":["b8bd3cdd-f224-4237-b0d7-99c217ff8e67"],"AIPUUID":["a1ee611a-a4f5-4ba9-b7ce-b92695746514"]},"sort":["b8bd3cdd-f224-4237-b0d7-99c217ff8e67"]},{"_index":"aips","_type":"aipfile","_id":"X-_nQAWiTdm7HIlaVRjDFA","_score":null,"fields":{"FILEUUID":["68babd3e-7e6b-40e5-99f6-00ea724d4ce8"],"AIPUUID":["a1ee611a-a4f5-4ba9-b7ce-b92695746514"]},"sort":["68babd3e-7e6b-40e5-99f6-00ea724d4ce8"]},{"_index":"aips","_type":"aipfile","_id":"05XQnT-5TDeIYQ4WeUgLLA","_score":null,"fields":{"FILEUUID":["547bbd92-d8a0-4624-a9d3-69ba706eacee"],"AIPUUID":["a1ee611a-a4f5-4ba9-b7ce-b92695746514"]},"sort":["547bbd92-d8a0-4624-a9d3-69ba706eacee"]}]}}'}
+    headers:
+      content-length: ['850']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: PUT
+    uri: http://localhost:9200/aips
+  response:
+    body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[aips]
+        already exists]","status":400}'}
+    headers:
+      content-length: ['75']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: '{"query": {"term": {"AIPUUID": "a1ee611a-a4f5-4ba9-b7ce-b92695746514"}}}'
+    headers: {}
+    method: DELETE
+    uri: http://localhost:9200/aips/aipfile/_query
+  response:
+    body: {string: !!python/unicode '{"_indices":{"aips":{"_shards":{"total":1,"successful":1,"failed":0}}}}'}
+    headers:
+      content-length: ['71']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"query": {"term": {"AIPUUID": "a1ee611a-a4f5-4ba9-b7ce-b92695746514"}}}'
+    headers: {}
+    method: GET
+    uri: http://127.0.0.1:9200/aips/aipfile/_search?fields=AIPUUID%2CFILEUUID
+  response:
+    body: {string: !!python/unicode '{"took":1,"timed_out":false,"_shards":{"total":1,"successful":1,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'}
+    headers:
+      content-length: ['122']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 200, message: OK}
+version: 1

--- a/src/archivematicaCommon/tests/test_elasticsearch_functions.py
+++ b/src/archivematicaCommon/tests/test_elasticsearch_functions.py
@@ -1,0 +1,69 @@
+
+from elasticsearch import Elasticsearch
+import os
+import sys
+import unittest
+import vcr
+
+sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+import elasticSearchFunctions
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+class TestElasticSearchFunctions(unittest.TestCase):
+
+    def setUp(self):
+        self.conn = Elasticsearch('127.0.0.1:9200')
+        self.aip_uuid = 'a1ee611a-a4f5-4ba9-b7ce-b92695746514'
+
+    @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_delete_aip.yaml'))
+    def test_delete_aip(self):
+        # Verify AIP exists
+        results = self.conn.search(
+            index='aips',
+            doc_type='aip',
+            body={'query': {'term': {'uuid': self.aip_uuid}}},
+            fields='uuid',
+        )
+        assert results['hits']['total'] == 1
+        assert results['hits']['hits'][0]['fields']['uuid'] == [self.aip_uuid]
+        # Delete AIP
+        success = elasticSearchFunctions.delete_aip(self.aip_uuid)
+        # Verify AIP gone
+        assert success is True
+        results = self.conn.search(
+            index='aips',
+            doc_type='aip',
+            body={'query': {'term': {'uuid': self.aip_uuid}}},
+            fields='uuid',
+        )
+        assert results['hits']['total'] == 0
+
+    @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_delete_aip_files.yaml'))
+    def test_delete_aip_files(self):
+        # Verify AIP exists
+        results = self.conn.search(
+            index='aips',
+            doc_type='aipfile',
+            body={'query': {'term': {'AIPUUID': self.aip_uuid}}},
+            fields='AIPUUID,FILEUUID',
+            sort='FILEUUID:desc',
+        )
+        assert results['hits']['total'] == 3
+        assert results['hits']['hits'][0]['fields']['AIPUUID'] == [self.aip_uuid]
+        assert results['hits']['hits'][0]['fields']['FILEUUID'] == ['b8bd3cdd-f224-4237-b0d7-99c217ff8e67']
+        assert results['hits']['hits'][1]['fields']['AIPUUID'] == [self.aip_uuid]
+        assert results['hits']['hits'][1]['fields']['FILEUUID'] == ['68babd3e-7e6b-40e5-99f6-00ea724d4ce8']
+        assert results['hits']['hits'][2]['fields']['AIPUUID'] == [self.aip_uuid]
+        assert results['hits']['hits'][2]['fields']['FILEUUID'] == ['547bbd92-d8a0-4624-a9d3-69ba706eacee']
+        # Delete AIP
+        success = elasticSearchFunctions.connect_and_delete_aip_files(self.aip_uuid)
+        # Verify AIP gone
+        assert success is True
+        results = self.conn.search(
+            index='aips',
+            doc_type='aipfile',
+            body={'query': {'term': {'AIPUUID': self.aip_uuid}}},
+            fields='AIPUUID,FILEUUID',
+        )
+        assert results['hits']['total'] == 0

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -478,8 +478,8 @@ def list_display(request):
     # get list of UUIDs of AIPs that are deleted or pending deletion
     aips_deleted_or_pending_deletion = []
     should_haves = [
-        {'term': {'status': 'DEL_REQ'}},
-        {'term': {'status': 'DELETED'}},
+        {'match': {'status': 'DEL_REQ'}},
+        {'match': {'status': 'DELETED'}},
     ]
     query = {
         "query": {
@@ -495,7 +495,7 @@ def list_display(request):
         fields='uuid,status'
     )
     for deleted_aip in deleted_aip_results['hits']['hits']:
-        aips_deleted_or_pending_deletion.append(deleted_aip['uuid'])
+        aips_deleted_or_pending_deletion.append(deleted_aip['fields']['uuid'][0])
 
     # Fetch results and paginate
     def es_pager(page, page_size):


### PR DESCRIPTION
- "term" query no longer matches `DEL_REQ` in Elasticsearch 1.x; use a "match" query instead
- Fix `elasticSearchFunctions.delete_matching_documents`, which used the old pyes-style function name/parameters and had an invalid query
