### PR TITLE
Fix test integrity errors

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 django_find_projects=false
 python_paths=/usr/share/archivematica/dashboard/;/usr/lib/archivematica/archivematicaCommon/
 DJANGO_SETTINGS_MODULE=settings.test
+norecursedirs = .svn _build tmp* node_modules bower_components

--- a/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
+++ b/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
@@ -144,7 +144,6 @@ def update_files(sip_uuid, files):
         databaseFunctions.insertIntoDerivations(
             sourceFileUUID=file_info['uuid'],
             derivedFileUUID=file_info['derivation'],
-            relatedEventUUID=file_info['derivation_event'],
         )
 
 def parse_dc(sip_uuid, root):

--- a/src/MCPClient/tests/fixtures/archivesspace.json
+++ b/src/MCPClient/tests/fixtures/archivesspace.json
@@ -22,5 +22,25 @@
         "currenttask": "5ded9d05-dd24-484a-a8b2-73ec5d35aa63",
         "replaces": null
     }
+},
+{
+    "fields": {
+        "tasktypepkreference": "",
+        "lastmodified": "2015-10-29T22:49:37",
+        "replaces": null,
+        "description": "Choose Config for ArchivesSpace DIP Upload",
+        "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84"
+    },
+    "model": "main.taskconfig",
+    "pk": "5ded9d05-dd24-484a-a8b2-73ec5d35aa63"
+},
+{
+    "fields": {
+        "lastmodified": "2012-10-02T00:25:10",
+        "replaces": null,
+        "description": "get replacement dic from user choice"
+    },
+    "model": "main.tasktype",
+    "pk": "9c84b047-9a6d-463f-9836-eafa49743b84"
 }
 ]

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -144,7 +144,7 @@ def insertIntoEvents(fileUUID, eventIdentifierUUID="", eventType="", eventDateTi
                          event_outcome_detail=eventOutcomeDetailNote,
                          linking_agent=agent)
 
-def insertIntoDerivations(sourceFileUUID="", derivedFileUUID="", relatedEventUUID=""):
+def insertIntoDerivations(sourceFileUUID="", derivedFileUUID="", relatedEventUUID=None):
     """
     Creates a new entry in the Derivations table using the supplied arguments. The two files in this relationship should already exist in the Files table.
 

--- a/src/archivematicaCommon/lib/utilities/FPRClient/client.py
+++ b/src/archivematicaCommon/lib/utilities/FPRClient/client.py
@@ -83,7 +83,8 @@ class FPRClient(object):
 
         # Create
         try:
-            obj = model.objects.create(**valid_fields)
+            with django.db.transaction.atomic():
+                obj = model.objects.create(**valid_fields)
         except django.db.utils.IntegrityError:
             self.retry[model].append(valid_fields)
             print 'Integrity error failed; will retry later'

--- a/src/archivematicaCommon/lib/utilities/FPRClient/identification_links.json
+++ b/src/archivematicaCommon/lib/utilities/FPRClient/identification_links.json
@@ -1,0 +1,83 @@
+[
+{
+    "fields": {
+        "microservicegroup": "Identify file format",
+        "defaultexitmessage": "Failed",
+        "reloadfilelist": true,
+        "lastmodified": "2013-11-07T22:51:42",
+        "defaultnextchainlink": null,
+        "currenttask": "97545cb5-3397-4934-9bc5-143b774e4fa7",
+        "replaces": null
+    },
+    "model": "main.microservicechainlink",
+    "pk": "f09847c2-ee51-429a-9478-a860477f6b8d"
+},
+{
+    "fields": {
+        "tasktypepkreference": null,
+        "lastmodified": "2013-11-07T22:51:42",
+        "replaces": null,
+        "description": "Select file format identification command",
+        "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84"
+    },
+    "model": "main.taskconfig",
+    "pk": "97545cb5-3397-4934-9bc5-143b774e4fa7"
+},
+{
+    "fields": {
+        "microservicegroup": "Normalize",
+        "defaultexitmessage": "Failed",
+        "reloadfilelist": true,
+        "lastmodified": "2013-11-07T22:51:42",
+        "defaultnextchainlink": null,
+        "currenttask": "f8d0b7df-68e8-4214-a49d-60a91ed27029",
+        "replaces": null
+    },
+    "model": "main.microservicechainlink",
+    "pk": "7a024896-c4f7-4808-a240-44c87c762bc5"
+},
+{
+    "fields": {
+        "tasktypepkreference": null,
+        "lastmodified": "2013-11-07T22:51:42",
+        "replaces": null,
+        "description": "Select pre-normalize file format identification command",
+        "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84"
+    },
+    "model": "main.taskconfig",
+    "pk": "f8d0b7df-68e8-4214-a49d-60a91ed27029"
+},
+{
+    "fields": {
+        "microservicegroup": "Process submission documentation",
+        "defaultexitmessage": "Failed",
+        "reloadfilelist": true,
+        "lastmodified": "2014-09-11T16:09:53",
+        "defaultnextchainlink": null,
+        "currenttask": "0c95f944-837f-4ada-a396-2c7a818806c6",
+        "replaces": null
+    },
+    "model": "main.microservicechainlink",
+    "pk": "087d27be-c719-47d8-9bbb-9a7d8b609c44"
+},
+{
+    "fields": {
+        "tasktypepkreference": null,
+        "lastmodified": "2014-09-11T16:09:53",
+        "replaces": null,
+        "description": "Select file format identification command",
+        "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84"
+    },
+    "model": "main.taskconfig",
+    "pk": "0c95f944-837f-4ada-a396-2c7a818806c6"
+},
+{
+    "fields": {
+        "lastmodified": "2012-10-02T00:25:10",
+        "replaces": null,
+        "description": "get replacement dic from user choice"
+    },
+    "model": "main.tasktype",
+    "pk": "9c84b047-9a6d-463f-9836-eafa49743b84"
+}
+]

--- a/src/archivematicaCommon/lib/utilities/FPRClient/test_fprclient.py
+++ b/src/archivematicaCommon/lib/utilities/FPRClient/test_fprclient.py
@@ -40,6 +40,9 @@ class TestFPRClient(TestCase):
     Test fetching and updating rules.
     """
 
+    fixture_files = ['identification_links.json', ]
+    fixtures = [os.path.join(THIS_DIR, p) for p in fixture_files]
+
     # ID commands that replace each other
     rule_a = {
         "replaces": None,
@@ -99,6 +102,9 @@ class TestFPRClient(TestCase):
 
     def setUp(self):
         self.fprclient = client.FPRClient(fprserver=FPRSERVER)
+
+    def test_fixtures(self):
+        assert main.models.MicroServiceChainLink.objects.count() == 3
 
     def test_insert_initial_chain(self):
         """ Insert a chain of rules into a new install. """

--- a/src/archivematicaCommon/lib/utilities/FPRClient/test_fprclient.py
+++ b/src/archivematicaCommon/lib/utilities/FPRClient/test_fprclient.py
@@ -3,7 +3,7 @@ import os
 import sys
 import vcr
 
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 
 sys.path.append("/usr/share/archivematica/dashboard/")
 from fpr import models
@@ -35,7 +35,7 @@ class TestGetFromFPRRESTAPI(TestCase):
         records = list(getFromRestAPI.each_record("id-command", url=FPRSERVER))
         assert len(records) == 2
 
-class TestFPRClient(TestCase):
+class TestFPRClient(TransactionTestCase):
     """
     Test fetching and updating rules.
     """

--- a/src/dashboard/src/manage.py
+++ b/src/dashboard/src/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.local")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
SQLite doesn't enforce referential integrity, so tests fail when run against a real DB.  Add fixtures/clean up code to fix this. Some updates relate to Django's new transaction approach.
