### PR TITLE
Elasticsearch: index only needed fields

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -386,9 +386,6 @@ def set_up_mapping(client, index):
 def index_aip(client, uuid, name, filePath, pathToMETS, size=None, aips_in_aic=None, identifiers=[]):
     tree = ElementTree.parse(pathToMETS)
 
-    # TODO add a conditional to toggle this
-    remove_tool_output_from_mets(tree)
-
     root = tree.getroot()
     # Extract AIC identifier, other specially-indexed information
     aic_identifier = None
@@ -400,16 +397,11 @@ def index_aip(client, uuid, name, filePath, pathToMETS, size=None, aips_in_aic=N
             aic_identifier = dublincore.findtext('dc:identifier', namespaces=ns.NSMAP) or dublincore.findtext('dcterms:identifier', namespaces=ns.NSMAP)
         is_part_of = dublincore.findtext('dcterms:isPartOf', namespaces=ns.NSMAP)
 
-    # convert METS XML to dict
-    xml = ElementTree.tostring(root)
-    mets_data = rename_dict_keys_with_child_dicts(normalize_dict_values(xmltodict.parse(xml)))
-
     aipData = {
         'uuid': uuid,
         'name': name,
         'filePath': filePath,
         'size': (size or os.path.getsize(filePath)) / float(1024) / float(1024),
-        'mets': mets_data,
         'origin': get_dashboard_uuid(),
         'created': os.path.getmtime(pathToMETS),
         'AICID': aic_identifier,

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -398,6 +398,8 @@ def index_aip(client, uuid, name, filePath, pathToMETS, size=None, aips_in_aic=N
             aic_identifier = dublincore.findtext('dc:identifier', namespaces=ns.NSMAP) or dublincore.findtext('dcterms:identifier', namespaces=ns.NSMAP)
         is_part_of = dublincore.findtext('dcterms:isPartOf', namespaces=ns.NSMAP)
 
+    accession_ids = [r[0] for r in File.objects.filter(sip_id=uuid).values_list('transfer__accessionid') if r[0]]
+
     aipData = {
         'uuid': uuid,
         'name': name,
@@ -410,6 +412,7 @@ def index_aip(client, uuid, name, filePath, pathToMETS, size=None, aips_in_aic=N
         'countAIPsinAIC': aips_in_aic,
         'identifiers': identifiers,
         'transferMetadata': _extract_transfer_metadata(root),
+        'accession_ids': accession_ids,
     }
     wait_for_cluster_yellow_status(client)
     try_to_index(client, aipData, 'aips', 'aip')

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -333,6 +333,7 @@ def set_up_mapping_transfer_index(client):
     transferfile_mapping = {
         'filename'     : {'type': 'string'},
         'relative_path': {'type': 'string'},
+        'original_path': {'type': 'string'},
         'fileuuid'     : MACHINE_READABLE_FIELD_SPEC,
         'sipuuid'      : MACHINE_READABLE_FIELD_SPEC,
         'accessionid'  : MACHINE_READABLE_FIELD_SPEC,
@@ -725,10 +726,12 @@ def index_transfer_files(client, uuid, pathToTransfer, index, type_, status=''):
                 f = File.objects.get(currentlocation=relative_path,
                                      transfer_id=uuid)
                 file_uuid = f.uuid
+                original_path = f.originallocation
                 formats = _get_file_formats(f)
                 bulk_extractor_reports = _list_bulk_extractor_reports(pathToTransfer, file_uuid)
             except File.DoesNotExist:
                 file_uuid = ''
+                original_path = ''
                 formats = []
                 bulk_extractor_reports = []
 
@@ -747,6 +750,7 @@ def index_transfer_files(client, uuid, pathToTransfer, index, type_, status=''):
                 indexData = {
                   'filename'     : filename,
                   'relative_path': relative_path,
+                  'original_path': original_path,
                   'fileuuid'     : file_uuid,
                   'sipuuid'      : uuid,
                   'accessionid'  : accession_id,


### PR DESCRIPTION
This is very WIP and here for discussion right now.

We've been running into various issues from indexing the entire METS file in ES; this was based on a discussion Justin and I had about indexing only the fields that we're explicitly making searchable.

As a part of this we're also likely to find fields that we may have expected to be searchable that were only actually searchable by accident because we indexed the entire METS file, even though they were never exposed in the search interface.

This is connected to https://github.com/artefactual/archivematica/issues/1199.