### PR TITLE
Correcting duplicate files checksums verification.

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCheckMD5NoGUI.sh
+++ b/src/MCPClient/lib/clientScripts/archivematicaCheckMD5NoGUI.sh
@@ -38,7 +38,7 @@ cd "$checkFolder"
 #check for passing checksums
 "${checksumTool}" -r -m "$md5Digest" . > $passTmp
 #check for failing checksums
-"${checksumTool}" -r -n -m "$md5Digest" . > $failTmp
+"${checksumTool}" -r -x "$md5Digest" . > $failTmp
 cd $tmpDir      
 
 


### PR DESCRIPTION
This commit changes the behaviour of the transfer checksums verification to
check correctly duplicate files (same content, different file names).

The microservice _Verify transfer checksums_ (_Job: Verify metadata directory
checksums_) does not work properly in case there are same files with different
names in the transfer. For example (hash is _md5_ but it is the same for _sha1_ and _sha256_):

```
89808652ad47f2bb97df733e8a2e14ba objects/collection/folder/a.jpg
89808652ad47f2bb97df733e8a2e14ba objects/collection/folder/b.jpg
```

Such transfer fails and the _a.jpg_ file is reported as corrupted (hash does not
match) because the md5deep is called

```
md5deep -r -n -m
```

which compares the computed hashes first (so the computed hash for the _b.jpg_
matches the line for _a.jpg_).

This behaviour catches duplicate files which is probably not the goal of the
Verify transfer checksums microservice.

This request call for the <hash>deep should be

```
md5deep -r -x
```

This slight change in the call works as intended: reports only those files not
listed in _checksum.<hash>_ or those with corrupted (mismatched) hashes.
Duplicate files are matched correctly (and not reported).
