### PR TITLE
WIP: customize tokenization for path fields

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -104,6 +104,21 @@ PATH_STRING_MULTIFIELD = {
     },
 }
 
+MULTI_FIELDS = {
+    'transfers': {
+        'transferfile': {
+            'relative_path': ['raw', 'path', 'word'],
+        },
+        'transfer': {},
+    },
+    'aips': {
+        'aipfile': {
+            'filePath': ['raw', 'path', 'word'],
+        },
+        'aip': {},
+    },
+}
+
 class ElasticsearchError(Exception):
     """ Not operational errors. """
     pass

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -283,14 +283,12 @@ def aip_mapping_is_correct(client):
     return mapping['aipfile']['properties']['AIPUUID']['index'] == 'not_analyzed'
 
 
-def create_index(client, index, attempt=1):
-    if attempt > 3:
-        return
-    response = client.indices.create(index, ignore=400)
-    if 'error' in response and 'IndexAlreadyExistsException' in response['error']:
-        return
+def create_index(client, index):
+    client.indices.create(index, ignore=400)
+    # Always put the mapping, even if the index already exists, because
+    # there may have been changes to the mapping structure; rerunning this
+    # will allow additional fields to be added to the index
     set_up_mapping(client, index)
-    create_index(client, index, attempt + 1)
 
 
 def _sortable_string_field_specification(field_name):

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -338,7 +338,7 @@ def set_up_mapping_aip_index(client):
         'AICID': MACHINE_READABLE_FIELD_SPEC,
         'sipName': {'type': 'string'},
         'indexedAt': {'type': 'double'},
-        'filePath': {'type': 'string'},
+        'filePath': PATH_STRING_MULTIFIELD,
         'fileExtension': {'type': 'string'},
         'origin': {'type': 'string'},
         'identifiers': {'type': 'string'},

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -518,6 +518,8 @@ def transfer_backlog(request, ui):
                 fields,
                 types,
                 filters=elasticSearchFunctions.BACKLOG_FILTER,
+                search_index='transfers',
+                doc_type='transferfile',
             )
         except:
             logger.exception('Error accessing index.')

--- a/src/dashboard/src/media/js/ingest/backlog.js
+++ b/src/dashboard/src/media/js/ingest/backlog.js
@@ -37,6 +37,7 @@ function renderBacklogSearchForm(search_uri, on_success, on_error) {
   // default field name field
   search.addSelect('field', {title: 'field name'}, {
     ''             : 'Any',
+    'relative_path': 'Path',
     'filename'     : 'File name',
     'file_extension': 'File extension',
     'accessionid'  : 'Accession number',


### PR DESCRIPTION
The default tokenization used by Elasticsearch doesn't deal well with the ways that path strings are constructed; substring searches often fail to bring up files and SIPs which would be expected by users. For example, trying to search for "events" will fail to bring up files in a SIP named "Events_2005-d1c6c1a2-f613-497f-a527-64eb6861f03c".

This adds several new custom analyzers to perform tokenization, which split strings on path delimeters and on logical word separators within strings (such as `-` and `_`). Fields which need these analyzers are now created as multifields, allowing searches for those fields to attempt to match all of the defined subfields. This WIP PR tests this by defining `transferfile`'s `relative_path` field as a multifield with unanalyzed, path-analyzed, and word-analyzed copies of the field.
