### PR TITLE
Move getDashboardUUID into archivematicaFunctions

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS.py
@@ -34,10 +34,9 @@ django.setup()
 from main.models import File
 
 # archivematicaCommon
-from archivematicaFunctions import escape
+from archivematicaFunctions import escape, get_dashboard_uuid
 from custom_handlers import get_script_logger
 from databaseFunctions import getAccessionNumberFromTransfer, getUTCDate
-from elasticSearchFunctions import getDashboardUUID
 
 
 def createMetsHdr(sip_uuid):
@@ -48,7 +47,7 @@ def createMetsHdr(sip_uuid):
                              TYPE="OTHER",
                              OTHERTYPE="SOFTWARE")
     name = etree.SubElement(agent, ns.metsBNS + "name")
-    name.text = getDashboardUUID()
+    name.text = get_dashboard_uuid()
     note = etree.SubElement(agent, ns.metsBNS + "note")
     note.text = "Archivematica dashboard UUID"
 

--- a/src/MCPClient/lib/clientScripts/upload-archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload-archivesspace.py
@@ -8,7 +8,7 @@ from main.models import ArchivesSpaceDIPObjectResourcePairing, File
 from fpr.models import FormatVersion
 
 # archivematicaCommon
-from elasticSearchFunctions import getDashboardUUID
+from archivematicaFunctions import get_dashboard_uuid
 from xml2obj import mets_file
 
 # Third party dependencies, alphabetical by import source
@@ -63,7 +63,7 @@ def upload_to_archivesspace(files, client, xlink_show, xlink_actuate, object_typ
     if not uri.endswith('/'):
         uri += '/'
     pairs = get_pairs(dip_uuid)
-    dashboard_uuid = getDashboardUUID()
+    dashboard_uuid = get_dashboard_uuid()
 
     # get mets object if needed
     mets = None

--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -53,6 +53,8 @@ def get_setting(setting, default=''):
     except DashboardSetting.DoesNotExist:
         return default
 
+def get_dashboard_uuid():
+    return get_setting('dashboard_uuid', default=None)
 
 class OrderedListsDict(collections.OrderedDict):
     """

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -35,9 +35,10 @@ from xml.etree import ElementTree
 
 sys.path.append("/usr/share/archivematica/dashboard")
 from django.db.models import Q
-from main.models import DashboardSetting, File, Transfer
+from main.models import File, Transfer
 
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
+from archivematicaFunctions import get_dashboard_uuid
 import version
 
 sys.path.append("/usr/lib/archivematica/archivematicaCommon/externals")
@@ -91,12 +92,6 @@ def remove_tool_output_from_mets(doc):
         parent.clear()
 
     print "Removed FITS output from METS."
-
-def getDashboardUUID():
-    try:
-        return DashboardSetting.objects.get(name='dashboard_uuid').value
-    except DashboardSetting.DoesNotExist:
-        pass
 
 def getElasticsearchServerHostAndPort():
     clientConfigFilePath = '/etc/archivematica/MCPClient/clientConfig.conf'
@@ -359,7 +354,7 @@ def connect_and_index_aip(uuid, name, filePath, pathToMETS, size=None, aips_in_a
         'filePath': filePath,
         'size': (size or os.path.getsize(filePath)) / float(1024) / float(1024),
         'mets': mets_data,
-        'origin': getDashboardUUID(),
+        'origin': get_dashboard_uuid(),
         'created': os.path.getmtime(pathToMETS),
         'AICID': aic_identifier,
         'isPartOf': is_part_of,
@@ -513,7 +508,7 @@ def index_mets_file_metadata(conn, uuid, metsFilePath, index, type, sipName, ide
             'dmdSec': rename_dict_keys_with_child_dicts(normalize_dict_values(dmdSecData)),
             'amdSec': {},
         },
-        'origin': getDashboardUUID(),
+        'origin': get_dashboard_uuid(),
         'identifiers': identifiers,
         'transferMetadata': _extract_transfer_metadata(root, nsmap),
     }
@@ -707,7 +702,7 @@ def index_transfer_files(conn, uuid, pathToTransfer, index, type):
         accession_id = transfer_name = ''
 
     # Get dashboard UUID
-    dashboard_uuid = getDashboardUUID()
+    dashboard_uuid = get_dashboard_uuid()
 
     for filepath in list_files_in_dir(pathToTransfer):
         if os.path.isfile(filepath):


### PR DESCRIPTION
This is one of only a few functions in `elasticSearchFunctions` that uses the database, which I'm slowly moving out of this module.
