### PR TITLE
Checksums: Use checksumtype setting everywhere

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaBagWithEmptyDirectories.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaBagWithEmptyDirectories.py
@@ -23,7 +23,12 @@
 import argparse
 import os
 import sys
+
+import django
+django.setup()
+
 # archivematicaCommon
+from archivematicaFunctions import get_setting
 from custom_handlers import get_script_logger
 from executeOrRunSubProcess import executeOrRun
 
@@ -101,6 +106,8 @@ if __name__ == '__main__':
     parser.add_argument('payload_entries', metavar='Payload', nargs='+',
                    help='All the files/folders that should go in the bag.')
     parser.add_argument('--writer', dest='writer')
-    parser.add_argument('--payloadmanifestalgorithm', dest='algorithm')
+
+    algorithm = get_setting('checksum_type', 'sha512')
+
     args = parser.parse_args()
-    bag_with_empty_directories(args.operation, args.destination, args.sip_directory, args.payload_entries, args.writer, args.algorithm)
+    bag_with_empty_directories(args.operation, args.destination, args.sip_directory, args.payload_entries, args.writer, algorithm)

--- a/src/MCPClient/lib/clientScripts/archivematicaBagWithEmptyDirectories.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaBagWithEmptyDirectories.py
@@ -68,28 +68,28 @@ def create_directories(base_dir, dir_list):
         except os.error:
             pass
 
-def bag_with_empty_directories(args):
+def bag_with_empty_directories(operation, destination, sip_directory, payload_entries, writer, algorithm):
     """ Run bagit create bag command, and create any empty directories from the SIP. """
     # Get list of directories in SIP
-    dir_list = get_sip_directories(args.sip_directory)
+    dir_list = get_sip_directories(sip_directory)
 
     # These are passed to this script as paths relative to their location in
     # the SIP; passing the full SIP location each time has the potential to
     # overflow the 1000-character limit the job's command has in the database,
     # especially with long SIP names.
-    full_paths = [os.path.join(args.sip_directory, p) for p in args.payload_entries]
+    full_paths = [os.path.join(sip_directory, p) for p in payload_entries]
     # Ensure all payload items actually exist
     payload_entries = [e for e in full_paths if os.path.exists(e)]
 
     # Reconstruct bagit arguments
     # Goal: bagit <operation> <destination> <flattened payload list> <optional args>
-    bagit_args = [args.operation, args.destination]
+    bagit_args = [operation, destination]
     bagit_args.extend(payload_entries)
-    bagit_args.extend(['--writer', args.writer, '--payloadmanifestalgorithm', args.algorithm])
+    bagit_args.extend(['--writer', writer, '--payloadmanifestalgorithm', algorithm])
 
     # Run bagit bag creator
     run_bag(bagit_args)
-    create_directories(os.path.join(args.destination, "data"), dir_list)
+    create_directories(os.path.join(destination, "data"), dir_list)
 
 if __name__ == '__main__':
     logger = get_script_logger("archivematica.mcp.client.bagWithEmptyDirectories")
@@ -103,4 +103,4 @@ if __name__ == '__main__':
     parser.add_argument('--writer', dest='writer')
     parser.add_argument('--payloadmanifestalgorithm', dest='algorithm')
     args = parser.parse_args()
-    bag_with_empty_directories(args)
+    bag_with_empty_directories(args.operation, args.destination, args.sip_directory, args.payload_entries, args.writer, args.algorithm)

--- a/src/MCPClient/lib/clientScripts/createPointerFile.py
+++ b/src/MCPClient/lib/clientScripts/createPointerFile.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 from main.models import DublinCore
 
 # archivematicaCommon
+from archivematicaFunctions import get_setting
 from custom_handlers import get_script_logger
 import fileOperations
 from externals import checksummingTools
@@ -66,7 +67,7 @@ def main(aip_uuid, aip_name, compression, sip_dir, aip_filename):
         print >> sys.stderr, "File {} does not exist or is inaccessible.  Aborting.".format(aip_path)
         return -1
     # Calculate checksum
-    checksum_algorithm = 'sha256'
+    checksum_algorithm = get_setting('checksum_type', 'sha256')
     checksum = checksummingTools.get_file_checksum(aip_path, checksum_algorithm)
     # Get package type (AIP, AIC)
     sip_metadata_uuid = '3e48343d-e2d2-4956-aaa3-b54d26eb9761'

--- a/src/MCPClient/lib/clientScripts/verifyBAG.py
+++ b/src/MCPClient/lib/clientScripts/verifyBAG.py
@@ -17,9 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-# @package Archivematica
-# @subpackage archivematicaClientScript
-# @author Joseph Perry <joseph@artefactual.com>
+from __future__ import print_function
+
 import os
 import sys
 # archivematicaCommon
@@ -28,34 +27,41 @@ from executeOrRunSubProcess import executeOrRun
 
 logger = get_script_logger("archivematica.mcp.client.verifyBAG")
 
-printSubProcessOutput=True
+def verify_bag(bag):
+    verificationCommands = [
+        ["/usr/share/bagit/bin/bag", "verifyvalid", bag],  # Validity
+        ["/usr/share/bagit/bin/bag", "verifycomplete", bag],  # Completness
+        ["/usr/share/bagit/bin/bag", "verifypayloadmanifests", bag],  # Checksums in manifests
+    ]
+    bagInfoPath = os.path.join(bag, "bag-info.txt")
+    if os.path.isfile(bagInfoPath):
+        for line in open(bagInfoPath, 'r'):
+            if line.startswith("Payload-Oxum"):
+                # Generate Payload-Oxum and check against Payload-Oxum in bag-info.txt.
+                verificationCommands.append(
+                    ["/usr/share/bagit/bin/bag", "checkpayloadoxum", bag]
+                )
+                break
 
-bag = sys.argv[1]
-verificationCommands = []
-verificationCommands.append("/usr/share/bagit/bin/bag verifyvalid \"%s\"" % (bag)) #Verifies the validity of a bag.
-verificationCommands.append("/usr/share/bagit/bin/bag verifycomplete \"%s\"" % (bag)) #Verifies the completeness of a bag.
-verificationCommands.append("/usr/share/bagit/bin/bag verifypayloadmanifests \"%s\"" % (bag)) #Verifies the checksums in all payload manifests.
-
-bagInfoPath = os.path.join(bag, "bag-info.txt")
-if os.path.isfile(bagInfoPath):
-    for line in open(bagInfoPath,'r'):
-        if line.startswith("Payload-Oxum"):
-            verificationCommands.append("/usr/share/bagit/bin/bag checkpayloadoxum \"%s\"" % (bag)) #Generates Payload-Oxum and checks against Payload-Oxum in bag-info.txt.
+    for item in os.listdir(bag):
+        if item.startswith("tagmanifest-") and item.endswith(".txt"):
+            # Verify the checksums in all tag manifests.
+            verificationCommands.append(
+                ["/usr/share/bagit/bin/bag", "verifytagmanifests", bag]
+            )
             break
 
-for item in os.listdir(bag):
-    if item.startswith("tagmanifest-") and item.endswith(".txt"):        
-        verificationCommands.append("/usr/share/bagit/bin/bag verifytagmanifests \"%s\"" % (bag)) #Verifies the checksums in all tag manifests.
-        break
-        
-exitCode = 0
-for command in verificationCommands:
-    ret = executeOrRun("command", command, printing=printSubProcessOutput)
-    exit, stdOut, stdErr = ret
-    if exit != 0:
-        print >>sys.stderr, "Failed test: ", command
-        exitCode=1
-    else:
-        print >>sys.stderr, "Passed test: ", command
-quit(exitCode)
+    exitCode = 0
+    for command in verificationCommands:
+        ret = executeOrRun("command", command)
+        rc, _, _ = ret
+        if rc != 0:
+            print("Failed test: %s", command, file=sys.stderr)
+            exitCode = 1
+        else:
+            print("Passed test: %s", command)
+    return exitCode
 
+if __name__ == '__main__':
+    bag = sys.argv[1]
+    sys.exit(verify_bag(bag))

--- a/src/MCPServer/share/mysql_dev_8896_checksum_algorithms.sql
+++ b/src/MCPServer/share/mysql_dev_8896_checksum_algorithms.sql
@@ -4,3 +4,6 @@ INSERT INTO DashboardSettings (name, value) VALUES ('checksum_type', 'sha256');
 
 -- Expand checksum column so it can hold larger hashes (such as SHA-512)
 ALTER TABLE `Files` CHANGE COLUMN `checksum` `checksum` VARCHAR(128) CHARACTER SET 'utf8' COLLATE 'utf8_unicode_ci' NULL DEFAULT NULL;
+
+-- Remove checksumtype from create bag parameters
+UPDATE StandardTasksConfigs SET arguments='create "%SIPDirectory%%SIPName%-%SIPUUID%" "%SIPDirectory%" "logs/" "objects/" "METS.%SIPUUID%.xml" "thumbnails/" "metadata/" --writer filesystem' WHERE pk='045f84de-2669-4dbc-a31b-43a4954d0481';


### PR DESCRIPTION
Use configured checksumtype when creating pointer file and AIP bag. Remove from SQL. Also clean up the verify bag code and reduce duplicates.

The `-w` flag (`?w=1` on github) may be useful.
