### PR TITLE
ArchivesSpaceClient: dispatch on resource type properly

### DIFF
--- a/src/archivematicaCommon/tests/fixtures/test_resource_type.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_resource_type.yaml
@@ -1,0 +1,24 @@
+interactions:
+- request:
+    body: password=admin
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Content-Length: ['14']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.3.0 CPython/2.7.10 Darwin/14.4.0]
+    method: POST
+    uri: http://localhost:8089/users/admin/login
+  response:
+    body: {string: !!python/unicode '{"session":"aee48628790858481963be28725c8023a0d4c8c01e3911ce5ca5ae74ad9f7501","user":{"lock_version":27,"username":"admin","name":"Administrator","is_system_user":true,"create_time":"2015-06-11T17:04:21Z","system_mtime":"2015-07-15T19:12:18Z","user_mtime":"2015-07-15T19:12:18Z","jsonmodel_type":"user","groups":[],"is_admin":true,"uri":"/users/1","agent_record":{"ref":"/agents/people/1"},"permissions":{"/repositories/1":["update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record","administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed"],"_archivesspace":["administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed","update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record"]}}}
+
+'}
+    headers:
+      cache-control: ['private, must-revalidate, max-age=0']
+      content-length: ['2205']
+      content-type: [application/json]
+      date: ['Wed, 15 Jul 2015 19:12:17 GMT']
+      server: [Jetty(8.1.5.v20120716)]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+version: 1

--- a/src/archivematicaCommon/tests/test_archivesspace_client.py
+++ b/src/archivematicaCommon/tests/test_archivesspace_client.py
@@ -2,10 +2,11 @@
 import os
 import sys
 
+import pytest
 import vcr
 
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
-from archivesspace.client import ArchivesSpaceClient
+from archivesspace.client import ArchivesSpaceClient, ArchivesSpaceError
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 AUTH = {
@@ -120,3 +121,15 @@ def test_augment_ids():
     assert len(data) == 2
     assert data[0]['title'] == 'Test fonds'
     assert data[1]['title'] == 'Some other fonds'
+
+@vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_resource_type.yaml'))
+def test_get_resource_type():
+    client = ArchivesSpaceClient(**AUTH)
+    assert client.resource_type('/repositories/2/resources/2') == 'resource'
+    assert client.resource_type('/repositories/2/archival_objects/3') == 'resource_component'
+
+@vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_resource_type.yaml'))
+def test_get_resource_type_raises_on_invalid_input():
+    client = ArchivesSpaceClient(**AUTH)
+    with pytest.raises(ArchivesSpaceError):
+        client.resource_type('invalid')


### PR DESCRIPTION
There were a few issues with the original code; several places depended on an external resource_type parameter being passed in, and that parameter inconsistently used `"collection"` (for historical reasons) and `"resource"` to refer to a resource-level record. This patch instead determines the resource_type automatically, and renders the parameter a no-op. (It's retained for compatibility with the ATK client, though that should probably also get adjusted at some point.)
