### PR TITLE
Transfer type identification, refs #9171

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaSetTransferType.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaSetTransferType.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python2
 
+"""
+mysql> SELECT pk, arguments FROM StandardTasksConfigs WHERE execute = 'archivematicaSetTransferType_v0.0';
++--------------------------------------+------------------------+
+| pk                                   | arguments              |
++--------------------------------------+------------------------+
+| 353f326a-c599-4e66-8e1c-6262316e3729 | "%SIPUUID%" "TRIM"     |
+| 36ad6300-5a2c-491b-867b-c202541749e8 | "%SIPUUID%" "Standard" |
+| 6c261f8f-17ce-4b58-86c2-ac3bfb0d2850 | "%SIPUUID%" "Dspace"   |
+| 7b455fc5-b201-4233-ba1c-e05be059b279 | "%SIPUUID%" "Maildir"  |
++--------------------------------------+------------------------+
+4 rows in set (0.00 sec)
+"""
+
 # This file is part of Archivematica.
 #
 # Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>

--- a/src/MCPClient/lib/clientScripts/archivematicaSetTransferType.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaSetTransferType.py
@@ -1,18 +1,5 @@
 #!/usr/bin/env python2
 
-"""
-mysql> SELECT pk, arguments FROM StandardTasksConfigs WHERE execute = 'archivematicaSetTransferType_v0.0';
-+--------------------------------------+------------------------+
-| pk                                   | arguments              |
-+--------------------------------------+------------------------+
-| 353f326a-c599-4e66-8e1c-6262316e3729 | "%SIPUUID%" "TRIM"     |
-| 36ad6300-5a2c-491b-867b-c202541749e8 | "%SIPUUID%" "Standard" |
-| 6c261f8f-17ce-4b58-86c2-ac3bfb0d2850 | "%SIPUUID%" "Dspace"   |
-| 7b455fc5-b201-4233-ba1c-e05be059b279 | "%SIPUUID%" "Maildir"  |
-+--------------------------------------+------------------------+
-4 rows in set (0.00 sec)
-"""
-
 # This file is part of Archivematica.
 #
 # Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
@@ -48,4 +35,9 @@ if __name__ == '__main__':
     transferUUID = sys.argv[1]
     transferType = sys.argv[2]
 
-    Transfer.objects.filter(uuid=transferUUID).update(type=transferType)
+    transfer = Transfer.objects.get(uuid=transferUUID)
+    if transfer.type is not None:
+        sys.exit(0)
+
+    transfer.type = transferType
+    transfer.save()

--- a/src/MCPClient/lib/clientScripts/verifyBAG.py
+++ b/src/MCPClient/lib/clientScripts/verifyBAG.py
@@ -20,42 +20,51 @@
 # @package Archivematica
 # @subpackage archivematicaClientScript
 # @author Joseph Perry <joseph@artefactual.com>
+from __future__ import print_function
 import os
 import sys
+
 # archivematicaCommon
 from custom_handlers import get_script_logger
 from executeOrRunSubProcess import executeOrRun
 
-logger = get_script_logger("archivematica.mcp.client.verifyBAG")
+logger = get_script_logger('archivematica.mcp.client.verifyBAG')
 
-printSubProcessOutput=True
+PRINT_SUBPROCESS_OUTPUT = True
+BAG = '/usr/share/bagit/bin/bag'
+BAG_INFO = 'bag-info.txt'
 
-bag = sys.argv[1]
-verificationCommands = []
-verificationCommands.append("/usr/share/bagit/bin/bag verifyvalid \"%s\"" % (bag)) #Verifies the validity of a bag.
-verificationCommands.append("/usr/share/bagit/bin/bag verifycomplete \"%s\"" % (bag)) #Verifies the completeness of a bag.
-verificationCommands.append("/usr/share/bagit/bin/bag verifypayloadmanifests \"%s\"" % (bag)) #Verifies the checksums in all payload manifests.
 
-bagInfoPath = os.path.join(bag, "bag-info.txt")
-if os.path.isfile(bagInfoPath):
-    for line in open(bagInfoPath,'r'):
-        if line.startswith("Payload-Oxum"):
-            verificationCommands.append("/usr/share/bagit/bin/bag checkpayloadoxum \"%s\"" % (bag)) #Generates Payload-Oxum and checks against Payload-Oxum in bag-info.txt.
+def verifyBAG(path):
+    bag_info = os.path.join(path, BAG_INFO)
+    verification_commands = (
+        '{} verifyvalid {}'.format(BAG, path),              # Verifies the validity of a bag
+        '{} verifycomplete {}'.format(BAG, path),           # Verifies the completeness of a bag
+        '{} verifypayloadmanifests {}'.format(BAG, path),   # Verifies the checksums in all payload manifests
+    )
+
+    if os.path.isfile(bag_info):
+        for line in open(bag_info, 'r'):
+            if line.startswith('Payload-Oxum'):
+                verification_commands.append('{} checkpayloadoxum {}'.format(BAG, path)) # Generates Payload-Oxum and checks against Payload-Oxum in bag-info.txt
+                break
+
+    for item in os.listdir(path):
+        if item.startswith('tagmanifest-') and item.endswith('.txt'):
+            verification_commands.append('{} verifytagmanifests {}'.format(BAG, path)) # Verifies the checksums in all tag manifests
             break
 
-for item in os.listdir(bag):
-    if item.startswith("tagmanifest-") and item.endswith(".txt"):        
-        verificationCommands.append("/usr/share/bagit/bin/bag verifytagmanifests \"%s\"" % (bag)) #Verifies the checksums in all tag manifests.
-        break
-        
-exitCode = 0
-for command in verificationCommands:
-    ret = executeOrRun("command", command, printing=printSubProcessOutput)
-    exit, stdOut, stdErr = ret
-    if exit != 0:
-        print >>sys.stderr, "Failed test: ", command
-        exitCode=1
-    else:
-        print >>sys.stderr, "Passed test: ", command
-quit(exitCode)
+    exit_code = 0
+    for command in verification_commands:
+        exit, stdout, stderr = executeOrRun('command', command, printing=PRINT_SUBPROCESS_OUTPUT)
+        if exit != 0:
+            print('Failed test:', command, file=sys.stderr)
+            exit_code = 1
+        else:
+            print('Passed test:', command, file=sys.stderr)
 
+    return exit_code
+
+
+if __name__ == '__main__':
+    sys.exit(verifyBAG(sys.argv[1]))

--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -25,11 +25,10 @@ urlpatterns = patterns('',
     url(r'transfer/unapproved', views.unapproved_transfers),
     url(r'transfer/status/(?P<unit_uuid>' + settings.UUID_REGEX + ')', views.status, {'unit_type': 'unitTransfer'}),
     url(r'transfer/start_transfer/', views.start_transfer_api),
+    url(r'transfer/reingest', views.reingest_to_transfer),
     url(r'ingest/status/(?P<unit_uuid>' + settings.UUID_REGEX + ')', views.status, {'unit_type': 'unitSIP'}),
     url(r'ingest/waiting', views.waiting_for_user_input),
-
-    url(r'^ingest/reingest', views.start_reingest),
-
+    url(r'ingest/reingest', views.reingest_to_ingest),
     url(r'administration/dips/atom/levels/$', views.get_levels_of_description),
     url(r'administration/dips/atom/fetch_levels/$', views.fetch_levels_of_description_from_atom),
     url(r'filesystem/metadata/$', views.path_metadata),

--- a/src/dashboard/src/components/archival_storage/forms.py
+++ b/src/dashboard/src/components/archival_storage/forms.py
@@ -24,8 +24,13 @@ class CreateAICForm(forms.Form):
 class ReingestAIPForm(forms.Form):
     METADATA_ONLY = 'metadata'
     OBJECTS = 'objects'
+    FULL = 'full'
     REINGEST_CHOICES = (
-        (METADATA_ONLY, 'Re-ingest metadata only'),
-        (OBJECTS, 'Re-ingest metadata and objects')
+        (METADATA_ONLY, 'Metadata re-ingest'),
+        (OBJECTS, 'Partial re-ingest'),
+        (FULL, 'Full re-ingest'),
     )
     reingest_type = forms.ChoiceField(choices=REINGEST_CHOICES,  widget=forms.RadioSelect, required=True)
+    processing_config = forms.CharField(required=False, initial='default',
+        help_text='Only needed in full re-ingest',
+        widget=forms.TextInput(attrs={'placeholder': 'default'}))

--- a/src/dashboard/src/templates/archival_storage/reingest_request.html
+++ b/src/dashboard/src/templates/archival_storage/reingest_request.html
@@ -13,6 +13,23 @@ form li>label {
   clear: both;
   width: auto;
 }
+form ul:after {
+  visibility: hidden;
+  display: block;
+  font-size: 0;
+  content: " ";
+  clear: both;
+  height: 0;
+}
+input#id_processing_config {
+  display: block;
+  clear: left;
+}
+.helptext {
+  display: inline-block;
+  margin-top: -10px;
+  color: #999;
+}
 </style>
 
 {% endblock %}
@@ -25,7 +42,8 @@ form li>label {
     {% csrf_token %}
     <p>Package: {{ package_uuid }}</p>
     <div class='clearfix'>{{ form }}</div>
-    <a href="{% url 'archival_storage_index' %}" class='btn'>Cancel</a> <input class='btn primary' type="submit" value="Re-ingest Package" />
+    <a href="{% url 'archival_storage_index' %}" class='btn'>Cancel</a> <input class='btn primary' type="submit" value="Re-ingest package" />
   </form>
+
 </div>
 {% endblock %}


### PR DESCRIPTION
Redmine ticket: https://projects.artefactual.com/issues/9171

The [Transfer](https://github.com/artefactual/archivematica/blob/8b859d75111607eb0b31a9e3c2db85750f1e9041/src/dashboard/src/main/models.py#L252-L272) model has two fields related to the type of the transfer:
- `Transfer.typeoftransfer`: currently unused.
- `Transfer.transfer`
  - Client scripts making use of it:
    - `archivematicaSetTransferType.py`
    - `archivematicaCreateMETS2.py`

`archivematicaSetTransferType.py` sets a value for `Transfer.type` so it can be used later by `archivematicaCreateMETS2.py`. This doesn't happen in only some cases:
- Set transfer type: DSpace
- Set transfer type: Standard
- Set transfer type: TRIM
- Set transfer type: Maildir

The concept of transfer type is also used in the dashboard when it comes to start a new transfer:
- `components.api.views.approve_transfer`
- `components.filesystem_ajax.views.start_transfer`

The type is used to determine what [watchedDirectory/activeTransfers](https://github.com/artefactual/archivematica/tree/qa/1.x/src/MCPServer/share/sharedDirectoryStructure/watchedDirectories/activeTransfers) the transfer is going to start in, which determines the starting chain. One of the following values is expected:

```
'standard' => 'standardTransfer',
'unzipped bag' => 'baggitDirectory',
'zipped bag' => 'baggitZippedDirectory',
'dspace' => 'Dspace',
'maildir' => 'maildir',
'TRIM' => 'TRIM'
```

This map is hard-coded in three different places:
- [src/dashboard/src/templates/transfer/grid.html](https://github.com/artefactual/archivematica/blob/36dda44e8ad8fea2506f3dca83194738dc70108c/src/dashboard/src/templates/transfer/grid.html#L175-L186)
- [components.api.views.approve_transfer_via_mcp](https://github.com/artefactual/archivematica/blob/36dda44e8ad8fea2506f3dca83194738dc70108c/src/dashboard/src/components/api/views.py#L370-L377)
- [components.filesystem_ajax.views](https://github.com/artefactual/archivematica/blob/8b859d75111607eb0b31a9e3c2db85750f1e9041/src/dashboard/src/components/filesystem_ajax/views.py#L58-L65)
### Actions
- Delete `Transfer.typeOfTransfer`
- Investigate why the dropdown in the Ingest tab is missing the option `maildir`?
