### PR TITLE
arrange_contents: fix calling without the `path` parameter

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -114,13 +114,16 @@ def contents(request):
     return helpers.json_response(response)
 
 def arrange_contents(request):
-    base_path = base64.b64decode(request.GET.get('path', DEFAULT_ARRANGE_PATH))
+    path = request.GET.get('path')
+    if path is not None:
+        base_path = base64.b64decode(path)
+        # Must indicate that base_path is a folder by ending with /
+        if not base_path.endswith('/'):
+            base_path += '/'
 
-    # Must indicate that base_path is a folder by ending with /
-    if not base_path.endswith('/'):
-        base_path += '/'
-
-    if not base_path.startswith(DEFAULT_ARRANGE_PATH):
+        if not base_path.startswith(DEFAULT_ARRANGE_PATH):
+            base_path = DEFAULT_ARRANGE_PATH
+    else:
         base_path = DEFAULT_ARRANGE_PATH
 
     # Query SIP Arrangement for results

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -116,7 +116,14 @@ def contents(request):
 def arrange_contents(request):
     path = request.GET.get('path')
     if path is not None:
-        base_path = base64.b64decode(path)
+        try:
+            base_path = base64.b64decode(path)
+        except TypeError:
+            response = {
+                'success': False,
+                'message': 'Could not base64-decode provided path: {}'.format(path),
+            }
+            helpers.json_response(response, status_code=400)
         # Must indicate that base_path is a folder by ending with /
         if not base_path.endswith('/'):
             base_path += '/'


### PR DESCRIPTION
`DEFAULT_ARRANGE_PATH` is not base64-encoded; trying to decode it raises an exception.
