### PR TITLE
Reduce MCP Server database usage

### DIFF
--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -45,7 +45,7 @@ import time
 import uuid
 
 import django
-sys.path.append('/usr/share/archivematica/dashboard')
+sys.path.append('/usr/lib/archivematica/MCPServer')
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
 django.setup()
 
@@ -357,6 +357,6 @@ if __name__ == '__main__':
     t.start()
     cleanupOldDbEntriesOnNewRun()
     watchDirectories()
-    
+
     # This is blocking the main thread with the worker loop
     RPCServer.startRPCServer()

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -1,0 +1,45 @@
+# This file is part of Archivematica.
+#
+# Copyright 2010-2015 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+import os, sys, ConfigParser
+import django_mysqlpool
+
+# Get DB settings from main configuration file
+config = ConfigParser.SafeConfigParser()
+config.read('/etc/archivematica/archivematicaCommon/dbsettings')
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django_mysqlpool.backends.mysqlpool',
+        'NAME': 'MCP',                                # Or path to database file if using sqlite3.
+        'USER': config.get('client', 'user'),         # Not used with sqlite3.
+        'PASSWORD': config.get('client', 'password'), # Not used with sqlite3.
+        'HOST': config.get('client', 'host'),         # Set to empty string for localhost. Not used with sqlite3.
+        'PORT': '',                                   # Set to empty string for default. Not used with sqlite3.
+    }
+}
+
+MYSQLPOOL_BACKEND = 'QueuePool'
+MYSQLPOOL_ARGUMENTS = {
+    'use_threadlocal': False,
+}
+
+CONN_MAX_AGE = 14400
+ 
+# Make this unique, and don't share it with anybody.
+SECRET_KEY = 'e7b-$#-3fgu)j1k01)3tp@^e0=yv1hlcc4k-b6*ap^zezv2$48'
+

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -26,6 +26,7 @@ import sys
 import uuid
 
 sys.path.append("/usr/share/archivematica/dashboard")
+from django_mysqlpool import auto_close_db
 from django.utils import timezone
 from main.models import Derivation, Event, File, FileID, FPCommandOutput, Job, SIP, Task, Transfer, UnitVariable
 
@@ -43,6 +44,7 @@ def getDeciDate(date):
             #ret += replacementChar
     return str("{:10.10f}".format(float(ret)))
 
+@auto_close_db
 def insertIntoFiles(fileUUID, filePath, enteredSystem=None, transferUUID="", sipUUID="", use="original"):
     """
     Creates a new entry in the Files table using the supplied arguments.
@@ -78,6 +80,7 @@ def insertIntoFiles(fileUUID, filePath, enteredSystem=None, transferUUID="", sip
 
     File.objects.create(**kwargs)
 
+@auto_close_db
 def getAgentForFileUUID(fileUUID):
     """
     Fetches the ID for the agent associated with the given file, if one exists.
@@ -119,6 +122,7 @@ def getAgentForFileUUID(fileUUID):
                 pass
     return agent
 
+@auto_close_db
 def insertIntoEvents(fileUUID, eventIdentifierUUID="", eventType="", eventDateTime=None, eventDetail="", eventOutcome="", eventOutcomeDetailNote=""):
     """
     Creates a new entry in the Events table using the supplied arguments.
@@ -144,6 +148,7 @@ def insertIntoEvents(fileUUID, eventIdentifierUUID="", eventType="", eventDateTi
                          event_outcome_detail=eventOutcomeDetailNote,
                          linking_agent=agent)
 
+@auto_close_db
 def insertIntoDerivations(sourceFileUUID="", derivedFileUUID="", relatedEventUUID=""):
     """
     Creates a new entry in the Derivations table using the supplied arguments. The two files in this relationship should already exist in the Files table.
@@ -161,6 +166,7 @@ def insertIntoDerivations(sourceFileUUID="", derivedFileUUID="", relatedEventUUI
                               derived_file_id=derivedFileUUID,
                               event_id=relatedEventUUID)
 
+@auto_close_db
 def insertIntoFPCommandOutput(fileUUID="", fitsXMLString="", ruleUUID=""):
     """
     Creates a new entry in the FPCommandOutput table using the supplied argument.
@@ -174,6 +180,7 @@ def insertIntoFPCommandOutput(fileUUID="", fitsXMLString="", ruleUUID=""):
     FPCommandOutput.objects.create(file_id=fileUUID, content=fitsXMLString,
                                    rule_id=ruleUUID)
 
+@auto_close_db
 def insertIntoFilesIDs(fileUUID="", formatName="", formatVersion="", formatRegistryName="", formatRegistryKey=""):
     """
     Creates a new entry in the FilesIDs table using the provided data.
@@ -189,7 +196,7 @@ def insertIntoFilesIDs(fileUUID="", formatName="", formatVersion="", formatRegis
 
 #user approved?
 #client connected/disconnected.
-
+@auto_close_db
 def logTaskCreatedSQL(taskManager, commandReplacementDic, taskUUID, arguments):
     """
     Creates a new entry in the Tasks table using the supplied data.
@@ -214,6 +221,7 @@ def logTaskCreatedSQL(taskManager, commandReplacementDic, taskUUID, arguments):
                         arguments=arguments,
                         createdtime=getUTCDate())
 
+@auto_close_db
 def logTaskCompletedSQL(task):
     """
     Fetches execution data from the completed task and logs it to the database.
@@ -235,17 +243,18 @@ def logTaskCompletedSQL(task):
     task.stderror = stdError
     task.save()
 
+@auto_close_db
 def logJobCreatedSQL(job):
     """
     Logs a job's properties into the Jobs table in the database.
 
     :param jobChainLink job: A jobChainLink instance.
-    :returns None:    
+    :returns None:
     """
     unitUUID =  job.unit.UUID
     decDate = getDeciDate("." + str(job.createdDate.microsecond))
     if job.unit.owningUnit != None:
-        unitUUID = job.unit.owningUnit.UUID 
+        unitUUID = job.unit.owningUnit.UUID
     Job.objects.create(jobuuid=job.UUID,
                        jobtype=job.description,
                        directory=job.unit.currentPath,
@@ -260,6 +269,7 @@ def logJobCreatedSQL(job):
 
     # TODO -un hardcode executing exeCommand
 
+@auto_close_db
 def fileWasRemoved(fileUUID, utcDate=None, eventDetail = "", eventOutcomeDetailNote = "", eventOutcome=""):
     """
     Logs the removal of a file from the database.
@@ -290,6 +300,7 @@ def fileWasRemoved(fileUUID, utcDate=None, eventDetail = "", eventOutcomeDetailN
     f.currentlocation = None
     f.save()
 
+@auto_close_db
 def createSIP(path, UUID=None, sip_type='SIP'):
     """
     Create a new SIP object for a SIP at the given path.
@@ -310,6 +321,7 @@ def createSIP(path, UUID=None, sip_type='SIP'):
 
     return UUID
 
+@auto_close_db
 def getAccessionNumberFromTransfer(UUID):
     """
     Fetches the accession number from a transfer, given its UUID.

--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -2,3 +2,4 @@ bagit==1.5.2
 Django>=1.7,<1.8
 elasticsearch>=1.0.0,<2.0.0
 requests==2.7.0
+django-mysqlpool


### PR DESCRIPTION
This branch adds a new dependency to the MCP Server, a python module called django-mysqlpool.  This module provides the ability to pool database connections (it uses SQLAlchemy to do that).  

The implementation here only adds connection pooling to the MCP Server.  Probably it should/could be added to the dashboard and MCP Client packages as well.  90% of the database load in a typical Archivematica installation seems to come from the MCPServer, so this is the low hanging fruit.

This particular solution is mysql specific, which is not a factor at the moment, but admittedly it does sort of defeat the purpose of using an ORM if you are still tightly coupled to one db backend.  

Basic testing has shown a reduction in time to process a transfer of maybe 8 to 10%.  The size of the machine used is a big variable here, ymmv.  Mostly this reduces the number of database connections required by the MCPServer, from dozens or hundreds down to less than 10.

This pull request adds some changes which could be considered optional.  Instead of changing the dashboards django settings, a new settings module is added to the MCPServer, which includes the smallest possible settings file that still seems to work.  This seems important because the MCP Server is using the Django ORM, in order to be able to access Models, but it is not a django app.  MCP Server does not need most of Django.  
