### PR TITLE
Return notes from ArchivesSpaceClient and allow them to be edited

### DIFF
--- a/src/archivematicaCommon/lib/archivesspace/client.py
+++ b/src/archivematicaCommon/lib/archivesspace/client.py
@@ -158,6 +158,7 @@ class ArchivesSpaceClient(object):
         Currently supported fields are:
             * title
             * targetfield
+            * notes
 
         :raises ValueError: if the 'id' field isn't specified, or no fields to edit were specified.
         """
@@ -177,6 +178,29 @@ class ArchivesSpaceClient(object):
                 fields_updated = True
             except KeyError:
                 continue
+
+        if 'notes' in new_record and new_record['notes']:
+            note = new_record['notes'][0]
+            new_note = {
+                'jsonmodel_type': 'note_multipart',
+                'publish': True,
+                'subnotes': [{
+                    'content': note['content'],
+                    'jsonmodel_type': 'note_text',
+                    'publish': True,
+                }],
+                'type': note['type'],
+            }
+            # This only supports editing a single note, and a single piece of content
+            # within that note.
+            # If the record already has at least one note, then replace the first note
+            # within that record with this one.
+            if not record['notes']:
+                record['notes'] = [new_note]
+            else:
+                record['notes'][0] = new_note
+
+            fields_updated = True
 
         if not fields_updated:
             raise ValueError('No fields to update specified!')

--- a/src/archivematicaCommon/lib/archivesspace/client.py
+++ b/src/archivematicaCommon/lib/archivesspace/client.py
@@ -706,7 +706,7 @@ class ArchivesSpaceClient(object):
         })
         self._post(parent_archival_object, data=json.dumps(parent_record))
 
-    def add_child(self, parent, title="", level=""):
+    def add_child(self, parent, title="", level="", start_date="", end_date="", date_expression=""):
         """
         Adds a new resource component parented within `parent`.
 
@@ -731,6 +731,16 @@ class ArchivesSpaceClient(object):
             "jsonmodel_type": "archival_object",
             "resource": {"ref": resource}
         }
+
+        if start_date:
+            date = {
+                'begin': start_date,
+                'date_type': 'inclusive',
+                'label': 'creation',
+                'expression': expression,
+            }
+            if end_date:
+                date['end'] = end_date
 
         # "parent" always refers to an archival_object instance; if this is rooted
         # directly to a resource, leave it out.

--- a/src/archivematicaCommon/lib/archivesspace/client.py
+++ b/src/archivematicaCommon/lib/archivesspace/client.py
@@ -114,6 +114,23 @@ class ArchivesSpaceClient(object):
                              params=params,
                              expected_response=expected_response)
 
+    def _format_notes(self, record):
+        """
+        Extracts notes from a record and reformats them in a simplified format.
+        """
+        notes = []
+        for note in record['notes']:
+            n = {}
+            n['type'] = note['type']
+            try:
+                n['content'] = note['subnotes'][0]['content']
+            except IndexError:
+                n['content'] = ''
+
+            notes.append(n)
+
+        return notes
+
     def resource_type(self, resource_id):
         """
         Given an ID, determines whether a given resource is a resource or a resource_component.
@@ -246,7 +263,8 @@ class ArchivesSpaceClient(object):
                 'identifier': identifier,
                 'title': record.get('title', ''),
                 'dates': dates,
-                'levelOfDescription': record['level']
+                'levelOfDescription': record['level'],
+                'notes': self._format_notes(full_record),
             }
             if record['children'] and descend:
                 result['children'] = [format_record(child, level) for child in record['children']]
@@ -281,7 +299,8 @@ class ArchivesSpaceClient(object):
                 'identifier': record.get('component_id', ''),
                 'title': record.get('title', ''),
                 'dates': dates,
-                'levelOfDescription': record['level']
+                'levelOfDescription': record['level'],
+                'notes': self._format_notes(record),
             }
 
             children = fetch_children(record['uri'])
@@ -434,7 +453,8 @@ class ArchivesSpaceClient(object):
                 'dates': dates,
                 'levelOfDescription': record['level'],
                 'children': [] if has_children else False,
-                'has_children': has_children
+                'has_children': has_children,
+                'notes': self._format_notes(record),
             }
 
         params = {

--- a/src/archivematicaCommon/lib/archivesspace/client.py
+++ b/src/archivematicaCommon/lib/archivesspace/client.py
@@ -159,6 +159,9 @@ class ArchivesSpaceClient(object):
             * title
             * targetfield
             * notes
+            * start_date
+            * end_date
+            * date_expression
 
         :raises ValueError: if the 'id' field isn't specified, or no fields to edit were specified.
         """
@@ -199,6 +202,24 @@ class ArchivesSpaceClient(object):
                 record['notes'] = [new_note]
             else:
                 record['notes'][0] = new_note
+
+            fields_updated = True
+
+        if 'start_date' in new_record:
+            date = {
+                'begin': new_record['start_date'],
+                'date_type': 'inclusive',
+                'label': 'creation',
+            }
+            if 'end_date' in new_record:
+                date['end'] = new_record['end_date']
+            if 'date_expression' in new_record:
+                date['expression'] = new_record['date_expression']
+
+            if len(record['dates']) == 0:
+                record['dates'] = [date]
+            else:
+                record['dates'][0] = date
 
             fields_updated = True
 

--- a/src/archivematicaCommon/lib/archivistsToolkit/client.py
+++ b/src/archivematicaCommon/lib/archivistsToolkit/client.py
@@ -157,6 +157,10 @@ class ArchivistsToolkitClient(object):
           'title': 'Parent',
           'levelOfDescription': 'collection',
           'dates': '1880-1889',
+          'notes': [
+            'type': 'odd',
+            'content': 'This is a note',
+          ],
           'children': [{
             'id': '23',
             'sortPosition': '2',
@@ -164,6 +168,7 @@ class ArchivistsToolkitClient(object):
             'title': 'Child A',
             'levelOfDescription': 'Sousfonds',
             'dates': '1880-1888',
+            'notes': [],
             'children': [{
               'id': '24',
               'sortPosition': '3',
@@ -171,6 +176,7 @@ class ArchivistsToolkitClient(object):
               'title': 'Grandchild A',
               'levelOfDescription': 'Item',
               'dates': '1880-1888',
+              'notes': [],
               'children': False
             },
             {
@@ -179,6 +185,7 @@ class ArchivistsToolkitClient(object):
               'identifier': 'GR02',
               'title': 'Grandchild B',
               'levelOfDescription': 'Item',
+              'notes': [],
               'children': False
             }]
           },
@@ -189,6 +196,7 @@ class ArchivistsToolkitClient(object):
             'title': 'Child B',
             'levelOfDescription': 'Sousfonds',
             'dates': '1889',
+            'notes': [],
             'children': False
           }]
         }
@@ -266,6 +274,9 @@ class ArchivistsToolkitClient(object):
             else:
                 resource_data['children'] = False
                 resource_data['has_children'] = False
+
+        # TODO: implement fetching notes
+        resource_data['notes'] = []
 
         return resource_data
 

--- a/src/archivematicaCommon/tests/fixtures/test_edit_archival_object.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_edit_archival_object.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: password=admin
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['14']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.10 Darwin/15.0.0]
+    method: POST
+    uri: http://localhost:8089/users/admin/login
+  response:
+    body: {string: !!python/unicode '{"session":"fd47f17b9643680d69818993e40ed986f771b70a41360b1df3b7dc26d5fd7983","user":{"lock_version":361,"username":"admin","name":"Administrator","is_system_user":true,"create_time":"2015-06-11T17:04:21Z","system_mtime":"2015-11-02T22:53:06Z","user_mtime":"2015-11-02T22:53:06Z","jsonmodel_type":"user","groups":[],"is_admin":true,"uri":"/users/1","agent_record":{"ref":"/agents/people/1"},"permissions":{"/repositories/1":["update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record","administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed"],"_archivesspace":["administer_system","become_user","cancel_importer_job","create_repository","delete_archival_record","delete_classification_record","delete_event_record","delete_repository","import_records","index_system","manage_agent_record","manage_repository","manage_subject_record","manage_users","manage_vocabulary_record","mediate_edits","merge_agents_and_subjects","merge_archival_record","suppress_archival_record","system_config","transfer_archival_record","transfer_repository","update_accession_record","update_classification_record","update_digital_object_record","update_event_record","update_resource_record","view_all_records","view_repository","view_suppressed","update_location_record","delete_vocabulary_record","update_subject_record","delete_subject_record","update_agent_record","delete_agent_record","update_vocabulary_record","merge_subject_record","merge_agent_record"]}}}
+
+'}
+    headers:
+      cache-control: ['private, must-revalidate, max-age=0']
+      content-length: ['2206']
+      content-type: [application/json]
+      date: ['Mon, 02 Nov 2015 22:53:06 GMT']
+      server: [Jetty(8.1.5.v20120716)]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.10 Darwin/15.0.0]
+      X-ArchivesSpace-Session: [!!python/unicode fd47f17b9643680d69818993e40ed986f771b70a41360b1df3b7dc26d5fd7983]
+    method: GET
+    uri: http://localhost:8089/repositories/2/archival_objects/3
+  response:
+    body: {string: !!python/unicode '{"lock_version":7,"position":0,"publish":false,"ref_id":"e61c441cd04eb5731ce64de35a4339ff","component_id":"F1-1-1","title":"Test
+        subseries","display_string":"Test subseries, 2014-01-01 - 2015-01-01","restrictions_apply":false,"created_by":"admin","last_modified_by":"admin","create_time":"2015-06-11T17:20:19Z","system_mtime":"2015-10-29T23:50:50Z","user_mtime":"2015-10-29T23:50:50Z","suppressed":false,"level":"subseries","jsonmodel_type":"archival_object","external_ids":[],"subjects":[],"linked_events":[],"extents":[],"dates":[{"lock_version":0,"begin":"2014-01-01","end":"2015-01-01","created_by":"admin","last_modified_by":"admin","create_time":"2015-10-29T23:50:50Z","system_mtime":"2015-10-29T23:50:50Z","user_mtime":"2015-10-29T23:50:50Z","date_type":"inclusive","label":"creation","jsonmodel_type":"date"}],"external_documents":[],"rights_statements":[],"linked_agents":[],"instances":[],"notes":[],"uri":"/repositories/2/archival_objects/3","repository":{"ref":"/repositories/2"},"resource":{"ref":"/repositories/2/resources/1"},"parent":{"ref":"/repositories/2/archival_objects/1"},"has_unpublished_ancestor":true}
+
+'}
+    headers:
+      cache-control: ['private, must-revalidate, max-age=0']
+      content-length: ['1128']
+      content-type: [application/json]
+      date: ['Mon, 02 Nov 2015 22:53:06 GMT']
+      server: [Jetty(8.1.5.v20120716)]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.10 Darwin/15.0.0]
+      X-ArchivesSpace-Session: [!!python/unicode fd47f17b9643680d69818993e40ed986f771b70a41360b1df3b7dc26d5fd7983]
+    method: GET
+    uri: http://localhost:8089/repositories/2/archival_objects/3
+  response:
+    body: {string: !!python/unicode '{"lock_version":7,"position":0,"publish":false,"ref_id":"e61c441cd04eb5731ce64de35a4339ff","component_id":"F1-1-1","title":"Test
+        subseries","display_string":"Test subseries, 2014-01-01 - 2015-01-01","restrictions_apply":false,"created_by":"admin","last_modified_by":"admin","create_time":"2015-06-11T17:20:19Z","system_mtime":"2015-10-29T23:50:50Z","user_mtime":"2015-10-29T23:50:50Z","suppressed":false,"level":"subseries","jsonmodel_type":"archival_object","external_ids":[],"subjects":[],"linked_events":[],"extents":[],"dates":[{"lock_version":0,"begin":"2014-01-01","end":"2015-01-01","created_by":"admin","last_modified_by":"admin","create_time":"2015-10-29T23:50:50Z","system_mtime":"2015-10-29T23:50:50Z","user_mtime":"2015-10-29T23:50:50Z","date_type":"inclusive","label":"creation","jsonmodel_type":"date"}],"external_documents":[],"rights_statements":[],"linked_agents":[],"instances":[],"notes":[],"uri":"/repositories/2/archival_objects/3","repository":{"ref":"/repositories/2"},"resource":{"ref":"/repositories/2/resources/1"},"parent":{"ref":"/repositories/2/archival_objects/1"},"has_unpublished_ancestor":true}
+
+'}
+    headers:
+      cache-control: ['private, must-revalidate, max-age=0']
+      content-length: ['1128']
+      content-type: [application/json]
+      date: ['Mon, 02 Nov 2015 22:53:06 GMT']
+      server: [Jetty(8.1.5.v20120716)]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"lock_version": 7, "system_mtime": "2015-10-29T23:50:50Z", "extents":
+      [], "jsonmodel_type": "archival_object", "ref_id": "e61c441cd04eb5731ce64de35a4339ff",
+      "instances": [], "create_time": "2015-06-11T17:20:19Z", "created_by": "admin",
+      "parent": {"ref": "/repositories/2/archival_objects/1"}, "title": "Test edited
+      subseries", "display_string": "Test subseries, 2014-01-01 - 2015-01-01", "publish":
+      false, "subjects": [], "external_documents": [], "linked_agents": [], "repository":
+      {"ref": "/repositories/2"}, "has_unpublished_ancestor": true, "user_mtime":
+      "2015-10-29T23:50:50Z", "rights_statements": [], "linked_events": [], "external_ids":
+      [], "suppressed": false, "dates": [{"expression": "November, 2014 to November,
+      2015", "begin": "2014-11-01", "end": "2015-11-01", "date_type": "inclusive",
+      "label": "creation"}], "component_id": "F1-1-1", "resource": {"ref": "/repositories/2/resources/1"},
+      "level": "subseries", "notes": [{"type": "odd", "publish": true, "jsonmodel_type":
+      "note_multipart", "subnotes": [{"content": "This is a test note", "publish":
+      true, "jsonmodel_type": "note_text"}]}], "uri": "/repositories/2/archival_objects/3",
+      "last_modified_by": "admin", "restrictions_apply": false, "position": 0}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1221']
+      User-Agent: [python-requests/2.7.0 CPython/2.7.10 Darwin/15.0.0]
+      X-ArchivesSpace-Session: [!!python/unicode fd47f17b9643680d69818993e40ed986f771b70a41360b1df3b7dc26d5fd7983]
+    method: POST
+    uri: http://localhost:8089/repositories/2/archival_objects/3
+  response:
+    body: {string: !!python/unicode '{"status":"Updated","id":3,"lock_version":8,"stale":true,"uri":"/repositories/2/archival_objects/3","warnings":[]}
+
+'}
+    headers:
+      cache-control: ['private, must-revalidate, max-age=0']
+      content-length: ['115']
+      content-type: [application/json]
+      date: ['Mon, 02 Nov 2015 22:53:06 GMT']
+      server: [Jetty(8.1.5.v20120716)]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/2.7.10 Darwin/15.0.0]
+      X-ArchivesSpace-Session: [!!python/unicode fd47f17b9643680d69818993e40ed986f771b70a41360b1df3b7dc26d5fd7983]
+    method: GET
+    uri: http://localhost:8089/repositories/2/archival_objects/3
+  response:
+    body: {string: !!python/unicode '{"lock_version":8,"position":0,"publish":false,"ref_id":"e61c441cd04eb5731ce64de35a4339ff","component_id":"F1-1-1","title":"Test
+        edited subseries","display_string":"Test edited subseries, November, 2014
+        to November, 2015","restrictions_apply":false,"created_by":"admin","last_modified_by":"admin","create_time":"2015-06-11T17:20:19Z","system_mtime":"2015-11-02T22:53:07Z","user_mtime":"2015-11-02T22:53:07Z","suppressed":false,"level":"subseries","jsonmodel_type":"archival_object","external_ids":[],"subjects":[],"linked_events":[],"extents":[],"dates":[{"lock_version":0,"expression":"November,
+        2014 to November, 2015","begin":"2014-11-01","end":"2015-11-01","created_by":"admin","last_modified_by":"admin","create_time":"2015-11-02T22:53:07Z","system_mtime":"2015-11-02T22:53:07Z","user_mtime":"2015-11-02T22:53:07Z","date_type":"inclusive","label":"creation","jsonmodel_type":"date"}],"external_documents":[],"rights_statements":[],"linked_agents":[],"instances":[],"notes":[{"type":"odd","jsonmodel_type":"note_multipart","subnotes":[{"content":"This
+        is a test note","publish":true,"jsonmodel_type":"note_text"}],"persistent_id":"063373886a2f23d03fe1a51f7c96ca8b","publish":true}],"uri":"/repositories/2/archival_objects/3","repository":{"ref":"/repositories/2"},"resource":{"ref":"/repositories/2/resources/1"},"parent":{"ref":"/repositories/2/archival_objects/1"},"has_unpublished_ancestor":true}
+
+'}
+    headers:
+      cache-control: ['private, must-revalidate, max-age=0']
+      content-length: ['1404']
+      content-type: [application/json]
+      date: ['Mon, 02 Nov 2015 22:53:07 GMT']
+      server: [Jetty(8.1.5.v20120716)]
+      x-content-type-options: [nosniff]
+    status: {code: 200, message: OK}
+version: 1

--- a/src/dashboard/src/components/access/views.py
+++ b/src/dashboard/src/components/access/views.py
@@ -172,7 +172,10 @@ def record_children(client, request, system='', record_id=''):
         try:
             new_id = client.add_child(record_id,
                                       title=new_record_data.get('title', ''),
-                                      level=new_record_data.get('level', ''))
+                                      level=new_record_data.get('level', ''),
+                                      start_date=new_record_data.get('start_date', ''),
+                                      end_date=new_record_data.get('end_date', ''),
+                                      date_expression=new_record_data.get('date_expression', ''))
         except ArchivesSpaceError as e:
             response = {
                 'success': False,


### PR DESCRIPTION
This currently supports a subset of ArchivesSpace's notes functionality, supporting a single block of text in a single note. (ArchivesSpace allows arbitrary numbers of notes, and each note may contain arbitrary numbers of blocks of text.)
