### PR TITLE
ES: specify all fields for AIP mapping

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -256,6 +256,12 @@ def set_up_mapping_aip_index(conn):
         'FILEUUID': MACHINE_READABLE_FIELD_SPEC,
         'isPartOf': MACHINE_READABLE_FIELD_SPEC,
         'AICID': MACHINE_READABLE_FIELD_SPEC,
+        'sipName': {'type': 'string'},
+        'indexedAt': {'type': 'double'},
+        'filePath': {'type': 'string'},
+        'fileExtension': {'type': 'string'},
+        'origin': {'type': 'string'},
+        'identifiers': {'type': 'string'},
         # Prevent autodetection for dc:date
         'METS': {'properties': {'dmdSec': {'properties': {'ns0:xmlData_dict_list': {'properties': {'ns1:dublincore_dict_list': {'properties': {'dc:date': {'type': 'string'}}}}}}}}},
     }


### PR DESCRIPTION
Archival storage now performs some faceting on archival storage data, which requires those fields to exist in the mapping. Depending on automatic mapping structure meant that these queries would throw exceptions until the first time data was indexed containing these fields. This was manifested in archival storage as an exception when trying to search when the AIP store is empty.
