### PR TITLE
MCPClient: README - clientScripts logging convention

### DIFF
--- a/src/MCPClient/README
+++ b/src/MCPClient/README
@@ -1,3 +1,0 @@
-This folder contains the archivematica client. 
-
-The archivematica client gets instructions from the MCP and performs them.

--- a/src/MCPClient/README.md
+++ b/src/MCPClient/README.md
@@ -1,0 +1,12 @@
+# MCPClient
+
+This directory contains the Archivematica MCP client, frequently referred as
+`MCPClient`. Its main responsibility is to perform the tasks assigned by
+`MCPServer`. These tasks are dispatched via Gearman. Technically speaking,
+`MCPClient` is a pool of Gearman workers each one running in a separate thread.
+
+The programs responsible of performing the Gearman jobs are contained in the
+`lib/clientScripts/` directory. We frequently implement them as Python or Bash
+scripts. When using Python, it's preferred to use the `logging` module - that
+gives us the possibility to dispatch the log messages to more than one handler,
+e.g. `stdout`, `stderr`, etc...


### PR DESCRIPTION
Please feel free to reword. I'm not very good at this, but I wanted to write down somewhere our clientScripts convention about logging vs printing to stdout/stderr.
