### PR TITLE
Reingest parse: Add checksumtype support

### DIFF
--- a/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
+++ b/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
@@ -46,6 +46,9 @@ def parse_files(root):
         checksum = amdsec.findtext('.//premis:messageDigest', namespaces=ns.NSMAP)
         print('checksum', checksum)
 
+        checksumtype = amdsec.findtext('.//premis:messageDigestAlgorithm', namespaces=ns.NSMAP)
+        print('checksumtype', checksumtype)
+
         size = amdsec.findtext('.//premis:size', namespaces=ns.NSMAP)
         print('size', size)
 
@@ -88,6 +91,7 @@ def parse_files(root):
             'current_path': current_path,
             'use': filegrpuse,
             'checksum': checksum,
+            'checksumtype': checksumtype,
             'size': size,
             'format_version': format_version,
             'derivation': derivation,
@@ -124,6 +128,7 @@ def update_files(sip_uuid, files):
         # Update other file info
         models.File.objects.filter(uuid=file_info['uuid']).update(
             checksum=file_info['checksum'],
+            checksumtype=file_info['checksumtype'],
             size=file_info['size'],
             currentlocation=file_info['current_path']
         )

--- a/src/MCPClient/tests/fixtures/mets_no_metadata.xml
+++ b/src/MCPClient/tests/fixtures/mets_no_metadata.xml
@@ -545,8 +545,8 @@
             <premis:objectCharacteristics>
               <premis:compositionLevel>0</premis:compositionLevel>
               <premis:fixity>
-                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
-                <premis:messageDigest>51132e5ce1b5d2c2c363f05495f447ea924ab29c2cda2c11037b5fca2119e45a</premis:messageDigest>
+                <premis:messageDigestAlgorithm>md5</premis:messageDigestAlgorithm>
+                <premis:messageDigest>d41d8cd98f00b204e9800998ecf8427e</premis:messageDigest>
               </premis:fixity>
               <premis:size>12222</premis:size>
               <premis:format>
@@ -608,11 +608,11 @@
             </premis:eventIdentifier>
             <premis:eventType>message digest calculation</premis:eventType>
             <premis:eventDateTime>2015-06-24T00:27:24</premis:eventDateTime>
-            <premis:eventDetail>program="python"; module="hashlib.sha256()"</premis:eventDetail>
+            <premis:eventDetail>program="python"; module="hashlib.md5()"</premis:eventDetail>
             <premis:eventOutcomeInformation>
               <premis:eventOutcome/>
               <premis:eventOutcomeDetail>
-                <premis:eventOutcomeDetailNote>51132e5ce1b5d2c2c363f05495f447ea924ab29c2cda2c11037b5fca2119e45a</premis:eventOutcomeDetailNote>
+                <premis:eventOutcomeDetailNote>d41d8cd98f00b204e9800998ecf8427e</premis:eventOutcomeDetailNote>
               </premis:eventOutcomeDetail>
             </premis:eventOutcomeInformation>
             <premis:linkingAgentIdentifier>
@@ -708,11 +708,11 @@
             </premis:eventIdentifier>
             <premis:eventType>fixity check</premis:eventType>
             <premis:eventDateTime>2015-06-24T00:27:28</premis:eventDateTime>
-            <premis:eventDetail>program="python"; module="hashlib.sha256()"</premis:eventDetail>
+            <premis:eventDetail>program="python"; module="hashlib.md5()"</premis:eventDetail>
             <premis:eventOutcomeInformation>
               <premis:eventOutcome>Pass</premis:eventOutcome>
               <premis:eventOutcomeDetail>
-                <premis:eventOutcomeDetailNote>51132e5ce1b5d2c2c363f05495f447ea924ab29c2cda2c11037b5fca2119e45a verified</premis:eventOutcomeDetailNote>
+                <premis:eventOutcomeDetailNote>d41d8cd98f00b204e9800998ecf8427e verified</premis:eventOutcomeDetailNote>
               </premis:eventOutcomeDetail>
             </premis:eventOutcomeInformation>
             <premis:linkingAgentIdentifier>

--- a/src/MCPClient/tests/test_parse_mets_to_db.py
+++ b/src/MCPClient/tests/test_parse_mets_to_db.py
@@ -338,6 +338,7 @@ class TestParseFiles(TestCase):
             'current_path': '%SIPDirectory%objects/evelyn_s_photo.jpg',
             'use': 'original',
             'checksum': 'd2bed92b73c7090bb30a0b30016882e7069c437488e1513e9deaacbe29d38d92',
+            'checksumtype': 'sha256',
             'size': '158131',
             'format_version': fpr.models.FormatVersion.objects.get(uuid='01fac958-274d-41ef-978f-d9cf711b3c4a'),
             'derivation': '8140ebe5-295c-490b-a34a-83955b7c844e',
@@ -349,6 +350,7 @@ class TestParseFiles(TestCase):
             'current_path': '%SIPDirectory%objects/evelyn_s_photo-6383b731-99e0-432d-a911-a0d2dfd1ce76.tif',
             'use': 'preservation',
             'checksum': 'd82448f154b9185bc777ecb0a3602760eb76ba85dd3098f073b2c91a03f571e9',
+            'checksumtype': 'sha256',
             'size': '1446772',
             'format_version': fpr.models.FormatVersion.objects.get(uuid='2ebdfa17-2257-49f8-8035-5f304bb46918'),
             'derivation': None,
@@ -359,7 +361,8 @@ class TestParseFiles(TestCase):
             'original_path': "%SIPDirectory%objects/submissionDocumentation/transfer-no-metadata-46260807-ece1-4a0e-b70a-9814c701146b/METS.xml",
             'current_path': '%SIPDirectory%objects/submissionDocumentation/transfer-no-metadata-46260807-ece1-4a0e-b70a-9814c701146b/METS.xml',
             'use': 'submissionDocumentation',
-            'checksum': '51132e5ce1b5d2c2c363f05495f447ea924ab29c2cda2c11037b5fca2119e45a',
+            'checksum': 'd41d8cd98f00b204e9800998ecf8427e',
+            'checksumtype': 'md5',
             'size': '12222',
             'format_version': fpr.models.FormatVersion.objects.get(uuid='d60e5243-692e-4af7-90cd-40c53cb8dc7d'),
             'derivation': None,
@@ -382,6 +385,7 @@ class TestParseFiles(TestCase):
         assert orig['current_path'] == self.ORIG_INFO['current_path']
         assert orig['use'] == self.ORIG_INFO['use']
         assert orig['checksum'] == self.ORIG_INFO['checksum']
+        assert orig['checksumtype'] == self.ORIG_INFO['checksumtype']
         assert orig['size'] == self.ORIG_INFO['size']
         assert orig['format_version'] == self.ORIG_INFO['format_version']
         assert orig['derivation'] == self.ORIG_INFO['derivation']
@@ -392,6 +396,7 @@ class TestParseFiles(TestCase):
         assert mets['current_path'] == self.METS_INFO['current_path']
         assert mets['use'] == self.METS_INFO['use']
         assert mets['checksum'] == self.METS_INFO['checksum']
+        assert mets['checksumtype'] == self.METS_INFO['checksumtype']
         assert mets['size'] == self.METS_INFO['size']
         assert mets['format_version'] == self.METS_INFO['format_version']
         assert mets['derivation'] == self.METS_INFO['derivation']
@@ -402,6 +407,7 @@ class TestParseFiles(TestCase):
         assert pres['current_path'] == self.PRES_INFO['current_path']
         assert pres['use'] == self.PRES_INFO['use']
         assert pres['checksum'] == self.PRES_INFO['checksum']
+        assert pres['checksumtype'] == self.PRES_INFO['checksumtype']
         assert pres['size'] == self.PRES_INFO['size']
         assert pres['format_version'] == self.PRES_INFO['format_version']
         assert pres['derivation'] == self.PRES_INFO['derivation']
@@ -420,6 +426,7 @@ class TestParseFiles(TestCase):
         assert orig.filegrpuse == self.ORIG_INFO['use']
         assert orig.filegrpuuid == ''
         assert orig.checksum == self.ORIG_INFO['checksum']
+        assert orig.checksumtype == self.ORIG_INFO['checksumtype']
         assert orig.size == int(self.ORIG_INFO['size'])
         assert models.Event.objects.get(file_uuid_id=self.ORIG_INFO['uuid'], event_type='reingestion')
         assert models.FileFormatVersion.objects.get(file_uuid_id=self.ORIG_INFO['uuid'], format_version=self.ORIG_INFO['format_version'])
@@ -433,6 +440,7 @@ class TestParseFiles(TestCase):
         assert pres.filegrpuse == self.PRES_INFO['use']
         assert pres.filegrpuuid == ''
         assert pres.checksum == self.PRES_INFO['checksum']
+        assert pres.checksumtype == self.PRES_INFO['checksumtype']
         assert pres.size == int(self.PRES_INFO['size'])
         assert models.Event.objects.get(file_uuid_id=self.PRES_INFO['uuid'], event_type='reingestion')
         assert models.FileFormatVersion.objects.get(file_uuid_id=self.PRES_INFO['uuid'], format_version=self.PRES_INFO['format_version'])
@@ -445,6 +453,7 @@ class TestParseFiles(TestCase):
         assert mets.filegrpuse == self.METS_INFO['use']
         assert mets.filegrpuuid == ''
         assert mets.checksum == self.METS_INFO['checksum']
+        assert mets.checksumtype == self.METS_INFO['checksumtype']
         assert mets.size == int(self.METS_INFO['size'])
         assert models.Event.objects.get(file_uuid_id=self.METS_INFO['uuid'], event_type='reingestion')
         assert models.FileFormatVersion.objects.get(file_uuid_id=self.METS_INFO['uuid'], format_version=self.METS_INFO['format_version'])


### PR DESCRIPTION
Parse the checksumtype from the METS. Update tests.

Fixes reingest for the changes in  #317
