### PR TITLE
Revert "ArchivesSpace: Do not open matching GUI with JS"

### DIFF
--- a/src/dashboard/src/media/js/ingest.js
+++ b/src/dashboard/src/media/js/ingest.js
@@ -331,6 +331,13 @@ $(function()
             window.location.href = '/ingest/' + this.model.sip.get('uuid') + '/upload/atk/';
           }
 
+          // redirect to object/resource mapping pages
+          if ('- Upload DIP to ArchivesSpace' == $select.find('option:selected').text())
+          {
+            $('body').html('<h1>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Loading...</h1>');
+            window.location.href = '/ingest/' + this.model.sip.get('uuid') + '/upload/as/';
+          }
+
           // if ('Upload DIP' == this.model.get('type') && 13 == value)
           if ('- Upload DIP to Atom' == $select.find('option:selected').text())
           {


### PR DESCRIPTION
This reverts commit c2cc8f6cee06fdb79c0851d8a607837f19ee8c07.

After some discussion, we determined that this was not the best solution to the problem at this point in time. We don't have a clear UI that drives users to this feature, so expecting users to know to click on the small clipboard icon seems liable to result in a great deal of confusion.

This shouldn't affect most automation users, as Holly suggests they may well not notice the popup is there or even have the dashboard UI open at the point at which it would be triggered.

Fixes #9347.
