### PR TITLE
Logging (again/still)

### DIFF
--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -211,10 +211,46 @@ def startThreads(t=1):
         t.daemon = True
         t.start()
 
+LOGGING_CONFIG = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'detailed': {
+            'format': '%(levelname)-8s  %(asctime)s  %(name)s:%(module)s:%(funcName)s:%(lineno)d:  %(message)s',
+            'datefmt': '%Y-%m-%d %H:%M:%S'
+        },
+    },
+    'handlers': {
+        'logfile': {
+            'level': 'INFO',
+            'class': 'custom_handlers.GroupWriteRotatingFileHandler',
+            'filename': '/var/log/archivematica/MCPClient/MCPClient.log',
+            'formatter': 'detailed',
+            'backupCount': 5,
+            'maxBytes': 4 * 1024 * 1024,  # 20 MiB
+        },
+        'verboselogfile': {
+            'level': 'DEBUG',
+            'class': 'custom_handlers.GroupWriteRotatingFileHandler',
+            'filename': '/var/log/archivematica/MCPClient/MCPClient.debug.log',
+            'formatter': 'detailed',
+            'backupCount': 5,
+            'maxBytes': 4 * 1024 * 1024,  # 100 MiB
+        },
+    },
+    'loggers': {
+        'archivematica': {
+            'level': 'DEBUG',
+        },
+    },
+    'root': {
+        'handlers': ['logfile', 'verboselogfile'],
+        'level': 'WARNING',
+    }
+}
 if __name__ == '__main__':
-    logger = logging.getLogger("archivematica")
-    logger.addHandler(GroupWriteRotatingFileHandler("/var/log/archivematica/MCPClient/MCPClient.log", maxBytes=4194304))
-    logger.setLevel(logging.INFO)
+    logging.config.dictConfig(LOGGING_CONFIG)
+    logger = logging.getLogger("archivematica.mcp.client")
 
     loadSupportedModules(config.get('MCPClient', "archivematicaClientModules"))
     startThreads(config.getint('MCPClient', "numberOfTasks"))

--- a/src/MCPServer/etc/serverConfig.conf
+++ b/src/MCPServer/etc/serverConfig.conf
@@ -24,66 +24,24 @@
 # @version svn: $Id$
 
 [MCPServer]
-AIPCompressionAlgorithm = lzma
-AIPCompressionLevel = 1 
-fileUUIDSHumanReadable  =  FileUUIDs.log
-moduleConfigDir  =  /etc/archivematica/MCPServer/mcpModulesConfig
-#to listen on localhost only, uncomment the following line 
 MCPArchivematicaServer  =  localhost:4730
 GearmanServerWorker = localhost:4730
-archivematicaProtocol  =  /etc/archivematica/MCPServer/archivematicaProtocol
 watchDirectoryPath  =  /var/archivematica/sharedDirectory/watchedDirectories/
 sharedDirectory  =  /var/archivematica/sharedDirectory/
 processingDirectory  =  /var/archivematica/sharedDirectory/currentlyProcessing/
 rejectedDirectory  =  %%sharedPath%%rejected/
 watchDirectoriesPollInterval = 1
-MCPWaitForCopyToCompleteSeconds  =  1
-actOnCopied  =  true
-forceNoApprovalRequiredOnAllJobs = false
-limitGearmanConnections = 30000
-processingXMLFile = processingMCP.xml 
+processingXMLFile = processingMCP.xml
 waitOnAutoApprove = 0
 
-#transferD
-##delayTimer = number of seconds to wait before marking a file as removed, after it is noted as having been moved, and not claimed by a movedTo event.
-delayTimer = 3
-##waitToActOnMoves = duration to wait for microservices to update the location of the SIP/transfer in the db
-waitToActOnMoves = 1
 singleInstancePIDFile = /tmp/archivematicaMCPServerPID
-
 
 [Protocol]
 #seperates Values when transported from client to server
 delimiter = <!&\delimiter/&!>
-#seconds to pause between sending Keep alives
-keepAlivePause = 600
-maxLen = 1000000
-
-#--TO CLIENT--
-#To load server configs into the client  --NOT USED/NEEDED (everything can happen on server side)
-addToServerConf = addToServerConf
-#to tell the client to perform a task
-performTask = performTask
-#keeps idle connection open 
-keepAlive = keepAlive
-
-#--TO SERVER--
-#inform the server the client is capable of running a certain type of task
-addToListTaskHandler = addToListTaskHandler
-#inform the server a task is completed 
-taskCompleted = taskCompleted
-#tell the server how many threads this client will run 
-maxTasks = setMaxTasks 
-setName = setName
-requestLockForWrite = requestLockForWrite
 
 #--Gearman--
 limitGearmanConnections = 10000
 limitTaskThreads = 75
 limitTaskThreadsSleep = 0.2
 reservedAsTaskProcessingThreads = 8
-
-
-
-
-

--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -291,7 +291,7 @@ LOGGING_CONFIG = {
         },
     },
     'handlers': {
-        'debug_logfile': {
+        'verboselogfile': {
             'level': 'DEBUG',
             'class': 'custom_handlers.GroupWriteRotatingFileHandler',
             'filename': '/var/log/archivematica/MCPServer/MCPServer.debug.log',
@@ -307,31 +307,16 @@ LOGGING_CONFIG = {
             'backupCount': 5,
             'maxBytes': 4 * 1024 * 1024,  # 4 MiB
         },
-        'null': {
-            'level': 'DEBUG',
-            'class': 'logging.NullHandler',
-        },
     },
     'loggers': {
-        'archivematica.mcp.server': {
-            'handlers': ['debug_logfile', 'logfile'],
+        'archivematica': {
             'level': 'DEBUG',
-            'propagate': False,
         },
-        'archivematica.common': {
-            'handlers': ['debug_logfile', 'logfile'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-        'py.warnings': {
-            'handlers': ['null'],
-            'propagate': False,
-        }
     },
     'root': {
-        'handlers': ['logfile'],
-        'level': 'INFO',
-    }
+        'handlers': ['logfile', 'verboselogfile'],
+        'level': 'WARNING',
+    },
 }
 
 if __name__ == '__main__':

--- a/src/archivematicaCommon/lib/custom_handlers.py
+++ b/src/archivematicaCommon/lib/custom_handlers.py
@@ -37,14 +37,10 @@ def get_script_logger(name, formatter=SCRIPT_FILE_FORMAT, logfile="/var/log/arch
         },
         'loggers': {
             root: {  # 'archivematica'
-                'handlers': ['logfile'],
                 'level': level,
-                'propagate': False,
             },
             name: {  # 'archivematica.mcp.client.script_name'
-                'handlers': ['logfile'],
                 'level': level,
-                'propagate': False,
             },
         },
         'root': {  # Everything else

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -224,6 +224,14 @@ LOGGING = {
             'backupCount': 5,
             'maxBytes': 20 * 1024 * 1024,  # 20 MiB
         },
+        'verboselogfile': {
+            'level': 'DEBUG',
+            'class': 'custom_handlers.GroupWriteRotatingFileHandler',
+            'filename': '/var/log/archivematica/dashboard/dashboard.debug.log',
+            'formatter': 'detailed',
+            'backupCount': 5,
+            'maxBytes': 100 * 1024 * 1024,  # 100 MiB
+        },
     },
     'loggers': {
         'django.request': {
@@ -248,7 +256,7 @@ LOGGING = {
         },
     },
     'root': {
-        'handlers': ['logfile'],
+        'handlers': ['logfile', 'verboselogfile'],
         'level': 'WARNING',
     },
 }

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -231,26 +231,26 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': True,
         },
-        'django': {
-            'handlers': ['console', 'logfile'],
-            'propagate': True,
-            'level': 'ERROR',
-        },
-        'archivematica.dashboard': {
-            'handlers': ['console', 'logfile'],
-            'level': 'DEBUG',
+        'archivematica.mcp': {
             'propagate': False,
         },
         'archivematica': {
-            'handlers': ['console', 'logfile'],
             'level': 'DEBUG',
-            'propagate': False,
         },
         'elasticsearch': {
-            'handlers': ['console', 'logfile'],
             'level': 'INFO',
-        }
-    }
+        },
+        'archivesspace': {  # for archivematicaCommon/lib/archivesspace
+            'level': 'INFO',
+        },
+        'archiviststoolkit': {  # for archivematicaCommon/lib/archivistsToolkit
+            'level': 'INFO',
+        },
+    },
+    'root': {
+        'handlers': ['logfile'],
+        'level': 'WARNING',
+    },
 }
 
 # login-related settings


### PR DESCRIPTION
Tweak the logging dictConfig for the dashboard to catch or silence things better.  This should silence archivematica.mcp logs, log all other archivematica logs at DEBUG, and elasticsearch/archivesspace/archiviststoolkit at INFO. Everything else gets logged at WARNING.  Adds a dashboard.debug.log.

MCPClient also gets a MCPClient.debug.log file, and logs all archivematica logs, and everything else at WARNING

Tweaked MCPServer logging to log all archivematica logs and everything else at WARNING. No longer silences py.warnings.

Tweaked client script logging to remove duplicate handles.

This may get further work to read logging config from /etc/ instead of from code.
