### PR TITLE
Added a configuration option to use a different databse name

### DIFF
--- a/src/archivematicaCommon/etc/dbsettings
+++ b/src/archivematicaCommon/etc/dbsettings
@@ -2,4 +2,4 @@
 user=archivematica
 password=demo
 host=localhost
-
+db=archivematica

--- a/src/archivematicaCommon/etc/dbsettings
+++ b/src/archivematicaCommon/etc/dbsettings
@@ -2,4 +2,4 @@
 user=archivematica
 password=demo
 host=localhost
-db=archivematica
+db=MCP

--- a/src/archivematicaCommon/lib/databaseInterface.py
+++ b/src/archivematicaCommon/lib/databaseInterface.py
@@ -32,7 +32,7 @@ printSQL = False
 printErrors = True
 
 #DB_CONNECTION_OPTS = dict(db="MCP", read_default_file="/etc/archivematica/archivematicaCommon/dbsettings")
-DB_CONNECTION_OPTS = dict(db="MCP", read_default_file="/etc/archivematica/archivematicaCommon/dbsettings", charset="utf8", use_unicode = True)
+DB_CONNECTION_OPTS = dict(read_default_file="/etc/archivematica/archivematicaCommon/dbsettings", charset="utf8", use_unicode = True)
 
 def reconnect():
     global database

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -41,7 +41,7 @@ config.read('/etc/archivematica/archivematicaCommon/dbsettings')
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',         # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'MCP',                                # Or path to database file if using sqlite3.
+        'NAME': config.get('client', 'db'),                                # Or path to database file if using sqlite3.
         'USER': config.get('client', 'user'),         # Not used with sqlite3.
         'PASSWORD': config.get('client', 'password'), # Not used with sqlite3.
         'HOST': config.get('client', 'host'),         # Set to empty string for localhost. Not used with sqlite3.


### PR DESCRIPTION
Added a new variable to the dbsettings-file "db" that contains the name of the database. Updated database interface code to support this. This allows users to choose a different database name from the default (MCP).

Tested on a development environment.
