### PR TITLE
Initialize Django in MCP client scripts ref. #8879

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaFITS.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaFITS.py
@@ -35,12 +35,16 @@ from databaseFunctions import insertIntoFPCommandOutput
 from databaseFunctions import insertIntoEvents
 import databaseInterface
 
+# initialize Django (required for Django 1.7)
+import django
+django.setup()
+
 databaseInterface.printSQL = False
 excludeJhoveProperties = True
 formats = []
 FITSNS = "{http://hul.harvard.edu/ois/xml/ns/fits/fits_output}"
 
-            
+
 def excludeJhoveProperties(fits):
     """Exclude <properties> from <fits><toolOutput><tool name="Jhove" version="1.5"><repInfo> because that field contains unnecessary excess data and the key data are covered by output from other FITS tools."""
     formatValidation = None

--- a/src/MCPClient/lib/clientScripts/dip_generation_helper.py
+++ b/src/MCPClient/lib/clientScripts/dip_generation_helper.py
@@ -13,6 +13,10 @@ from main import models
 import archivesspace
 import archivematicaFunctions
 
+# initialize Django (required for Django 1.7)
+import django
+django.setup()
+
 def create_archivesspace_client():
     """
     Create an ArchivesSpace client instance.

--- a/src/MCPClient/lib/clientScripts/upload-archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload-archivesspace.py
@@ -12,6 +12,9 @@ from archivesspace.client import ArchivesSpaceClient
 from elasticSearchFunctions import getDashboardUUID
 from xml2obj import mets_file
 
+# initialize Django (required for Django 1.7)
+import django
+django.setup()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Standalone scripts require to initialize Django to avoid
an AppRegistryNotReady exception

So far identified 3 scripts, others may also need to be fixed.
