### PR TITLE
AS/ATK clients: include resource/resource_component type in records

### DIFF
--- a/src/archivematicaCommon/lib/archivesspace/client.py
+++ b/src/archivematicaCommon/lib/archivesspace/client.py
@@ -304,6 +304,7 @@ class ArchivesSpaceClient(object):
 
             result = {
                 'id': record['record_uri'],
+                'type': 'resource',
                 'sortPosition': level,
                 'identifier': identifier,
                 'title': record.get('title', ''),
@@ -340,6 +341,7 @@ class ArchivesSpaceClient(object):
 
             result = {
                 'id': record['uri'],
+                'type': 'resource_component',
                 'sortPosition': level,
                 'identifier': record.get('component_id', ''),
                 'title': record.get('title', ''),
@@ -492,6 +494,7 @@ class ArchivesSpaceClient(object):
 
             return {
                 'id': record['uri'],
+                'type': 'resource',
                 'sortPosition': 1,
                 'identifier': identifier,
                 'title': record.get('title', ''),
@@ -580,6 +583,7 @@ class ArchivesSpaceClient(object):
             identifier = resolved['ref_id'] if 'ref_id' in resolved else resolved.get('component_id', '')
             return {
                 'id': record['ref'],
+                'type': self.resource_type(record['ref']),
                 'identifier': identifier,
                 'title': resolved.get('title', ''),
                 'levelOfDescription': resolved.get('level', ''),

--- a/src/archivematicaCommon/lib/archivistsToolkit/client.py
+++ b/src/archivematicaCommon/lib/archivistsToolkit/client.py
@@ -152,6 +152,7 @@ class ArchivistsToolkitClient(object):
             The dict follows this format:
         {
           'id': '31',
+          'type': 'resource',
           'sortPosition': '1',
           'identifier': 'PR01',
           'title': 'Parent',
@@ -163,6 +164,7 @@ class ArchivistsToolkitClient(object):
           ],
           'children': [{
             'id': '23',
+            'type': 'resource_component',
             'sortPosition': '2',
             'identifier': 'CH01',
             'title': 'Child A',
@@ -171,6 +173,7 @@ class ArchivistsToolkitClient(object):
             'notes': [],
             'children': [{
               'id': '24',
+              'type': 'resource_component',
               'sortPosition': '3',
               'identifier': 'GR01',
               'title': 'Grandchild A',
@@ -181,6 +184,7 @@ class ArchivistsToolkitClient(object):
             },
             {
               'id': '25',
+              'type': 'resource_component',
               'sortPosition': '4',
               'identifier': 'GR02',
               'title': 'Grandchild B',
@@ -191,6 +195,7 @@ class ArchivistsToolkitClient(object):
           },
           {
             'id': '26',
+            'type': 'resource_component',
             'sortPosition': '5',
             'identifier': 'CH02',
             'title': 'Child B',
@@ -223,6 +228,7 @@ class ArchivistsToolkitClient(object):
 
             for row in cursor.fetchall():
                 resource_data['id']                 = resource_id
+                resource_data['type']               = 'resource'
                 resource_data['sortPosition']       = sort_data['position']
                 resource_data['title']              = row[0]
                 resource_data['dates']              = row[1]
@@ -233,6 +239,7 @@ class ArchivistsToolkitClient(object):
 
             for row in cursor.fetchall():
                 resource_data['id']                 = resource_id
+                resource_data['type']               = 'resource_component'
                 resource_data['sortPosition']       = sort_data['position']
                 resource_data['title']              = row[0]
                 resource_data['dates']              = row[1]

--- a/src/archivematicaCommon/tests/test_archivesspace_client.py
+++ b/src/archivematicaCommon/tests/test_archivesspace_client.py
@@ -22,6 +22,7 @@ def test_listing_collections():
     collections = client.find_collections()
     assert len(collections) == 2
     assert collections[0]['title'] == 'Test fonds'
+    assert collections[0]['type'] == 'resource'
 
 
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_listing_collections_search.yaml'))
@@ -30,6 +31,7 @@ def test_listing_collections_search():
     collections = client.find_collections(search_pattern='Test fonds')
     assert len(collections) == 1
     assert collections[0]['title'] == 'Test fonds'
+    assert collections[0]['type'] == 'resource'
 
     no_results = client.find_collections(search_pattern='No such fonds')
     assert len(no_results) == 0
@@ -41,10 +43,12 @@ def test_listing_collections_sort():
     asc = client.find_collections(sort_by='asc')
     assert len(asc) == 2
     assert asc[0]['title'] == 'Some other fonds'
+    assert asc[0]['type'] == 'resource'
 
     desc = client.find_collections(sort_by='desc')
     assert len(desc) == 2
     assert desc[0]['title'] == 'Test fonds'
+    assert desc[0]['type'] == 'resource'
 
 
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_find_resource_id.yaml'))
@@ -74,6 +78,7 @@ def test_find_resource_children():
     assert type(data) == dict
     assert len(data['children']) == 2
     assert data['title'] == 'Test fonds'
+    assert data['type'] == 'resource'
 
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_find_resource_children_recursion.yaml'))
 def test_find_resource_children_recursion_level():
@@ -121,6 +126,7 @@ def test_find_by_id_refid():
     item = data[0]
     assert item['identifier'] == 'a118514fab1b2ee6a7e9ad259e1de355'
     assert item['id'] == '/repositories/2/archival_objects/752250'
+    assert item['type'] == 'resource_component'
     assert item['title'] == 'Test AO'
     assert item['levelOfDescription'] == 'file'
 
@@ -130,7 +136,9 @@ def test_augment_ids():
     data = client.augment_resource_ids(['/repositories/2/resources/1', '/repositories/2/resources/2'])
     assert len(data) == 2
     assert data[0]['title'] == 'Test fonds'
+    assert data[0]['type'] == 'resource'
     assert data[1]['title'] == 'Some other fonds'
+    assert data[1]['type'] == 'resource'
 
 @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_resource_type.yaml'))
 def test_get_resource_type():


### PR DESCRIPTION
The AS/ATK records don't currently return whether a given record is a resource or a resource_component. This could be useful for other systems to render, and is also useful in order to allow the appraisal tab to determine whether a record is an AS/ATK record or a different type of record.
