### PR TITLE
RCPServer: never return empty strings

### DIFF
--- a/src/MCPServer/lib/RPCServer.py
+++ b/src/MCPServer/lib/RPCServer.py
@@ -60,25 +60,19 @@ def gearmanApproveJob(gearman_worker, gearman_job):
         jobUUID = data["jobUUID"]
         chain = data["chain"]
         agent = str(data["uid"])
-        ret = cPickle.dumps(approveJob(jobUUID, chain, agent))
-        if not ret:
-            ret = ""
-        return ""
-    #catch OS errors
+        return cPickle.dumps(approveJob(jobUUID, chain, agent))
+    # catch OS errors
     except Exception:
         LOGGER.exception('Error approving job')
-        return ""
+        raise
 
 def gearmanGetJobsAwaitingApproval(gearman_worker, gearman_job):
     try:
-        ret = cPickle.dumps(getJobsAwaitingApproval())
-        if not ret:
-            ret = ""
-        return ret
-    #catch OS errors
+        return cPickle.dumps(getJobsAwaitingApproval())
+    # catch OS errors
     except Exception:
         LOGGER.exception('Error getting jobs awaiting approval')
-        return ""
+        raise
 
 
 def startRPCServer():


### PR DESCRIPTION
- Several of these conditions were unreachable, e.g. the return value could never have been falsy.
- An empty string is not a valid cPickle serialization, so this results in confusing, hard-to-debug exceptions in places consuming these values.

Refs #9030.
