### PR TITLE
Close unusable database connections, refs #9021

### DIFF
--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -56,6 +56,7 @@ from main.models import Task
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 from custom_handlers import GroupWriteRotatingFileHandler
 import databaseFunctions
+from archivematicaFunctions import close_db_connections
 from executeOrRunSubProcess import executeOrRun
 printOutputLock = threading.Lock()
 
@@ -86,6 +87,7 @@ def loadSupportedModules(file):
             loadSupportedModulesSupport(key, value)
 
 
+@close_db_connections
 def executeCommand(gearman_worker, gearman_job):
     try:
         execute = gearman_job.task
@@ -159,6 +161,7 @@ Unable to determine if it completed successfully."""
         return cPickle.dumps({"exitCode": -1, "stdOut": output[0], "stdError": output[1]})
 
 
+@close_db_connections
 def startThread(threadNumber):
     """Setup a gearman client, for the thread."""
     gm_worker = gearman.GearmanWorker([config.get('MCPClient', "MCPArchivematicaServer")])
@@ -184,6 +187,7 @@ def startThread(threadNumber):
                 failSleep += failSleepIncrementor
 
 
+@close_db_connections
 def flushOutputs():
     while True:
         sys.stdout.flush()

--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -63,7 +63,7 @@ sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 import databaseInterface
 import databaseFunctions
 from externals.singleInstance import singleinstance
-from archivematicaFunctions import unicodeToStr
+from archivematicaFunctions import unicodeToStr, close_db_connections
 
 from main.models import Job, SIP, Task, WatchedDirectory
 
@@ -138,6 +138,7 @@ def findOrCreateSipInDB(path, waitSleep=dbWaitSleep, unit_type='SIP'):
     return UUID
 
 @log_exceptions
+@close_db_connections
 def createUnitAndJobChain(path, config, terminate=False):
     path = unicodeToStr(path)
     if os.path.isdir(path):
@@ -240,6 +241,7 @@ def signal_handler(signalReceived, frame):
     exit(0)
 
 @log_exceptions
+@close_db_connections
 def debugMonitor():
     """Periodically prints out status of MCP, including whether the database lock is locked, thread count, etc."""
     global countOfCreateUnitAndJobChainThreaded
@@ -255,6 +257,7 @@ def debugMonitor():
         time.sleep(3600)
 
 @log_exceptions
+@close_db_connections
 def flushOutputs():
     while True:
         sys.stdout.flush()

--- a/src/MCPServer/lib/jobChainLink.py
+++ b/src/MCPServer/lib/jobChainLink.py
@@ -38,6 +38,7 @@ from linkTaskManagerUnitVariableLinkPull import linkTaskManagerUnitVariableLinkP
 
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 from databaseFunctions import logJobCreatedSQL, getUTCDate
+from archivematicaFunctions import close_db_connections
 
 sys.path.append("/usr/share/archivematica/dashboard")
 from main.models import Job, MicroServiceChainLink, MicroServiceChainLinkExitCode, TaskType
@@ -133,6 +134,7 @@ class jobChainLink:
                 return self.defaultNextChainLink
 
     @log_exceptions
+    @close_db_connections
     def setExitMessage(self, message):
         Job.objects.filter(jobuuid=self.UUID).update(currentstep=str(message))
 
@@ -149,6 +151,7 @@ class jobChainLink:
             LOGGER.debug('No exit message')
 
     @log_exceptions
+    @close_db_connections
     def linkProcessingComplete(self, exitCode, passVar=None):
         self.updateExitMessage(exitCode)
         self.jobChain.nextChainLink(self.getNextChainLinkPK(exitCode), passVar=passVar)

--- a/src/MCPServer/lib/linkTaskManagerChoice.py
+++ b/src/MCPServer/lib/linkTaskManagerChoice.py
@@ -38,7 +38,7 @@ global choicesAvailableForUnits
 choicesAvailableForUnits = {}
 choicesAvailableForUnitsLock = threading.Lock()
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
-from archivematicaFunctions import unicodeToStr
+from archivematicaFunctions import unicodeToStr, close_db_connections
 sys.path.append("/usr/share/archivematica/dashboard")
 from main.models import MicroServiceChainChoice
 
@@ -134,6 +134,7 @@ class linkTaskManagerChoice(LinkTaskManager):
         return ret
 
     @log_exceptions
+    @close_db_connections
     def proceedWithChoice(self, chain, agent, delayTimerStart=False):
         if agent:
             self.unit.setVariable("activeAgent", agent, None)

--- a/src/MCPServer/lib/taskStandard.py
+++ b/src/MCPServer/lib/taskStandard.py
@@ -35,6 +35,7 @@ from utils import log_exceptions
 from django.utils import timezone
 
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+from archivematicaFunctions import close_db_connections
 from fileOperations import writeToFile
 
 LOGGER = logging.getLogger('archivematica.mcp.server')
@@ -60,6 +61,7 @@ class taskStandard():
         self.outputLock = outputLock
 
     @log_exceptions
+    @close_db_connections
     def performTask(self):
         from archivematicaMCP import limitGearmanConnectionsSemaphore
         limitGearmanConnectionsSemaphore.acquire()

--- a/src/MCPServer/lib/watchDirectory.py
+++ b/src/MCPServer/lib/watchDirectory.py
@@ -26,8 +26,9 @@ import os
 import time
 import threading
 import sys
+
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
-from archivematicaFunctions import unicodeToStr
+from archivematicaFunctions import unicodeToStr, close_db_connections
 
 from utils import log_exceptions
 from archivematicaMCP import debug
@@ -67,6 +68,7 @@ class archivematicaWatchDirectory:
             self.start()
 
     @log_exceptions
+    @close_db_connections
     def start(self):
         """Based on polling example: http://timgolden.me.uk/python/win32_how_do_i/watch_directory_for_changes.html"""
         self.run = True

--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -26,6 +26,9 @@ import lxml.etree as etree
 import os
 import re
 
+from django.db import close_old_connections
+
+
 REQUIRED_DIRECTORIES = [
     "logs",
     "logs/fileMeta",
@@ -211,9 +214,7 @@ def close_db_connections(fn):
     Similar to Django's behavior within HTTP request cycles.
     """
     def wrapped(*args,  **kwargs):
-        from django.db import close_old_connections
         try:
-            close_old_connections()
             return fn(*args, **kwargs)
         finally:
             close_old_connections()

--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -200,3 +200,21 @@ def create_structured_directory(basepath, manual_normalization=False, printing=F
     create_directories(REQUIRED_DIRECTORIES, basepath=basepath, printing=printing)
     if manual_normalization:
         create_directories(MANUAL_NORMALIZATION_DIRECTORIES, basepath=basepath, printing=printing)
+
+
+def close_db_connections(fn):
+    """
+    Decorator to wrap a threaded function in a try-catch ensuring that the
+    database connections are closed if unrecoverable errors have occurred or if
+    it outlived its maximum age.
+
+    Similar to Django's behavior within HTTP request cycles.
+    """
+    def wrapped(*args,  **kwargs):
+        from django.db import close_old_connections
+        try:
+            close_old_connections()
+            return fn(*args, **kwargs)
+        finally:
+            close_old_connections()
+    return wrapped


### PR DESCRIPTION
Wrap threaded functions to ensure that their database connections are only
recycled if they haven't outlived its maximum age or are in a recoverable
state, like Django does before and after HTTP requests.

It relies on `BaseDatabaseWrapper.close_if_unusable_or_obsolete()` in
`django.db.backends.base`.
