### PR TITLE
Unzipped Bag: Restructure doesn't move processingMCP

### DIFF
--- a/src/MCPClient/lib/clientScripts/verifyAndRestructureTransferBag.py
+++ b/src/MCPClient/lib/clientScripts/verifyAndRestructureTransferBag.py
@@ -99,9 +99,12 @@ def restructureBagForComplianceFileUUIDsAssigned(unitPath, unitIdentifier, unitI
         if os.path.isfile(src):
             if item.startswith("manifest"):
                 dst = os.path.join(unitPath, "metadata", item)
+                fileOperations.updateFileLocation2(src, dst, unitPath, unitIdentifier, unitIdentifierType, unitPathReplaceWith)
+            elif item in OPTIONAL_FILES:
+                print "not moving:", item
             else:
                 dst = os.path.join(bagFileDefaultDest, item)
-            fileOperations.updateFileLocation2(src, dst, unitPath, unitIdentifier, unitIdentifierType, unitPathReplaceWith)
+                fileOperations.updateFileLocation2(src, dst, unitPath, unitIdentifier, unitIdentifierType, unitPathReplaceWith)
     for item in os.listdir(unitDataPath):
         itemPath =  os.path.join(unitDataPath, item)
         if os.path.isdir(itemPath) and item not in REQUIRED_DIRECTORIES:


### PR DESCRIPTION
When verifying and restructuring a bag, do not move OPTIONAL_FILES (currently just processingMCP).  This fixes a problem where the automation-tools processingMCP was being moved and then not used.
