### PR TITLE
SIP arrange APIs: various bugfixes

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -140,6 +140,13 @@ def arrange_contents(request):
     # need the objects, just the arrange_path
     paths = models.SIPArrange.objects.filter(sip_created=False).filter(aip_created=False).filter(arrange_path__startswith=base_path).order_by('arrange_path')
 
+    if len(paths) == 0:
+        response = {
+            'success': False,
+            'message': 'No files or directories found under path "{}"'.format(base_path)
+        }
+        return helpers.json_response(response, status_code=404)
+
     # Convert the response into an entries [] and directories []
     # 'entries' contains everything (files and directories)
     entries = set()

--- a/src/dashboard/tests/test_filesystem_ajax.py
+++ b/src/dashboard/tests/test_filesystem_ajax.py
@@ -64,6 +64,12 @@ class TestSIPArrange(TestCase):
         assert response_dict['properties'][base64.b64encode("evelyn_s_second_photo")]['display_string'] == '1 objects'
         assert len(response_dict) == 3
 
+    def test_arrange_contents_404(self):
+        response = self.client.get(reverse('components.filesystem_ajax.views.arrange_contents'), {'path': base64.b64encode('/arrange/nosuchpath/')}, follow=True)
+        assert response.status_code == 404
+        response_dict = json.loads(response.content)
+        assert response_dict['success'] is False
+
     def test_delete_arranged_files(self):
         # Check to-be-deleted exists
         response = self.client.get(reverse('components.filesystem_ajax.views.arrange_contents'), {'path': base64.b64encode('/arrange')}, follow=True)


### PR DESCRIPTION
- Handle `storage_service.ResourceNotFound` exception gracefully, returning JSON-formatted responses instead of 500ing
- Return 404 when listing the contents of arrange if the requested path doesn't exist, instead of reporting that there are no files within the requested path
