### PR TITLE
Dev/issue 8995 store after upload

### DIFF
--- a/src/MCPServer/share/mysql_dev.sh
+++ b/src/MCPServer/share/mysql_dev.sh
@@ -10,5 +10,6 @@ echo 'Running mysql_dev1'
 # ...
 # optional delete unused MCSL's
 mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_delete_links.sql;"
+mysql -u root "${dbpassword}" --execute="USE ${databaseName}; SOURCE $currentDir/mysql_dev_dip_storage_after_upload.sql;"
 
 touch $currentDir/mysql_dev.complete

--- a/src/MCPServer/share/mysql_dev_dip_storage_after_upload.sql
+++ b/src/MCPServer/share/mysql_dev_dip_storage_after_upload.sql
@@ -1,0 +1,15 @@
+-- Add a new microservice chain to optionally store DIPs that currently
+-- exist in the uploadedDIPs directory. Modify existing DIP upload links
+-- to redirect to this chain after completion, allowing a DIP to be both
+-- uploaded and copied to the DIP store.
+
+-- Issue 8895
+
+
+SET @uploadAtomTail = '651236d2-d77f-4ca7-bfe9-6332e96608ff' COLLATE utf8_unicode_ci;
+SET @uploadCdmTail = 'f12ece2c-fb7e-44de-ba87-7e3c5b6feb74' COLLATE utf8_unicode_ci;
+SET @uploadAtkTail = 'bb1f1ed8-6c92-46b9-bab6-3a37ffb665f1' COLLATE utf8_unicode_ci;
+SET @storeStart = 'ed5d8475-3793-4fb0-a8df-94bd79b26a4c' COLLATE utf8_unicode_ci;
+
+UPDATE MicroServiceChainLinks SET defaultNextChainLink=@storeStart WHERE pk IN (@uploadAtomTail, @uploadCdmTail, @uploadAtkTail);
+UPDATE MicroServiceChainLinksExitCodes SET nextmicroservicechainlink = @storeStart where microServiceChainLink IN (@uploadAtomTail, @uploadCdmTail, @uploadAtkTail);

--- a/src/dashboard/src/components/administration/views_processing.py
+++ b/src/dashboard/src/components/administration/views_processing.py
@@ -281,6 +281,13 @@ def index(request):
                         target
                     )
 
+                    # use store DIP location for both DIP store chains
+                    if field['name'] == 'store_dip_location':
+                        xmlChoices.add_choice(
+                            '95172864-469a-4420-a4e7-e0df70349abc',
+                            target
+                        )
+
         xmlChoices.write_to_file(file_path)
 
         messages.info(request, 'Saved!')


### PR DESCRIPTION
- add new chain/links for post-upload DIP storage
- modify AtoM and ATK upload links to continue to new chain
- add ability to select default post-upload DIP storage destination location
