### PR TITLE
Better configuration

### DIFF
--- a/src/MCPClient/etc/clientConfig.conf
+++ b/src/MCPClient/etc/clientConfig.conf
@@ -1,39 +1,28 @@
-#!/bin/bash
-
-# This file is part of Archivematica.
-#
-# Copyright 2010-2012 Artefactual Systems Inc. <http://artefactual.com>
-# 
-# Archivematica is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Archivematica is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
-
-
-# @package Archivematica
-# @subpackage MCPClient
-# @author Joseph Perry <joseph@artefactual.com>
-# @version svn: $Id$
-
 [MCPClient]
-MCPArchivematicaServer = localhost:4730
-sharedDirectoryMounted = /var/archivematica/sharedDirectory/
-maxThreads = 2
-archivematicaClientModules = /etc/archivematica/MCPClient/archivematicaClientModules
-clientScriptsDirectory = /usr/lib/archivematica/MCPClient/clientScripts/
-LoadSupportedCommandsSpecial = True
-#numberOfTasks 0 means detect number of cores, and use that.
-numberOfTasks = 0 
-elasticsearchServer = localhost:9200
-disableElasticsearchIndexing = False
+
+# MCP server
+server = localhost:4730
+
+shared_directory = /var/archivematica/sharedDirectory/
 temp_dir = /var/archivematica/sharedDirectory/tmp
-kioskMode = False
-django_settings_module = settings.common
+client_scripts_directory = /usr/lib/archivematica/MCPClient/clientScripts/
+
+# Client scripts, also known as client tasks or client modules...
+modules_file = /etc/archivematica/MCPClient/archivematicaClientModules
+load_special_scripts = yes
+
+# Number of Gearman workers. If undefined, only one worker will be used. When
+# zero, we will match the number of CPUs available in the machine. Each worker
+# is executed in a different system thread.
+workers = 0
+
+# Elasticsearch settings
+elasticsearch_server = localhost:9200
+elasticsearch_indexing_enabled = yes
+
+# MySQL settings
+db_name = MCP
+db_user = archivematica
+db_password = demo
+db_host = localhost
+db_port = 3306

--- a/src/MCPClient/init/archivematica-mcp-client.conf
+++ b/src/MCPClient/init/archivematica-mcp-client.conf
@@ -25,6 +25,9 @@ stop on runlevel [016]
 
 env CONF=/etc/archivematica/MCPClient
 env LOCATION=/usr/lib/archivematica/MCPClient/archivematicaClient.py
+env ARCHIVEMATICA_MCPCLIENT_CONFIG=/etc/archivematica/MCPClient/clientConfig.conf
+env DJANGO_SETTINGS_MODULE=settings.common
+env PYTHONPATH=/usr/lib/archivematica/MCPClient:/usr/lib/archivematica/archivematicaCommon:/usr/share/archivematica/dashboard
 
 setuid archivematica
 setgid archivematica

--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -32,210 +32,168 @@
 #The server will send the transcoder association pk, and file uuid to run.
 #The client is responsible for running the correct command on the file.
 
-import ConfigParser
 import cPickle
-import gearman
 import logging
 import os
+import socket
 import time
-from socket import gethostname
 import sys
 import threading
 import traceback
 
-
-LOGGING_CONFIG = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'detailed': {
-            'format': '%(levelname)-8s  %(asctime)s  %(name)s:%(module)s:%(funcName)s:%(lineno)d:  %(message)s',
-            'datefmt': '%Y-%m-%d %H:%M:%S'
-        },
-    },
-    'handlers': {
-        'logfile': {
-            'level': 'INFO',
-            'class': 'custom_handlers.GroupWriteRotatingFileHandler',
-            'filename': '/var/log/archivematica/MCPClient/MCPClient.log',
-            'formatter': 'detailed',
-            'backupCount': 5,
-            'maxBytes': 4 * 1024 * 1024,  # 20 MiB
-        },
-        'verboselogfile': {
-            'level': 'DEBUG',
-            'class': 'custom_handlers.GroupWriteRotatingFileHandler',
-            'filename': '/var/log/archivematica/MCPClient/MCPClient.debug.log',
-            'formatter': 'detailed',
-            'backupCount': 5,
-            'maxBytes': 4 * 1024 * 1024,  # 100 MiB
-        },
-    },
-    'loggers': {
-        'archivematica': {
-            'level': 'DEBUG',
-        },
-    },
-    'root': {
-        'handlers': ['logfile', 'verboselogfile'],
-        'level': 'WARNING',
-    }
-}
-
-logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger("archivematica.mcp.client")
-
-config = ConfigParser.SafeConfigParser(
-    defaults={'django_settings_module': 'settings.common'})
-config.read("/etc/archivematica/MCPClient/clientConfig.conf")
-
-os.environ['DJANGO_SETTINGS_MODULE'] = config.get('MCPClient', 'django_settings_module')
-sys.path.append("/usr/lib/archivematica/MCPClient")
+import gearman
 
 import django
-sys.path.append("/usr/share/archivematica/dashboard")
 django.setup()
-
 from main.models import Task
 
-sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 from django_mysqlpool import auto_close_db
 from custom_handlers import GroupWriteRotatingFileHandler
+from externals.detectCores import detectCPUs
 import databaseFunctions
 from executeOrRunSubProcess import executeOrRun
 
+from .config import LOGGING_CONFIG, settings
+from .modules import replacement_dict, supported_modules
 
-replacementDic = {
-    "%sharedPath%": config.get('MCPClient', "sharedDirectoryMounted"),
-    "%clientScriptsDirectory%": config.get('MCPClient', "clientScriptsDirectory")
-}
-supportedModules = {}
-
-def loadSupportedModulesSupport(key, value):
-    for key2, value2 in replacementDic.iteritems():
-        value = value.replace(key2, value2)
-    if not os.path.isfile(value):
-        logger.error('Warning! Module can\'t find file, or relies on system path: {%s} %s', key, value)
-    supportedModules[key] = value + " "
-
-def loadSupportedModules(file):
-    supportedModulesConfig = ConfigParser.RawConfigParser()
-    supportedModulesConfig.read(file)
-    for key, value in supportedModulesConfig.items('supportedCommands'):
-        loadSupportedModulesSupport(key, value)
-
-    loadSupportedCommandsSpecial = config.get('MCPClient', "LoadSupportedCommandsSpecial")
-    if loadSupportedCommandsSpecial.lower() == "yes" or \
-    loadSupportedCommandsSpecial.lower() == "true":
-        for key, value in supportedModulesConfig.items('supportedCommandsSpecial'):
-            loadSupportedModulesSupport(key, value)
+logging.config.dictConfig(LOGGING_CONFIG)
+logger = logging.getLogger('archivematica.mcp.client')
 
 
 @auto_close_db
-def executeCommand(gearman_worker, gearman_job):
+def execute_task(gearman_worker, gearman_job):
+    """
+    This is the function callback that processes the tasks assigned to this
+    worker. It should return a serialized dict (using cPickle) with the
+    following three fields: `exitCode`, `stdOut` and `stdError`.
+    """
     try:
         execute = gearman_job.task
-        logger.info('Executing %s (%s)', execute, gearman_job.unique)
+        worker_id = gearman_worker.worker_client_id
+        date = databaseFunctions.getUTCDate()
         data = cPickle.loads(gearman_job.data)
-        utcDate = databaseFunctions.getUTCDate()
-        arguments = data["arguments"]#.encode("utf-8")
-        if isinstance(arguments, unicode):
-            arguments = arguments.encode("utf-8")
 
-        sInput = ""
-        clientID = gearman_worker.worker_client_id
+        logger.info('Executing %s (%s)', execute, gearman_job.unique)
+
+        # Extract arguments and ensure that they are encoded in utf-8
+        arguments = data['arguments']
+        if isinstance(arguments, unicode):
+            arguments = arguments.encode('utf-8')
 
         task = Task.objects.get(taskuuid=gearman_job.unique)
         if task.starttime is not None:
-            exitCode = -1
-            stdOut = ""
-            stdError = """Detected this task has already started!
-Unable to determine if it completed successfully."""
-            return cPickle.dumps({"exitCode" : exitCode, "stdOut": stdOut, "stdError": stdError})
-        else:
-            task.client = clientID
-            task.starttime = utcDate
-            task.save()
+            return cPickle.dumps({
+                'exitCode': -1,
+                'stdOut': '',
+                'stdError': 'Detected this task has already started! Unable to determine if it completed successfully.'
+            })
 
-        if execute not in supportedModules:
-            output = ["Error!", "Error! - Tried to run and unsupported command." ]
-            exitCode = -1
-            return cPickle.dumps({"exitCode" : exitCode, "stdOut": output[0], "stdError": output[1]})
-        command = supportedModules[execute]
+        # Update task
+        task.client = worker_id
+        task.starttime = date
+        task.save()
 
-        replacementDic["%date%"] = utcDate.isoformat()
-        replacementDic["%jobCreatedDate%"] = data["createdDate"]
+        # Exit if the module is not supported by this client
+        if execute not in supported_modules:
+            return cPickle.dumps({
+                'exitCode': -1,
+                'stdOut': 'Error!',
+                'stdError': 'Error! - Tried to run and unsupported command.'
+            })
+
+        command = supported_modules[execute]
+
         # Replace replacement strings
-        for key in replacementDic.iterkeys():
-            command = command.replace ( key, replacementDic[key] )
-            arguments = arguments.replace ( key, replacementDic[key] )
-
-        key = "%taskUUID%"
+        repdict = replacement_dict.copy()
+        repdict['%date%'] = date.isoformat()
+        repdict['%jobCreatedDate%'] = data['createdDate']
+        for key in repdict.iterkeys():
+            command = command.replace(key, repdict[key])
+            arguments = arguments.replace(key, repdict[key])
+        key = '%taskUUID%'
         value = gearman_job.unique.__str__()
         arguments = arguments.replace(key, value)
-
-        # Add useful environment vars for client scripts
-        lib_paths = ['/usr/share/archivematica/dashboard/', '/usr/lib/archivematica/archivematicaCommon']
-        env_updates = {
-            'PYTHONPATH': os.pathsep.join(lib_paths),
-            'DJANGO_SETTINGS_MODULE': config.get('MCPClient', 'django_settings_module')
-        }
+        command += '{} '.format(arguments)
 
         # Execute command
-        command += " " + arguments
         logger.info('<processingCommand>{%s}%s</processingCommand>', gearman_job.unique, command)
-        exitCode, stdOut, stdError = executeOrRun("command", command, sInput, printing=False, env_updates=env_updates)
-        return cPickle.dumps({"exitCode": exitCode, "stdOut": stdOut, "stdError": stdError})
+        exitCode, stdOut, stdError = executeOrRun("command", command, stdIn='', printing=False)
+        return cPickle.dumps({
+            'exitCode': exitCode,
+            'stdOut': stdOut,
+            'stdError': stdError
+        })
+
     except OSError as ose:
-        logger.exception('Execution failed')
-        output = ["Archivematica Client Error!", traceback.format_exc()]
-        exitCode = 1
-        return cPickle.dumps({"exitCode": exitCode, "stdOut": output[0], "stdError": output[1]})
+        logger.exception('Gearman task failed')
+        return cPickle.dumps({
+            'exitCode': 1,
+            'stdOut': 'Archivematica Client Error!',
+            'stdError': traceback.format_exc()
+        })
+
     except Exception as e:
-        logger.exception('Unexpected error')
-        output = ["", traceback.format_exc()]
-        return cPickle.dumps({"exitCode": -1, "stdOut": output[0], "stdError": output[1]})
+        logger.exception('Gearman task failed (unexpected error)')
+        return cPickle.dumps({
+            'exitCode': -1,
+            'stdOut': '',
+            'stdError': traceback.format_exc()
+        })
 
 
 @auto_close_db
-def startThread(threadNumber):
-    """Setup a gearman client, for the thread."""
-    gm_worker = gearman.GearmanWorker([config.get('MCPClient', "MCPArchivematicaServer")])
-    hostID = gethostname() + "_" + threadNumber.__str__()
-    gm_worker.set_client_id(hostID)
-    for key in supportedModules.iterkeys():
-        logger.info('Registering: %s', key)
-        gm_worker.register_task(key, executeCommand)
+def start_worker(worker_id):
+    """
+    Start a Gearman worker loop. If the Gearman server is unavailable this
+    function will retry more connection attempts with a delay between attempts
+    that starts with 1 second and increments 2 seconds each time. The function
+    gives up when the delay reaches 30 seconds.
+    """
+    worker = gearman.GearmanWorker([settings.get('MCPClient', 'server')])
 
-    failMaxSleep = 30
-    failSleep = 1
-    failSleepIncrementor = 2
+    host_id = '{}_{}'.format(socket.gethostname(), worker_id)
+    worker.set_client_id(host_id)
+
+    for key in supported_modules.iterkeys():
+        logger.info('Registering function %s', key)
+        worker.register_task(key, execute_task)
+
+    fail_sleep = 1
+    fail_sleep_inc = 2
+    fail_max_sleep = 30
     while True:
         try:
-            gm_worker.work()
+            # Loop indefinitely, complete tasks from all connections.
+            worker.work()
         except gearman.errors.ServerUnavailable as inst:
-            logger.error('Gearman server is unavailable: %s. Retrying in %d seconds.', inst.args, failSleep)
-            time.sleep(failSleep)
-            if failSleep < failMaxSleep:
-                failSleep += failSleepIncrementor
+            logger.error('Gearman server is unavailable: %s. Retrying in %s seconds.', inst.args, fail_sleep)
+            time.sleep(fail_sleep)
+            if fail_sleep < fail_max_sleep:
+                fail_sleep += fail_sleep_inc
 
 
-def startThreads(t=1):
-    """Start a processing thread for each core (t=0), or a specified number of threads."""
-    if t == 0:
-        from externals.detectCores import detectCPUs
-        t = detectCPUs()
-    for i in range(t):
-        t = threading.Thread(target=startThread, args=(i+1, ))
+def start_workers():
+    """
+    Start daemonic threaded Gearman workers.
+    """
+    workers = 1
+    try:
+        workers = settings.getint('MCPClient', 'workers')
+    except:
+        pass
+    if workers == 0:
+        workers = detectCPUs()
+    for i in range(workers):
+        t = threading.Thread(target=start_worker, args=(i+1,))
         t.daemon = True
         t.start()
 
 
 if __name__ == '__main__':
     try:
-        loadSupportedModules(config.get('MCPClient', "archivematicaClientModules"))
-        startThreads(config.getint('MCPClient', "numberOfTasks"))
+        start_workers()
         while True:
             time.sleep(100)
     except (KeyboardInterrupt, SystemExit):
+        # TODO: clean up worker threads!
         logger.info('Received keyboard interrupt, quitting threads.')

--- a/src/MCPClient/lib/clientScripts/backlogUpdatingTransferFileIndex.py
+++ b/src/MCPClient/lib/clientScripts/backlogUpdatingTransferFileIndex.py
@@ -29,6 +29,7 @@ django.setup()
 from custom_handlers import get_script_logger
 import elasticSearchFunctions
 
+
 if __name__ == '__main__':
     logger = get_script_logger("archivematica.mcp.client.backlogUpdatingTransferFileIndex")
 
@@ -37,5 +38,6 @@ if __name__ == '__main__':
     transferName = sys.argv[2]
     transferDirectory = sys.argv[3]
     print 'Processing ' + transferUUID + '...'
-    found = elasticSearchFunctions.connect_and_change_transfer_file_status(transferUUID, 'backlog') 
+    client = elasticSearchFunctions.connect(settings.get_elasticsearch_hosts())
+    found = elasticSearchFunctions.change_transfer_file_status(client, transferUUID, 'backlog')
     print 'Updated ' + str(found) + ' transfer file entries.'

--- a/src/MCPClient/lib/clientScripts/elasticSearchIndexProcessTransfer.py
+++ b/src/MCPClient/lib/clientScripts/elasticSearchIndexProcessTransfer.py
@@ -40,7 +40,8 @@ def index_transfer(transfer_path, transfer_uuid):
     if not indexing_enabled:
         print('Skipping indexing because it is currently disabled.')
         return 0
-    return elasticSearchFunctions.connect_and_index_files('transfers', 'transferfile', transfer_uuid, transfer_path)
+    client = elasticSearchFunctions.connect(settings.get_elasticsearch_hosts())
+    return elasticSearchFunctions.index_files(client, 'transfers', 'transferfile', transfer_uuid, transfer_path)
 
 
 if __name__ == '__main__':

--- a/src/MCPClient/lib/clientScripts/elasticSearchIndexProcessTransfer.py
+++ b/src/MCPClient/lib/clientScripts/elasticSearchIndexProcessTransfer.py
@@ -20,7 +20,8 @@
 # @package Archivematica
 # @subpackage archivematicaClientScript
 # @author Mike Cantelon <mike@artefactual.com>
-import ConfigParser
+
+from __future__ import print_function
 import sys
 
 # elasticSearchFunctions requires Django to be set up
@@ -30,34 +31,22 @@ django.setup()
 from custom_handlers import get_script_logger
 import elasticSearchFunctions
 
-exitCode = 0
+from config import settings
+
+
+def index_transfer(transfer_path, transfer_uuid):
+    # Check if Elasticsearch is enabled and exit otherwise
+    indexing_enabled = settings.getboolean('MCPClient', 'elasticsearch_indexing_enabled', fallback=True)
+    if not indexing_enabled:
+        print('Skipping indexing because it is currently disabled.')
+        return 0
+    return elasticSearchFunctions.connect_and_index_files('transfers', 'transferfile', transfer_uuid, transfer_path)
+
 
 if __name__ == '__main__':
-    logger = get_script_logger("archivematica.mcp.client.elasticSearchIndexProcessTransfer")
+    logger = get_script_logger('archivematica.mcp.client.elasticSearchIndexProcessTransfer')
 
-    clientConfigFilePath = '/etc/archivematica/MCPClient/clientConfig.conf'
-    config = ConfigParser.SafeConfigParser()
-    config.read(clientConfigFilePath)
-
-    elasticsearchDisabled = False
-
-    try:
-        elasticsearchDisabled = config.getboolean('MCPClient', "disableElasticsearchIndexing")
-    except:
-        pass
-
-    if elasticsearchDisabled is True:
-        print 'Skipping indexing: indexing is currently disabled in ' + clientConfigFilePath + '.'
-
-    else:
-        pathToTransfer = sys.argv[1]
-        transferUUID = sys.argv[2]
-
-        exitCode = elasticSearchFunctions.connect_and_index_files(
-            'transfers',
-            'transferfile',
-            transferUUID,
-            pathToTransfer
-        )
-
-quit(exitCode)
+    sys.exit(main(
+        transfer_path=sys.argv[1],
+        transfer_uuid=sys.argv[2]
+    ))

--- a/src/MCPClient/lib/clientScripts/indexAIP.py
+++ b/src/MCPClient/lib/clientScripts/indexAIP.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python2
 
 from __future__ import print_function
-import ConfigParser
 from glob import glob
 import os
 import sys
@@ -17,6 +16,8 @@ import elasticSearchFunctions
 import storageService as storage_service
 from identifier_functions import extract_identifiers_from_mods
 
+from config import settings
+
 
 def list_mods(sip_path):
     return glob('{}/submissionDocumentation/**/mods/*.xml'.format(sip_path))
@@ -29,18 +30,10 @@ def index_aip():
     sip_path = sys.argv[3]  # %SIPDirectory%
     sip_type = sys.argv[4]  # %SIPType%
 
-    # Check if ElasticSearch is enabled
-    client_config_path = '/etc/archivematica/MCPClient/clientConfig.conf'
-    config = ConfigParser.SafeConfigParser()
-    config.read(client_config_path)
-    elastic_search_disabled = False
-    try:
-        elastic_search_disabled = config.getboolean(
-            'MCPClient', "disableElasticsearchIndexing")
-    except ConfigParser.NoOptionError:
-        pass
-    if elastic_search_disabled:
-        print('Skipping indexing: indexing is currently disabled in', client_config_path)
+    # Check if Elasticsearch is enabled and exit otherwise
+    indexing_enabled = settings.getboolean('MCPClient', 'elasticsearch_indexing_enabled', fallback=True)
+    if not indexing_enabled:
+        print('Skipping indexing because it is currently disabled.')
         return 0
 
     print('SIP UUID:', sip_uuid)

--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
+
 from __future__ import print_function
 import argparse
-import ConfigParser
 import csv
 import errno
 import os
@@ -26,6 +26,9 @@ from custom_handlers import get_script_logger
 import databaseFunctions
 import fileOperations
 from dicts import ReplacementDict
+
+from config import settings
+
 
 # Return codes
 SUCCESS = 0
@@ -343,13 +346,7 @@ def main(opts):
     # TODO is this still needed, with the storage service?
     if 'thumbnail' in opts.purpose:
         thumbnail_filepath = cl.commandObject.output_location
-        clientConfigFilePath = '/etc/archivematica/MCPClient/clientConfig.conf'
-        config = ConfigParser.SafeConfigParser()
-        config.read(clientConfigFilePath)
-        try:
-            shared_path = config.get('MCPClient', 'sharedDirectoryMounted')
-        except:
-            shared_path = '/var/archivematica/sharedDirectory/'
+        shared_path = settings.get('MCPClient', 'shared_directory', fallback='/var/archivematica/sharedDirectory/')
         thumbnail_storage_dir = os.path.join(
             shared_path,
             'www',

--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -13,10 +13,14 @@ from custom_handlers import get_script_logger
 import elasticSearchFunctions
 import storageService as storage_service
 
+from config import settings
+
+
 def post_store_hook(sip_uuid):
     """
     Hook for doing any work after an AIP is stored successfully.
     """
+    client = elasticSearchFunctions.connect(settings.get_elasticsearch_hosts())
 
     # SIP ARRANGEMENT
 
@@ -41,7 +45,7 @@ def post_store_hook(sip_uuid):
                 user_email='archivematica system',
                 reason_for_deletion='All files in Transfer are now in AIPs.'
             )
-            elasticSearchFunctions.connect_and_remove_transfer_files(transfer_uuid)
+            elasticSearchFunctions.remove_transfer_files(client, transfer_uuid)
 
     # POST-STORE CALLBACK
     storage_service.post_store_aip_callback(sip_uuid)

--- a/src/MCPClient/lib/clientScripts/removeAIPFilesFromIndex.py
+++ b/src/MCPClient/lib/clientScripts/removeAIPFilesFromIndex.py
@@ -29,10 +29,14 @@ django.setup()
 from custom_handlers import get_script_logger
 import elasticSearchFunctions
 
+from config import settings
+
+
 if __name__ == '__main__':
     logger = get_script_logger("archivematica.mcp.client.removeAIPFilesFromIndex")
 
     AIPUUID = sys.argv[1]
     print 'Removing indexed files for AIP ' + AIPUUID + '...'
-    elasticSearchFunctions.connect_and_delete_aip_files(AIPUUID)
+    client = elasticSearchFunctions.connect(settings.get_elasticsearch_hosts())
+    elasticSearchFunctions.delete_aip_files(client, AIPUUID)
     print 'Done.'

--- a/src/MCPClient/lib/clientScripts/verifyAIP.py
+++ b/src/MCPClient/lib/clientScripts/verifyAIP.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-import ConfigParser
+
 import os
 import shutil
 import sys
@@ -7,6 +7,8 @@ import sys
 # archivematicaCommon
 from custom_handlers import get_script_logger
 from executeOrRunSubProcess import executeOrRun
+
+from config import settings
 
 
 def extract_aip(aip_path, extract_path):
@@ -24,7 +26,9 @@ def extract_aip(aip_path, extract_path):
 
 
 def verify_aip():
-    """ Verify the AIP was bagged correctly by extracting it and running verification on its contents.
+    """"
+    Verify the AIP was bagged correctly by extracting it and running
+    verification on its contents.
 
     sys.argv[1] = UUID
       UUID of the SIP, which will become the UUID of the AIP
@@ -35,10 +39,7 @@ def verify_aip():
     sip_uuid = sys.argv[1]  # %sip_uuid%
     aip_path = sys.argv[2]  # SIPDirectory%%sip_name%-%sip_uuid%.7z
 
-    clientConfigFilePath = '/etc/archivematica/MCPClient/clientConfig.conf'
-    config = ConfigParser.SafeConfigParser()
-    config.read(clientConfigFilePath)
-    temp_dir = config.get('MCPClient', 'temp_dir')
+    temp_dir = settings.get('MCPClient', 'temp_dir', fallback='/var/archivematica/sharedDirectory/tmp')
 
     is_uncompressed_aip = os.path.isdir(aip_path)
 

--- a/src/MCPClient/lib/config.py
+++ b/src/MCPClient/lib/config.py
@@ -19,6 +19,10 @@ def _load_settings():
 settings = _load_settings()
 
 
+def get_elasticsearch_hosts():
+    return settings.get('MCPClient', 'elasticsearch_server', fallback='127.0.0.1:9200')
+
+
 LOGGING_CONFIG = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/src/MCPClient/lib/config.py
+++ b/src/MCPClient/lib/config.py
@@ -1,0 +1,58 @@
+import os
+
+from env_configparser import EnvConfigParser
+import config
+
+
+ENV_PREFIX = 'ARCHIVEMATICA_MCPCLIENT'
+ENV_CONFIG_FILE = '{}_CONFIG'.format(ENV_PREFIX)
+ENV_CONFIG_FILE_SEPARATOR = ':'
+
+
+def _load_settings():
+    config = EnvConfigParser(prefix=ENV_PREFIX)
+    if ENV_CONFIG_FILE in os.environ:
+        config.read(os.environ[ENV_CONFIG_FILE].split(ENV_CONFIG_FILE_SEPARATOR))
+    return config
+
+
+settings = _load_settings()
+
+
+LOGGING_CONFIG = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'detailed': {
+            'format': '%(levelname)-8s  %(asctime)s  %(name)s:%(module)s:%(funcName)s:%(lineno)d:  %(message)s',
+            'datefmt': '%Y-%m-%d %H:%M:%S'
+        },
+    },
+    'handlers': {
+        'logfile': {
+            'level': 'INFO',
+            'class': 'custom_handlers.GroupWriteRotatingFileHandler',
+            'filename': '/var/log/archivematica/MCPClient/MCPClient.log',
+            'formatter': 'detailed',
+            'backupCount': 5,
+            'maxBytes': 4 * 1024 * 1024,  # 20 MiB
+        },
+        'verboselogfile': {
+            'level': 'DEBUG',
+            'class': 'custom_handlers.GroupWriteRotatingFileHandler',
+            'filename': '/var/log/archivematica/MCPClient/MCPClient.debug.log',
+            'formatter': 'detailed',
+            'backupCount': 5,
+            'maxBytes': 4 * 1024 * 1024,  # 100 MiB
+        },
+    },
+    'loggers': {
+        'archivematica': {
+            'level': 'DEBUG',
+        },
+    },
+    'root': {
+        'handlers': ['logfile', 'verboselogfile'],
+        'level': 'WARNING',
+    }
+}

--- a/src/MCPClient/lib/modules.py
+++ b/src/MCPClient/lib/modules.py
@@ -1,0 +1,49 @@
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+import os
+import logging
+
+from config import settings, LOGGING_CONFIG
+
+logging.config.dictConfig(LOGGING_CONFIG)
+logger = logging.getLogger('archivematica.mcp.client')
+
+
+replacement_dict = {
+    "%sharedPath%": settings.get('MCPClient', 'shared_directory'),
+    "%clientScriptsDirectory%": settings.get('MCPClient', 'client_scripts_directory')
+}
+
+
+def _load_modules():
+    modules_config = configparser.RawConfigParser()
+    modules_config.read(settings.get('MCPClient', 'modules_file'))
+    modules = {}
+
+    # Load regular modules
+    for key, value in modules_config.items('supportedCommands'):
+        modules[key] = _interpolate_module_value(value)
+
+    # Load special modules
+    load_special_scripts = settings.getboolean('MCPClient', 'load_special_scripts')
+    if load_special_scripts:
+        for key, value in modules_config.items('supportedCommandsSpecial'):
+            modules[key] = _interpolate_module_value(value)
+
+    # Report if the module cannot be found
+    for key, value in modules.iteritems():
+        if not os.path.isfile(value):
+            logger.error('Warning! Module %s could not be found: %s', key, value)
+
+    return modules
+
+
+def _interpolate_module_value(value):
+    for k, v in replacement_dict.iteritems():
+        value = value.replace(k, v)
+    return value + " "
+
+
+supported_modules = _load_modules()

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -15,21 +15,19 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, ConfigParser
 import django_mysqlpool
 
-# Get DB settings from main configuration file
-config = ConfigParser.SafeConfigParser()
-config.read('/etc/archivematica/archivematicaCommon/dbsettings')
+from ..config import settings
+
 
 DATABASES = {
     'default': {
         'ENGINE': 'django_mysqlpool.backends.mysqlpool',
-        'NAME': 'MCP',                                     # Or path to database file if using sqlite3.
-        'USER': config.get('client', 'user'),              # Not used with sqlite3.
-        'PASSWORD': config.get('client', 'password'),      # Not used with sqlite3.
-        'HOST': config.get('client', 'host'),              # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                                        # Set to empty string for default. Not used with sqlite3.
+        'NAME': settings.get('MCPClient', 'db_name'),
+        'USER': settings.get('MCPClient', 'db_user'),
+        'PASSWORD': settings.get('MCPClient', 'db_password'),
+        'HOST': settings.get('MCPClient', 'db_host'),
+        'PORT': settings.get('MCPClient', 'db_port'),
     }
 }
 

--- a/src/archivematicaCommon/lib/env_configparser.py
+++ b/src/archivematicaCommon/lib/env_configparser.py
@@ -1,0 +1,73 @@
+import os
+import ConfigParser
+import functools
+
+
+def fallback_option(fn):
+    def wrapper(*args, **kwargs):
+        fallback = kwargs.pop('fallback', None)
+        try:
+            return fn(*args, **kwargs)
+        except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+            if fallback:
+                return fallback
+            raise
+    return functools.wraps(fn)(wrapper)
+
+
+class EnvConfigParser(ConfigParser.SafeConfigParser):
+    """
+    EnvConfigParser enables the user to provide configuration defaults using
+    the string environment, e.g. given:
+
+      - String environment prefix (prefix) = "ARCHIVEMATICA_MCPSERVER"
+      - Configuration section: "network"
+      - Configuration option: "tls"
+
+    This parser will first try to find the configuration value in the string
+    environment matching one of the two following keys:
+
+      - ARCHIVEMATICA_MCPSERVER_NETWORK_TLS
+      - ARCHIVEMATICA_MCPSERVER_TLS
+
+    It the variable is not set in the string environment the reader falls back
+    on the main configuration backend.
+
+    Additionally, the getters (get(), getint(), etc...) accept a new parameter
+    (fallback) that returns the value given to it instead of an exception when
+    the section or option trying to be match are undefined.
+    """
+    ENVVAR_SEPARATOR = '_'
+
+    def __init__(self, defaults=None, env=None, prefix=''):
+        self._environ = os.environ if env is None else env
+        self._prefix = prefix.rstrip('_')
+        ConfigParser.SafeConfigParser.__init__(self, defaults)
+
+    def _get_envvar(self, section, option):
+        for key in (
+            self.ENVVAR_SEPARATOR.join([self._prefix, section, option]).upper(),
+            self.ENVVAR_SEPARATOR.join([self._prefix, option]).upper(),
+        ):
+            if key in self._environ:
+                return self._environ[key]
+
+    @fallback_option
+    def get(self, *args, **kwargs):
+        section, option = args
+        ret = self._get_envvar(section, option)
+        if ret:
+            return ret
+        return ConfigParser.SafeConfigParser.get(self, *args, **kwargs)
+
+    @fallback_option
+    def getint(self, *args, **kwargs):
+        return ConfigParser.SafeConfigParser.getint(self, *args, **kwargs)
+
+    @fallback_option
+    def getfloat(self, *args, **kwargs):
+        return ConfigParser.SafeConfigParser.getfloat(self, *args, **kwargs)
+
+    @fallback_option
+    def getboolean(self, *args, **kwargs):
+        return ConfigParser.SafeConfigParser.getboolean(self, *args, **kwargs)

--- a/src/archivematicaCommon/tests/test_config.py
+++ b/src/archivematicaCommon/tests/test_config.py
@@ -1,0 +1,94 @@
+from __future__ import absolute_import
+import os
+import StringIO
+import ConfigParser
+
+from django.test import TestCase
+import pytest
+
+from env_configparser import EnvConfigParser
+
+
+class TestConfigReader(TestCase):
+    def setUp(self):
+        """
+        Make sure that we are not mutating the global environment.
+        """
+        self.environ = os.environ.copy()
+
+    def tearDown(self):
+        self.environ = None
+
+    def read_test_config(self, test_config, prefix=''):
+        buf = StringIO.StringIO(test_config)
+        config = EnvConfigParser(env=self.environ, prefix=prefix)
+        config.readfp(buf)
+        return config
+
+    def test_env_lookup_int(self):
+        """
+        Note that the environment precedes the configuration.
+        """
+        self.environ['ARCHIVEMATICA_NICESERVICE_QUEUE_MAX_SIZE'] = '100'
+        config = self.read_test_config(
+            prefix='ARCHIVEMATICA_NICESERVICE',
+            test_config=
+"""
+[queue]
+max_size = 500
+""")
+        assert config.getint('queue', 'max_size') == 100
+
+    def test_env_lookup_nosection_bool(self):
+        """
+        The environment string matches the option even though the corresponding
+        section was not included.
+        """
+        self.environ['ARCHIVEMATICA_NICESERVICE_TLS'] = 'off'
+        config = self.read_test_config(
+            prefix='ARCHIVEMATICA_NICESERVICE',
+            test_config=
+"""
+[network]
+tls = on
+""")
+        assert config.getboolean('network', 'tls') == False
+
+    def test_unknown_section(self):
+        """
+        Confirm that `EnvConfigParser` throws a `NoSectionError` exception
+        when undefined.
+        """
+        config = self.read_test_config(
+"""
+[main]
+foo = bar
+""")
+        with pytest.raises(ConfigParser.NoSectionError):
+            assert config.get('undefined_section', 'foo')
+
+    def test_unknown_option(self):
+        """
+        Confirm that `EnvConfigParser` throws a `NoOptionError` exception
+        when undefined.
+        """
+        config = self.read_test_config(
+"""
+[main]
+foo = bar
+""")
+        with pytest.raises(ConfigParser.NoOptionError):
+            assert config.get('main', 'undefined_option')
+
+    def test_unknown_option_with_fallback(self):
+        """
+        A fallback keyword argument can be used to obtain a value from the
+        configuration even if it's undefiend.
+        """
+        config = self.read_test_config(
+"""
+[main]
+foo = bar
+""")
+        assert config.getboolean('main', 'undefined_option', fallback=True) == True
+        assert config.getint('undefined_section', 'undefined_option', fallback=12345) == 12345

--- a/src/archivematicaCommon/tests/test_elasticsearch_functions.py
+++ b/src/archivematicaCommon/tests/test_elasticsearch_functions.py
@@ -1,7 +1,7 @@
-
-from elasticsearch import Elasticsearch
 import os
 import sys
+
+from elasticsearch import Elasticsearch
 import pytest
 import unittest
 import vcr
@@ -14,13 +14,14 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 class TestElasticSearchFunctions(unittest.TestCase):
 
     def setUp(self):
-        self.conn = Elasticsearch('127.0.0.1:9200')
+        hosts = os.environ.get('ELASTICSEARCH_SERVER', '127.0.0.1:9200')
+        self.client = elasticSearchFunctions.connect(hosts)
         self.aip_uuid = 'a1ee611a-a4f5-4ba9-b7ce-b92695746514'
 
     @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_delete_aip.yaml'))
     def test_delete_aip(self):
         # Verify AIP exists
-        results = self.conn.search(
+        results = self.client.search(
             index='aips',
             doc_type='aip',
             body={'query': {'term': {'uuid': self.aip_uuid}}},
@@ -29,10 +30,10 @@ class TestElasticSearchFunctions(unittest.TestCase):
         assert results['hits']['total'] == 1
         assert results['hits']['hits'][0]['fields']['uuid'] == [self.aip_uuid]
         # Delete AIP
-        success = elasticSearchFunctions.delete_aip(self.aip_uuid)
+        success = elasticSearchFunctions.delete_aip(self.client, self.aip_uuid)
         # Verify AIP gone
         assert success is True
-        results = self.conn.search(
+        results = self.client.search(
             index='aips',
             doc_type='aip',
             body={'query': {'term': {'uuid': self.aip_uuid}}},
@@ -43,7 +44,7 @@ class TestElasticSearchFunctions(unittest.TestCase):
     @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_delete_aip_files.yaml'))
     def test_delete_aip_files(self):
         # Verify AIP exists
-        results = self.conn.search(
+        results = self.client.search(
             index='aips',
             doc_type='aipfile',
             body={'query': {'term': {'AIPUUID': self.aip_uuid}}},
@@ -58,10 +59,10 @@ class TestElasticSearchFunctions(unittest.TestCase):
         assert results['hits']['hits'][2]['fields']['AIPUUID'] == [self.aip_uuid]
         assert results['hits']['hits'][2]['fields']['FILEUUID'] == ['547bbd92-d8a0-4624-a9d3-69ba706eacee']
         # Delete AIP
-        success = elasticSearchFunctions.connect_and_delete_aip_files(self.aip_uuid)
+        success = elasticSearchFunctions.delete_aip_files(self.client, self.aip_uuid)
         # Verify AIP gone
         assert success is True
-        results = self.conn.search(
+        results = self.client.search(
             index='aips',
             doc_type='aipfile',
             body={'query': {'term': {'AIPUUID': self.aip_uuid}}},
@@ -71,19 +72,19 @@ class TestElasticSearchFunctions(unittest.TestCase):
 
     @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_list_tags.yaml'))
     def test_list_tags(self):
-        assert elasticSearchFunctions.connect_and_get_file_tags('a410501b-64ac-4b81-92ca-efa9e815366d') == ['test1']
+        assert elasticSearchFunctions.get_file_tags(self.client, 'a410501b-64ac-4b81-92ca-efa9e815366d') == ['test1']
 
     @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_list_tags_no_matches.yaml'))
     def test_list_tags_fails_when_file_cant_be_found(self):
         with pytest.raises(elasticSearchFunctions.EmptySearchResultError):
-            elasticSearchFunctions.connect_and_get_file_tags('no_such_file')
+            elasticSearchFunctions.get_file_tags(self.client, 'no_such_file')
 
     @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_set_tags.yaml'))
     def test_set_tags(self):
-        elasticSearchFunctions.connect_and_set_file_tags('2101fa74-bc27-405b-8e29-614ebd9d5a89', ['test'])
-        assert elasticSearchFunctions.connect_and_get_file_tags('2101fa74-bc27-405b-8e29-614ebd9d5a89') == ['test']
+        elasticSearchFunctions.set_file_tags(self.client, '2101fa74-bc27-405b-8e29-614ebd9d5a89', ['test'])
+        assert elasticSearchFunctions.get_file_tags(self.client, '2101fa74-bc27-405b-8e29-614ebd9d5a89') == ['test']
 
     @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_set_tags_no_matches.yaml'))
     def test_set_tags_fails_when_file_cant_be_found(self):
         with pytest.raises(elasticSearchFunctions.EmptySearchResultError):
-            elasticSearchFunctions.connect_and_set_file_tags('no_such_file', [])
+            elasticSearchFunctions.set_file_tags(self.client, 'no_such_file', [])

--- a/src/dashboard/src/components/appraisal/views.py
+++ b/src/dashboard/src/components/appraisal/views.py
@@ -15,6 +15,6 @@ logger = logging.getLogger('archivematica.dashboard')
       Appraisal
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ """
 
-@decorators.elasticsearch_required()
+@decorators.elasticsearch()
 def appraisal(request):
     return render(request, 'appraisal/appraisal.html')

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -25,9 +25,10 @@ import sys
 import tempfile
 import uuid
 
-import django.http
+from django.conf import settings as django_settings
 from django.db import connection, IntegrityError
 from django.db.models import Q
+import django.http
 import django.template.defaultfilters
 
 import requests
@@ -39,7 +40,6 @@ from main import models
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 import archivematicaFunctions
 import databaseFunctions
-import elasticSearchFunctions
 import storageService as storage_service
 
 # for unciode sorting support

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -64,7 +64,7 @@ logger = logging.getLogger('archivematica.dashboard')
       Ingest
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ """
 
-@decorators.elasticsearch_required()
+@decorators.elasticsearch()
 def ingest_grid(request):
     polling_interval = django_settings.POLLING_INTERVAL
     microservices_help = django_settings.MICROSERVICES_HELP
@@ -510,14 +510,13 @@ def _es_results_to_appraisal_tab_format(record, record_map, directory_list, not_
     record_map[dir]['object_count'] += 1
 
 
-@decorators.elasticsearch_required()
+@decorators.elasticsearch()
 def transfer_backlog(request, ui):
     """
     AJAX endpoint to query for and return transfer backlog items.
     """
     # Get search parameters from request
     results = None
-    conn = elasticSearchFunctions.connect_and_create_index('transfers')
 
     if not 'query' in request.GET:
         query = elasticSearchFunctions.MATCH_ALL_QUERY
@@ -541,8 +540,9 @@ def transfer_backlog(request, ui):
 
     # perform search
     try:
+        es_client = elasticSearchFunctions.connect(django_settings.ELASTICSEARCH_SERVER)
         results = elasticSearchFunctions.search_all_results(
-            conn,
+            es_client,
             body=query,
             index='transfers',
             doc_type='transferfile',

--- a/src/dashboard/src/components/transfer/views.py
+++ b/src/dashboard/src/components/transfer/views.py
@@ -45,7 +45,7 @@ logger = logging.getLogger('archivematica.dashboard')
       Transfer
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ """
 
-@decorators.elasticsearch_required()
+@decorators.elasticsearch()
 def grid(request):
     try:
         source_directories = storage_service.get_location(purpose="TS")

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -311,3 +311,6 @@ TEXTAREA_ATTRS           = {'rows': '4', 'class': 'span11'}
 TEXTAREA_WITH_HELP_ATTRS = {'rows': '4', 'class': 'span11 has_contextual_help'}
 INPUT_ATTRS              = {'class': 'span11'}
 INPUT_WITH_HELP_ATTRS    = {'class': 'span11 has_contextual_help'}
+
+ELASTICSEARCH_SERVER = os.environ.get('ARCHIVEMATICA_DASHBOARD_ELASTICSEARCH_SERVER')
+ELASTICSEARCH_INDEXING_ENABLED = os.environ.get('ARCHIVEMATICA_DASHBOARD_ELASTICSEARCH_INDEXING_ENABLED')


### PR DESCRIPTION
# WIP, please ignore for now!
- **_I'm breaking this into smaller pull requests.**_
- Still figuring it out how to do this trying to keep backward compatibility.

---

The main goal of this pull request is to clean up the configuration system in `dashboard`, `mcp-sever` and `mcp-client` - making sure that they can run separately and completely abandon the assumption that they are running in the same machine. This is currently true when it's about configuration or source code availability. This pull request fixes the configuration part of it.

It is a big pull request, please read the commits individually.
#### Action items
- [x] MCPClient:
  - Abandon dbsettings
  - Use `EnvConfigParser`
  - **Move get_script_logger to MCPClient, add CLIENT_SCRIPTS_LOGGING_CONFIG?**. Not done.
- [ ] MCPServer:
  - Abandon dbsettings
  - Use `EnvConfigParser`...
- [ ] dashboard:
  - Abandon dbsettings
  - Don't read clientConf (currently: `kioskMode`,  `disableElasticsearchIndexing`, `sharedDirectoryMounted`... see also `get_client_config_value` function)
  - Make sure envs are used
- [ ] `elasticSearchFunctions` (archivematicaCommons):
  - Should not check on local installation of Elasticsearch
  - Should not depend on `clientConfig`, receive connection parameters instead!
- [ ] `databaseInterface` (archivematicaCommons):
  - It is going to be deleted. See #341 and #354.
