### PR TITLE
emailFailReport: restore --date argument

### DIFF
--- a/src/MCPServer/share/mysql_dev.sh
+++ b/src/MCPServer/share/mysql_dev.sh
@@ -59,6 +59,7 @@ migrations=(
   mysql_dev_8974_migrations.sql
   mysql_dev_delete_links.sql
   mysql_dev_delete_views.sql
+  mysql_dev_update_args_email_report.sql
 )
 
 failed=()

--- a/src/MCPServer/share/mysql_dev_update_args_email_report.sql
+++ b/src/MCPServer/share/mysql_dev_update_args_email_report.sql
@@ -1,0 +1,2 @@
+-- Delete `date` and `server` arguments as they are not needed
+UPDATE StandardTasksConfigs SET arguments = '--unitType "%unitType%" --unitIdentifier "%SIPUUID%" --unitName "%SIPName%"' WHERE execute = 'emailFailReport_v0.0';


### PR DESCRIPTION
It's not really being used but deleting it broke the report because the corresponding entry in StandardTasksConfigs use that argument. Not sure if it'd be best instead to update the task argument string?
