### PR TITLE
Add EnvConfigParser subclass with environment string support

### DIFF
--- a/src/archivematicaCommon/lib/env_configparser.py
+++ b/src/archivematicaCommon/lib/env_configparser.py
@@ -1,0 +1,72 @@
+import os
+import ConfigParser
+import functools
+
+
+def fallback_option(fn):
+    def wrapper(*args, **kwargs):
+        fallback = kwargs.pop('fallback', None)
+        try:
+            return fn(*args, **kwargs)
+        except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+            if fallback:
+                return fallback
+            raise
+    return functools.wraps(fn)(wrapper)
+
+
+class EnvConfigParser(ConfigParser.SafeConfigParser):
+    """
+    EnvConfigParser enables the user to provide configuration defaults using
+    the string environment, e.g. given:
+
+      - String environment prefix (prefix) = "ARCHIVEMATICA_MCPSERVER"
+      - Configuration section: "network"
+      - Configuration option: "tls"
+
+    This parser will first try to find the configuration value in the string
+    environment matching one of the two following keys:
+
+      - ARCHIVEMATICA_MCPSERVER_NETWORK_TLS
+      - ARCHIVEMATICA_MCPSERVER_TLS
+
+    If the variable is not set in the string environment the reader falls back
+    on the main configuration backend.
+
+    Additionally, the getters (get(), getint(), etc...) accept a new parameter
+    (fallback) that returns the value given to it instead of an exception when
+    the section or option trying to be match are undefined.
+    """
+    ENVVAR_SEPARATOR = '_'
+
+    def __init__(self, defaults=None, env=None, prefix=''):
+        self._environ = env or os.environ
+        self._prefix = prefix.rstrip('_')
+        ConfigParser.SafeConfigParser.__init__(self, defaults)
+
+    def _get_envvar(self, section, option):
+        for key in (
+            self.ENVVAR_SEPARATOR.join([self._prefix, section, option]).upper(),
+            self.ENVVAR_SEPARATOR.join([self._prefix, option]).upper(),
+        ):
+            if key in self._environ:
+                return self._environ[key]
+
+    @fallback_option
+    def get(self, section, option, **kwargs):
+        ret = self._get_envvar(section, option)
+        if ret:
+            return ret
+        return ConfigParser.SafeConfigParser.get(self, section, option, **kwargs)
+
+    @fallback_option
+    def getint(self, *args, **kwargs):
+        return ConfigParser.SafeConfigParser.getint(self, *args, **kwargs)
+
+    @fallback_option
+    def getfloat(self, *args, **kwargs):
+        return ConfigParser.SafeConfigParser.getfloat(self, *args, **kwargs)
+
+    @fallback_option
+    def getboolean(self, *args, **kwargs):
+        return ConfigParser.SafeConfigParser.getboolean(self, *args, **kwargs)

--- a/src/archivematicaCommon/tests/test_env_configparser.py
+++ b/src/archivematicaCommon/tests/test_env_configparser.py
@@ -1,0 +1,95 @@
+from __future__ import absolute_import
+import os
+import StringIO
+import ConfigParser
+
+from django.test import TestCase
+import pytest
+
+from env_configparser import EnvConfigParser
+
+
+class TestConfigReader(TestCase):
+    def setUp(self):
+        """
+        Make sure that we are not mutating the global environment. `os.environ`
+        is an instance of `os._Environ` which implements a `copy` method.
+        """
+        self.environ = os.environ.copy()
+
+    def tearDown(self):
+        self.environ = None
+
+    def read_test_config(self, test_config, prefix=''):
+        buf = StringIO.StringIO(test_config)
+        config = EnvConfigParser(env=self.environ, prefix=prefix)
+        config.readfp(buf)
+        return config
+
+    def test_env_lookup_int(self):
+        """
+        Note that the environment precedes the configuration.
+        """
+        self.environ['ARCHIVEMATICA_NICESERVICE_QUEUE_MAX_SIZE'] = '100'
+        config = self.read_test_config(
+            prefix='ARCHIVEMATICA_NICESERVICE',
+            test_config=
+"""
+[queue]
+max_size = 500
+""")
+        assert config.getint('queue', 'max_size') == 100
+
+    def test_env_lookup_nosection_bool(self):
+        """
+        The environment string matches the option even though the corresponding
+        section was not included.
+        """
+        self.environ['ARCHIVEMATICA_NICESERVICE_TLS'] = 'off'
+        config = self.read_test_config(
+            prefix='ARCHIVEMATICA_NICESERVICE',
+            test_config=
+"""
+[network]
+tls = on
+""")
+        assert config.getboolean('network', 'tls') == False
+
+    def test_unknown_section(self):
+        """
+        Confirm that `EnvConfigParser` throws a `NoSectionError` exception
+        when undefined.
+        """
+        config = self.read_test_config(
+"""
+[main]
+foo = bar
+""")
+        with pytest.raises(ConfigParser.NoSectionError):
+            assert config.get('undefined_section', 'foo')
+
+    def test_unknown_option(self):
+        """
+        Confirm that `EnvConfigParser` throws a `NoOptionError` exception
+        when undefined.
+        """
+        config = self.read_test_config(
+"""
+[main]
+foo = bar
+""")
+        with pytest.raises(ConfigParser.NoOptionError):
+            assert config.get('main', 'undefined_option')
+
+    def test_unknown_option_with_fallback(self):
+        """
+        A fallback keyword argument can be used to obtain a value from the
+        configuration even if it's undefiend.
+        """
+        config = self.read_test_config(
+"""
+[main]
+foo = bar
+""")
+        assert config.getboolean('main', 'undefined_option', fallback=True) == True
+        assert config.getint('undefined_section', 'undefined_option', fallback=12345) == 12345


### PR DESCRIPTION
Planning to use `EnvConfigParser` in the future. Let me know what you think!

---

Main two differences comparing it to its ancestor `SafeConfigParser` are:
- The settings are looked up first in the string environment, trying to match
  both `section` and `option` first and only `option` as a fallback, e.g.
  `ARCHIVEMATICA_SECTION_OPTION` and `ARCHIVEMATICA_OPTION`.
- All the getters (`get`, `getint`, `getfloat`, `getbool`) learn a new keyword
  argument `fallback` so its value is returned when the configuration option
  is undefined, instead of throwing exceptions like `NoSectionError` or
  `NoOptionError`, as with a Python dictionary. This mimics the behavior
  introduced in the `configparser` module in Python 3. For example, you could
  write:
  
  ```
  tls_enabled = config.getboolean('network', 'tls', fallback=False)
  ```
  
  instead of:
  
  ```
  try:
      tls_enabled = config.getboolean('network', 'tls')
  except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
      tls_enabled = False
  ```

**Attention! This class is py2-only compatible!**
