### PR TITLE
Django ORM fixes

### DIFF
--- a/src/MCPClient/lib/clientScripts/file_to_folder.py
+++ b/src/MCPClient/lib/clientScripts/file_to_folder.py
@@ -4,6 +4,8 @@ from __future__ import print_function
 import os
 import sys
 
+import django
+django.setup()
 # dashboard
 from main.models import Transfer
 

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -905,6 +905,12 @@ class FPCommandOutput(models.Model):
     content = models.TextField(null=True)
     rule = models.ForeignKey('fpr.FPRule', db_column='ruleUUID', to_field='uuid')
 
+    class Meta(object):
+        db_table = u'FPCommandOutput'
+
+    def __unicode__(self):
+        return u'<file: {file}; rule: {rule}; content: {content}'.format(file=self.file, rule=self.rule, content=self.content[:20])
+
 class FileID(models.Model):
     """
     This table duplicates file ID values from FPR formats. It predates the current FPR tables.


### PR DESCRIPTION
- Init Django in file_to_folder (only used in DSpace path)
- Make FPCommandOutput use legacy table, instead of creating its own. (@mistydemeo was this done intentionally? My problem was FPCommandOutput seem to disappear when queried at MySQL command line)
