### PR TITLE
Make `filepath` parameter to /filesystem/delete/ APIs mandatory

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -191,7 +191,14 @@ def delete(request):
 
 
 def delete_arrange(request):
-    filepath = base64.b64decode(request.POST.get('filepath', ''))
+    try:
+        filepath = base64.b64decode(request.POST['filepath'])
+    except KeyError:
+        response = {
+            'success': False,
+            'message': 'No filepath to delete was provided!'
+        }
+        return helpers.json_response(response, status_code=400)
     models.SIPArrange.objects.filter(arrange_path__startswith=filepath).delete()
     return helpers.json_response({'message': 'Delete successful.'})
 

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -159,7 +159,14 @@ def arrange_contents(request):
 
 
 def delete(request):
-    filepath = request.POST.get('filepath', '')
+    try:
+        filepath = request.POST['filepath']
+    except KeyError:
+        response = {
+            'success': False,
+            'message': 'No filepath to delete was provided!'
+        }
+        return helpers.json_response(response, status_code=400)
     filepath = os.path.join('/', filepath)
     error = filesystem_ajax_helpers.check_filepath_exists(filepath)
 


### PR DESCRIPTION
Defaulting to an empty string means that this deletes the entire contents of arrange. This is very easy to do by accident when calling this API manually, for example if the user accidentally passes the parameters as URL parameters or JSON data instead of form-encoded data.
