### PR TITLE
pymysql (now mysqlclient)

### DIFF
--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -4,7 +4,7 @@ django-annoying==0.7.7
 django-autoslug==1.7.1
 django-mysqlpool==0.1-9
 django-extensions==1.1.1
-MySQL-python==1.2.5
+mysqlclient==1.3.7
 gearman==2.0.2
 lxml==3.5.0
 requests==2.7.0

--- a/src/MCPServer/requirements/base.txt
+++ b/src/MCPServer/requirements/base.txt
@@ -1,6 +1,6 @@
 Django>=1.7,<1.8
 django-mysqlpool==0.1-9
 django-extensions==1.1.1
-MySQL-python==1.2.5
+mysqlclient==1.3.7
 gearman==2.0.2
 lxml==3.5.0

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -11,7 +11,7 @@ elasticsearch>=1.0.0,<2.0.0
 gearman==2.0.2
 lazy-paged-sequence
 git+git://github.com/artefactual-labs/agentarchives.git
-MySQL-python==1.2.5
+mysqlclient==1.3.7
 # Required by storage-service component
 slumber==0.6.0
 pytz


### PR DESCRIPTION
I'm all in with https://github.com/PyMySQL/PyMySQL, it's fast and also works with PyPy. However, it requires using `pymysql.install_as_MySQLdb` so Django won't break when it's trying to import `MySQdb`. That's fine, but as you'll see there is some monkey-patching work going on.

Django [prefers](https://docs.djangoproject.com/en/1.7/ref/databases/#mysql-db-api-drivers) to use https://github.com/PyMySQL/mysqlclient-python, which is a fork of the original MySQL-python connector with Python 3 support. It would not require changes in our code though other than the corresponding updates of requirements.txt files.

Thoughts? This pull request implements the pure-python version, it seems to ork but it's not complete (missing client scripts) and it has not been fully tested yet!
