### PR TITLE
Rename endpoint, s/ransfer/transfer

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/urls.py
+++ b/src/dashboard/src/components/filesystem_ajax/urls.py
@@ -30,7 +30,7 @@ urlpatterns = patterns('',
     url(r'^move_within_arrange/$', views.move_within_arrange),
     url(r'^create_directory_within_arrange/$', views.create_directory_within_arrange),
     url(r'^copy_to_arrange/$', views.copy_to_arrange),
-    url(r'^ransfer/$', views.start_transfer_logged_in),
+    url(r'^transfer/$', views.start_transfer_logged_in),
     url(r'^copy_from_arrange/$', views.copy_from_arrange_to_completed),
     url(r'^copy_metadata_files/$', views.copy_metadata_files),
 )

--- a/src/dashboard/src/media/js/transfer/component_form.js
+++ b/src/dashboard/src/media/js/transfer/component_form.js
@@ -137,7 +137,7 @@ var TransferComponentFormView = Backbone.View.extend({
 
     $('.activity-indicator').show();
     $.ajax({
-      url: '/filesystem/ransfer/',
+      url: '/filesystem/transfer/',
       type: 'POST',
       cache: false,
       async: false,


### PR DESCRIPTION
As @mistydemeo said:

> At one time in the past a bad regex meant that `/filesystem/transfer` would be interpreted as `/transfer`. So the API got named `ransfer` and it’s never been changed even after the regex ambiguity was fixed.
