### PR TITLE
Decouple renderBacklogSearchForm from originals_browser

### DIFF
--- a/src/dashboard/src/media/js/ingest/backlog.js
+++ b/src/dashboard/src/media/js/ingest/backlog.js
@@ -1,4 +1,4 @@
-function renderBacklogSearchForm(openInNewTab) {
+function renderBacklogSearchForm(search_uri, on_success) {
   // create new form instance, providing a single row of default data
   var search = new advancedSearch.AdvancedSearchView({
     el: $('#search_form_container'),
@@ -56,7 +56,7 @@ function renderBacklogSearchForm(openInNewTab) {
 
   function backlogSearchSubmit() {
     // Query Django, which queries ElasticSearch, to get the backlog file info
-    var query_url = '/ingest/backlog/' + '?' + search.toUrlParams();
+    var query_url = search_uri + '?' + search.toUrlParams();
     $.get(
       query_url,
       null,
@@ -64,7 +64,7 @@ function renderBacklogSearchForm(openInNewTab) {
         if (status == 'success') {
           // Originals browser from ingest_file_browser.js
           // Search information needs to go here
-          originals_browser.display_data(data)
+          on_success(data)
         } else {
           console.log('Failed to get transfer backlog data from '+query_url);
         }

--- a/src/dashboard/src/templates/ingest/grid.html
+++ b/src/dashboard/src/templates/ingest/grid.html
@@ -35,7 +35,7 @@
   <script type="text/javascript">
     $(document).ready(function()
       {
-        renderBacklogSearchForm(true);
+        renderBacklogSearchForm('/ingest/backlog/', originals_browser.display_data.bind(originals_browser));
 
         {% if polling_interval %}
           window.pollingInterval = {{ polling_interval }};


### PR DESCRIPTION
This will be used by the appraisal tab, so it needs to be able to

a) Look up arbitrary URLs,
b) Send the data to arbitrary places.

Note that the openInNewTab parameter I removed hasn't done anything since d5b83fa6.
