### PR TITLE
Forms: normalize and validate dates

### DIFF
--- a/src/dashboard/src/components/helpers.py
+++ b/src/dashboard/src/components/helpers.py
@@ -29,10 +29,13 @@ from django.utils.dateformat import format
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger, InvalidPage
 from django.core.urlresolvers import reverse
 from django.db.models import Max
+from django import forms
 from django.http import HttpResponse, HttpResponseRedirect
 from django.core.servers.basehttp import FileWrapper
 from django.shortcuts import render
 from main import models
+
+import dateutil.parser
 
 logger = logging.getLogger('archivematica.dashboard')
 
@@ -334,3 +337,24 @@ def default_processing_config_path():
         get_server_config_value('sharedDirectory'),
         'sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml'
     )
+
+def clean_date(date):
+    """
+    Attempt to normalize a user-provided date value, for use in forms.
+
+    Parses a user-provided date, which can be in arbitrary formats, and returns a yyyy-MM-dd formatted version of the same date.
+    The current implemention uses python-dateutil to parse the date.
+    If the provided date value is falsy, returns the provided date without change.
+
+    :param str date: A string representation of a date.
+
+    :raises ValidationError: if the date cannot be parsed.
+    """
+    if date:
+        try:
+            return dateutil.parser.parse(date).strftime('%Y-%m-%d')
+        except ValueError:
+            raise forms.ValidationError('Unable to interpret as a date: %(date)s',
+                                        params={'date': date})
+    else:
+        return date

--- a/src/dashboard/src/components/ingest/forms.py
+++ b/src/dashboard/src/components/ingest/forms.py
@@ -19,6 +19,8 @@ from django import forms
 from main import models
 from django.conf import settings
 
+from helpers import clean_date
+
 class DublinCoreMetadataForm(forms.ModelForm):
     class Meta:
         model = models.DublinCore
@@ -65,6 +67,9 @@ class DublinCoreMetadataForm(forms.ModelForm):
             data = self.aic_prefix+data
         return data
 
+    def clean_date(self):
+        return clean_date(self.cleaned_data['date'])
+
 class AICDublinCoreMetadataForm(DublinCoreMetadataForm):
     class Meta:
         model = models.DublinCore
@@ -81,3 +86,5 @@ class AICDublinCoreMetadataForm(DublinCoreMetadataForm):
             data = self.aic_prefix+data
         return data
 
+    def clean_date(self):
+        return clean_date(self.cleaned_data['date'])

--- a/src/dashboard/src/components/rights/forms.py
+++ b/src/dashboard/src/components/rights/forms.py
@@ -18,6 +18,7 @@
 from django import forms
 from django.conf import settings
 
+from helpers import clean_date
 from main import models
 
 class RightsForm(forms.ModelForm):
@@ -53,6 +54,12 @@ class RightsGrantedForm(forms.ModelForm):
             'enddate': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The ending date of the rights or restrictions granted"}),
             'enddateopen': forms.widgets.CheckboxInput(attrs={'title': 'Use "OPEN" for an open ended term of restriction. Omit end date if the ending date is unknown or the permission statement applies to many objects with different end dates.'}), }
 
+    def clean_startdate(self):
+        return clean_date(self.cleaned_data['startdate'])
+
+    def clean_enddate(self):
+        return clean_date(self.cleaned_data['enddate'])
+
 class RightsGrantedNotesForm(forms.ModelForm):
     class Meta:
         model = models.RightsStatementRightsGrantedNote
@@ -70,6 +77,15 @@ class RightsCopyrightForm(forms.ModelForm):
             'copyrightstatusdeterminationdate': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The date that the copyright status recorded in 'copyright status' was determined."}),
             'copyrightapplicablestartdate': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The date when the particular copyright applies or is applied to the content."}),
             'copyrightapplicableenddate': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The date when the particular copyright no longer applies or is applied to the content."}), }
+
+    def clean_copyrightstatusdeterminationdate(self):
+        return clean_date(self.cleaned_data['copyrightstatusdeterminationdate'])
+
+    def clean_copyrightapplicablestartdate(self):
+        return clean_date(self.cleaned_data['copyrightapplicablestartdate'])
+
+    def clean_copyrightapplicableenddate(self):
+        return clean_date(self.cleaned_data['copyrightapplicableenddate'])
 
 class RightsStatementCopyrightDocumentationIdentifierForm(forms.ModelForm):
     class Meta:
@@ -99,6 +115,15 @@ class RightsStatuteForm(forms.ModelForm):
             'statuteapplicablestartdate': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The date when the statute begins to apply or is applied to the content."}),
             'statuteapplicableenddate': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The date when the statute ceasees to apply or be applied to the content."}), }
 
+    def clean_statutedeterminationdate(self):
+        return clean_date(self.cleaned_data['statutedeterminationdate'])
+
+    def clean_statuteapplicablestartdate(self):
+        return clean_date(self.cleaned_data['statuteapplicablestartdate'])
+
+    def clean_statuteapplicableenddate(self):
+        return clean_date(self.cleaned_data['statuteapplicableenddate'])
+
 class RightsStatuteNoteForm(forms.ModelForm):
     class Meta:
         model = models.RightsStatementStatuteInformationNote
@@ -115,6 +140,12 @@ class RightsOtherRightsForm(forms.ModelForm):
             'otherrightsapplicablestartdate': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The date when the other right applies or is applied to the content."}),
             'otherrightsapplicableenddate': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The date when the other right no longer applies or is applied to the content."}), }
 
+    def clean_otherrightsapplicablestartdate(self):
+        return clean_date(self.cleaned_data['otherrightsapplicablestartdate'])
+
+    def clean_otherrightsapplicableenddate(self):
+        return clean_date(self.cleaned_data['otherrightsapplicableenddate'])
+
 class RightsLicenseForm(forms.ModelForm):
     class Meta:
         model = models.RightsStatementLicense
@@ -123,6 +154,12 @@ class RightsLicenseForm(forms.ModelForm):
             'licenseterms': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "Text describing the license or agreement by which permission as granted."}),
             'licenseapplicablestartdate': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The date at which the license first applies or is applied to the content."}),
             'licenseapplicableenddate': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The end date at which the license no longer applies or is applied to the content."}), }
+
+    def clean_licenseapplicablestartdate(self):
+        return clean_date(self.cleaned_data['licenseapplicablestartdate'])
+
+    def clean_licenseapplicableenddate(self):
+        return clean_date(self.cleaned_data['licenseapplicableenddate'])
 
 class RightsLicenseNoteForm(forms.ModelForm):
     class Meta:


### PR DESCRIPTION
These were previously treated as pure text, so any value was permissible. However, Elasticsearch may now opportunistically parse these into dates, which means that we have to be more careful about validating them. Use dateutil to try to normalize these values; if we can't, raise a ValidationError to provide the user the chance to fix it.

We probably want to get this into 1.5.x instead of 1.4.x since this introduces new constraints into the date field, even though this fixes a bug that's present in the 1.4.x series. (cc @sromkey for opinions on that.)
