### PR TITLE
Tests use in memory DB

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 django_find_projects=false
 python_paths=/usr/share/archivematica/dashboard/;/usr/lib/archivematica/archivematicaCommon/
-DJANGO_SETTINGS_MODULE=settings.local
+DJANGO_SETTINGS_MODULE=settings.test

--- a/src/dashboard/src/settings/test.py
+++ b/src/dashboard/src/settings/test.py
@@ -1,0 +1,13 @@
+from common import *
+
+########## IN-MEMORY TEST DATABASE
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+    },
+}


### PR DESCRIPTION
Added a testing-focused settings file that uses an in-memory sqlite DB.

Pro: Much much faster than using MySQL, requires less setup
Con: MySQL and sqlite enforce constraints differently, so testing vs production are different

Another testing-vs-production difference: because Django is creating the DB instead of our hand-rolled SQL, the production and testing environments are different, especially around foreign keys.  I think this is true regardless of DB backend, though, just a different set of errors show up depending on backend.
