### PR TITLE
Shebangs use /usr/bin/env python2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ dev (1.5.0)
 * MCPServer: remove duplicate ReplacementDict code (#8509)
 * Dashboard: use GroupWriteRotatingFileHandler to ensure group-writeability of rotated logs (#8587)
 * Dashboard: always show arguments in job detail view
+* Tests: Use an in-memory database
+* Specify python2 in shebangs.  Python version choice respects path.
 
 1.4.0
 =====

--- a/localDevSetup/installDependsFromDebianFile.py
+++ b/localDevSetup/installDependsFromDebianFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/localDevSetup/removeUnitsFromWatchedDirectories.py
+++ b/localDevSetup/removeUnitsFromWatchedDirectories.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaAssignFileUUID.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaAssignFileUUID.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaBagWithEmptyDirectories.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaBagWithEmptyDirectories.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 # This file is part of Archivematica.
 #
 # Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>

--- a/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 #
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 # This file is part of Archivematica.

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSMetadataCSV.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSMetadataCSV.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 #
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRights.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRights.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 #
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRightsDspaceMDRef.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRightsDspaceMDRef.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 #
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSTrim.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSTrim.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 #
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateProcessedStructmap.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateProcessedStructmap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 from __future__ import print_function
 import os

--- a/src/MCPClient/lib/clientScripts/archivematicaFITS.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaFITS.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaMaildirToMbox.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaMaildirToMbox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 import sys
 import os
 # archivematicaCommon

--- a/src/MCPClient/lib/clientScripts/archivematicaMoveSIP.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaMoveSIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaMoveTransfer.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaMoveTransfer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaSetTransferType.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaSetTransferType.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaTranscribeFile.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaTranscribeFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 from __future__ import print_function
 import os

--- a/src/MCPClient/lib/clientScripts/archivematicaTransferMetadata.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaTransferMetadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 from __future__ import print_function
 from argparse import ArgumentParser

--- a/src/MCPClient/lib/clientScripts/archivematicaUpdateSizeAndChecksum.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaUpdateSizeAndChecksum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/archivematicaXMLNamesSpace.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaXMLNamesSpace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 dcNS="http://purl.org/dc/elements/1.1/"
 dctermsNS = "http://purl.org/dc/terms/"

--- a/src/MCPClient/lib/clientScripts/backlogUpdatingTransferFileIndex.py
+++ b/src/MCPClient/lib/clientScripts/backlogUpdatingTransferFileIndex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/characterizeFile.py
+++ b/src/MCPClient/lib/clientScripts/characterizeFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 #
 # Collects characterization commands for the provided file, then either
 # a) Inserts the tool's XML output into the database, or

--- a/src/MCPClient/lib/clientScripts/checkForAccessDirectory.py
+++ b/src/MCPClient/lib/clientScripts/checkForAccessDirectory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/checkForServiceDirectory.py
+++ b/src/MCPClient/lib/clientScripts/checkForServiceDirectory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/checkForSubmissionDocumenation.py
+++ b/src/MCPClient/lib/clientScripts/checkForSubmissionDocumenation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/checkTransferDirectoryForObjects.py
+++ b/src/MCPClient/lib/clientScripts/checkTransferDirectoryForObjects.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/compressAIP.py
+++ b/src/MCPClient/lib/clientScripts/compressAIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import argparse
 import os.path

--- a/src/MCPClient/lib/clientScripts/copyTransferSubmissionDocumentation.py
+++ b/src/MCPClient/lib/clientScripts/copyTransferSubmissionDocumentation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/copyTransfersMetadataAndLogs.py
+++ b/src/MCPClient/lib/clientScripts/copyTransfersMetadataAndLogs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/createAICMETS.py
+++ b/src/MCPClient/lib/clientScripts/createAICMETS.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python2 -OO
+#! /usr/bin/env python2
 
 import argparse
 from lxml import etree

--- a/src/MCPClient/lib/clientScripts/createEvent.py
+++ b/src/MCPClient/lib/clientScripts/createEvent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/createEventsForGroup.py
+++ b/src/MCPClient/lib/clientScripts/createEventsForGroup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/createPointerFile.py
+++ b/src/MCPClient/lib/clientScripts/createPointerFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -OO
+#!/usr/bin/env python2
 
 import argparse
 from lxml import etree

--- a/src/MCPClient/lib/clientScripts/createSIPfromTransferObjects.py
+++ b/src/MCPClient/lib/clientScripts/createSIPfromTransferObjects.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/createSIPsfromTRIMTransferContainers.py
+++ b/src/MCPClient/lib/clientScripts/createSIPsfromTRIMTransferContainers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/determineAIPVersionKeyExitCode.py
+++ b/src/MCPClient/lib/clientScripts/determineAIPVersionKeyExitCode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/elasticSearchIndexProcessTransfer.py
+++ b/src/MCPClient/lib/clientScripts/elasticSearchIndexProcessTransfer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/emailFailReport.py
+++ b/src/MCPClient/lib/clientScripts/emailFailReport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/examineContents.py
+++ b/src/MCPClient/lib/clientScripts/examineContents.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 import os
 import subprocess
 import sys

--- a/src/MCPClient/lib/clientScripts/extractBagTransfer.py
+++ b/src/MCPClient/lib/clientScripts/extractBagTransfer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/extractContents.py
+++ b/src/MCPClient/lib/clientScripts/extractContents.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 from __future__ import print_function
 import os

--- a/src/MCPClient/lib/clientScripts/extractMaildirAttachments.py
+++ b/src/MCPClient/lib/clientScripts/extractMaildirAttachments.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/failedSIPCleanup.py
+++ b/src/MCPClient/lib/clientScripts/failedSIPCleanup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -OO
+#!/usr/bin/env python2
 
 import argparse
 import sys

--- a/src/MCPClient/lib/clientScripts/generateDIPFromAIPGenerateDIP.py
+++ b/src/MCPClient/lib/clientScripts/generateDIPFromAIPGenerateDIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/getAipStorageLocations.py
+++ b/src/MCPClient/lib/clientScripts/getAipStorageLocations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -OO
+#!/usr/bin/env python2
 
 import logging
 import sys

--- a/src/MCPClient/lib/clientScripts/identifyDspaceFiles.py
+++ b/src/MCPClient/lib/clientScripts/identifyDspaceFiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/identifyDspaceMETSFiles.py
+++ b/src/MCPClient/lib/clientScripts/identifyDspaceMETSFiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/identifyFileFormat.py
+++ b/src/MCPClient/lib/clientScripts/identifyFileFormat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import argparse
 import sys

--- a/src/MCPClient/lib/clientScripts/indexAIP.py
+++ b/src/MCPClient/lib/clientScripts/indexAIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -OO
+#!/usr/bin/env python2
 
 from __future__ import print_function
 import ConfigParser

--- a/src/MCPClient/lib/clientScripts/isMaildirAIP.py
+++ b/src/MCPClient/lib/clientScripts/isMaildirAIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/jsonMetadataToCSV.py
+++ b/src/MCPClient/lib/clientScripts/jsonMetadataToCSV.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 import csv
 import json

--- a/src/MCPClient/lib/clientScripts/loadDublinCore.py
+++ b/src/MCPClient/lib/clientScripts/loadDublinCore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import json
 import os

--- a/src/MCPClient/lib/clientScripts/loadLabelsFromCSV.py
+++ b/src/MCPClient/lib/clientScripts/loadLabelsFromCSV.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/manualNormalizationCheckForManualNormalizationDirectory.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationCheckForManualNormalizationDirectory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/manualNormalizationCreateMetadataAndRestructure.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationCreateMetadataAndRestructure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 """
 Associate manually normalized preservation files with their originals.
 

--- a/src/MCPClient/lib/clientScripts/manualNormalizationIdentifyFilesIncluded.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationIdentifyFilesIncluded.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/manualNormalizationMoveAccessFilesToDIP.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationMoveAccessFilesToDIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/manualNormalizationRemoveMNDirectories.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationRemoveMNDirectories.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/moveDspaceLicenseFilesToDSpaceLicenses.py
+++ b/src/MCPClient/lib/clientScripts/moveDspaceLicenseFilesToDSpaceLicenses.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/moveDspaceMetsFilesToDSpaceMETS.py
+++ b/src/MCPClient/lib/clientScripts/moveDspaceMetsFilesToDSpaceMETS.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/moveOrMerge.py
+++ b/src/MCPClient/lib/clientScripts/moveOrMerge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/src/MCPClient/lib/clientScripts/moveToBacklog.py
+++ b/src/MCPClient/lib/clientScripts/moveToBacklog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 import logging
 import os

--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -OO
+#!/usr/bin/env python2
 from __future__ import print_function
 import argparse
 import ConfigParser

--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -OO
+#!/usr/bin/env python2
 
 import argparse
 import sys

--- a/src/MCPClient/lib/clientScripts/removeAIPFilesFromIndex.py
+++ b/src/MCPClient/lib/clientScripts/removeAIPFilesFromIndex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/removeFilesWithoutPremisMetadata.py
+++ b/src/MCPClient/lib/clientScripts/removeFilesWithoutPremisMetadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/removeFilesWithoutPresmisMetadata.py
+++ b/src/MCPClient/lib/clientScripts/removeFilesWithoutPresmisMetadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/removeHiddenFilesAndDirectories.py
+++ b/src/MCPClient/lib/clientScripts/removeHiddenFilesAndDirectories.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/removeUnneededFiles.py
+++ b/src/MCPClient/lib/clientScripts/removeUnneededFiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -OO
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/src/MCPClient/lib/clientScripts/restructureBagAIPToSIP.py
+++ b/src/MCPClient/lib/clientScripts/restructureBagAIPToSIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/restructureDIPForContentDMUpload.py
+++ b/src/MCPClient/lib/clientScripts/restructureDIPForContentDMUpload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/restructureForCompliance.py
+++ b/src/MCPClient/lib/clientScripts/restructureForCompliance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 # This file is part of Archivematica.
 #
 # Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>

--- a/src/MCPClient/lib/clientScripts/restructureForComplianceMaildir.py
+++ b/src/MCPClient/lib/clientScripts/restructureForComplianceMaildir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 # This file is part of Archivematica.
 #
 # Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>

--- a/src/MCPClient/lib/clientScripts/restructureForComplianceSIP.py
+++ b/src/MCPClient/lib/clientScripts/restructureForComplianceSIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -OO
+#!/usr/bin/env python2
 
 import argparse
 import os

--- a/src/MCPClient/lib/clientScripts/retryNormalizeRemoveNormalized.py
+++ b/src/MCPClient/lib/clientScripts/retryNormalizeRemoveNormalized.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/sanitizeNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeNames.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/sanitizeSIPName.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeSIPName.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/saveDublinCore.py
+++ b/src/MCPClient/lib/clientScripts/saveDublinCore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import json
 import sys

--- a/src/MCPClient/lib/clientScripts/setMaildirFileGrpUseAndFileIDs.py
+++ b/src/MCPClient/lib/clientScripts/setMaildirFileGrpUseAndFileIDs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/storeAIP.py
+++ b/src/MCPClient/lib/clientScripts/storeAIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/transcoder.py
+++ b/src/MCPClient/lib/clientScripts/transcoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 # This file is part of Archivematica.
 #
 # Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>

--- a/src/MCPClient/lib/clientScripts/trimCreateRightsEntries.py
+++ b/src/MCPClient/lib/clientScripts/trimCreateRightsEntries.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/trimRestructureForCompliance.py
+++ b/src/MCPClient/lib/clientScripts/trimRestructureForCompliance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/trimVerifyChecksums.py
+++ b/src/MCPClient/lib/clientScripts/trimVerifyChecksums.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/trimVerifyManifest.py
+++ b/src/MCPClient/lib/clientScripts/trimVerifyManifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/upload-archivistsToolkit.py
+++ b/src/MCPClient/lib/clientScripts/upload-archivistsToolkit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # author: jhs
 # created: 2013-01-28

--- a/src/MCPClient/lib/clientScripts/upload-qubit.py
+++ b/src/MCPClient/lib/clientScripts/upload-qubit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Archivematica.

--- a/src/MCPClient/lib/clientScripts/validateFile.py
+++ b/src/MCPClient/lib/clientScripts/validateFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 """
 Runs a validation command on the provided file, and generates an Event from
 the results.

--- a/src/MCPClient/lib/clientScripts/verifyAIP.py
+++ b/src/MCPClient/lib/clientScripts/verifyAIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 import ConfigParser
 import os
 import shutil

--- a/src/MCPClient/lib/clientScripts/verifyAndRestructureTransferBag.py
+++ b/src/MCPClient/lib/clientScripts/verifyAndRestructureTransferBag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/verifyBAG.py
+++ b/src/MCPClient/lib/clientScripts/verifyBAG.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/verifyChecksumsInFileSecOfDspaceMETSFiles.py
+++ b/src/MCPClient/lib/clientScripts/verifyChecksumsInFileSecOfDspaceMETSFiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/verifyPREMISChecksums.py
+++ b/src/MCPClient/lib/clientScripts/verifyPREMISChecksums.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/verifySIPCompliance.py
+++ b/src/MCPClient/lib/clientScripts/verifySIPCompliance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/lib/clientScripts/verifyTransferCompliance.py
+++ b/src/MCPClient/lib/clientScripts/verifyTransferCompliance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPClient/tests/test_json_conversion.py
+++ b/src/MCPClient/tests/test_json_conversion.py
@@ -14,7 +14,7 @@ def test_json_csv_conversion(tmpdir):
     csv_path = os.path.join(str(tmpdir), 'metadata.csv')
     with open(json_path, 'w') as jsonfile:
         jsonfile.write(JSON)
-    subprocess.call([THIS_DIR + '/../lib/clientScripts/jsonMetadataToCSV.py', '', json_path])
+    subprocess.check_call([os.path.join(THIS_DIR, '../lib/clientScripts/jsonMetadataToCSV.py'), '', json_path])
     with open(csv_path) as csvfile:
         csvdata = csvfile.read()
 

--- a/src/MCPServer/lib/RPCServer.py
+++ b/src/MCPServer/lib/RPCServer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/jobChain.py
+++ b/src/MCPServer/lib/jobChain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/jobChainLink.py
+++ b/src/MCPServer/lib/jobChainLink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/linkTaskManager.py
+++ b/src/MCPServer/lib/linkTaskManager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/linkTaskManagerAssignMagicLink.py
+++ b/src/MCPServer/lib/linkTaskManagerAssignMagicLink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/linkTaskManagerChoice.py
+++ b/src/MCPServer/lib/linkTaskManagerChoice.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/linkTaskManagerDirectories.py
+++ b/src/MCPServer/lib/linkTaskManagerDirectories.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/linkTaskManagerFiles.py
+++ b/src/MCPServer/lib/linkTaskManagerFiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/linkTaskManagerGetMicroserviceGeneratedListInStdOut.py
+++ b/src/MCPServer/lib/linkTaskManagerGetMicroserviceGeneratedListInStdOut.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/linkTaskManagerGetUserChoiceFromMicroserviceGeneratedList.py
+++ b/src/MCPServer/lib/linkTaskManagerGetUserChoiceFromMicroserviceGeneratedList.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/linkTaskManagerLoadMagicLink.py
+++ b/src/MCPServer/lib/linkTaskManagerLoadMagicLink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/linkTaskManagerReplacementDicFromChoice.py
+++ b/src/MCPServer/lib/linkTaskManagerReplacementDicFromChoice.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/linkTaskManagerSetUnitVariable.py
+++ b/src/MCPServer/lib/linkTaskManagerSetUnitVariable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/linkTaskManagerUnitVariableLinkPull.py
+++ b/src/MCPServer/lib/linkTaskManagerUnitVariableLinkPull.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/taskStandard.py
+++ b/src/MCPServer/lib/taskStandard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/unit.py
+++ b/src/MCPServer/lib/unit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/unitDIP.py
+++ b/src/MCPServer/lib/unitDIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/unitFile.py
+++ b/src/MCPServer/lib/unitFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/unitSIP.py
+++ b/src/MCPServer/lib/unitSIP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/unitTransfer.py
+++ b/src/MCPServer/lib/unitTransfer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPServer/lib/watchDirectory.py
+++ b/src/MCPServer/lib/watchDirectory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPrpcCLI/lib/MCPrpcCLI.py
+++ b/src/MCPrpcCLI/lib/MCPrpcCLI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/MCPrpcCLI/lib/info.py
+++ b/src/MCPrpcCLI/lib/info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/archivematicaCommon/lib/archivematicaMCPFileUUID.py
+++ b/src/archivematicaCommon/lib/archivematicaMCPFileUUID.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 #
 # This file is part of Archivematica.
 #

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/archivematicaCommon/lib/databaseInterface.py
+++ b/src/archivematicaCommon/lib/databaseInterface.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/archivematicaCommon/lib/dicts.py
+++ b/src/archivematicaCommon/lib/dicts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 # This file is part of Archivematica.
 #
 # Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
@@ -147,7 +147,7 @@ def executeOrRun(type, text, stdIn="", printing=True, arguments=[], env_updates=
         text = "#!/bin/bash\n" + text
         return createAndRunScript(text, stdIn=stdIn, printing=printing, arguments=arguments, env_updates=env_updates)
     if type == "pythonScript":
-        text = "#!/usr/bin/python -OO\n" + text
+        text = "#!/usr/bin/env python2\n" + text
         return createAndRunScript(text, stdIn=stdIn, printing=printing, arguments=arguments, env_updates=env_updates)
     if type == "as_is":
         return createAndRunScript(text, stdIn=stdIn, printing=printing, arguments=arguments, env_updates=env_updates)

--- a/src/archivematicaCommon/lib/externals/HTML/HTML.py
+++ b/src/archivematicaCommon/lib/externals/HTML/HTML.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: iso-8859-1 -*-
 """
 HTML.py - v0.04 2009-07-28 Philippe Lagadec

--- a/src/archivematicaCommon/lib/externals/checksummingTools.py
+++ b/src/archivematicaCommon/lib/externals/checksummingTools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 import hashlib
 
 #Borrowed from http://stackoverflow.com/questions/1131220/get-md5-hash-of-a-files-without-open-it-in-python

--- a/src/archivematicaCommon/lib/externals/detectCores.py
+++ b/src/archivematicaCommon/lib/externals/detectCores.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 #Author Bruce Eckel (www.BruceEckel.com)
 #Source http://www.artima.com/weblogs/viewpost.jsp?thread=230001
 

--- a/src/archivematicaCommon/lib/externals/extractMaildirAttachments.py
+++ b/src/archivematicaCommon/lib/externals/extractMaildirAttachments.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 # vim:fileencoding=utf8
 
 #Author Ian Lewis

--- a/src/archivematicaCommon/lib/externals/singleInstance.py
+++ b/src/archivematicaCommon/lib/externals/singleInstance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 #Author Larry Bates http://code.activestate.com/recipes/users/651848/
 #Source {{{ http://code.activestate.com/recipes/546512/ (r1)
 #license: PSF http://docs.python.org/license.html

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 # This file is part of Archivematica.
 #
 # Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>

--- a/src/archivematicaCommon/lib/sharedVariablesAcrossModules.py
+++ b/src/archivematicaCommon/lib/sharedVariablesAcrossModules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/archivematicaCommon/lib/utilities/FPRClient/client.py
+++ b/src/archivematicaCommon/lib/utilities/FPRClient/client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -OO
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/src/archivematicaCommon/lib/utilities/FPRClient/getFromRestAPI.py
+++ b/src/archivematicaCommon/lib/utilities/FPRClient/getFromRestAPI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 
 # This file is part of Archivematica.
 #

--- a/src/dashboard/src/components/ingest/views_NormalizationReport.py
+++ b/src/dashboard/src/components/ingest/views_NormalizationReport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 # This file is part of Archivematica.

--- a/src/dashboard/src/manage.py
+++ b/src/dashboard/src/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 from django.core.management import execute_manager
 try:
     import settings # Assumed to be in the same directory.

--- a/src/dashboard/tests/test_filesystem_ajax.py
+++ b/src/dashboard/tests/test_filesystem_ajax.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python2
+#! /usr/bin/env python2
 
 import base64
 import json


### PR DESCRIPTION
Update shebangs to use the environment's python2, instead of the system python. This will make it easier to run in virtualenvs, especially on systems where `/usr/bin/python` is not `python2`.

`/usr/bin/env` doesn't take arguments, so removing `-00` where it exists.

Any thoughts on changing `executeOrRunSubProcess.executeOrRun` to interpret 'pythonScript' as 'python2' ?
