### PR TITLE
Add new /access/ API

### DIFF
--- a/src/archivematicaCommon/lib/archivesspace/client.py
+++ b/src/archivematicaCommon/lib/archivesspace/client.py
@@ -148,7 +148,8 @@ class ArchivesSpaceClient(object):
         :param resource_id long: The URI of the resource to fetch children from.
         :param resource_type str: no-op; not required or used in this implementation.
 
-        :return list: A list of strings representing the record URIs for all children of the requested record.
+        :return: A list of strings representing the record URIs for all children of the requested record.
+        :rtype list:
         """
         def fetch_children(children):
             results = []
@@ -272,8 +273,9 @@ class ArchivesSpaceClient(object):
         :param string search_pattern: If specified, limits fetched children to those whose titles or IDs match the provided query.
             See ArchivistsToolkitClient.find_collection_ids for documentation of the query format.
 
-        :return dict: A dict containing detailed metadata about both the requested resource and its children.
+        :return: A dict containing detailed metadata about both the requested resource and its children.
             Consult ArchivistsToolkitClient.get_resource_component_and_children for the output format.
+        :rtype dict:
         """
         resource_type = self.resource_type(resource_id)
         if resource_type == 'resource':
@@ -286,7 +288,8 @@ class ArchivesSpaceClient(object):
         Given the URL to a component, returns the parent resource's URL.
 
         :param string component_id: The URL of the resource.
-        :return string: The URL of the component's parent resource.
+        :return: The URL of the component's parent resource.
+        :rtype: string
         """
         response = self._get(component_id)
         return response.json()['resource']['ref']
@@ -296,10 +299,11 @@ class ArchivesSpaceClient(object):
         Given the URL to a component, returns the parent component's URL.
 
         :param string component_id: The URL of the component.
-        :return tuple: A tuple containing:
+        :return: A tuple containing:
             * The type of the parent record; valid values are ArchivesSpaceClient.RESOURCE and ArchivesSpaceClient.RESOURCE_COMPONENT.
             * The URL of the parent record.
             If the provided URL fragment references a resource, this method will simply return the same URL.
+        :rtype tuple:
         """
         response = self.get_record(component_id)
         if 'parent' in response:
@@ -324,7 +328,8 @@ class ArchivesSpaceClient(object):
             Substring matching will not be performed; however, wildcards are supported.
             For example, searching "F1" will only return records with the identifier "F1", while searching "F*" will return "F1", "F2", etc.
 
-        :return list: A list containing every matched resource's URL.
+        :return: A list containing every matched resource's URL.
+        :rtype list:
         """
         params = {
             'page': page,
@@ -500,7 +505,8 @@ class ArchivesSpaceClient(object):
         Consult the documentation of ArchivistsToolkitClient.get_resource_component_children for the format of the returned dicts.
 
         :param list resource_ids: A list of one or more resource IDs.
-        :return list: A list containing metadata dicts.
+        :return: A list containing metadata dicts.
+        :rtype list:
         """
         resources_augmented = []
         for id in resource_ids:

--- a/src/archivematicaCommon/lib/archivesspace/client.py
+++ b/src/archivematicaCommon/lib/archivesspace/client.py
@@ -357,6 +357,23 @@ class ArchivesSpaceClient(object):
         return self._get(self.repository + '/search', params=params).json()['total_hits']
 
     def find_collections(self, search_pattern='', identifier='', accession='', fetched=0, page=1, page_size=30, sort_by=None):
+        """
+        Fetches a list of all resource IDs for every resource in the database.
+
+        :param string search_pattern: A search pattern to use in looking up resources by title or resourceid.
+            The search will match any title or resourceid containing this string;
+            for example, "text" will match "this title has this text in it".
+            If omitted, then all resources will be fetched.
+        :param string identifier: Restrict records to only those with this identifier.
+            This refers to the human-assigned record identifier, not the automatically generated internal ID.
+            This value can contain wildcards.
+        :param string accession: Restrict records to only those associated with this accession.
+            This should be provided using ArchivesSpace's internal format, for instance /repositories/2/accessions/1; it does not refer to human-assigned accession identifiers.
+            Use ArchivesSpaceClient.find_collections_by_accession to locate records via a human-assigned accession identifier.
+
+        :return: A list containing every matched resource's ID.
+        :rtype: list
+        """
         def format_record(record):
             dates = self._fetch_dates_from_record(record)
             identifier = record['id_0'] if 'id_0' in record else record.get('component_id', '')

--- a/src/archivematicaCommon/lib/archivistsToolkit/client.py
+++ b/src/archivematicaCommon/lib/archivistsToolkit/client.py
@@ -169,25 +169,24 @@ class ArchivistsToolkitClient(object):
                 resource_data['identifier']         = row[2]
                 resource_data['levelOfDescription'] = row[3]
 
-        resource_data['children'] = False
-
         # fetch children if we haven't reached the maximum recursion level
-        if (not recurse_max_level) or level < recurse_max_level:
-            if resource_type == 'collection':
-                if query == '':
-                    cursor.execute("SELECT resourceComponentId FROM ResourcesComponents WHERE parentResourceComponentId IS NULL AND resourceId=%s ORDER BY FIND_IN_SET(resourceLevel, 'subseries,file'), title ASC", (resource_id))
-                else:
-                    cursor.execute("SELECT resourceComponentId FROM ResourcesComponents WHERE parentResourceComponentId IS NULL AND resourceId=%s AND (title LIKE %s OR persistentID LIKE %s) ORDER BY FIND_IN_SET(resourceLevel, 'subseries,file'), title ASC", (resource_id, '%' + query + '%', '%' + query + '%'))
+        if resource_type == 'collection':
+            if query == '':
+                cursor.execute("SELECT resourceComponentId FROM ResourcesComponents WHERE parentResourceComponentId IS NULL AND resourceId=%s ORDER BY FIND_IN_SET(resourceLevel, 'subseries,file'), title ASC", (resource_id))
             else:
-                if query == '':
-                    cursor.execute("SELECT resourceComponentId FROM ResourcesComponents WHERE parentResourceComponentId=%s ORDER BY FIND_IN_SET(resourceLevel, 'subseries,file'), title ASC", (resource_id))
-                else:
-                    cursor.execute("SELECT resourceComponentId FROM ResourcesComponents WHERE parentResourceComponentId=%s AND (title LIKE %s OR persistentID LIKE %s) ORDER BY FIND_IN_SET(resourceLevel, 'subseries,file'), title ASC", (resource_id, '%' + query + '%', '%' + query + '%'))
+                cursor.execute("SELECT resourceComponentId FROM ResourcesComponents WHERE parentResourceComponentId IS NULL AND resourceId=%s AND (title LIKE %s OR persistentID LIKE %s) ORDER BY FIND_IN_SET(resourceLevel, 'subseries,file'), title ASC", (resource_id, '%' + query + '%', '%' + query + '%'))
+        else:
+            if query == '':
+                cursor.execute("SELECT resourceComponentId FROM ResourcesComponents WHERE parentResourceComponentId=%s ORDER BY FIND_IN_SET(resourceLevel, 'subseries,file'), title ASC", (resource_id))
+            else:
+                cursor.execute("SELECT resourceComponentId FROM ResourcesComponents WHERE parentResourceComponentId=%s AND (title LIKE %s OR persistentID LIKE %s) ORDER BY FIND_IN_SET(resourceLevel, 'subseries,file'), title ASC", (resource_id, '%' + query + '%', '%' + query + '%'))
 
-            rows = cursor.fetchall()
+        rows = cursor.fetchall()
 
+        if (not recurse_max_level) or level < recurse_max_level:
             if len(rows):
                 resource_data['children'] = []
+                resource_data['has_children'] = True
 
                 for row in rows:
                     resource_data['children'].append(
@@ -198,6 +197,13 @@ class ArchivistsToolkitClient(object):
                             sort_data
                         )
                     )
+        else:
+            if len(rows):
+                resource_data['children'] = []
+                resource_data['has_children'] = True
+            else:
+                resource_data['children'] = False
+                resource_data['has_children'] = False
 
         return resource_data
 

--- a/src/archivematicaCommon/lib/archivistsToolkit/client.py
+++ b/src/archivematicaCommon/lib/archivistsToolkit/client.py
@@ -247,6 +247,10 @@ class ArchivistsToolkitClient(object):
             The search will match any title or resourceid containing this string;
             for example, "text" will match "this title has this text in it".
             If omitted, then all resources will be fetched.
+        :param string identifier: Restrict records to only those with this identifier.
+            This refers to the human-assigned record identifier, not the automatically generated internal ID.
+            Unlike the ArchivesSpaceClient version of this method, wildcards are not supported; however, identifiers which begin or end with this string will be returned.
+            For example, if the passed identifier is "A1", then records with an identifier of "A1", "SAA1", "A10", and "SAA10" will all be returned.
 
         :return list: A list containing every matched resource's ID.
         """

--- a/src/archivematicaCommon/lib/archivistsToolkit/client.py
+++ b/src/archivematicaCommon/lib/archivistsToolkit/client.py
@@ -47,7 +47,8 @@ class ArchivistsToolkitClient(object):
         :param string resource_type: Specifies whether the resource to fetch is a collection or a child element.
             Defaults to 'collection'.
 
-        :return list: A list of longs representing the database resource IDs for all children of the requested record.
+        :return: A list of longs representing the database resource IDs for all children of the requested record.
+        :rtype list:
         """
         ret = []
 
@@ -87,7 +88,7 @@ class ArchivistsToolkitClient(object):
         :param string search_pattern: If specified, limits fetched children to those whose titles or IDs match the provided query.
             See ArchivistsToolkitClient.find_collection_ids for documentation of the query format.
 
-        :return dict: A dict containing detailed metadata about both the requested resource and its children.
+        :return: A dict containing detailed metadata about both the requested resource and its children.
             The dict follows this format:
         {
           'id': '31',
@@ -131,6 +132,7 @@ class ArchivistsToolkitClient(object):
             'children': False
           }]
         }
+        :rtype list:
         """
         # we pass the sort position as a dict so it passes by reference and we
         # can use it to share state during recursion
@@ -214,7 +216,8 @@ class ArchivistsToolkitClient(object):
         If the immediate parent of the component is itself a component, this method will progress up the tree until a resource is found.
 
         :param long component_id: The ID of the ResourceComponent.
-        :return long: The ID of the component's parent resource.
+        :return: The ID of the component's parent resource.
+        :rtype: long
         """
         cursor = self.db.cursor()
 
@@ -232,9 +235,10 @@ class ArchivistsToolkitClient(object):
         Given the ID of a component, returns the parent component's ID.
 
         :param string component_id: The ID of the component.
-        :return tuple: A tuple containing:
+        :return: A tuple containing:
             * The type of the parent record; valid values are ArchivesSpaceClient.RESOURCE and ArchivesSpaceClient.RESOURCE_COMPONENT.
             * The ID of the parent record.
+        :rtype tuple:
         """
         cursor = self.db.cursor()
 
@@ -258,7 +262,8 @@ class ArchivistsToolkitClient(object):
             Unlike the ArchivesSpaceClient version of this method, wildcards are not supported; however, identifiers which begin or end with this string will be returned.
             For example, if the passed identifier is "A1", then records with an identifier of "A1", "SAA1", "A10", and "SAA10" will all be returned.
 
-        :return list: A list containing every matched resource's ID.
+        :return: A list containing every matched resource's ID.
+        :rtype: list
         """
         cursor = self.db.cursor()
 
@@ -307,7 +312,8 @@ class ArchivistsToolkitClient(object):
         Consult the documentation of ArchivistsToolkitClient.get_resource_component_children for the format of the returned dicts.
 
         :param list resource_ids: A list of one or more resource IDs.
-        :return list: A list containing metadata dicts.
+        :return: A list containing metadata dicts.
+        :rtype: list
         """
         resources_augmented = []
         for id in resource_ids:

--- a/src/dashboard/src/components/access/urls.py
+++ b/src/dashboard/src/components/access/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url, patterns
+from components.access import views
+
+urlpatterns = patterns('',
+    url(r'(?P<system>archivesspace|atk)/$', views.all_records),
+    url(r'(?P<system>archivesspace|atk)/(?P<record_id>[A-Za-z0-9-_]+)/$', views.get_record),
+    url(r'(?P<system>archivesspace|atk)/accession/(?P<accession>.+)/$', views.get_records_by_accession),
+    url(r'(?P<system>archivesspace|atk)/(?P<record_id>.+)/children/$', views.record_children),
+)

--- a/src/dashboard/src/components/access/views.py
+++ b/src/dashboard/src/components/access/views.py
@@ -1,0 +1,112 @@
+# Standard library, alphabetical by import source
+from functools import wraps
+import json
+import logging
+import sys
+
+# Django Core, alphabetical by import source
+import django.http
+
+# External dependencies, alphabetical
+import MySQLdb  # for ATK exceptions
+
+# This project, alphabetical by import source
+from components import helpers
+from components.ingest.views_atk import get_atk_system_client
+from components.ingest.views_as import get_as_system_client
+
+sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+from archivesspace.client import ArchivesSpaceError, AuthenticationError
+
+logger = logging.getLogger('archivematica.dashboard')
+
+""" @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+      Access
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ """
+
+
+def _get_client_by_type(system):
+    if system == "archivesspace":
+        return get_as_system_client()
+    elif system == "atk":
+        return get_atk_system_client()
+    else:
+        raise ValueError("Unrecognized access system: {}".format(system))
+
+
+def _authenticate_to_archivesspace(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            system = kwargs['system']
+            # append the client onto the positional argument list
+            client = _get_client_by_type(system)
+        except AuthenticationError:
+            response = {
+                "success": False,
+                "message": "Unable to authenticate to ArchivesSpace server using the default user! Check administrative settings."
+            }
+            return django.http.HttpResponseServerError(json.dumps(response),
+                                                       content_type="application/json")
+        except ArchivesSpaceError:
+            response = {
+                "success": False,
+                "message": "Unable to connect to ArchivesSpace server at the default location! Check administrative settings."
+            }
+            return django.http.HttpResponseServerError(json.dumps(response),
+                                                       content_type="application/json")
+        except (MySQLdb.ProgrammingError, MySQLdb.OperationalError) as e:
+            response = {
+                "success": False,
+                "message": "Unable to connect to Archivist's Toolkit database; failed with error: {}".format(e),
+            }
+            return django.http.HttpResponseServerError(json.dumps(response),
+                                                       content_type="application/json")
+
+        return func(client, *args, **kwargs)
+    return wrapper
+
+
+@_authenticate_to_archivesspace
+def all_records(client, request, system=''):
+    page = request.GET.get('page', 1)
+    page_size = request.GET.get('page_size', 30)
+    search_pattern = request.GET.get('title', '')
+    identifier = request.GET.get('identifier', '')
+
+    return helpers.json_response(client.find_collections(search_pattern=search_pattern,
+                                                         identifier=identifier,
+                                                         page=page,
+                                                         page_size=page_size))
+
+
+@_authenticate_to_archivesspace
+def get_record(client, request, system='', record_id=''):
+    record_id = record_id.replace('-', '/')
+
+    try:
+        records = client.get_resource_component_and_children(record_id,
+                                                             recurse_max_level=3)
+        return helpers.json_response(records)
+    except ArchivesSpaceError as e:
+        return helpers.json_response({"error": True, "message": str(e)})
+
+
+@_authenticate_to_archivesspace
+def get_records_by_accession(client, request, system='', accession=''):
+    page = request.GET.get('page', 1)
+    page_size = request.GET.get('page_size', 30)
+
+    try:
+        records = client.find_collections_by_accession(accession, page=page, page_size=page_size)
+        return helpers.json_response(records)
+    except ArchivesSpaceError as e:
+        return helpers.json_response({"error": True, "message": str(e)})
+
+
+@_authenticate_to_archivesspace
+def record_children(client, request, system='', record_id=''):
+    if request.method == 'PUT':
+        pass
+    elif request.method == 'GET':
+        return helpers.json_response(get_record(client, request, system=system, record_id=record_id)['children'])

--- a/src/dashboard/src/urls.py
+++ b/src/dashboard/src/urls.py
@@ -32,5 +32,6 @@ urlpatterns = patterns('',
     url(r'^filesystem/', include('components.filesystem_ajax.urls')),
     url(r'^api/', include('components.api.urls')),
     url(r'^file/', include('components.file.urls')),
+    url(r'^access/', include('components.access.urls')),
     url(r'', include('main.urls'))
 )


### PR DESCRIPTION
This API allows retrieving Archivist's Toolkit or ArchivesSpace records, using the same instances configured for use with the upload scripts.
