### PR TITLE
Add requirements.txt where missing and delete unused deps

### DIFF
--- a/src/MCPClient/debian/control
+++ b/src/MCPClient/debian/control
@@ -7,14 +7,43 @@ Standards-Version: 3.9.3
 Homepage: http://archivematica.org
 
 Package: archivematica-mcp-client
-Architecture: i386 amd64 
-Depends: ${shlibs:Depends}, ${misc:Depends}, archivematica-common,
- atool, bagit, bulk-extractor, clamav, clamav-daemon, ffmpeg (>= 7:2.1.0), libavcodec-extra-56, fits (>= 0.8.0-3),
- gearman, imagemagick, inkscape, jhove, libimage-exiftool-perl, libxml2-utils, logapp,
- md5deep, mediainfo, nailgun-client, nfs-common, openjdk-7-jre-headless, p7zip-full,
- pbzip2, postfix, python-fido, python-gearman, python-lxml,
- python-mysqldb, python-unidecode, readpst,
- rsync, siegfried, sleuthkit, tesseract-ocr, tika, tree, ufraw, unrar-free, uuid
+Architecture: i386 amd64
+Depends:
+	${shlibs:Depends},
+	${misc:Depends},
+	archivematica-common,
+	atool,
+	bagit,
+	bulk-extractor,
+	clamav,
+	clamav-daemon,
+	ffmpeg (>= 7:2.1.0),
+	libavcodec-extra-56,
+	fits (>= 0.8.0-3),
+	gearman,
+	imagemagick,
+	inkscape,
+	jhove,
+	libimage-exiftool-perl,
+	libxml2-utils,
+	logapp,
+	md5deep,
+	mediainfo,
+	nailgun-client,
+	nfs-common,
+	openjdk-7-jre-headless,
+	p7zip-full,
+	pbzip2,
+	postfix,
+	python-fido,
+	readpst,
+	rsync,
+	siegfried,
+	sleuthkit,
+	tesseract-ocr,
+	tika,
+	tree,
+	ufraw,
+	unrar-free,
+	uuid
 Description: MCP Client for Archivematica
-  
-  

--- a/src/MCPClient/requirements.txt
+++ b/src/MCPClient/requirements.txt
@@ -1,0 +1,1 @@
+-r requirements/production.txt

--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -1,0 +1,11 @@
+bagit==1.5.2
+Django>=1.7,<1.8
+django-annoying==0.7.7
+django-autoslug==1.7.1
+django-mysqlpool==0.1-9
+django-extensions==1.1.1
+MySQL-python==1.2.5
+gearman==2.0.2
+lxml==3.5.0
+requests==2.7.0
+unidecode==0.04.19

--- a/src/MCPClient/requirements/production.txt
+++ b/src/MCPClient/requirements/production.txt
@@ -1,0 +1,1 @@
+-r base.txt

--- a/src/MCPClient/requirements/test.txt
+++ b/src/MCPClient/requirements/test.txt
@@ -1,0 +1,1 @@
+-r base.txt

--- a/src/MCPServer/debian/control
+++ b/src/MCPServer/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.3
 Homepage: http://archivematica.org
 
 Package: archivematica-mcp-server
-Architecture: i386 amd64 
+Architecture: i386 amd64
 Depends:
 	${shlibs:Depends},
 	${misc:Depends},
@@ -15,12 +15,7 @@ Depends:
 	archivematica-dashboard(>=1.2.0),
 	dbconfig-common,
 	mysql-server,
-	python-pyinotify,
-	python-gearman,
-	python-mysqldb,
-	python-lxml,
 	gearman,
 	uuid
 Description: MCP Server for Archivematica
   Workflow manager for Archivematica 
-  

--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -37,7 +37,6 @@ import logging
 import logging.config
 import getpass
 import os
-import pyinotify
 import signal
 import sys
 import threading
@@ -228,14 +227,7 @@ def signal_handler(signalReceived, frame):
     stopSignalReceived = True
     threads = threading.enumerate()
     for thread in threads:
-        if isinstance(thread, pyinotify.ThreadedNotifier):
-            logger.info('Stopping %s %s', type(thread), thread)
-            try:
-                thread.stop()
-            except Exception as inst:
-                logger.exception('Error stopping thread')
-        else:
-            logger.warning('Not stopping %s %s', type(thread), thread)
+        logger.warning('Not stopping %s %s', type(thread), thread)
     sys.stdout.flush()
     sys.stderr.flush()
     sys.exit(0)

--- a/src/MCPServer/requirements.txt
+++ b/src/MCPServer/requirements.txt
@@ -1,0 +1,1 @@
+-r requirements/production.txt

--- a/src/MCPServer/requirements/base.txt
+++ b/src/MCPServer/requirements/base.txt
@@ -1,0 +1,6 @@
+Django>=1.7,<1.8
+django-mysqlpool==0.1-9
+django-extensions==1.1.1
+MySQL-python==1.2.5
+gearman==2.0.2
+lxml==3.5.0

--- a/src/MCPServer/requirements/production.txt
+++ b/src/MCPServer/requirements/production.txt
@@ -1,0 +1,1 @@
+-r base.txt

--- a/src/MCPServer/requirements/test.txt
+++ b/src/MCPServer/requirements/test.txt
@@ -1,0 +1,1 @@
+-r base.txt

--- a/src/archivematicaCommon/debian/control
+++ b/src/archivematicaCommon/debian/control
@@ -7,7 +7,11 @@ Standards-Version: 3.9.3
 Homepage: http://archivematica.org
 
 Package: archivematica-common
-Architecture: i386 amd64 
-Depends: ${shlibs:Depends}, ${misc:Depends}, python, python-pip, python2.7-elementtree, python-mimeparse, python-dateutil
+Architecture: i386 amd64
+Depends:
+	${shlibs:Depends},
+	${misc:Depends},
+	python,
+	python-pip
 Description: Common libraries for archivematica
-  This package is a support package for archivematica. It contains a library of functions used in the archivematica system.  
+  This package is a support package for archivematica. It contains a library of functions used in the archivematica system.

--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -2,5 +2,6 @@ bagit==1.5.2
 Django>=1.7,<1.8
 elasticsearch>=1.0.0,<2.0.0
 requests==2.7.0
+python-dateutil==2.4.2
 django-mysqlpool
 git+git://github.com/artefactual-labs/agentarchives.git

--- a/src/dashboard/debian/control
+++ b/src/dashboard/debian/control
@@ -13,10 +13,6 @@ Depends:
 	${misc:Depends},
 	apache2-mpm-prefork,
 	libapache2-mod-wsgi,
-	python-pip,
-	python-dateutil,
-	python-gearman,
-	python-simplejson
+	python-pip
 Description: Web Dashboard for Archivematica
   Web based dashboard interface used to control an Archivematica pipeline.
-  

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -8,12 +8,16 @@ django-extensions==1.1.1
 django-autoslug==1.7.1
 django-annoying==0.7.7
 elasticsearch>=1.0.0,<2.0.0
+gearman==2.0.2
 lazy-paged-sequence
 git+git://github.com/artefactual-labs/agentarchives.git
+MySQL-python==1.2.5
 # Required by storage-service component
 slumber==0.6.0
 pytz
 pyopenssl
+python-dateutil==2.4.2
 ndg-httpsclient
 pyasn1
 requests==2.7.0
+lxml==3.5.0


### PR DESCRIPTION
#### dashboard:
- debian/control
  - \- python-dateutil **(moved to requirements.txt)**
  - \- python-gearman **(moved to requirements.txt)**
  - \- python-simplejson **(unused)**
- requirements.txt
  - \+ gearman==2.0.2
  - \+ python-dateutil==2.4.2
#### MCPClient:
- debian/control
  - \- python-lxml **(moved to requirements.txt)**
  - \- python-gearman **(moved to requirements.txt)**
  - \- python-mysqldb **(moved to requirements.txt)**
  - \- python-unidecode **(moved to requirements.txt)**
- requriements.txt
  - \+ bagit==1.5.2
  - \+ Django>=1.7,<1.8
  - \+ django-annoying==0.7.7
  - \+ django-autoslug==1.7.1
  - \+ django-mysqlpool==0.1-9
  - \+ django-extensions==1.1.1
  - \+ MySQL-python==1.2.5
  - \+ gearman==2.0.2
  - \+ lxml==3.5.0
  - \+ requests==2.7.0
  - \+ unidecode==0.04.19
#### MCPServer:
- debian/control
  - \- python-pyinotify **(unused)**
  - \- python-gearman **(moved to requirements.txt)**
  - \- python-mysqldb **(moved to requirements.txt)**
  - \- python-lxml **(moved to requirements.txt)**
- requirements.txt
  - \+ Django>=1.7,<1.8
  - \+ django-mysqlpool==0.1-9
  - \+ django-extensions==1.1.1
  - \+ MySQL-python==1.2.5
  - \+ gearman==2.0.2
  - \+ lxml==3.5.0
#### archivematicaCommon:
- debian/control
  - \- python2.7-elementtree **(unneeded)**
  - \- python-mimeparse **(unused)**
  - \- python-dateutil **(moved to requirements.txt)**
- requirements.txt
  - \+ python-dateutil==2.4.2
