### PR TITLE
MCPServer: wait until database is available

### DIFF
--- a/src/MCPServer/init/archivematica-mcp-server.conf
+++ b/src/MCPServer/init/archivematica-mcp-server.conf
@@ -18,7 +18,7 @@
 description     "Archivematica MCP Server"
 author          "Austin Trask <austin@artefactual.com>, Joseph Perry <joseph@artefactual.com>"
 
-start on (started mysql)
+start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [016]
 
 env CONF=/etc/archivematica/MCPServer

--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -56,6 +56,11 @@ import watchDirectory
 import RPCServer
 from utils import log_exceptions
 
+# Block until the datatabase is available. This is the latest it can be done
+# before the application hits the database.
+from wait_db import wait_db
+wait_db()
+
 from jobChain import jobChain
 from unitSIP import unitSIP
 from unitDIP import unitDIP

--- a/src/MCPServer/lib/wait_db.py
+++ b/src/MCPServer/lib/wait_db.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python2
+
+# This file is part of Archivematica.
+#
+# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import time
+
+import django
+
+
+"""
+Using the default logging module-level functions intentionally as the custom
+application logger 'archivematica.mcp.server' is not available at this time.
+"""
+
+
+def wait_db():
+    """
+    Simple retry pattern when django.db.connection.cursor() raises an
+    OperationalError exception. In MySQL, this frequently happens when there
+    are too many connections, the host name coult not be resolved,
+    communication errors, etc...
+    """
+    attempt = 1
+    fail_sleep = 1
+    fail_sleep_inc = 2
+    fail_max_sleep = 30
+    while True:
+        try:
+            cursor = django.db.connection.cursor()
+        except django.db.utils.OperationalError:
+            if fail_sleep < fail_max_sleep:
+                fail_sleep += fail_sleep_inc
+            logging.error('Connection attempt to MySQL failed (attempt %d). Trying again in %d seconds...', attempt, fail_sleep)
+            attempt += 1
+            time.sleep(fail_sleep)
+        else:
+            logging.info('The connection to the database succeeded.')
+            cursor.close()
+            return


### PR DESCRIPTION
I'm trying to eliminate the need to deploy services in specific order. This
commit allows us to start MCPServer even when MySQL is not available. But the
application will block and wait during initialization until it is available.

Stanza `start` in Upstart service has been update to stop depending on a local
MySQL service.
