### PR TITLE
MCPClient: Accept KeyboardInterrupt in main thread

### DIFF
--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -252,8 +252,10 @@ if __name__ == '__main__':
     logging.config.dictConfig(LOGGING_CONFIG)
     logger = logging.getLogger("archivematica.mcp.client")
 
-    loadSupportedModules(config.get('MCPClient', "archivematicaClientModules"))
-    startThreads(config.getint('MCPClient', "numberOfTasks"))
-    tl = threading.Lock()
-    tl.acquire()
-    tl.acquire()
+    try:
+        loadSupportedModules(config.get('MCPClient', "archivematicaClientModules"))
+        startThreads(config.getint('MCPClient', "numberOfTasks"))
+        while True:
+            time.sleep(100)
+    except (KeyboardInterrupt, SystemExit):
+        logger.info('Received keyboard interrupt, quitting threads.')


### PR DESCRIPTION
I know that we are not cleaning up our daemon threads but IMO that is a different
battle. What I want to achieve now is to listen to keyboard interrupt signals,
which is necessary when you are not using a supervisor and you are attached to
the process, e.g. when you are running the interpreter directly in a container.
