### PR TITLE
ArchivesSpace digital object component support

### DIFF
--- a/src/MCPClient/etc/archivematicaClientModules
+++ b/src/MCPClient/etc/archivematicaClientModules
@@ -131,4 +131,5 @@ verifyMD5_v0.0 = %clientScriptsDirectory%verifyMD5.sh
 verifyPREMISChecksums_v0.0 = %clientScriptsDirectory%verifyPREMISChecksums.py
 verifySIPCompliance_v0.0 = %clientScriptsDirectory%verifySIPCompliance.py
 verifyTransferCompliance_v0.0 = %clientScriptsDirectory%verifyTransferCompliance.py
+writeDigitalObjectComponentsToArchivesSpace_v0.0 = %clientScriptsDirectory%writeDigitalObjectComponentsToArchivesSpace.py
 

--- a/src/MCPClient/lib/clientScripts/writeDigitalObjectComponentsToArchivesSpace.py
+++ b/src/MCPClient/lib/clientScripts/writeDigitalObjectComponentsToArchivesSpace.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python2
+
+from argparse import ArgumentParser
+from collections import defaultdict
+from csv import DictWriter
+from glob import iglob
+import os
+import sys
+from uuid import uuid4
+
+from main.models import ArchivesSpaceDOComponent
+
+# archivematicaCommon
+from elasticSearchFunctions import getDashboardUUID
+
+from agentarchives.archivesspace import ArchivesSpaceClient
+
+
+def process_digital_object_components(client, writer, current_location):
+    dashboard_uuid = getDashboardUUID()
+
+    component_ids = [os.path.basename(path).split('digital_object_component_')[1] for path in
+                     iglob(os.path.join(current_location, 'digital_object_component_*'))]
+
+    components = ArchivesSpaceDOComponent.objects.filter(id__in=component_ids)
+    # exit early to avoid the expense of hitting up ASpace
+    if components.count() == 0:
+        return
+
+    # In most circumstances an AIP being processed will be associated
+    # with only a single archival object, but since that isn't guaranteed at
+    # the database level let's operate with the assumption this could happen.
+    archival_object_map = defaultdict(list)
+    for component in components:
+        archival_object_map[component.resourceid].append(component)
+
+    for resource_id, components in archival_object_map.iteritems():
+        do_id = client.add_digital_object(resource_id, dashboard_uuid, str(uuid4))['id']
+        for component in components:
+            if component.digitalobjectid:
+                continue  # already created
+
+            doc = client.add_digital_object_component(do_id,
+                                                      label=component.label,
+                                                      title=component.title)
+            # Track status about this component having been created for future use
+            component.digitalobjectid = do_id
+            component.remoteid = doc['id']
+            component.save()
+
+            writer.writerow({
+                'component_id': component.id,
+                'digital_object_component_id': component.remoteid,
+            })
+
+            yield 'Created digital object component "{}" associated with record "{}"'.format(doc['id'], resource_id)
+
+
+def main(current_location, host, port, user, passwd):
+    with open(os.path.join(current_location, 'metadata', 'digital_object_components.csv'), 'w') as csvfile:
+        writer = DictWriter(csvfile, ['component_id', 'digital_object_component_id'])
+        writer.writeheader()
+
+        client = ArchivesSpaceClient(host=host, port=port, user=user, passwd=passwd)
+
+        for message in process_digital_object_components(client, writer, current_location):
+            print(message)
+
+        return 0
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('--current-location',
+                        type=str, help='%SIPDirectory%')
+    parser.add_argument('--host', default="localhost",
+                        metavar="host", help="hostname of ArchivesSpace")
+    parser.add_argument('--port', type=int, default=8089,
+                        metavar="port", help="Port used by ArchivesSpace backend API")
+    parser.add_argument('--user', metavar="Administrative user")
+    parser.add_argument('--passwd', metavar="Administrative user password")
+
+    args = parser.parse_args()
+
+    sys.exit(main(args.current_location, args.host, args.port, args.user, args.passwd))


### PR DESCRIPTION
This adds a few pieces of digital object-related functionality.

The Bentley/appraisal tab workflow for ArchivesSpace digital objects differs significantly from the existing DIP upload. This workflow is based around AIP storage, _not_ DIP upload, and handles the creation of file records differently.

This workflow begins in the appraisal tab, rather than at DIP storage.
- In the appraisal tab, the user creates digital object components associated with a given archival object
- The user drags one or more files into those components.
- Archivematica stores information about the digital object components and the files which are stored within those components in its database. (This is to ATK pairing.)
- When the AIP is stored, Archivematica creates one digital object associated with the archival object, and creates the components as children of that digital object. No ArchivesSpace records are created for individual files.
- The Storage Service is sent information on the division of the AIP into digital object components at the time the AIP is stored, and repackages the AIP into multiple ZIP files which are stored in DSpace or Fedora in records associated with those digital object components.

Changes in this PR:
- ~~Adds support for creating digital object components in ArchivesSpace to ArchivesSpaceClient. These are small records containing only a label and/or title which are children of digital objects.~~ This was merged in the agentarchives repo, and removed as these no longer exist here.
- ~~Add stub digital object methods to ArchivistsToolkitClient. (ATK doesn't have digital object components, and we haven't yet added DO support.)~~
- Adds models to represent DO components in the AM database~~, and to pair paths within a SIP with those components.~~
- Adds new access views to support adding/listing/editing DO components and their files.
