### PR TITLE
elasticSearchFunctions: global client as module attribute

### DIFF
--- a/localDevSetup/eraseElasticSearchIndexes.py
+++ b/localDevSetup/eraseElasticSearchIndexes.py
@@ -5,9 +5,9 @@ import sys
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings.common'
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
-from elasticSearchFunctions import getElasticsearchServerHostAndPort
+import elasticSearchFunctions
 
-from elasticsearch import Elasticsearch, ConnectionError, TransportError
+from elasticsearch import ConnectionError, TransportError
 
 # allow "-f" to override prompt
 options = sys.argv[1:]
@@ -17,16 +17,19 @@ if len(sys.argv) < 2 or not '-f' in options:
         print 'Not going to erase the indexes.'
         sys.exit(0)
 
-conn = Elasticsearch(hosts=getElasticsearchServerHostAndPort())
+
+elasticSearchFunctions.setup_reading_from_client_conf()
+client = elasticSearchFunctions.get_client()
+
 try:
-    conn.info()
+    client.info()
 except (ConnectionError, TransportError):
     print "Connection error: Elasticsearch may not be running."
     sys.exit(1)
 
 # delete transfers ElasticSearch index
 # Ignore 404, in case the index is missing (e.g. already deleted)
-conn.indices.delete('transfers', ignore=404)
-conn.indices.delete('aips', ignore=404)
+client.indices.delete('transfers', ignore=404)
+client.indices.delete('aips', ignore=404)
 
 print "ElasticSearch indexes deleted."

--- a/src/MCPClient/lib/clientScripts/archivematicaSetTransferType.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaSetTransferType.py
@@ -30,6 +30,7 @@ from main.models import Transfer
 # archivematicaCommon
 from custom_handlers import get_script_logger
 
+
 if __name__ == '__main__':
     logger = get_script_logger("archivematica.mcp.client.setTransferType")
     transferUUID = sys.argv[1]

--- a/src/MCPClient/lib/clientScripts/indexAIP.py
+++ b/src/MCPClient/lib/clientScripts/indexAIP.py
@@ -43,6 +43,9 @@ def index_aip():
         print('Skipping indexing: indexing is currently disabled in', client_config_path)
         return 0
 
+    elasticSearchFunctions.setup_reading_from_client_conf(config)
+    client = elasticSearchFunctions.get_client()
+
     print('SIP UUID:', sip_uuid)
     aip_info = storage_service.get_file_info(uuid=sip_uuid)
     print('AIP info:', aip_info)
@@ -70,11 +73,12 @@ def index_aip():
     print('Indexing AIP info')
     # Delete ES index before creating new one if reingesting
     if 'REIN' in sip_type:
-        elasticSearchFunctions.delete_aip(sip_uuid)
+        elasticSearchFunctions.delete_aip(client, sip_uuid)
         print('Deleted outdated entry for AIP with UUID', sip_uuid, ' from archival storage')
 
     # Index AIP
-    elasticSearchFunctions.connect_and_index_aip(
+    elasticSearchFunctions.index_aip(
+        client,
         sip_uuid,
         sip_name,
         aip_info['current_full_path'],
@@ -88,9 +92,10 @@ def index_aip():
     # Even though we treat MODS identifiers as SIP-level, we need to index them
     # here because the archival storage tab actually searches on the
     # aips/aipfile index.
-    exitCode = elasticSearchFunctions.connect_and_index_files(
+    exitCode = elasticSearchFunctions.index_files(
+        client,
         index='aips',
-        type='aipfile',
+        type_='aipfile',
         uuid=sip_uuid,
         pathToArchive=sip_path,
         identifiers=identifiers,

--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -13,10 +13,13 @@ from custom_handlers import get_script_logger
 import elasticSearchFunctions
 import storageService as storage_service
 
+
 def post_store_hook(sip_uuid):
     """
     Hook for doing any work after an AIP is stored successfully.
     """
+    elasticSearchFunctions.setup_reading_from_client_conf()
+    client = elasticSearchFunctions.get_client()
 
     # SIP ARRANGEMENT
 
@@ -41,7 +44,7 @@ def post_store_hook(sip_uuid):
                 user_email='archivematica system',
                 reason_for_deletion='All files in Transfer are now in AIPs.'
             )
-            elasticSearchFunctions.connect_and_remove_transfer_files(transfer_uuid)
+            elasticSearchFunctions.remove_transfer_files(client, transfer_uuid)
 
     # POST-STORE CALLBACK
     storage_service.post_store_aip_callback(sip_uuid)

--- a/src/MCPClient/lib/clientScripts/removeAIPFilesFromIndex.py
+++ b/src/MCPClient/lib/clientScripts/removeAIPFilesFromIndex.py
@@ -29,10 +29,15 @@ django.setup()
 from custom_handlers import get_script_logger
 import elasticSearchFunctions
 
-if __name__ == '__main__':
-    logger = get_script_logger("archivematica.mcp.client.removeAIPFilesFromIndex")
 
-    AIPUUID = sys.argv[1]
-    print 'Removing indexed files for AIP ' + AIPUUID + '...'
-    elasticSearchFunctions.connect_and_delete_aip_files(AIPUUID)
-    print 'Done.'
+logger = get_script_logger("archivematica.mcp.client.removeAIPFilesFromIndex")
+
+
+if __name__ == '__main__':
+    aip_uuid = sys.argv[1]
+
+    elasticSearchFunctions.setup_reading_from_client_conf()
+    client = elasticSearchFunctions.get_client()
+
+    logger.info('Removing indexed files for AIP %s...', aip_uuid)
+    elasticSearchFunctions.delete_aip_files(client, AIPUUID)

--- a/src/archivematicaCommon/tests/fixtures/test_delete_aip.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_delete_aip.yaml
@@ -14,7 +14,7 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: http://localhost:9200/aips
+    uri: http://127.0.0.1:9200/aips
   response:
     body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[aips]
         already exists]","status":400}'}
@@ -26,7 +26,7 @@ interactions:
     body: '{"query": {"term": {"uuid": "a1ee611a-a4f5-4ba9-b7ce-b92695746514"}}}'
     headers: {}
     method: DELETE
-    uri: http://localhost:9200/aips/aip/_query
+    uri: http://127.0.0.1:9200/aips/aip/_query
   response:
     body: {string: !!python/unicode '{"_indices":{"aips":{"_shards":{"total":1,"successful":1,"failed":0}}}}'}
     headers:

--- a/src/archivematicaCommon/tests/fixtures/test_delete_aip_files.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_delete_aip_files.yaml
@@ -14,7 +14,7 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: http://localhost:9200/aips
+    uri: http://127.0.0.1:9200/aips
   response:
     body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[aips]
         already exists]","status":400}'}
@@ -26,7 +26,7 @@ interactions:
     body: '{"query": {"term": {"AIPUUID": "a1ee611a-a4f5-4ba9-b7ce-b92695746514"}}}'
     headers: {}
     method: DELETE
-    uri: http://localhost:9200/aips/aipfile/_query
+    uri: http://127.0.0.1:9200/aips/aipfile/_query
   response:
     body: {string: !!python/unicode '{"_indices":{"aips":{"_shards":{"total":1,"successful":1,"failed":0}}}}'}
     headers:

--- a/src/archivematicaCommon/tests/fixtures/test_list_tags.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_list_tags.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: http://localhost:9200/transfers
+    uri: http://127.0.0.1:9200/transfers
   response:
     body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[transfers]
         already exists]","status":400}'}
@@ -15,7 +15,7 @@ interactions:
     body: '{"query": {"term": {"fileuuid": "a410501b-64ac-4b81-92ca-efa9e815366d"}}}'
     headers: {}
     method: GET
-    uri: http://localhost:9200/transfers/transferfile/_search?fields=tags
+    uri: http://127.0.0.1:9200/transfers/transferfile/_search?fields=tags
   response:
     body: {string: !!python/unicode '{"took":4,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":1,"max_score":1.6931472,"hits":[{"_index":"transfers","_type":"transferfile","_id":"AU9MJzaYgAJJz92ebm-j","_score":1.6931472,"fields":{"tags":["test1"]}}]}}'}
     headers:

--- a/src/archivematicaCommon/tests/fixtures/test_list_tags_no_matches.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_list_tags_no_matches.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: http://localhost:9200/transfers
+    uri: http://127.0.0.1:9200/transfers
   response:
     body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[transfers]
         already exists]","status":400}'}
@@ -15,7 +15,7 @@ interactions:
     body: '{"query": {"term": {"fileuuid": "no_such_file"}}}'
     headers: {}
     method: GET
-    uri: http://localhost:9200/transfers/transferfile/_search?fields=tags
+    uri: http://127.0.0.1:9200/transfers/transferfile/_search?fields=tags
   response:
     body: {string: !!python/unicode '{"took":1,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'}
     headers:

--- a/src/archivematicaCommon/tests/fixtures/test_set_tags.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_set_tags.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: http://localhost:9200/transfers
+    uri: http://127.0.0.1:9200/transfers
   response:
     body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[transfers]
         already exists]","status":400}'}
@@ -15,7 +15,7 @@ interactions:
     body: '{"query": {"term": {"fileuuid": "2101fa74-bc27-405b-8e29-614ebd9d5a89"}}}'
     headers: {}
     method: GET
-    uri: http://localhost:9200/_all/transferfile/_search?size=50000
+    uri: http://127.0.0.1:9200/_all/transferfile/_search?size=50000
   response:
     body: {string: !!python/unicode '{"took":2,"timed_out":false,"_shards":{"total":10,"successful":10,"failed":0},"hits":{"total":1,"max_score":1.6931472,"hits":[{"_index":"transfers","_type":"transferfile","_id":"AU9MJzbIgAJJz92ebm-q","_score":1.6931472,"_source":{"accessionid":"","status":"backlog","sipuuid":"f646a630-9697-46a2-875a-a603f2d68cc1","tags":["test"],"file_extension":"tga","relative_path":"Images-f646a630-9697-46a2-875a-a603f2d68cc1/objects/pictures/MARBLES.TGA","bulk_extractor_reports":[],"origin":"42105a31-3507-4790-9a8d-2afbdd9ef3a1","size":4.0638933181762695,"created":1.4400914032641463E9,"format":[{"puid":"fmt/402","group":"Image
         (Raster)","format":"Truevision TGA Bitmap 2.0"}],"ingestdate":"2015-08-20","filename":"MARBLES.TGA","fileuuid":"2101fa74-bc27-405b-8e29-614ebd9d5a89"}}]}}'}
@@ -27,7 +27,7 @@ interactions:
     body: '{"doc": {"tags": ["test"]}}'
     headers: {}
     method: POST
-    uri: http://localhost:9200/transfers/transferfile/AU9MJzbIgAJJz92ebm-q/_update
+    uri: http://127.0.0.1:9200/transfers/transferfile/AU9MJzbIgAJJz92ebm-q/_update
   response:
     body: {string: !!python/unicode '{"_index":"transfers","_type":"transferfile","_id":"AU9MJzbIgAJJz92ebm-q","_version":9}'}
     headers:
@@ -38,7 +38,7 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: http://localhost:9200/transfers
+    uri: http://127.0.0.1:9200/transfers
   response:
     body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[transfers]
         already exists]","status":400}'}
@@ -50,7 +50,7 @@ interactions:
     body: '{"query": {"term": {"fileuuid": "2101fa74-bc27-405b-8e29-614ebd9d5a89"}}}'
     headers: {}
     method: GET
-    uri: http://localhost:9200/transfers/transferfile/_search?fields=tags
+    uri: http://127.0.0.1:9200/transfers/transferfile/_search?fields=tags
   response:
     body: {string: !!python/unicode '{"took":1,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":1,"max_score":1.6931472,"hits":[{"_index":"transfers","_type":"transferfile","_id":"AU9MJzbIgAJJz92ebm-q","_score":1.6931472,"fields":{"tags":["test"]}}]}}'}
     headers:

--- a/src/archivematicaCommon/tests/fixtures/test_set_tags_no_matches.yaml
+++ b/src/archivematicaCommon/tests/fixtures/test_set_tags_no_matches.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers: {}
     method: PUT
-    uri: http://localhost:9200/transfers
+    uri: http://127.0.0.1:9200/transfers
   response:
     body: {string: !!python/unicode '{"error":"IndexAlreadyExistsException[[transfers]
         already exists]","status":400}'}
@@ -15,7 +15,7 @@ interactions:
     body: '{"query": {"term": {"fileuuid": "no_such_file"}}}'
     headers: {}
     method: GET
-    uri: http://localhost:9200/_all/transferfile/_search?size=50000
+    uri: http://127.0.0.1:9200/_all/transferfile/_search?size=50000
   response:
     body: {string: !!python/unicode '{"took":1,"timed_out":false,"_shards":{"total":10,"successful":10,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'}
     headers:

--- a/src/archivematicaCommon/tests/test_elasticsearch_functions.py
+++ b/src/archivematicaCommon/tests/test_elasticsearch_functions.py
@@ -1,7 +1,7 @@
-
-from elasticsearch import Elasticsearch
 import os
 import sys
+
+from elasticsearch import Elasticsearch
 import pytest
 import unittest
 import vcr
@@ -14,13 +14,15 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 class TestElasticSearchFunctions(unittest.TestCase):
 
     def setUp(self):
-        self.conn = Elasticsearch('127.0.0.1:9200')
+        hosts = os.environ.get('ELASTICSEARCH_SERVER', '127.0.0.1:9200')
+        elasticSearchFunctions.setup(hosts)
+        self.client = elasticSearchFunctions.get_client()
         self.aip_uuid = 'a1ee611a-a4f5-4ba9-b7ce-b92695746514'
 
     @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_delete_aip.yaml'))
     def test_delete_aip(self):
         # Verify AIP exists
-        results = self.conn.search(
+        results = self.client.search(
             index='aips',
             doc_type='aip',
             body={'query': {'term': {'uuid': self.aip_uuid}}},
@@ -29,10 +31,10 @@ class TestElasticSearchFunctions(unittest.TestCase):
         assert results['hits']['total'] == 1
         assert results['hits']['hits'][0]['fields']['uuid'] == [self.aip_uuid]
         # Delete AIP
-        success = elasticSearchFunctions.delete_aip(self.aip_uuid)
+        success = elasticSearchFunctions.delete_aip(self.client, self.aip_uuid)
         # Verify AIP gone
         assert success is True
-        results = self.conn.search(
+        results = self.client.search(
             index='aips',
             doc_type='aip',
             body={'query': {'term': {'uuid': self.aip_uuid}}},
@@ -43,7 +45,7 @@ class TestElasticSearchFunctions(unittest.TestCase):
     @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_delete_aip_files.yaml'))
     def test_delete_aip_files(self):
         # Verify AIP exists
-        results = self.conn.search(
+        results = self.client.search(
             index='aips',
             doc_type='aipfile',
             body={'query': {'term': {'AIPUUID': self.aip_uuid}}},
@@ -58,10 +60,10 @@ class TestElasticSearchFunctions(unittest.TestCase):
         assert results['hits']['hits'][2]['fields']['AIPUUID'] == [self.aip_uuid]
         assert results['hits']['hits'][2]['fields']['FILEUUID'] == ['547bbd92-d8a0-4624-a9d3-69ba706eacee']
         # Delete AIP
-        success = elasticSearchFunctions.connect_and_delete_aip_files(self.aip_uuid)
+        success = elasticSearchFunctions.delete_aip_files(self.client, self.aip_uuid)
         # Verify AIP gone
         assert success is True
-        results = self.conn.search(
+        results = self.client.search(
             index='aips',
             doc_type='aipfile',
             body={'query': {'term': {'AIPUUID': self.aip_uuid}}},
@@ -71,19 +73,19 @@ class TestElasticSearchFunctions(unittest.TestCase):
 
     @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_list_tags.yaml'))
     def test_list_tags(self):
-        assert elasticSearchFunctions.connect_and_get_file_tags('a410501b-64ac-4b81-92ca-efa9e815366d') == ['test1']
+        assert elasticSearchFunctions.get_file_tags(self.client, 'a410501b-64ac-4b81-92ca-efa9e815366d') == ['test1']
 
     @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_list_tags_no_matches.yaml'))
     def test_list_tags_fails_when_file_cant_be_found(self):
         with pytest.raises(elasticSearchFunctions.EmptySearchResultError):
-            elasticSearchFunctions.connect_and_get_file_tags('no_such_file')
+            elasticSearchFunctions.get_file_tags(self.client, 'no_such_file')
 
     @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_set_tags.yaml'))
     def test_set_tags(self):
-        elasticSearchFunctions.connect_and_set_file_tags('2101fa74-bc27-405b-8e29-614ebd9d5a89', ['test'])
-        assert elasticSearchFunctions.connect_and_get_file_tags('2101fa74-bc27-405b-8e29-614ebd9d5a89') == ['test']
+        elasticSearchFunctions.set_file_tags(self.client, '2101fa74-bc27-405b-8e29-614ebd9d5a89', ['test'])
+        assert elasticSearchFunctions.get_file_tags(self.client, '2101fa74-bc27-405b-8e29-614ebd9d5a89') == ['test']
 
     @vcr.use_cassette(os.path.join(THIS_DIR, 'fixtures', 'test_set_tags_no_matches.yaml'))
     def test_set_tags_fails_when_file_cant_be_found(self):
         with pytest.raises(elasticSearchFunctions.EmptySearchResultError):
-            elasticSearchFunctions.connect_and_set_file_tags('no_such_file', [])
+            elasticSearchFunctions.set_file_tags(self.client, 'no_such_file', [])

--- a/src/dashboard/src/apache/django.wsgi
+++ b/src/dashboard/src/apache/django.wsgi
@@ -14,6 +14,7 @@ class WSGIEnvironment(WSGIHandler):
     def __call__(self, environ, start_response):
         self.update_environment(environ)
         django.setup()
+        self.setup_elasticsearch()
         if settings.DEBUG:
             self.enable_monitor()
         return super(WSGIEnvironment, self).__call__(environ, start_response)
@@ -30,6 +31,10 @@ class WSGIEnvironment(WSGIHandler):
 
     def enable_monitor(self):
         monitor.start()
+
+    def setup_elasticsearch(self):
+        import elasticSearchFunctions
+        elasticSearchFunctions.setup_reading_from_client_conf()
 
 
 application = WSGIEnvironment()

--- a/src/dashboard/src/components/appraisal/views.py
+++ b/src/dashboard/src/components/appraisal/views.py
@@ -7,7 +7,6 @@ from django.shortcuts import render
 # External dependencies, alphabetical
 
 # This project, alphabetical by import source
-from components import decorators
 
 logger = logging.getLogger('archivematica.dashboard')
 
@@ -15,6 +14,5 @@ logger = logging.getLogger('archivematica.dashboard')
       Appraisal
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ """
 
-@decorators.elasticsearch_required()
 def appraisal(request):
     return render(request, 'appraisal/appraisal.html')

--- a/src/dashboard/src/components/backlog/views.py
+++ b/src/dashboard/src/components/backlog/views.py
@@ -18,6 +18,7 @@
 import logging
 import requests
 
+from django.conf import settings as django_settings
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, Http404, HttpResponseRedirect
@@ -36,7 +37,7 @@ from components import helpers
 logger = logging.getLogger('archivematica.dashboard')
 
 
-def check_and_remove_deleted_transfers():
+def check_and_remove_deleted_transfers(es_client):
     """
     Check the storage service to see if transfers marked in ES as 'pending deletion' have been deleted yet. If so,
     remove the transfer and its files from ES. This is a bit of a kludge (that we do elsewhere e.g. in the storage tab),
@@ -44,8 +45,6 @@ def check_and_remove_deleted_transfers():
 
     :return: None
     """
-    conn = elasticSearchFunctions.connect_and_create_index('transfers')
-
     query = {
         'query': {
             'bool': {
@@ -58,7 +57,7 @@ def check_and_remove_deleted_transfers():
         }
     }
 
-    deletion_pending_results = conn.search(
+    deletion_pending_results = es_client.search(
         body=query,
         index='transfers',
         doc_type='transfer',
@@ -76,8 +75,8 @@ def check_and_remove_deleted_transfers():
             continue
 
         if status == 'DELETED':
-            elasticSearchFunctions.connect_and_remove_backlog_transfer_files(transfer_uuid)
-            elasticSearchFunctions.connect_and_remove_backlog_transfer(transfer_uuid)
+            elasticSearchFunctions.remove_backlog_transfer_files(es_client, transfer_uuid)
+            elasticSearchFunctions.remove_backlog_transfer(es_client, transfer_uuid)
 
 
 def execute(request):
@@ -87,7 +86,8 @@ def execute(request):
     :param request: The Django request object
     :return: The main backlog page rendered
     """
-    check_and_remove_deleted_transfers()
+    es_client = elasticSearchFunctions.get_client()
+    check_and_remove_deleted_transfers(es_client)
     return render(request, 'backlog/backlog.html', locals())
 
 
@@ -113,7 +113,6 @@ def get_es_property_from_column_index(index, file_mode):
     return table_columns[file_mode][index]
 
 
-@decorators.elasticsearch_required()
 def search(request):
     """
     A JSON end point that returns results for various backlog transfers and their files.
@@ -131,18 +130,18 @@ def search(request):
     order_by = get_es_property_from_column_index(int(request.GET.get('iSortCol_0', 0)), file_mode)
     sort_direction = request.GET.get('sSortDir_0', 'asc')
 
-    conn = elasticSearchFunctions.connect_and_create_index('transfers')
+    es_client = elasticSearchFunctions.get_client()
 
     if 'query' not in request.GET:
         queries, ops, fields, types = (['*'], ['or'], [''], ['term'])
 
-    query = advanced_search.assemble_query(queries, ops, fields, types, search_index='transfers',
+    query = advanced_search.assemble_query(es_client, queries, ops, fields, types, search_index='transfers',
                                            doc_type='transferfile', filters={'term': {'status': 'backlog'}})
     try:
         doc_type = 'transferfile' if file_mode else 'transfer'
 
-        hit_count = conn.search(index='transfers', doc_type=doc_type, body=query, search_type='count')['hits']['total']
-        hits = conn.search(
+        hit_count = es_client.search(index='transfers', doc_type=doc_type, body=query, search_type='count')['hits']['total']
+        hits = es_client.search(
             index='transfers',
             doc_type=doc_type,
             body=query,
@@ -196,7 +195,8 @@ def delete(request, uuid):
         )
 
         messages.info(request, response['message'])
-        elasticSearchFunctions.connect_and_mark_backlog_deletion_requested(uuid)
+        es_client = elasticSearchFunctions.get_client()
+        elasticSearchFunctions.mark_backlog_deletion_requested(es_client, uuid)
 
     except requests.exceptions.ConnectionError:
         error_message = 'Unable to connect to storage server. Please contact your administrator.'

--- a/src/dashboard/src/components/decorators.py
+++ b/src/dashboard/src/components/decorators.py
@@ -15,18 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-
-from django.shortcuts import render_to_response, render
+from django.shortcuts import render_to_response
 from django.http import Http404
 from django.utils.functional import wraps
 from django.template import RequestContext
 
 from contrib import utils
-from components import helpers
-
 from main import models
-import elasticSearchFunctions
+
 
 # Try to update context instead of sending new params
 def load_jobs(view):
@@ -40,28 +36,13 @@ def load_jobs(view):
         return view(request, uuid, *args, **kwargs)
     return inner
 
-# Requires ES server be running
-def elasticsearch_required():
-    def decorator(func):
-        def inner(request, *args, **kwargs):
-            elasticsearch_disabled = helpers.get_client_config_value('disableElasticsearchIndexing')
-            if elasticsearch_disabled:
-                return func(request, *args, **kwargs)
-            else:
-                status = elasticSearchFunctions.check_server_status()
-                if status == 'OK':
-                    return func(request, *args, **kwargs)
-                else:
-                    return render(request, 'elasticsearch_error.html', {'status': status})
-        return wraps(func)(inner)
-    return decorator
 
 # Requires confirmation from a prompt page before executing a request
 # (see http://djangosnippets.org/snippets/1922/)
 def confirm_required(template_name, context_creator, key='__confirm__'):
     def decorator(func):
         def inner(request, *args, **kwargs):
-            if request.POST.has_key(key):
+            if key in request.POST:
                 return func(request, *args, **kwargs)
             else:
                 context = context_creator and context_creator(request, *args, **kwargs) \

--- a/src/dashboard/src/components/file/views.py
+++ b/src/dashboard/src/components/file/views.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 # Django Core, alphabetical by import source
+from django.conf import settings as django_settings
 from django.views.generic import View
 
 # External dependencies, alphabetical
@@ -31,7 +32,8 @@ class TransferFileTags(View):
         Returns a JSON-encoded list of the file's tags on success.
         """
         try:
-            tags = elasticSearchFunctions.connect_and_get_file_tags(fileuuid)
+            es_client = elasticSearchFunctions.get_client()
+            tags = elasticSearchFunctions.get_file_tags(es_client, fileuuid)
         except elasticSearchFunctions.ElasticsearchError as e:
             response = {
                 'success': False,
@@ -68,7 +70,8 @@ class TransferFileTags(View):
             return helpers.json_response(response, status_code=400)
 
         try:
-            elasticSearchFunctions.connect_and_set_file_tags(fileuuid, tags)
+            es_client = elasticSearchFunctions.get_client()
+            elasticSearchFunctions.set_file_tags(es_client, fileuuid, tags)
         except elasticSearchFunctions.ElasticsearchError as e:
             response = {
                 'success': False,
@@ -87,7 +90,8 @@ class TransferFileTags(View):
         Deletes all tags for the given file.
         """
         try:
-            elasticSearchFunctions.connect_and_set_file_tags(fileuuid, [])
+            es_client = elasticSearchFunctions.get_client()
+            elasticSearchFunctions.set_file_tags(es_client, fileuuid, [])
         except elasticSearchFunctions.ElasticsearchError as e:
             response = {
                 'success': False,
@@ -133,7 +137,8 @@ def bulk_extractor(request, fileuuid):
         return helpers.json_response(response, status_code=400)
 
     try:
-        record = elasticSearchFunctions.get_transfer_file_info('fileuuid', fileuuid)
+        es_client = elasticSearchFunctions.get_client()
+        record = elasticSearchFunctions.get_transfer_file_info(es_client, 'fileuuid', fileuuid)
     except elasticSearchFunctions.ElasticsearchError as e:
         message = str(e)
         response = {
@@ -188,7 +193,8 @@ def _parse_bulk_extractor_report(data):
 
 def file_details(request, fileuuid):
     try:
-        source = elasticSearchFunctions.get_transfer_file_info('fileuuid', fileuuid)
+        es_client = elasticSearchFunctions.get_client()
+        source = elasticSearchFunctions.get_transfer_file_info(es_client, 'fileuuid', fileuuid)
     except elasticSearchFunctions.ElasticsearchError as e:
         message = str(e)
         response = {

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -25,9 +25,10 @@ import sys
 import tempfile
 import uuid
 
-import django.http
+from django.conf import settings as django_settings
 from django.db import connection, IntegrityError
 from django.db.models import Q
+import django.http
 import django.template.defaultfilters
 
 import requests
@@ -38,7 +39,6 @@ from main import models
 
 import archivematicaFunctions
 import databaseFunctions
-import elasticSearchFunctions
 import storageService as storage_service
 
 # for unciode sorting support

--- a/src/dashboard/src/components/transfer/views.py
+++ b/src/dashboard/src/components/transfer/views.py
@@ -45,7 +45,6 @@ logger = logging.getLogger('archivematica.dashboard')
       Transfer
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ """
 
-@decorators.elasticsearch_required()
 def grid(request):
     try:
         source_directories = storage_service.get_location(purpose="TS")

--- a/src/dashboard/src/contrib/utils.py
+++ b/src/dashboard/src/contrib/utils.py
@@ -17,6 +17,7 @@
 
 import os
 
+
 def get_directory_size(path='.'):
     total_size = 0
     for dirpath, dirnames, filenames in os.walk(path):
@@ -24,6 +25,7 @@ def get_directory_size(path='.'):
             fp = os.path.join(dirpath, f)
             total_size += os.path.getsize(fp)
     return total_size
+
 
 def get_directory_name(directory, default=None):
     """
@@ -50,6 +52,7 @@ def get_directory_name(directory, default=None):
         return directory
     else:
         return default
+
 
 def get_directory_name_from_job(job):
     return get_directory_name(job.directory, default=job.sipuuid)

--- a/src/dashboard/src/installer/middleware.py
+++ b/src/dashboard/src/installer/middleware.py
@@ -18,14 +18,15 @@
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
-from django.http import HttpResponse
 from django.shortcuts import redirect
 
-from re import compile
+from re import compile as re_compile
 
-EXEMPT_URLS = [compile(settings.LOGIN_URL.lstrip('/'))]
+
+EXEMPT_URLS = [re_compile(settings.LOGIN_URL.lstrip('/'))]
 if hasattr(settings, 'LOGIN_EXEMPT_URLS'):
-    EXEMPT_URLS += [compile(expr) for expr in settings.LOGIN_EXEMPT_URLS]
+    EXEMPT_URLS += [re_compile(expr) for expr in settings.LOGIN_EXEMPT_URLS]
+
 
 class ConfigurationCheckMiddleware:
     def process_request(self, request):
@@ -33,7 +34,7 @@ class ConfigurationCheckMiddleware:
             if reverse('installer.views.welcome') != request.path_info:
                 return redirect('installer.views.welcome')
         else:
-          if not request.user.is_authenticated():
-            path = request.path_info.lstrip('/')
-            if not any(m.match(path) for m in EXEMPT_URLS):
-                return redirect(settings.LOGIN_URL)
+            if not request.user.is_authenticated():
+                path = request.path_info.lstrip('/')
+                if not any(m.match(path) for m in EXEMPT_URLS):
+                    return redirect(settings.LOGIN_URL)

--- a/src/dashboard/src/main/urls.py
+++ b/src/dashboard/src/main/urls.py
@@ -26,9 +26,6 @@ urlpatterns = patterns('',
     # Forbidden
     url(r'forbidden/$', views.forbidden),
 
-    # Elasticsearch check
-    url(r'elasticsearch/$', views.elasticsearch_login_check),
-
     # Jobs and tasks (is part of ingest)
     url(r'jobs/(?P<uuid>' + settings.UUID_REGEX + ')/explore/$', views.jobs_explore),
     url(r'jobs/(?P<uuid>' + settings.UUID_REGEX + ')/list-objects/$', views.jobs_list_objects),

--- a/src/dashboard/src/main/views.py
+++ b/src/dashboard/src/main/views.py
@@ -15,22 +15,25 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+import subprocess
+
 from django.conf import settings as django_settings
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.http import Http404, HttpResponse
+
 from contrib.mcp.client import MCPClient
 from main import models
 from lxml import etree
-import os, subprocess, sys
 from components import helpers
-import components.decorators as decorators
-import elasticSearchFunctions
 from archivematicaFunctions import escape
+
 
 """ @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
       Home
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ """
+
 
 def home(request):
     # clean up user's session-specific data
@@ -58,16 +61,11 @@ def home(request):
         redirectUrl = reverse('components.transfer.views.grid')
     return redirect(redirectUrl)
 
+
 """ @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
       Status
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ """
 
-def elasticsearch_login_check(request):
-    status = elasticSearchFunctions.check_server_status_and_create_indexes_if_needed()
-    if status == 'OK':
-        return redirect('django.contrib.auth.views.login')
-    else:
-        return render(request, 'elasticsearch_error.html', {'status': status})
 
 # TODO: hide removed elements
 def status(request):
@@ -82,9 +80,11 @@ def status(request):
 
     return helpers.json_response(response)
 
+
 """ @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
       Access
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ """
+
 
 def access_list(request):
     access = models.Access.objects.all()
@@ -99,23 +99,28 @@ def access_list(request):
             item.destination = item.resource
     return render(request, 'main/access.html', locals())
 
+
 def access_delete(request, id):
     access = get_object_or_404(models.Access, pk=id)
     access.delete()
     return redirect('main.views.access_list')
 
+
 """ @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
       Misc
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ """
 
+
 def forbidden(request):
     return render(request, 'forbidden.html')
+
 
 def task(request, uuid):
     task = models.Task.objects.get(taskuuid=uuid)
     task.duration = helpers.task_duration_in_seconds(task)
     objects = [task]
     return render(request, 'main/tasks.html', locals())
+
 
 def tasks(request, uuid):
     job = models.Job.objects.get(jobuuid=uuid)
@@ -142,6 +147,7 @@ def tasks(request, uuid):
 
     return render(request, 'main/tasks.html', locals())
 
+
 def tasks_subjobs(request, uuid):
     jobs = []
     possible_jobs = models.Job.objects.filter(subjobof=uuid)
@@ -157,6 +163,7 @@ def tasks_subjobs(request, uuid):
     else:
         return render(request, 'main/tasks_subjobs.html', locals())
 
+
 def jobs_list_objects(request, uuid):
     response = []
     job = models.Job.objects.get(jobuuid=uuid)
@@ -167,6 +174,7 @@ def jobs_list_objects(request, uuid):
             response.append(os.path.join(directory, name))
 
     return helpers.json_response(response)
+
 
 def jobs_explore(request, uuid):
     # Database query
@@ -225,8 +233,10 @@ def jobs_explore(request, uuid):
 
     return helpers.json_response(response)
 
+
 def formdata_delete(request, type, parent_id, delete_id):
   return formdata(request, type, parent_id, delete_id)
+
 
 def formdata(request, type, parent_id, delete_id = None):
     model    = None

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, ConfigParser
+import os
+import ConfigParser
 
 path_of_this_file = os.path.abspath(os.path.dirname(__file__))
 
@@ -138,7 +139,8 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'middleware.common.AJAXSimpleExceptionResponseMiddleware',
     'installer.middleware.ConfigurationCheckMiddleware',
-    'middleware.common.SpecificExceptionErrorPageResponseMiddleware'
+    'middleware.common.SpecificExceptionErrorPageResponseMiddleware',
+    'middleware.common.ElasticsearchMiddleware',
 )
 
 ROOT_URLCONF = 'urls'
@@ -261,7 +263,7 @@ LOGGING = {
 
 # login-related settings
 LOGIN_REDIRECT_URL = '/'
-LOGIN_URL = '/elasticsearch'
+LOGIN_URL = '/administration/accounts/login/'
 LOGIN_EXEMPT_URLS  = [
   r'^administration/accounts/login',
   r'^api'

--- a/src/dashboard/src/templates/elasticsearch_error.html
+++ b/src/dashboard/src/templates/elasticsearch_error.html
@@ -2,9 +2,9 @@
 
 {% block content %}
 
-  <h1>ElasticSearch server issue</h1>
+  <h1>Elasticsearch error</h1>
 
-  <h3>{{ status }}</h3>
+  <h3>Exception type: {{ exception_type }}</h3>
 
   <div class="alert-message block-message warning">
     <p>Sorry! The page that you are trying to view is not available.</p>


### PR DESCRIPTION
Elasticsearch's client is thread-safe. We use it in two different contents:
our `dashboard` application and `clientScripts`.

This commit stores the Elasticserach instance as an attribute of its module.
Access to the instance if provided via `get_client()`, but it requires previous
initialization. In the `dashboard` this is achieved in `apache/django.wsgi` while
clientScripts have to initialize it manually for now. An exception is raised if
the user tries to access to the client before initialization.

Usage example:

```
import elasticSearchFunctions
elasticSearchFunctions.setup(hosts=['127.0.0.1:9200'])
client = elasticSearchFunctions.get_client()
results = client.search(**{})
```

It's been provided an extra setup method that reads the configuration param
from `clientConf.conf` to ease the transaction. This will be used by both
`dashboard` and `clientScripts` until they enable other ways to provide that
configuration, which is work in progress.

In addition, the dashboard receives a new middleware that replaces the old
`elasticsearch_required` decorator. See `middleware.common.ElasticsearchMiddleware`.
It redirects the user to a custom Elasticsearch error page when one of the two
following exceptions have been raised in the view: `ElasticsearchException` and
`ImproperlyConfigured`. The main advantage here is to avoid an extra hit to the
Elasticsearch server (as the previous `check_server_status` function used to
do).
