### PR TITLE
Enable use of repository in ASpace config

### DIFF
--- a/src/MCPClient/lib/clientScripts/dip_generation_helper.py
+++ b/src/MCPClient/lib/clientScripts/dip_generation_helper.py
@@ -30,7 +30,8 @@ def create_archivesspace_client():
             host=config['%host%'],
             port=config['%port%'],
             user=config['%user%'],
-            passwd=config['%passwd%']
+            passwd=config['%passwd%'],
+            repository=config['%repository%']
         )
     except archivesspace.AuthenticationError:
         print("Unable to authenticate to ArchivesSpace server using the default user! Check administrative settings.")

--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -145,6 +145,7 @@ def administration_as_dips(request):
                 "%access_conditions%": new_asconfig.access_conditions,
                 "%use_conditions%": new_asconfig.use_conditions,
                 "%use_statement%": new_asconfig.use_statement,
+                "%repository%": str(new_asconfig.repository),
             }
 
             logger.debug('New ArchivesSpace settings: %s', (settings,))
@@ -387,7 +388,7 @@ def usage_clear(request, dir_id):
         # Determine if specific subdirectories need to be cleared, rather than
         # whole directory
         if 'subdirectories' in dir_info:
-            dirs_to_empty = [os.path.join(dir_info['path'], subdir) for subdir in dir_info['subdirectories']] 
+            dirs_to_empty = [os.path.join(dir_info['path'], subdir) for subdir in dir_info['subdirectories']]
         else:
             dirs_to_empty = [dir_info['path']]
 

--- a/src/dashboard/src/components/ingest/views_as.py
+++ b/src/dashboard/src/components/ingest/views_as.py
@@ -23,7 +23,8 @@ def get_as_system_client():
         host=config['%host%'],
         port=config['%port%'],
         user=config['%user%'],
-        passwd=config['%passwd%']
+        passwd=config['%passwd%'],
+        repository=config['%repository%']
     )
 
 


### PR DESCRIPTION
refs #9075

The ArchivesSpace DIP Upload settings page,
in the admistration tab of the dashboard,
allows a user to set a value for the repository
to connect to in ArchivesSpace.

This value is now saved to the ReplacementDic
and used in the matching gui.
