### PR TITLE
change uuid used in determing file format

### DIFF
--- a/src/MCPClient/lib/clientScripts/upload-archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload-archivesspace.py
@@ -134,7 +134,7 @@ def upload_to_archivesspace(files, client, xlink_show, xlink_actuate, object_typ
             # HACK remove DIP from the path because create DIP doesn't
             access_file_path = access_file.currentlocation.replace('%SIPDirectory%DIP/', dip_location)
             size = os.path.getsize(access_file_path)
-            fv = FormatVersion.objects.get(fileformatversion__file_uuid=access_file.uuid)
+            fv = FormatVersion.objects.get(fileformatversion__file_uuid=uuid)
             format_version = fv.description
             format_name = fv.format.description
 


### PR DESCRIPTION
the access file does not have file identification info in the database
use the original file uuid instead.

I am not 100% sure this is going to be correct in all circumstances.  I tested on a client site and it works as I want it to.  
