### PR TITLE
Dev-helper: Update pip dependencies

### DIFF
--- a/dev-helper
+++ b/dev-helper
@@ -96,6 +96,8 @@ function package-update() {
           colour sudo ./installDependsFromDebianFile.py ./../src/MCPServer/debian/control
           colour sudo pip install -r ../src/dashboard/src/requirements/production.txt     
           cd ..
+          sudo pip install --upgrade -r src/dashboard/src/requirements/base.txt
+          sudo pip install --upgrade -r src/archivematicaCommon/requirements/local.txt
   else
           echo "Not going to ${part}."
   fi

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 django_find_projects=false
 python_paths=/usr/share/archivematica/dashboard/;/usr/lib/archivematica/archivematicaCommon/
 DJANGO_SETTINGS_MODULE=settings.test
-norecursedirs = .svn _build tmp* node_modules bower_components
+norecursedirs = .svn _build tmp* node_modules bower_components share


### PR DESCRIPTION
Update pip dependencies. Don't find tests in share because /var/archivematica/sharedDirectory is sometimes symlinked there and has permissions problems.
