### PR TITLE
Elasticsearch: update transfer index format, add tag functions

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -248,7 +248,18 @@ def set_up_mapping(conn, index):
             'origin'       : machine_readable_field_spec,
             'ingestdate'   : {'type': 'date' , 'format': 'dateOptionalTime'},
             'created'      : {'type': 'double'},
+            'size'         : {'type': 'double'},
+            'tags'         : machine_readable_field_spec,
             'file_extension': machine_readable_field_spec,
+            'bulk_extractor_reports': machine_readable_field_spec,
+            'format'       : {
+                'type'      : 'nested',
+                'properties': {
+                    'puid'  : machine_readable_field_spec,
+                    'format': {'type': 'string'},
+                    'group' : {'type': 'string'},
+                }
+            }
         }
 
         print 'Creating transfer file mapping...'

--- a/src/archivematicaCommon/tests/fixtures/test_list_tags.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_list_tags.yaml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: PUT
+    uri: http://localhost:9200/transfers
+  response:
+    body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[transfers]
+        already exists]","status":400}'}
+    headers:
+      content-length: ['80']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: '{"query": {"term": {"fileuuid": "a410501b-64ac-4b81-92ca-efa9e815366d"}}}'
+    headers: {}
+    method: GET
+    uri: http://localhost:9200/transfers/transferfile/_search?fields=tags
+  response:
+    body: {string: !!python/unicode '{"took":4,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":1,"max_score":1.6931472,"hits":[{"_index":"transfers","_type":"transferfile","_id":"AU9MJzaYgAJJz92ebm-j","_score":1.6931472,"fields":{"tags":["test1"]}}]}}'}
+    headers:
+      content-length: ['248']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 200, message: OK}
+version: 1

--- a/src/archivematicaCommon/tests/fixtures/test_list_tags_no_matches.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_list_tags_no_matches.yaml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: PUT
+    uri: http://localhost:9200/transfers
+  response:
+    body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[transfers]
+        already exists]","status":400}'}
+    headers:
+      content-length: ['80']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: '{"query": {"term": {"fileuuid": "no_such_file"}}}'
+    headers: {}
+    method: GET
+    uri: http://localhost:9200/transfers/transferfile/_search?fields=tags
+  response:
+    body: {string: !!python/unicode '{"took":1,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'}
+    headers:
+      content-length: ['122']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 200, message: OK}
+version: 1

--- a/src/archivematicaCommon/tests/fixtures/test_set_tags.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_set_tags.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: PUT
+    uri: http://localhost:9200/transfers
+  response:
+    body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[transfers]
+        already exists]","status":400}'}
+    headers:
+      content-length: ['80']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: '{"query": {"term": {"fileuuid": "2101fa74-bc27-405b-8e29-614ebd9d5a89"}}}'
+    headers: {}
+    method: GET
+    uri: http://localhost:9200/_all/transferfile/_search?size=50000
+  response:
+    body: {string: !!python/unicode '{"took":2,"timed_out":false,"_shards":{"total":10,"successful":10,"failed":0},"hits":{"total":1,"max_score":1.6931472,"hits":[{"_index":"transfers","_type":"transferfile","_id":"AU9MJzbIgAJJz92ebm-q","_score":1.6931472,"_source":{"accessionid":"","status":"backlog","sipuuid":"f646a630-9697-46a2-875a-a603f2d68cc1","tags":["test"],"file_extension":"tga","relative_path":"Images-f646a630-9697-46a2-875a-a603f2d68cc1/objects/pictures/MARBLES.TGA","bulk_extractor_reports":[],"origin":"42105a31-3507-4790-9a8d-2afbdd9ef3a1","size":4.0638933181762695,"created":1.4400914032641463E9,"format":[{"puid":"fmt/402","group":"Image
+        (Raster)","format":"Truevision TGA Bitmap 2.0"}],"ingestdate":"2015-08-20","filename":"MARBLES.TGA","fileuuid":"2101fa74-bc27-405b-8e29-614ebd9d5a89"}}]}}'}
+    headers:
+      content-length: ['775']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"doc": {"tags": ["test"]}}'
+    headers: {}
+    method: POST
+    uri: http://localhost:9200/transfers/transferfile/AU9MJzbIgAJJz92ebm-q/_update
+  response:
+    body: {string: !!python/unicode '{"_index":"transfers","_type":"transferfile","_id":"AU9MJzbIgAJJz92ebm-q","_version":9}'}
+    headers:
+      content-length: ['87']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: PUT
+    uri: http://localhost:9200/transfers
+  response:
+    body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[transfers]
+        already exists]","status":400}'}
+    headers:
+      content-length: ['80']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: '{"query": {"term": {"fileuuid": "2101fa74-bc27-405b-8e29-614ebd9d5a89"}}}'
+    headers: {}
+    method: GET
+    uri: http://localhost:9200/transfers/transferfile/_search?fields=tags
+  response:
+    body: {string: !!python/unicode '{"took":1,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":1,"max_score":1.6931472,"hits":[{"_index":"transfers","_type":"transferfile","_id":"AU9MJzbIgAJJz92ebm-q","_score":1.6931472,"fields":{"tags":["test"]}}]}}'}
+    headers:
+      content-length: ['247']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 200, message: OK}
+version: 1

--- a/src/archivematicaCommon/tests/fixtures/test_set_tags_no_matches.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_set_tags_no_matches.yaml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: PUT
+    uri: http://localhost:9200/transfers
+  response:
+    body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[transfers]
+        already exists]","status":400}'}
+    headers:
+      content-length: ['80']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 400, message: Bad Request}
+- request:
+    body: '{"query": {"term": {"fileuuid": "no_such_file"}}}'
+    headers: {}
+    method: GET
+    uri: http://localhost:9200/_all/transferfile/_search?size=50000
+  response:
+    body: {string: !!python/unicode '{"took":1,"timed_out":false,"_shards":{"total":10,"successful":10,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'}
+    headers:
+      content-length: ['124']
+      content-type: [application/json; charset=UTF-8]
+    status: {code: 200, message: OK}
+version: 1

--- a/src/archivematicaCommon/tests/test_elasticsearch_functions.py
+++ b/src/archivematicaCommon/tests/test_elasticsearch_functions.py
@@ -2,6 +2,7 @@
 from elasticsearch import Elasticsearch
 import os
 import sys
+import pytest
 import unittest
 import vcr
 
@@ -67,3 +68,22 @@ class TestElasticSearchFunctions(unittest.TestCase):
             fields='AIPUUID,FILEUUID',
         )
         assert results['hits']['total'] == 0
+
+    @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_list_tags.yaml'))
+    def test_list_tags(self):
+        assert elasticSearchFunctions.connect_and_get_file_tags('a410501b-64ac-4b81-92ca-efa9e815366d') == ['test1']
+
+    @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_list_tags_no_matches.yaml'))
+    def test_list_tags_fails_when_file_cant_be_found(self):
+        with pytest.raises(elasticSearchFunctions.EmptySearchResultError):
+            elasticSearchFunctions.connect_and_get_file_tags('no_such_file')
+
+    @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_set_tags.yaml'))
+    def test_set_tags(self):
+        elasticSearchFunctions.connect_and_set_file_tags('2101fa74-bc27-405b-8e29-614ebd9d5a89', ['test'])
+        assert elasticSearchFunctions.connect_and_get_file_tags('2101fa74-bc27-405b-8e29-614ebd9d5a89') == ['test']
+
+    @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_set_tags_no_matches.yaml'))
+    def test_set_tags_fails_when_file_cant_be_found(self):
+        with pytest.raises(elasticSearchFunctions.EmptySearchResultError):
+            elasticSearchFunctions.connect_and_set_file_tags('no_such_file', [])


### PR DESCRIPTION
This is required for the appraisal tab backend APIs, such as #269.
