### PR TITLE
Don’t autodetect METS mappings (1.5 backport)

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -25,6 +25,7 @@ import base64
 import ConfigParser
 import cPickle
 import datetime
+import json
 import logging
 import MySQLdb
 import os
@@ -256,6 +257,17 @@ def set_up_mapping(conn, index):
         print 'Transfer mapping created.'
 
     if index == 'aips':
+        # Load external METS mappings
+        # These were generated from an AIP which had all the metadata fields filled out,
+        # and should represent a pretty complete structure.
+        # We don't want to leave this up to dynamic mapping, since automatic type
+        # detection may result in some fields being detected as date fields, and
+        # subsequently causing problems.
+        with open(os.path.normpath(os.path.join(__file__, "..", "elasticsearch", "aip_mets_mapping.json"))) as f:
+            aip_mets_mapping = json.load(f)
+        with open(os.path.normpath(os.path.join(__file__, "..", "elasticsearch", "aipfile_mets_mapping.json"))) as f:
+            aipfile_mets_mapping = json.load(f)
+
         print 'Creating AIP mapping...'
         conn.indices.put_mapping(doc_type='aip', body={'aip': {'date_detection': True}}, index='aips')
         print 'AIP mapping created.'
@@ -265,7 +277,7 @@ def set_up_mapping(conn, index):
             'size': {'type': 'double'},
             'uuid': machine_readable_field_spec,
             # Prevent autodetection for dc:date
-            'mets': {'properties': {'ns0:mets_dict_list': {'properties': {'ns0:dmdSec_dict_list': {'properties': {'ns0:mdWrap_dict_list': {'properties': {'ns0:xmlData_dict_list': {'properties': {'ns2:dublincore_dict_list': {'properties': {'dc:date': {'type': 'string'}}}}}}}}}}}}},
+            'mets': aip_mets_mapping,
         }
 
         print 'Creating AIP mapping...'
@@ -282,7 +294,7 @@ def set_up_mapping(conn, index):
             'isPartOf': machine_readable_field_spec,
             'AICID': machine_readable_field_spec,
             # Prevent autodetection for dc:date
-            'METS': {'properties': {'dmdSec': {'properties': {'ns0:xmlData_dict_list': {'properties': {'ns1:dublincore_dict_list': {'properties': {'dc:date': {'type': 'string'}}}}}}}}},
+            'METS': aipfile_mets_mapping,
         }
 
         print 'Creating AIP file mapping...'

--- a/src/archivematicaCommon/lib/elasticsearch/aip_mets_mapping.json
+++ b/src/archivematicaCommon/lib/elasticsearch/aip_mets_mapping.json
@@ -1,0 +1,742 @@
+{
+  "properties": {
+    "ns0:mets_dict_list": {
+      "properties": {
+        "ns0:metsHdr_dict_list": {
+          "properties": {
+            "@CREATEDATE": {
+              "type": "date",
+              "format": "dateOptionalTime"
+            }
+          }
+        },
+        "ns0:amdSec_dict_list": {
+          "properties": {
+            "ns0:techMD_dict_list": {
+              "properties": {
+                "ns0:mdWrap_dict_list": {
+                  "properties": {
+                    "@MDTYPE": {
+                      "type": "string"
+                    },
+                    "ns0:xmlData_dict_list": {
+                      "properties": {
+                        "ns4:object_dict_list": {
+                          "properties": {
+                            "ns4:originalName": {
+                              "type": "string"
+                            },
+                            "@xsi:type": {
+                              "type": "string"
+                            },
+                            "ns4:objectCharacteristics_dict_list": {
+                              "properties": {
+                                "ns4:size": {
+                                  "type": "string"
+                                },
+                                "ns4:fixity_dict_list": {
+                                  "properties": {
+                                    "ns4:messageDigestAlgorithm": {
+                                      "type": "string"
+                                    },
+                                    "ns4:messageDigest": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns4:format_dict_list": {
+                                  "properties": {
+                                    "ns4:formatRegistry_dict_list": {
+                                      "properties": {
+                                        "ns4:formatRegistryName": {
+                                          "type": "string"
+                                        },
+                                        "ns4:formatRegistryKey": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "ns4:formatDesignation_dict_list": {
+                                      "properties": {
+                                        "ns4:formatVersion": {
+                                          "type": "string"
+                                        },
+                                        "ns4:formatName": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "ns4:compositionLevel": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns4:objectIdentifier_dict_list": {
+                              "properties": {
+                                "ns4:objectIdentifierValue": {
+                                  "type": "string"
+                                },
+                                "ns4:objectIdentifierType": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "@version": {
+                              "type": "string"
+                            },
+                            "@xsi:schemaLocation": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "@ID": {
+                  "type": "string"
+                }
+              }
+            },
+            "ns0:sourceMD_dict_list": {
+              "properties": {
+                "ns0:mdWrap_dict_list": {
+                  "properties": {
+                    "@MDTYPE": {
+                      "type": "string"
+                    },
+                    "ns0:xmlData_dict_list": {
+                      "properties": {
+                        "transfer_metadata_dict_list": {
+                          "properties": {
+                            "imaging_process_notes": {
+                              "type": "string"
+                            },
+                            "examiner": {
+                              "type": "string"
+                            },
+                            "imaging_software": {
+                              "type": "string"
+                            },
+                            "media_number": {
+                              "type": "string"
+                            },
+                            "imaging_date": {
+                              "type": "string"
+                            },
+                            "media_format": {
+                              "type": "string"
+                            },
+                            "serial_number": {
+                              "type": "string"
+                            },
+                            "imaging_interface": {
+                              "type": "string"
+                            },
+                            "source_filesystem": {
+                              "type": "string"
+                            },
+                            "label_text": {
+                              "type": "string"
+                            },
+                            "media_manufacture": {
+                              "type": "string"
+                            },
+                            "media_density": {
+                              "type": "string"
+                            },
+                            "image_fixity": {
+                              "type": "string"
+                            },
+                            "image_format": {
+                              "type": "string"
+                            },
+                            "imaging_success": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "@ID": {
+                  "type": "string"
+                }
+              }
+            },
+            "@ID": {
+              "type": "string"
+            },
+            "ns0:rightsMD_dict_list": {
+              "properties": {
+                "ns0:mdWrap_dict_list": {
+                  "properties": {
+                    "@MDTYPE": {
+                      "type": "string"
+                    },
+                    "ns0:xmlData_dict_list": {
+                      "properties": {
+                        "ns4:rightsStatement_dict_list": {
+                          "properties": {
+                            "ns4:copyrightInformation_dict_list": {
+                              "properties": {
+                                "ns4:copyrightJurisdiction": {
+                                  "type": "string"
+                                },
+                                "ns4:copyrightStatusDeterminationDate": {
+                                  "type": "string"
+                                },
+                                "ns4:copyrightStatus": {
+                                  "type": "string"
+                                },
+                                "ns4:copyrightNote": {
+                                  "type": "string"
+                                },
+                                "ns4:copyrightApplicableDates_dict_list": {
+                                  "properties": {
+                                    "ns4:endDate": {
+                                      "type": "string"
+                                    },
+                                    "ns4:startDate": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns4:copyrightDocumentationIdentifier_dict_list": {
+                                  "properties": {
+                                    "ns4:copyrightDocumentationIdentifierType": {
+                                      "type": "string"
+                                    },
+                                    "ns4:copyrightDocumentationRole": {
+                                      "type": "string"
+                                    },
+                                    "ns4:copyrightDocumentationIdentifierValue": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "ns4:licenseInformation_dict_list": {
+                              "properties": {
+                                "ns4:licenseDocumentationIdentifier_dict_list": {
+                                  "properties": {
+                                    "ns4:licenseDocumentationIdentifierType": {
+                                      "type": "string"
+                                    },
+                                    "ns4:licenseDocumentationRole": {
+                                      "type": "string"
+                                    },
+                                    "ns4:licenseDocumentationIdentifierValue": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns4:licenseApplicableDates_dict_list": {
+                                  "properties": {
+                                    "ns4:endDate": {
+                                      "type": "string"
+                                    },
+                                    "ns4:startDate": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns4:licenseTerms": {
+                                  "type": "string"
+                                },
+                                "ns4:licenseNote": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns4:rightsGranted_dict_list": {
+                              "properties": {
+                                "ns4:restriction": {
+                                  "type": "string"
+                                },
+                                "ns4:termOfRestriction_dict_list": {
+                                  "properties": {
+                                    "ns4:endDate": {
+                                      "type": "string"
+                                    },
+                                    "ns4:startDate": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns4:termOfGrant_dict_list": {
+                                  "properties": {
+                                    "ns4:endDate": {
+                                      "type": "string"
+                                    },
+                                    "ns4:startDate": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns4:rightsGrantedNote": {
+                                  "type": "string"
+                                },
+                                "ns4:act": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns4:rightsStatementIdentifier_dict_list": {
+                              "properties": {
+                                "ns4:rightsStatementIdentifierType": {
+                                  "type": "string"
+                                },
+                                "ns4:rightsStatementIdentifierValue": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns4:rightsBasis": {
+                              "type": "string"
+                            },
+                            "ns4:otherRightsInformation_dict_list": {
+                              "properties": {
+                                "ns4:otherRightsNote": {
+                                  "type": "string"
+                                },
+                                "ns4:otherRightsApplicableDates_dict_list": {
+                                  "properties": {
+                                    "ns4:endDate": {
+                                      "type": "string"
+                                    },
+                                    "ns4:startDate": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns4:otherRightsDocumentationIdentifier_dict_list": {
+                                  "properties": {
+                                    "ns4:otherRightsDocumentationIdentifierValue": {
+                                      "type": "string"
+                                    },
+                                    "ns4:otherRightsDocumentationRole": {
+                                      "type": "string"
+                                    },
+                                    "ns4:otherRightsDocumentationIdentifierType": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns4:otherRightsBasis": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns4:linkingObjectIdentifier_dict_list": {
+                              "properties": {
+                                "ns4:linkingObjectIdentifierType": {
+                                  "type": "string"
+                                },
+                                "ns4:linkingObjectIdentifierValue": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns4:statuteInformation_dict_list": {
+                              "properties": {
+                                "ns4:statuteInformationDeterminationDate": {
+                                  "type": "string"
+                                },
+                                "ns4:statuteNote": {
+                                  "type": "string"
+                                },
+                                "ns4:statuteDocumentationIdentifier_dict_list": {
+                                  "properties": {
+                                    "ns4:statuteDocumentationIdentifierValue": {
+                                      "type": "string"
+                                    },
+                                    "ns4:statuteDocumentationIdentifierType": {
+                                      "type": "string"
+                                    },
+                                    "ns4:statuteDocumentationRole": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns4:statuteJurisdiction": {
+                                  "type": "string"
+                                },
+                                "ns4:statuteCitation": {
+                                  "type": "string"
+                                },
+                                "ns4:statuteApplicableDates_dict_list": {
+                                  "properties": {
+                                    "ns4:endDate": {
+                                      "type": "string"
+                                    },
+                                    "ns4:startDate": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "@xsi:schemaLocation": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "@ID": {
+                  "type": "string"
+                }
+              }
+            },
+            "ns0:digiprovMD_dict_list": {
+              "properties": {
+                "ns0:mdWrap_dict_list": {
+                  "properties": {
+                    "@MDTYPE": {
+                      "type": "string"
+                    },
+                    "ns0:xmlData_dict_list": {
+                      "properties": {
+                        "ns4:event_dict_list": {
+                          "properties": {
+                            "ns4:eventOutcomeInformation_dict_list": {
+                              "properties": {
+                                "ns4:eventOutcomeDetail_dict_list": {
+                                  "properties": {
+                                    "ns4:eventOutcomeDetailNote": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns4:eventOutcome": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns4:eventType": {
+                              "type": "string"
+                            },
+                            "ns4:eventDetail": {
+                              "type": "string"
+                            },
+                            "ns4:linkingAgentIdentifier_dict_list": {
+                              "properties": {
+                                "ns4:linkingAgentIdentifierValue": {
+                                  "type": "string"
+                                },
+                                "ns4:linkingAgentIdentifierType": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns4:eventIdentifier_dict_list": {
+                              "properties": {
+                                "ns4:eventIdentifierType": {
+                                  "type": "string"
+                                },
+                                "ns4:eventIdentifierValue": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns4:eventDateTime": {
+                              "type": "date",
+                              "format": "dateOptionalTime"
+                            },
+                            "@version": {
+                              "type": "string"
+                            },
+                            "@xsi:schemaLocation": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "ns4:agent_dict_list": {
+                          "properties": {
+                            "ns4:agentIdentifier_dict_list": {
+                              "properties": {
+                                "ns4:agentIdentifierType": {
+                                  "type": "string"
+                                },
+                                "ns4:agentIdentifierValue": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns4:agentName": {
+                              "type": "string"
+                            },
+                            "@version": {
+                              "type": "string"
+                            },
+                            "@xsi:schemaLocation": {
+                              "type": "string"
+                            },
+                            "ns4:agentType": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "@ID": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "@xmlns:ns0": {
+          "type": "string"
+        },
+        "@xmlns:ns2": {
+          "type": "string"
+        },
+        "@xmlns:ns5": {
+          "type": "string"
+        },
+        "@xmlns:ns4": {
+          "type": "string"
+        },
+        "ns0:dmdSec_dict_list": {
+          "properties": {
+            "ns0:mdWrap_dict_list": {
+              "properties": {
+                "@MDTYPE": {
+                  "type": "string"
+                },
+                "ns0:xmlData_dict_list": {
+                  "properties": {
+                    "ns2:dublincore_dict_list": {
+                      "properties": {
+                        "dc:contributor": {
+                          "type": "string"
+                        },
+                        "dc:source": {
+                          "type": "string"
+                        },
+                        "dc:coverage": {
+                          "type": "string"
+                        },
+                        "dc:provenance": {
+                          "type": "string"
+                        },
+                        "dc:creator": {
+                          "type": "string"
+                        },
+                        "dc:subject": {
+                          "type": "string"
+                        },
+                        "dc:identifier": {
+                          "type": "string"
+                        },
+                        "dc:language": {
+                          "type": "string"
+                        },
+                        "@xsi:schemaLocation": {
+                          "type": "string"
+                        },
+                        "dc:relation": {
+                          "type": "string"
+                        },
+                        "dc:date": {
+                          "type": "string"
+                        },
+                        "dc:publisher": {
+                          "type": "string"
+                        },
+                        "dc:format": {
+                          "type": "string"
+                        },
+                        "dc:title": {
+                          "type": "string"
+                        },
+                        "dc:description": {
+                          "type": "string"
+                        },
+                        "dc:rights": {
+                          "type": "string"
+                        },
+                        "dcterms:isPartOf": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "@ID": {
+              "type": "string"
+            }
+          }
+        },
+        "@xmlns:xsi": {
+          "type": "string"
+        },
+        "ns0:structMap_dict_list": {
+          "properties": {
+            "@LABEL": {
+              "type": "string"
+            },
+            "@ID": {
+              "type": "string"
+            },
+            "@TYPE": {
+              "type": "string"
+            },
+            "ns0:div_dict_list": {
+              "properties": {
+                "@LABEL": {
+                  "type": "string"
+                },
+                "@TYPE": {
+                  "type": "string"
+                },
+                "ns0:div_dict_list": {
+                  "properties": {
+                    "@ADMID": {
+                      "type": "string"
+                    },
+                    "@LABEL": {
+                      "type": "string"
+                    },
+                    "@TYPE": {
+                      "type": "string"
+                    },
+                    "@DMDID": {
+                      "type": "string"
+                    },
+                    "ns0:div_dict_list": {
+                      "properties": {
+                        "ns0:fptr_dict_list": {
+                          "properties": {
+                            "@FILEID": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "@LABEL": {
+                          "type": "string"
+                        },
+                        "@TYPE": {
+                          "type": "string"
+                        },
+                        "@DMDID": {
+                          "type": "string"
+                        },
+                        "ns0:div_dict_list": {
+                          "properties": {
+                            "ns0:fptr_dict_list": {
+                              "properties": {
+                                "@FILEID": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "@LABEL": {
+                              "type": "string"
+                            },
+                            "@TYPE": {
+                              "type": "string"
+                            },
+                            "ns0:div_dict_list": {
+                              "properties": {
+                                "ns0:fptr_dict_list": {
+                                  "properties": {
+                                    "@FILEID": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "@LABEL": {
+                                  "type": "string"
+                                },
+                                "@TYPE": {
+                                  "type": "string"
+                                },
+                                "ns0:div_dict_list": {
+                                  "properties": {
+                                    "ns0:fptr_dict_list": {
+                                      "properties": {
+                                        "@FILEID": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "@LABEL": {
+                                      "type": "string"
+                                    },
+                                    "@TYPE": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "@xsi:schemaLocation": {
+          "type": "string"
+        },
+        "@xmlns:dc": {
+          "type": "string"
+        },
+        "ns0:fileSec_dict_list": {
+          "properties": {
+            "ns0:fileGrp_dict_list": {
+              "properties": {
+                "ns0:file_dict_list": {
+                  "properties": {
+                    "@ADMID": {
+                      "type": "string"
+                    },
+                    "@GROUPID": {
+                      "type": "string"
+                    },
+                    "@ID": {
+                      "type": "string"
+                    },
+                    "ns0:FLocat_dict_list": {
+                      "properties": {
+                        "@OTHERLOCTYPE": {
+                          "type": "string"
+                        },
+                        "@LOCTYPE": {
+                          "type": "string"
+                        },
+                        "@ns5:href": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "@USE": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/archivematicaCommon/lib/elasticsearch/aipfile_mets_mapping.json
+++ b/src/archivematicaCommon/lib/elasticsearch/aipfile_mets_mapping.json
@@ -1,0 +1,474 @@
+{
+  "properties": {
+    "dmdSec": {
+      "properties": {
+        "ns0:xmlData_dict_list": {
+          "properties": {
+            "@xmlns:ns1": {
+              "type": "string"
+            },
+            "@xmlns:ns0": {
+              "type": "string"
+            },
+            "@xmlns:xsi": {
+              "type": "string"
+            },
+            "ns1:dublincore_dict_list": {
+              "properties": {
+                "dc:provenance": {
+                  "type": "string"
+                },
+                "dc:date": {
+                  "type": "string"
+                },
+                "@xsi:schemaLocation": {
+                  "type": "string"
+                },
+                "dc:title": {
+                  "type": "string"
+                },
+                "dc:description": {
+                  "type": "string"
+                }
+              }
+            },
+            "@xmlns:dc": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "amdSec": {
+      "properties": {
+        "ns0:amdSec_dict_list": {
+          "properties": {
+            "ns0:techMD_dict_list": {
+              "properties": {
+                "ns0:mdWrap_dict_list": {
+                  "properties": {
+                    "@MDTYPE": {
+                      "type": "string"
+                    },
+                    "ns0:xmlData_dict_list": {
+                      "properties": {
+                        "ns1:object_dict_list": {
+                          "properties": {
+                            "@version": {
+                              "type": "string"
+                            },
+                            "@xsi:type": {
+                              "type": "string"
+                            },
+                            "ns1:objectCharacteristics_dict_list": {
+                              "properties": {
+                                "ns1:compositionLevel": {
+                                  "type": "string"
+                                },
+                                "ns1:size": {
+                                  "type": "string"
+                                },
+                                "ns1:fixity_dict_list": {
+                                  "properties": {
+                                    "ns1:messageDigest": {
+                                      "type": "string"
+                                    },
+                                    "ns1:messageDigestAlgorithm": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns1:format_dict_list": {
+                                  "properties": {
+                                    "ns1:formatDesignation_dict_list": {
+                                      "properties": {
+                                        "ns1:formatName": {
+                                          "type": "string"
+                                        },
+                                        "ns1:formatVersion": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "ns1:formatRegistry_dict_list": {
+                                      "properties": {
+                                        "ns1:formatRegistryKey": {
+                                          "type": "string"
+                                        },
+                                        "ns1:formatRegistryName": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "ns1:originalName": {
+                              "type": "string"
+                            },
+                            "ns1:objectIdentifier_dict_list": {
+                              "properties": {
+                                "ns1:objectIdentifierType": {
+                                  "type": "string"
+                                },
+                                "ns1:objectIdentifierValue": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "@xsi:schemaLocation": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "@ID": {
+                  "type": "string"
+                }
+              }
+            },
+            "@xmlns:ns1": {
+              "type": "string"
+            },
+            "@xmlns:ns0": {
+              "type": "string"
+            },
+            "@xmlns:xsi": {
+              "type": "string"
+            },
+            "@ID": {
+              "type": "string"
+            },
+            "ns0:rightsMD_dict_list": {
+              "properties": {
+                "ns0:mdWrap_dict_list": {
+                  "properties": {
+                    "@MDTYPE": {
+                      "type": "string"
+                    },
+                    "ns0:xmlData_dict_list": {
+                      "properties": {
+                        "ns1:rightsStatement_dict_list": {
+                          "properties": {
+                            "ns1:otherRightsInformation_dict_list": {
+                              "properties": {
+                                "ns1:otherRightsDocumentationIdentifier_dict_list": {
+                                  "properties": {
+                                    "ns1:otherRightsDocumentationIdentifierValue": {
+                                      "type": "string"
+                                    },
+                                    "ns1:otherRightsDocumentationIdentifierType": {
+                                      "type": "string"
+                                    },
+                                    "ns1:otherRightsDocumentationRole": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns1:otherRightsBasis": {
+                                  "type": "string"
+                                },
+                                "ns1:otherRightsNote": {
+                                  "type": "string"
+                                },
+                                "ns1:otherRightsApplicableDates_dict_list": {
+                                  "properties": {
+                                    "ns1:startDate": {
+                                      "type": "string"
+                                    },
+                                    "ns1:endDate": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "ns1:rightsBasis": {
+                              "type": "string"
+                            },
+                            "ns1:licenseInformation_dict_list": {
+                              "properties": {
+                                "ns1:licenseNote": {
+                                  "type": "string"
+                                },
+                                "ns1:licenseTerms": {
+                                  "type": "string"
+                                },
+                                "ns1:licenseDocumentationIdentifier_dict_list": {
+                                  "properties": {
+                                    "ns1:licenseDocumentationRole": {
+                                      "type": "string"
+                                    },
+                                    "ns1:licenseDocumentationIdentifierValue": {
+                                      "type": "string"
+                                    },
+                                    "ns1:licenseDocumentationIdentifierType": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns1:licenseApplicableDates_dict_list": {
+                                  "properties": {
+                                    "ns1:startDate": {
+                                      "type": "string"
+                                    },
+                                    "ns1:endDate": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "ns1:rightsGranted_dict_list": {
+                              "properties": {
+                                "ns1:termOfRestriction_dict_list": {
+                                  "properties": {
+                                    "ns1:startDate": {
+                                      "type": "string"
+                                    },
+                                    "ns1:endDate": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns1:restriction": {
+                                  "type": "string"
+                                },
+                                "ns1:termOfGrant_dict_list": {
+                                  "properties": {
+                                    "ns1:startDate": {
+                                      "type": "string"
+                                    },
+                                    "ns1:endDate": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns1:rightsGrantedNote": {
+                                  "type": "string"
+                                },
+                                "ns1:act": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns1:rightsStatementIdentifier_dict_list": {
+                              "properties": {
+                                "ns1:rightsStatementIdentifierType": {
+                                  "type": "string"
+                                },
+                                "ns1:rightsStatementIdentifierValue": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns1:statuteInformation_dict_list": {
+                              "properties": {
+                                "ns1:statuteNote": {
+                                  "type": "string"
+                                },
+                                "ns1:statuteApplicableDates_dict_list": {
+                                  "properties": {
+                                    "ns1:startDate": {
+                                      "type": "string"
+                                    },
+                                    "ns1:endDate": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns1:statuteDocumentationIdentifier_dict_list": {
+                                  "properties": {
+                                    "ns1:statuteDocumentationIdentifierValue": {
+                                      "type": "string"
+                                    },
+                                    "ns1:statuteDocumentationRole": {
+                                      "type": "string"
+                                    },
+                                    "ns1:statuteDocumentationIdentifierType": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns1:statuteInformationDeterminationDate": {
+                                  "type": "string"
+                                },
+                                "ns1:statuteCitation": {
+                                  "type": "string"
+                                },
+                                "ns1:statuteJurisdiction": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns1:copyrightInformation_dict_list": {
+                              "properties": {
+                                "ns1:copyrightDocumentationIdentifier_dict_list": {
+                                  "properties": {
+                                    "ns1:copyrightDocumentationIdentifierType": {
+                                      "type": "string"
+                                    },
+                                    "ns1:copyrightDocumentationIdentifierValue": {
+                                      "type": "string"
+                                    },
+                                    "ns1:copyrightDocumentationRole": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns1:copyrightJurisdiction": {
+                                  "type": "string"
+                                },
+                                "ns1:copyrightStatusDeterminationDate": {
+                                  "type": "string"
+                                },
+                                "ns1:copyrightStatus": {
+                                  "type": "string"
+                                },
+                                "ns1:copyrightApplicableDates_dict_list": {
+                                  "properties": {
+                                    "ns1:startDate": {
+                                      "type": "string"
+                                    },
+                                    "ns1:endDate": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "ns1:copyrightNote": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns1:linkingObjectIdentifier_dict_list": {
+                              "properties": {
+                                "ns1:linkingObjectIdentifierValue": {
+                                  "type": "string"
+                                },
+                                "ns1:linkingObjectIdentifierType": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "@xsi:schemaLocation": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "@ID": {
+                  "type": "string"
+                }
+              }
+            },
+            "ns0:digiprovMD_dict_list": {
+              "properties": {
+                "ns0:mdWrap_dict_list": {
+                  "properties": {
+                    "@MDTYPE": {
+                      "type": "string"
+                    },
+                    "ns0:xmlData_dict_list": {
+                      "properties": {
+                        "ns1:event_dict_list": {
+                          "properties": {
+                            "ns1:eventOutcomeInformation_dict_list": {
+                              "properties": {
+                                "ns1:eventOutcome": {
+                                  "type": "string"
+                                },
+                                "ns1:eventOutcomeDetail_dict_list": {
+                                  "properties": {
+                                    "ns1:eventOutcomeDetailNote": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "ns1:eventIdentifier_dict_list": {
+                              "properties": {
+                                "ns1:eventIdentifierType": {
+                                  "type": "string"
+                                },
+                                "ns1:eventIdentifierValue": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns1:linkingAgentIdentifier_dict_list": {
+                              "properties": {
+                                "ns1:linkingAgentIdentifierValue": {
+                                  "type": "string"
+                                },
+                                "ns1:linkingAgentIdentifierType": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns1:eventDateTime": {
+                              "type": "date",
+                              "format": "dateOptionalTime"
+                            },
+                            "ns1:eventDetail": {
+                              "type": "string"
+                            },
+                            "ns1:eventType": {
+                              "type": "string"
+                            },
+                            "@version": {
+                              "type": "string"
+                            },
+                            "@xsi:schemaLocation": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "ns1:agent_dict_list": {
+                          "properties": {
+                            "ns1:agentIdentifier_dict_list": {
+                              "properties": {
+                                "ns1:agentIdentifierType": {
+                                  "type": "string"
+                                },
+                                "ns1:agentIdentifierValue": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "ns1:agentType": {
+                              "type": "string"
+                            },
+                            "@version": {
+                              "type": "string"
+                            },
+                            "@xsi:schemaLocation": {
+                              "type": "string"
+                            },
+                            "ns1:agentName": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "@ID": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is #402 backported to qa/1.5.x.
