### PR TITLE
MCPClient: leverage upstart's service logger

### DIFF
--- a/src/MCPClient/init/archivematica-mcp-client.conf
+++ b/src/MCPClient/init/archivematica-mcp-client.conf
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-description     "Archivematica MCP Client"
-author          "Austin Trask <austin@artefactual.com>, Joseph Perry <joseph@artefactual.com>"
+description "Archivematica MCP Client"
 
 start on (net-device-up
           and local-filesystems
@@ -29,43 +28,12 @@ env LOCATION=/usr/lib/archivematica/MCPClient/archivematicaClient.py
 setuid archivematica
 setgid archivematica
 
-pre-start script
-
-    # Check that $CONF directory exists
-    [ -d $CONF ]
-
-    # Wait for Gearman to start - timeout eventually
-    for i in $(seq 1 10)
-    do
-        gearadmin --getpid && break
-        sleep 3
-    done
-    gearadmin --getpid || exit 1
-    exit 0
-
-end script
-
 script
 
-    # Build LOGFILE path
-    HOSTNAME=`hostname`
-    LOGFILE=/var/log/archivematica/MCPClient/${HOSTNAME}.log
-    test -f /etc/default/locale && . /etc/default/locale || true 
+    # Is this still necessary?
+    test -f /etc/default/locale && . /etc/default/locale || true
     test -f /etc/environment && . /etc/environment || true
 
-    # Run
-    LANG=$LANG $LOCATION 2>>$LOGFILE 1>&2
-
-    # Logapp
-    # LOGTIME=true
-    # APPENDLOG=true
-    # CIRCULARLOG=true
-    # MAXLOGSIZE=10000 # Max 4000000
-    # logapp --logtime=$LOGTIME \
-    #        --maxlogsize=$MAXLOGSIZE \
-    #        --logfile="$LOGFILE" \
-    #        --appendlog=$APPENDLOG \
-    #        --circularlog=$CIRCULARLOG \
-    #          $LOCATION
+    LANG=$LANG $LOCATION
 
 end script


### PR DESCRIPTION
Upstart logs every service (job) in a log file by the same name under
`/var/log/upstart`. Both `stdout` and `stderr` are captured. Furthermore,
Ubuntu rotates the log files as described in `/etc/logrotate.d/upstart`.
This commit takes away this responsibility from our upstart service, making
easier for Ubuntu administrators to inspect `archivematica-mcp-client` in the
standard manner:

```
$ sudo less +FG /var/log/upstart/archivematica-mcp-client.log
```

In addition, the `pre-start` stanza that waits for Gearman to become available
is being deleted because: (1) Gearman server may not be running in the same
host, (2) MCPClient is already dealing with the situation were the Gearman
server cannot be reached (see `gearman.errors.ServerUnavailable` in
`archivematicaClient.py`) using a retry pattern with incremental delays.
