### PR TITLE
base64: escape invalid UTF-8 characters before encoding

### DIFF
--- a/src/dashboard/src/media/js/vendor/base64.js
+++ b/src/dashboard/src/media/js/vendor/base64.js
@@ -2,12 +2,33 @@
 
 var Base64 =
 {
-    // If passed string is UTF-8, decodes to bytes first before encoding.
+    // Returns true if the passed string consists of codepoints between 0 and 255
+    // which are valid within UTF-8.
+    all_bytes_valid_utf8: function (str) {
+        var invalid_chars = [0xc0, 0xc1, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9,
+                             0xF0, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF];
+
+        for (var i in str) {
+            var cp = str.codePointAt(i);
+            if (cp > 255 || invalid_chars.indexOf(cp) !== -1) {
+                return false
+            }
+        }
+
+        return true;
+    },
+
+    // Decodes the string before base64-encoding.
+    encode_escaped: function (str) {
+        return window.btoa(unescape(encodeURIComponent(str)));
+    },
+
+    // If passed string is not UTF-8, decodes to bytes first before encoding.
     encode: function (str) {
-        try {
+        if (this.all_bytes_valid_utf8(str)) {
             return window.btoa(str);
-        } catch (InvalidCharacterError) {
-            return window.btoa(unescape(encodeURIComponent(str)));
+        } else {
+            return this.encode_escaped(str);
         }
     },
 


### PR DESCRIPTION
Fixes #9324.
