### PR TITLE
Support multiple processing configs, refs #9105

### DIFF
--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -15,14 +15,23 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+import sys
+from lxml import etree
+from collections import OrderedDict
+
 from django import forms
 from django.conf import settings
-from django.forms import ModelForm
 from django.forms.widgets import TextInput, RadioSelect, CheckboxInput
+from django.utils.translation import ugettext as _
 
 from components import helpers
 from main import models
 from components.administration.models import ArchivistsToolkitConfig, ArchivesSpaceConfig
+
+sys.path.append('/usr/lib/archivematica/archivematicaCommon')
+import storageService as storage_service
+
 
 class AgentForm(forms.ModelForm):
     class Meta:
@@ -32,6 +41,7 @@ class AgentForm(forms.ModelForm):
             'identifiervalue': TextInput(attrs=settings.INPUT_ATTRS),
             'name': TextInput(attrs=settings.INPUT_ATTRS),
         }
+
 
 class SettingsForm(forms.Form):
     def __init__(self, *args, **kwargs):
@@ -64,7 +74,7 @@ class StorageSettingsForm(SettingsForm):
         label="Full URL of the storage service")
 
 
-class ArchivistsToolkitConfigForm(ModelForm):
+class ArchivistsToolkitConfigForm(forms.ModelForm):
     class Meta:
         model = ArchivistsToolkitConfig
         fields = ('host', 'port', 'dbname', 'dbuser', 'dbpass', 'atuser', 'premis', 'ead_actuate', 'ead_show', 'object_type', 'use_statement', 'uri_prefix', 'access_conditions', 'use_conditions')
@@ -86,7 +96,7 @@ class ArchivistsToolkitConfigForm(ModelForm):
         }
 
 
-class ArchivesSpaceConfigForm(ModelForm):
+class ArchivesSpaceConfigForm(forms.ModelForm):
     class Meta:
         model = ArchivesSpaceConfig
         fields = ('host', 'port', 'user', 'passwd', 'premis', 'xlink_actuate', 'xlink_show', 'use_statement', 'object_type', 'access_conditions', 'use_conditions', 'uri_prefix', 'repository')
@@ -105,6 +115,7 @@ class ArchivesSpaceConfigForm(ModelForm):
             'uri_prefix': TextInput(attrs=settings.INPUT_ATTRS),
             'repository': TextInput(attrs=settings.INPUT_ATTRS),
         }
+
 
 class AtomDipUploadSettingsForm(SettingsForm):
     dip_upload_atom_url = forms.CharField(required=True,
@@ -129,10 +140,276 @@ class AtomDipUploadSettingsForm(SettingsForm):
         help_text="Show additional details.",
         choices=((False, 'No'), (True, 'Yes')))
 
-class TaxonomyTermForm(ModelForm):
+
+class TaxonomyTermForm(forms.ModelForm):
     class Meta:
         model = models.TaxonomyTerm
         fields = ('taxonomy', 'term')
         widgets = {
             "term": TextInput(attrs=settings.INPUT_ATTRS)
         }
+
+
+class ProcessingConfigurationForm(forms.Form):
+    """
+    Build processing configuration form bounded to a processingMCP document.
+
+    Every processing field in this form requires the following
+    properties: type, name, label. In addition, these are some other
+    constraints based on the type:
+
+    - type = boolean
+      Required: yes_option or no_optino (or both)
+    - type = chain_choice
+      Optional: ignored_choices
+    - type = storage_service
+      Required: purpose
+    - type = days
+      Required: chain
+      Optional: placeholder, min_value
+    """
+
+    # The available processing fields indexed by choice_uuid.
+    processing_fields = OrderedDict()
+
+    processing_fields['de909a42-c5b5-46e1-9985-c031b50e9d30'] = {
+        'type': 'boolean',
+        'name': 'normalize_transfer',
+        'label': 'Approve normalization',
+        'yes_option': '1e0df175-d56d-450d-8bee-7df1dc7ae815',
+    }
+    processing_fields['7079be6d-3a25-41e6-a481-cee5f352fe6e'] = {
+        'type': 'boolean',
+        'name': 'transcribe_file',
+        'label': 'Transcribe files (OCR)',
+        'yes_option': '5a9985d3-ce7e-4710-85c1-f74696770fa9',
+        'no_option': '1170e555-cd4e-4b2f-a3d6-bfb09e8fcc53',
+    }
+    processing_fields['56eebd45-5600-4768-a8c2-ec0114555a3d'] = {
+        'type': 'boolean',
+        'name': 'tree',
+        'label': 'Generate transfer structure report',
+        'yes_option': 'df54fec1-dae1-4ea6-8d17-a839ee7ac4a7',
+        'no_option': 'e9eaef1e-c2e0-4e3b-b942-bfb537162795',
+    }
+    processing_fields['bb194013-597c-4e4a-8493-b36d190f8717'] = {
+        'type': 'chain_choice',
+        'name': 'create_sip',
+        'label': 'Create SIP(s)',
+        'ignored_choices': ['Reject transfer'],
+    }
+    processing_fields['dec97e3c-5598-4b99-b26e-f87a435a6b7f'] = {
+        'type': 'chain_choice',
+        'name': 'extract_packages',
+        'label': 'Extract packages',
+        'uuid': '01d80b27-4ad1-4bd1-8f8d-f819f18bf685',
+    }
+    processing_fields['f19926dd-8fb5-4c79-8ade-c83f61f55b40'] = {
+        'type': 'replace_dict',
+        'name': 'delete_packages',
+        'label': 'Delete packages after extraction',
+        'uuid': '85b1e45d-8f98-4cae-8336-72f40e12cbef',
+    }
+    processing_fields['cb8e5706-e73f-472f-ad9b-d1236af8095f'] = {
+        'type': 'chain_choice',
+        'name': 'normalize',
+        'label': 'Normalize',
+        'ignored_choices': ['Reject SIP'],
+    }
+    processing_fields['eeb23509-57e2-4529-8857-9d62525db048'] = {
+        'type': 'chain_choice',
+        'name':  'reminder',
+        'label': 'Reminder: add metadata if desired',
+    }
+    processing_fields['accea2bf-ba74-4a3a-bb97-614775c74459'] = {
+        'type': 'chain_choice',
+        'name': 'examine',
+        'label': 'Examine contents',
+    }
+    processing_fields['f09847c2-ee51-429a-9478-a860477f6b8d'] = {
+        'type': 'replace_dict',
+        'name': 'select_format_id_tool_transfer',
+        'label': 'Select file format identification command (Transfer)',
+    }
+    processing_fields['7a024896-c4f7-4808-a240-44c87c762bc5'] = {
+        'type': 'replace_dict',
+        'name': 'select_format_id_tool_ingest',
+        'label': 'Select file format identification command (Ingest)',
+    }
+    processing_fields['087d27be-c719-47d8-9bbb-9a7d8b609c44'] = {
+        'type': 'replace_dict',
+        'name': 'select_format_id_tool_submissiondocs',
+        'label': 'Select file format identification command (Submission documentation & metadata)',
+    }
+    processing_fields['01d64f58-8295-4b7b-9cab-8f1b153a504f'] = {
+        'type': 'replace_dict',
+        'name': 'compression_algo',
+        'label': 'Select compression algorithm',
+    }
+    processing_fields['01c651cb-c174-4ba4-b985-1d87a44d6754'] = {
+        'type': 'replace_dict',
+        'name': 'compression_level',
+        'label': 'Select compression level',
+    }
+    processing_fields['2d32235c-02d4-4686-88a6-96f4d6c7b1c3'] = {
+        'type': 'boolean',
+        'name': 'store_aip',
+        'label': 'Store AIP',
+        'yes_option': '9efab23c-31dc-4cbd-a39d-bb1665460cbe',
+    }
+    processing_fields['b320ce81-9982-408a-9502-097d0daa48fa'] = {
+        'type': 'storage_service',
+        'name': 'store_aip_location',
+        'label': 'Store AIP location',
+        'purpose': 'AS',
+    }
+    processing_fields['b7a83da6-ed5a-47f7-a643-1e9f9f46e364'] = {
+        'type': 'storage_service',
+        'name': 'store_dip_location',
+        'label': 'Store DIP location',
+        'purpose': 'DS',
+    }
+    processing_fields['755b4177-c587-41a7-8c52-015277568302'] = {
+        'type': 'boolean',
+        'name': 'quarantine_transfer',
+        'label': 'Send transfer to quarantine',
+        'yes_option': '97ea7702-e4d5-48bc-b4b5-d15d897806ab',
+        'no_option': 'd4404ab1-dc7f-4e9e-b1f8-aa861e766b8e',
+    }
+    processing_fields['19adb668-b19a-4fcb-8938-f49d7485eaf3'] = {
+        'type': 'days',
+        'name': 'quarantine_expiry_days',
+        'label': 'Remove from quarantine after (days)',
+        'placeholder': 'days',
+        'chain': '333643b7-122a-4019-8bef-996443f3ecc5',
+        'min_value': 0,
+    }
+
+    EMPTY_OPTION_NAME = _('None')
+    EMPTY_CHOICES = [
+        (None, EMPTY_OPTION_NAME),
+    ]
+    DEFAULT_FIELD_OPTS = {
+        'required': False,
+        'initial': None,
+    }
+
+    name = forms.RegexField(max_length=16, regex=r'^\w+$', required=True)
+
+    def __init__(self, *args, **kwargs):
+        super(ProcessingConfigurationForm, self).__init__(*args, **kwargs)
+        for choice_uuid, field in self.processing_fields.iteritems():
+            ftype = field['type']
+            opts = self.DEFAULT_FIELD_OPTS.copy()
+            if 'label' in field:
+                opts['label'] = field['label']
+            if ftype == 'days':
+                if 'min_value' in field:
+                    opts['min_value'] = field['min_value']
+                self.fields[choice_uuid] = forms.IntegerField(**opts)
+                if 'placeholder' in field:
+                    self.fields[choice_uuid].widget.attrs['placeholder'] = field['placeholder']
+            else:
+                choices = opts['choices'] = list(self.EMPTY_CHOICES)
+                if ftype == 'boolean':
+                    if 'yes_option' in field:
+                        choices.append((field['yes_option'], 'Yes'))
+                    if 'no_option' in field:
+                        choices.append((field['no_option'], 'No'))
+                elif ftype == 'chain_choice':
+                    chain_choices = models.MicroServiceChainChoice.objects.filter(choiceavailableatlink_id=choice_uuid)
+                    ignored_choices = field.get('ignored_choices', [])
+                    for item in chain_choices:
+                        chain = item.chainavailable
+                        if chain.description in ignored_choices:
+                            continue
+                        choices.append((chain.pk, chain.description))
+                elif ftype == 'replace_dict':
+                    link = models.MicroServiceChainLink.objects.get(pk=choice_uuid)
+                    replace_dicts = models.MicroServiceChoiceReplacementDic.objects.filter(choiceavailableatlink_id=link.pk)
+                    for item in replace_dicts:
+                        choices.append((item.pk, item.description))
+                elif ftype == 'storage_service':
+                    for loc in get_storage_locations(purpose=field['purpose']):
+                        choices.append((loc['resource_uri'], loc['description']))
+                self.fields[choice_uuid] = forms.ChoiceField(**opts)
+
+    def load_config(self, name):
+        """
+        Bound the choices found in the XML document to the form fields.
+        """
+        self.fields['name'].initial = name
+        self.fields['name'].widget.attrs['readonly'] = 'readonly'
+        config_path = os.path.join(helpers.processing_config_path(), '{}ProcessingMCP.xml'.format(name))
+        root = etree.parse(config_path)
+        for choice in root.findall('.//preconfiguredChoice'):
+            applies_to = choice.findtext('appliesTo')
+            go_to_chain = choice.findtext('goToChain')
+            fprops = self.processing_fields.get(applies_to)
+            field = self.fields.get(applies_to)
+            if fprops is None or go_to_chain is None or field is None:
+                continue
+            if fprops['type'] == 'days':
+                field.initial = int(float(choice.findtext('delay'))) / (24 * 60 * 60)
+            else:
+                field.initial = go_to_chain
+
+    def save_config(self):
+        """
+        Encode the configuration to XML and write it to disk.
+        """
+        name = self.cleaned_data['name']
+        del self.cleaned_data['name']
+        config_path = os.path.join(helpers.processing_config_path(), '{}ProcessingMCP.xml'.format(name))
+        config = PreconfiguredChoices(config_path)
+        for choice_uuid, value in self.cleaned_data.iteritems():
+            fprops = self.processing_fields.get(choice_uuid)
+            if fprops is None or value is None:
+                continue
+            field = self.fields.get(choice_uuid)
+            if field is None:
+                continue
+            if isinstance(field, forms.ChoiceField):
+                if not value: # Ignore empty string!
+                    continue
+            if fprops['type'] == 'days':
+                if value == 0:
+                    continue
+                delay = str(float(value) * (24 * 60 * 60))
+                config.add_choice(choice_uuid, fprops['chain'], delay_duration=delay, comment=fprops['label'])
+            else:
+                config.add_choice(choice_uuid, value, comment=fprops['label'])
+        config.save()
+
+
+def get_storage_locations(purpose):
+    try:
+        dirs = storage_service.get_location(purpose=purpose)
+        if len(dirs) == 0:
+            raise Exception('Storage server improperly configured.')
+    except Exception:
+        dirs = []
+    return dirs
+
+
+class PreconfiguredChoices(object):
+    """
+    Encode processing configuration XML documents and optionally write to disk.
+    """
+    def __init__(self):
+        self.xml = etree.Element('processingMCP')
+        self.choices = etree.SubElement(self.xml, 'preconfiguredChoices')
+
+    def add_choice(self, applies_to_text, go_to_chain_text, delay_duration=None, comment=None):
+        if comment is not None:
+            comment = etree.Comment(' {} '.format(comment))
+            self.choices.append(comment)
+        choice = etree.SubElement(self.choices, 'preconfiguredChoice')
+        etree.SubElement(choice, 'appliesTo').text = applies_to_text
+        etree.SubElement(choice, 'goToChain').text = go_to_chain_text
+        if delay_duration is not None:
+            etree.SubElement(choice, 'delay', {'unitCtime': 'yes'}).text = delay_duration
+
+    def save(self, config_path):
+        with open(config_path, 'w') as f:
+            f.write(etree.tostring(self.xml, pretty_print=True))

--- a/src/dashboard/src/components/administration/urls.py
+++ b/src/dashboard/src/components/administration/urls.py
@@ -18,6 +18,7 @@
 from django.conf.urls import url, patterns
 from django.conf import settings
 from components.administration import views
+from components.administration import views_processing
 
 urlpatterns = patterns('',
     url(r'^$', views.administration),
@@ -32,7 +33,10 @@ urlpatterns = patterns('',
     url(r'storage/$', views.storage),
     url(r'usage/$', views.usage),
     url(r'usage/clear/(?P<dir_id>\w+)/$', views.usage_clear),
-    url(r'processing/$', views.processing),
+    url(r'processing/$', views_processing.list),
+    url(r'processing/add/$', views_processing.edit),
+    url(r'processing/edit/(?P<name>\w{1,16})/$', views_processing.edit),
+    url(r'processing/delete/(?P<name>\w{1,16})$', views_processing.delete),
     url(r'premis/agent/$', views.premis_agent),
     url(r'api/$', views.api),
     url(r'general/$', views.general),

--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -32,7 +32,6 @@ from django.shortcuts import redirect, render
 
 from main import forms
 from main import models
-import components.administration.views_processing as processing_views
 from components.administration.forms import AtomDipUploadSettingsForm
 from components.administration.forms import AgentForm
 from components.administration.forms import ArchivesSpaceConfigForm
@@ -59,7 +58,7 @@ logger = logging.getLogger('archivematica.dashboard')
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ """
 
 def administration(request):
-    return redirect('components.administration.views.processing')
+    return redirect('components.administration.views_processing.list')
 
 def failure_report(request, report_id=None):
     if report_id != None:

--- a/src/dashboard/src/components/administration/views_processing.py
+++ b/src/dashboard/src/components/administration/views_processing.py
@@ -15,404 +15,65 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from lxml import etree
+
 import os
-import sys
+import re
+from glob import iglob
+import logging
 
-from django.core.urlresolvers import reverse
+from django.shortcuts import render, redirect
 from django.contrib import messages
-from django.shortcuts import redirect
-from django.shortcuts import render
+from django.http import Http404
 
-from main import models
 from components import helpers
-from components.helpers import hidden_features
+from .forms import ProcessingConfigurationForm
 
-path = "/usr/lib/archivematica/archivematicaCommon"
-if path not in sys.path:
-    sys.path.append(path)
-import storageService as storage_service
 
-class PreconfiguredChoices:
-    xml     = None
-    choices = None
+logger = logging.getLogger('archivematica.dashboard')
 
-    def __init__(self):
-        self.xml = etree.Element('processingMCP')
-        self.choices = etree.Element('preconfiguredChoices')
 
-    def add_choice(self, applies_to_text, go_to_chain_text, delay_duration=None):
-        choice = etree.Element('preconfiguredChoice')
+def list(request):
+    files = []
+    ignored = []
+    for item in iglob('{}/*ProcessingMCP.xml'.format(helpers.processing_config_path())):
+        basename = os.path.basename(item)
+        name = re.sub('ProcessingMCP\.xml$', '', basename)
+        if re.match(r'^\w{1,16}$', name) is None:
+            ignored.append((basename, name, item))
+            continue
+        files.append((basename, name, item))
+    return render(request, 'administration/processing.html', {'files': files, 'ignored': ignored})
 
-        applies_to = etree.Element('appliesTo')
-        applies_to.text = applies_to_text
-        choice.append(applies_to)
 
-        go_to_chain = etree.Element('goToChain')
-        go_to_chain.text = go_to_chain_text
-        choice.append(go_to_chain)
-
-        if delay_duration != None:
-            delay = etree.Element('delay', unitCtime='yes')
-            delay.text = delay_duration
-            choice.append(delay)
-
-        self.choices.append(choice)
-
-    def write_to_file(self, file_path):
-        self.xml.append(self.choices)
-        file = open(file_path, 'w')
-        file.write(etree.tostring(self.xml, pretty_print=True))
-
-def index(request):
-    file_path = helpers.default_processing_config_path()
-
-    # Lists of dicts declare what options to display, and where to look for
-    # the options
-    # name: Value of the `name` attribute in the <input> HTML element
-    # choice_uuid: UUID of the microservice chainlink at which the choice occurs
-    # label: Human-readable label to be displayed to the user
-    # yes_option and no_option: UUIDs for the yes and no choice chains, respectively
-    boolean_select_fields = [
-        {
-            "name":         "quarantine_transfer",
-            "choice_uuid":  "755b4177-c587-41a7-8c52-015277568302", # Workflow decision - send transfer to quarantine
-            "label":        "Send transfer to quarantine",
-            "yes_option":   "97ea7702-e4d5-48bc-b4b5-d15d897806ab", # Quarantine
-            "no_option":    "d4404ab1-dc7f-4e9e-b1f8-aa861e766b8e" # Skip quarantine
-        },
-        {
-            "name":         "normalize_transfer",
-            "choice_uuid":  "de909a42-c5b5-46e1-9985-c031b50e9d30",
-            "label":        "Approve normalization",
-            "yes_option":   "1e0df175-d56d-450d-8bee-7df1dc7ae815", # Approve
-            "action":       "Approve"
-        },
-        {
-            "name":         "store_aip",
-            "choice_uuid":  "2d32235c-02d4-4686-88a6-96f4d6c7b1c3",
-            "label":        "Store AIP",
-            "yes_option":   "9efab23c-31dc-4cbd-a39d-bb1665460cbe", # Store AIP
-            "action":       "Store AIP"
-        },
-        {
-            "name":         "transcribe_file",
-            "choice_uuid":  "7079be6d-3a25-41e6-a481-cee5f352fe6e",
-            "label":        "Transcribe files (OCR)",
-            "yes_option":   "5a9985d3-ce7e-4710-85c1-f74696770fa9",
-            "no_option":    "1170e555-cd4e-4b2f-a3d6-bfb09e8fcc53",
-        },
-        {
-            "name":         "tree",
-            "choice_uuid":  "56eebd45-5600-4768-a8c2-ec0114555a3d",
-            "label":        "Generate transfer structure report",
-            "yes_option":   "df54fec1-dae1-4ea6-8d17-a839ee7ac4a7", # Generate transfer structure report
-            "no_option":    "e9eaef1e-c2e0-4e3b-b942-bfb537162795",
-            "action":       "Generate transfer structure report"
-        },
-    ]
-
-    # name: Value of the `name` attribute in the <input> HTML element
-    # label: Human-readable label to be displayed to the user
-    # choice_uuid: UUID of the microservice chainlink at which the choice occurs
-    chain_choice_fields = [
-        {
-            "name":  "create_sip",
-            "label": "Create SIP(s)",
-            "choice_uuid": "bb194013-597c-4e4a-8493-b36d190f8717"
-        },
-        {
-            "name":  "extract_packages",
-            "label": "Extract packages",
-            "choice_uuid": "dec97e3c-5598-4b99-b26e-f87a435a6b7f",
-            "uuid": "01d80b27-4ad1-4bd1-8f8d-f819f18bf685"
-        },
-        {
-            "name":  "normalize",
-            "label": "Normalize",
-            "choice_uuid": "cb8e5706-e73f-472f-ad9b-d1236af8095f",
-        },
-        {
-            "name":  "reminder",
-            "label": "Reminder: add metadata if desired",
-            "choice_uuid": "eeb23509-57e2-4529-8857-9d62525db048",
-        },
-        {
-            "name":  "examine",
-            "label": "Examine contents",
-            "choice_uuid": "accea2bf-ba74-4a3a-bb97-614775c74459"
-        },
-    ]
-
-    populate_select_fields_with_chain_choice_options(chain_choice_fields)
-
-    # name: Value of the `name` attribute in the <input> HTML element
-    # choice_uuid: UUID of the microservice chainlink at which the choice occurs
-    replace_dict_fields = [
-        {
-            "name": "select_format_id_tool_transfer",
-            "label": "Select file format identification command (Transfer)",
-            "choice_uuid": 'f09847c2-ee51-429a-9478-a860477f6b8d'
-        },
-        {
-            "name": "select_format_id_tool_ingest",
-            "label": "Select file format identification command (Ingest)",
-            "choice_uuid": '7a024896-c4f7-4808-a240-44c87c762bc5'
-        },
-        {
-            "name": "select_format_id_tool_submissiondocs",
-            "label": "Select file format identification command (Submission documentation & metadata)",
-            "choice_uuid": '087d27be-c719-47d8-9bbb-9a7d8b609c44'
-        },
-        {
-            "name":  "delete_packages",
-            "label": "Delete packages after extraction",
-            "choice_uuid": "f19926dd-8fb5-4c79-8ade-c83f61f55b40",
-            "uuid": "85b1e45d-8f98-4cae-8336-72f40e12cbef"
-        },
-        {
-            "name":  "compression_algo",
-            "label": "Select compression algorithm",
-            "choice_uuid": "01d64f58-8295-4b7b-9cab-8f1b153a504f"
-        },
-        {
-            "name":  "compression_level",
-            "label": "Select compression level",
-            "choice_uuid": "01c651cb-c174-4ba4-b985-1d87a44d6754"
-        }
-    ]
-
-    def storage_dir_cb(storage_dir):
-        return {
-            'value': storage_dir['resource_uri'],
-            'label': storage_dir['description']
-        }
-
-    """ Return a dict of AIP Storage Locations and their descriptions."""
-    storage_directory_options = [{'value': '', 'label': '--Actions--'}]
-    dip_directory_options = [{'value': '', 'label': '--Actions--'}]
-    try:
-        storage_directories = storage_service.get_location(purpose="AS")
-        dip_directories = storage_service.get_location(purpose="DS")
-        if None in (storage_directories, dip_directories):
-            raise Exception("Storage server improperly configured.")
-    except Exception:
-        messages.warning(request, 'Error retrieving AIP/DIP storage locations: is the storage server running? Please contact an administrator.')
-    else:
-        storage_directory_options += [storage_dir_cb(d) for d in storage_directories]
-        dip_directory_options += [storage_dir_cb(d) for d in dip_directories]
-
-    storage_service_options = [
-        {
-            "name":          "store_aip_location",
-            "label":         "Store AIP location",
-            "choice_uuid":   "b320ce81-9982-408a-9502-097d0daa48fa",
-            "options":       storage_directory_options,
-            # Unlike other options, the correct value here is a literal string,
-            # not a pointer to a chain or dict in the database.
-            "do_not_lookup": True
-        },
-        {
-            "name":          "store_dip_location",
-            "label":         "Store DIP location",
-            "choice_uuid":   "b7a83da6-ed5a-47f7-a643-1e9f9f46e364",
-            "options":       dip_directory_options,
-            # Unlike other options, the correct value here is a literal string,
-            # not a pointer to a chain or dict in the database.
-            "do_not_lookup": True
-        }
-    ]
-
-    populate_select_fields_with_replace_dict_options(replace_dict_fields)
-
-    select_fields = chain_choice_fields + replace_dict_fields + storage_service_options
-
+def edit(request, name=None):
     if request.method == 'POST':
-        # render XML using request data
-        xmlChoices = PreconfiguredChoices()
-
-        # use toggle field submissions to add to XML
-        for field in boolean_select_fields:
-            enabled = request.POST.get(field['name'])
-            if enabled == 'yes':
-                if 'yes_option' in field:
-                    # can be set to either yes or no
-                    toggle = request.POST.get(field['name'] + '_toggle', '')
-                    if toggle == 'yes':
-                        go_to_chain_text = field['yes_option']
-                    elif 'no_option' in field:
-                        go_to_chain_text = field['no_option']
-
-                    if 'no_option' in field:
-                        xmlChoices.add_choice(
-                            field['choice_uuid'],
-                            go_to_chain_text
-                        )
-                    else:
-                        if toggle == 'yes':
-                            xmlChoices.add_choice(
-                                field['choice_uuid'],
-                                go_to_chain_text
-                            )
-
-        # set quarantine duration if applicable
-        quarantine_expiry_enabled = request.POST.get('quarantine_expiry_enabled', '')
-        quarantine_expiry         = request.POST.get('quarantine_expiry', '')
-        if quarantine_expiry_enabled == 'yes' and quarantine_expiry != '':
-            xmlChoices.add_choice(
-                '19adb668-b19a-4fcb-8938-f49d7485eaf3', # Remove from quarantine
-                '333643b7-122a-4019-8bef-996443f3ecc5', # Unquarantine
-                str(float(quarantine_expiry) * (24 * 60 * 60))
-            )
-
-        # use select field submissions to add to XML
-        for field in select_fields:
-            enabled = request.POST.get(field['name'] + '_enabled')
-            if enabled == 'yes':
-                field_value = request.POST.get(field['name'], '')
-                if field_value != '':
-                    if field.get('do_not_lookup', False):
-                        target = field_value
-                    else:
-                        target = uuid_from_description(field_value, field['choice_uuid'])
-
-                    xmlChoices.add_choice(
-                        field['choice_uuid'],
-                        target
-                    )
-
-        xmlChoices.write_to_file(file_path)
-
-        messages.info(request, 'Saved!')
-
-        return redirect('components.administration.views.processing')
+        form = ProcessingConfigurationForm(request.POST)
+        if form.is_valid():
+            try:
+                form.save_config()
+            except Exception:
+                msg = 'Failed to save processing config.'
+                logger.exception(msg)
+                messages.error(request, msg)
+            else:
+                messages.info(request, 'Saved!')
+            return redirect('components.administration.views_processing.list')
     else:
-        debug = request.GET.get('debug', '')
-        quarantine_expiry = ''
+        form = ProcessingConfigurationForm()
+        if name is not None:
+            try:
+                form.load_config(name)
+            except IOError:
+                raise Http404
+    return render(request, 'administration/processing_edit.html', {'form': form})
 
-        file = open(file_path, 'r')
-        xml = file.read()
 
-        # parse XML to work out locals()
-        root = etree.fromstring(xml)
-        choices = root.findall('.//preconfiguredChoice')
-
-        for item in boolean_select_fields:
-            item['checked']     = ''
-            item['yes_checked'] = ''
-            item['no_checked']  = ''
-
-        for choice in choices:
-            applies_to = choice.find('appliesTo').text
-            go_to_chain = choice.find('goToChain').text
-
-            # use toggle field submissions to add to XML
-            for field in boolean_select_fields:
-                if applies_to == field['choice_uuid']:
-                    set_field_property_by_name(boolean_select_fields, field['name'], 'checked', 'checked')
-
-                    if 'yes_option' in field:
-                        if go_to_chain == field['yes_option']:
-                            set_field_property_by_name(boolean_select_fields, field['name'], 'yes_checked', 'selected')
-                        else:
-                            set_field_property_by_name(boolean_select_fields, field['name'], 'no_checked', 'selected')
-
-            # a quarantine expiry was found
-            if applies_to == 'Remove from quarantine':
-                quarantine_expiry_enabled_checked = 'checked'
-                quarantine_expiry = float(choice.find('delay').text) / (24 * 60 * 60)
-
-            # check select fields for defaults
-            for field in select_fields:
-                if applies_to == field['choice_uuid'] and go_to_chain:
-                    try:
-                        chain = models.MicroServiceChain.objects.get(pk=go_to_chain)
-                        choice = chain.description
-                    except models.MicroServiceChain.DoesNotExist:
-                        try:
-                            choice = models.MicroServiceChoiceReplacementDic.objects.get(pk=go_to_chain).description
-                        except models.MicroServiceChoiceReplacementDic.DoesNotExist:
-                            # fallback for storage service options, which are
-                            # strings that don't map to chains or dicts in
-                            # the database
-                            choice = go_to_chain
-
-                    field['selected'] = choice
-                    field['checked'] = 'checked'
-
-    hide_features = hidden_features()
-    return render(request, 'administration/processing.html', locals())
-
-def lookup_chain_link(field):
-    return models.MicroServiceChainLink.objects.get(pk=field['choice_uuid'])
-
-def remove_option_by_value(options, value):
-    for option in options:
-        if option['value'] == value:
-            options.remove(option)
-
-def uuid_from_description(description, choice):
-    """
-    Attempts to fetch the UUID of either a MicroServiceChain or a
-    MicroServiceChoiceReplacementDic that matches the provided description.
-
-    "choice" is the pk of the choice with which the option is associated;
-    it will be used when looking up a replacement dict in order to ensure the
-    result is associated with the correct choice.
-    """
+def delete(request, name):
+    if name == 'default':
+        return redirect('components.administration.views_processing.list')
+    config_path = os.path.join(helpers.processing_config_path(), '{}ProcessingMCP.xml'.format(name))
     try:
-        choice = models.MicroServiceChainChoice.objects.get(choiceavailableatlink_id=choice,
-            chainavailable__description=description)
-        return choice.chainavailable.pk
-    except models.MicroServiceChainChoice.DoesNotExist:
-        return models.MicroServiceChoiceReplacementDic.objects.filter(description=description, choiceavailableatlink=choice)[0].pk
-
-def populate_select_field_options_with_chain_choices(field):
-    link = lookup_chain_link(field)
-
-    choices = models.MicroServiceChainChoice.objects.filter(choiceavailableatlink_id=link.pk)
-
-    field['options'] = [{'value': '', 'label': '--Actions--'}]
-    options = []
-    for choice in choices:
-        chain = choice.chainavailable
-        option = {'value': chain.description, 'label': chain.description}
-        options.append(option)
-
-    if field['label'] == 'Create SIP(s)':
-        remove_option_by_value(options, 'Reject transfer')
-
-    if field['label'] == 'Normalize':
-        remove_option_by_value(options, 'Reject SIP')
-
-    options.sort()
-    field['options'] += options
-
-def populate_select_field_options_with_replace_dict_values(field):
-    link = lookup_chain_link(field)
-
-    replace_dicts = models.MicroServiceChoiceReplacementDic.objects.filter(
-        choiceavailableatlink_id=link.pk
-    )
-
-    field['options'] = [{'value': '', 'label': '--Actions--'}]
-    options = []
-    for dict in replace_dicts:
-        option = {'value': dict.description, 'label': dict.description}
-        options.append(option)
-
-    options.sort()
-    field['options'] += options
-
-def populate_select_fields_with_chain_choice_options(fields):
-    for field in fields:
-        populate_select_field_options_with_chain_choices(field)
-
-def populate_select_fields_with_replace_dict_options(fields):
-    for field in fields:
-        populate_select_field_options_with_replace_dict_values(field)
-
-def set_field_property_by_name(fields, name, property, value):
-    for field in fields:
-        if field['name'] == name:
-            field[property] = value
+        os.remove(config_path)
+    except OSError:
+        pass
+    return redirect('components.administration.views_processing.list')

--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -33,4 +33,6 @@ urlpatterns = patterns('',
     url(r'administration/dips/atom/levels/$', views.get_levels_of_description),
     url(r'administration/dips/atom/fetch_levels/$', views.fetch_levels_of_description_from_atom),
     url(r'filesystem/metadata/$', views.path_metadata),
+
+    url(r'processing-configuration/(?P<name>\w{1,16})', views.processing_configuration),
 )

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -508,3 +508,21 @@ def path_metadata(request):
         }
 
         return helpers.json_response(body, status_code=201)
+
+
+def processing_configuration(request, name):
+    """
+    Return a processing configuration XML document given its name, i.e. where
+    name is "default" the returned file will be "defaultProcessingMCP.xml"
+    found in the standard processing configuration directory.
+    """
+    accepted_types = request.META.get('HTTP_ACCEPT', '').lower()
+    if accepted_types != '*/*' and 'xml' not in accepted_types:
+        return django.http.HttpResponse(status=415)
+    config_path = os.path.join(helpers.processing_config_path(), '{}ProcessingMCP.xml'.format(name))
+    try:
+        with open(config_path, 'r') as f:
+            content = f.read()
+        return django.http.HttpResponse(content, content_type='text/xml')
+    except IOError:
+        raise django.http.Http404

--- a/src/dashboard/src/components/archival_storage/forms.py
+++ b/src/dashboard/src/components/archival_storage/forms.py
@@ -29,4 +29,3 @@ class ReingestAIPForm(forms.Form):
         (OBJECTS, 'Re-ingest metadata and objects')
     )
     reingest_type = forms.ChoiceField(choices=REINGEST_CHOICES,  widget=forms.RadioSelect, required=True)
-

--- a/src/dashboard/src/components/helpers.py
+++ b/src/dashboard/src/components/helpers.py
@@ -329,10 +329,10 @@ def pad_destination_filepath_if_it_already_exists(filepath, original=None, attem
             return pad_destination_filepath_if_it_already_exists(new_filepath, original, attempt)
     return filepath
 
-def default_processing_config_path():
+def processing_config_path():
     return os.path.join(
         get_server_config_value('sharedDirectory'),
-        'sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml'
+        'sharedMicroServiceTasksConfigs/processingMCPConfigs'
     )
 
 def stream_file_from_storage_service(url, error_message='Remote URL returned {}'):

--- a/src/dashboard/src/templates/administration/processing.html
+++ b/src/dashboard/src/templates/administration/processing.html
@@ -1,8 +1,8 @@
 {% extends "layout_fluid.html" %}
-{% load breadcrumb %}
+{% load i18n %}
 
-{% block title %}Administration{% endblock %}
-{% block h1 %}Administration{% endblock %}
+{% block title %}{% trans "Administration" %}{% endblock %}
+{% block h1 %}{% trans "Administration" %}{% endblock %}
 {% block page_id %}Administration{% endblock %}
 
 {% block content %}
@@ -13,70 +13,45 @@
 
     <div class="span12">
 
-      <h3>Processing configuration</h3>
+      <h3>{% trans "Processing configuration" %}</h3>
 
-      <form method='POST'>
       <table>
-        {% for item in boolean_select_fields %}
+        {% for item in files %}
         <tr>
           <td>
-            <input type='checkbox' name='{{ item.name }}' value='yes' {{ item.checked }}> {{ item.label }}
+            <span title="{{ item.2 }}">{{ item.1 }}</attr>
           </td>
           <td>
-            <select name='{{ item.name }}_toggle'>
-              <option value='yes' {{ item.yes_checked }}>Yes</option>
-              {% if item.label != 'Approve normalization' %}
-              <option value='no' {{ item.no_checked }}>No</option>
-              {% endif %}
-            </select>
+            <a class="btn" href="{% url "components.administration.views_processing.edit" item.1 %}">{% trans "Edit" %}</a>
+            {% if item.1 != "default" %}
+              <a class="btn danger" href="{% url "components.administration.views_processing.delete" item.1 %}">{% trans "Delete" %}</a>
+            {% endif %}
           </td>
         </tr>
         {% endfor %}
-
-        <tr>
-          <td>
-            <input type='checkbox' name='quarantine_expiry_enabled' value='yes' {{ quarantine_expiry_enabled_checked }}>
-            Remove from quarantine after
-          </td>
-          <td colspan>
-            <input name='quarantine_expiry' value='{{ quarantine_expiry }}' class='span2' />
-            days
-          </td>
-        </tr>
-
-        {% for item in select_fields %}
-        <tr>
-          <td>
-            <input type='checkbox' name='{{ item.name }}_enabled' value='yes' {{ item.checked }}> {{ item.label }}
-          </td>
-          <td>
-            <select name="{{ item.name }}">
-              {% for option in item.options %}
-              <option value='{{ option.value }}'
-              {% if item.selected == option.value %}
-                selected
-              {% endif %}
-              >{{ option.label }}</option>
-              {% endfor %}
-            </select>
-          </td>
-        </tr>
-        {% endfor %}
-        <tr>
-          <td colspan="2">
-            <div style="float:right"><input type='submit' class='btn' value='Save'></div>
-          </td>
-        </tr>
       </table>
-      </form>
 
-      {% if debug %}
-      <div style='width: 700px; height: 600px;'>
-      <form method='POST'>
-        <textarea name='xml' style='width: 500px; height: 300px;'>{{ xml }}</textarea>
-      </form>
-      </div>
+      {% if not files %}
+        <div class="alert-message">
+          <p>{% trans "No processing configuration file found (*ProcessingMCP.xml)." %}</p>
+        </div>
       {% endif %}
+
+      {% if ignored %}
+        <hr />
+        <div>
+          <p>{% trans "The following files are being ignored because they don't meet the requirements." %}</p>
+          <ul>
+            {% for item in ignored %}
+            <li>{{ item.0 }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
+      <div class="form-stacked actions">
+        <a class="btn" href="{% url "components.administration.views_processing.edit" %}">{% trans "Add" %}</a>
+      </div>
 
     </div>
 

--- a/src/dashboard/src/templates/administration/processing_edit.html
+++ b/src/dashboard/src/templates/administration/processing_edit.html
@@ -1,0 +1,47 @@
+{% extends "layout_fluid.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Administration" %}{% endblock %}
+{% block h1 %}{% trans "Administration" %}{% endblock %}
+{% block page_id %}Administration{% endblock %}
+
+{% block content %}
+
+  <div class="row">
+
+    {% include "administration/sidebar.html" %}
+
+    <div class="span12">
+
+      <h3>{% trans "Processing configuration" %}</h3>
+      
+      <form class="form-stacked" method="post">
+
+        {% csrf_token %}
+
+        <table>
+
+          {% for field in form %}
+            <tr>
+              <td>
+                {{ field.label_tag }}
+                {{ field.errors }}
+              </td>
+              <td>{{ field }}</td>
+            </tr>
+          {% endfor %}
+
+        </table>
+
+        <div class="actions">
+          <input type="submit" class="btn primary" value="{% trans "Save" %}"/>
+          <a class="btn" href="{% url "components.administration.views_processing.list" %}">{% trans "Cancel" %}</a>
+        </div>
+
+      </form>
+
+    </div>
+
+  </div>
+
+{% endblock %}

--- a/src/dashboard/src/templates/administration/sidebar.html
+++ b/src/dashboard/src/templates/administration/sidebar.html
@@ -1,7 +1,7 @@
 {% load active %}
 <div class="span3 sidebar">
 
-  {% url 'components.administration.views.processing' as url_processing %}
+  {% url 'components.administration.views_processing.list' as url_processing %}
   {% url 'components.administration.views.general' as url_general %}
   {% url 'components.administration.views.failure_report' as failure_report %}
   {% url 'components.administration.views.atom_dips' as url_dip %}


### PR DESCRIPTION
Redmine ticket: https://projects.artefactual.com/issues/9105

The processing configuration form is now a subclass of Django's `Form`.

An upcoming commit should expose the different configurations available via the API.
