### PR TITLE
Add API to create stub SIP objects; allow SIPs to be started from stubs

### DIFF
--- a/src/dashboard/src/components/access/urls.py
+++ b/src/dashboard/src/components/access/urls.py
@@ -9,6 +9,8 @@ urlpatterns = patterns('',
     url(r'(?P<system>archivesspace|atk)/(?P<record_id>[A-Za-z0-9-_]+)/copy_to_arrange/$', views.access_copy_to_arrange),
     url(r'(?P<system>archivesspace|atk)/(?P<record_id>[A-Za-z0-9-_]+)/copy_from_arrange/$', views.access_arrange_start_sip),
     url(r'(?P<system>archivesspace|atk)/(?P<record_id>[A-Za-z0-9-_]+)/create_directory_within_arrange/$', views.access_create_directory),
+    url(r'(?P<system>archivesspace|atk)/(?P<record_id>[A-Za-z0-9-_]+)/rights/$', views.access_sip_rights),
+    url(r'(?P<system>archivesspace|atk)/(?P<record_id>[A-Za-z0-9-_]+)/metadata/$', views.access_sip_metadata),
     url(r'(?P<system>archivesspace|atk)/accession/(?P<accession>.+)/$', views.get_records_by_accession),
     url(r'(?P<system>archivesspace|atk)/(?P<record_id>.+)/children/$', views.record_children),
     # this API exists only for ArchivesSpace, not ATK

--- a/src/dashboard/src/components/access/views.py
+++ b/src/dashboard/src/components/access/views.py
@@ -431,4 +431,8 @@ def access_arrange_start_sip(request, mapping):
     Starts the SIP associated with this record.
     """
     ArchivesSpaceDOComponent.objects.filter(resourceid=mapping.identifier, started=False).update(started=True)
-    return filesystem_views.copy_from_arrange_to_completed(request, filepath=mapping.arrange_path + '/')
+    arrange = SIPArrange.objects.get(arrange_path=os.path.join(mapping.arrange_path, ''))
+    sip_uuid = arrange.sip.uuid if arrange.sip else None
+    return filesystem_views.copy_from_arrange_to_completed(request,
+                                                           filepath=mapping.arrange_path + '/',
+                                                           sip_uuid=sip_uuid)

--- a/src/dashboard/src/components/ingest/urls.py
+++ b/src/dashboard/src/components/ingest/urls.py
@@ -24,6 +24,7 @@ from components.ingest import views_as
 urlpatterns = patterns('',
     url(r'^$', views.ingest_grid,
         name='ingest_index'),
+    url(r'^sips/$', views.SipsView.as_view()),
     url(r'^aic/(?P<uuid>' + settings.UUID_REGEX + ')/metadata/add/$', views.aic_metadata_add),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/metadata/$', views.ingest_metadata_list),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/metadata/add/$', views.ingest_metadata_edit),

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -39,6 +39,7 @@ from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render, redirect
 from django.template import RequestContext
 from django.utils.text import slugify
+from django.views.generic import View
 
 # External dependencies, alphabetical
 
@@ -74,6 +75,17 @@ def ingest_grid(request):
         messages.warning(request, 'Error retrieving originals/arrange directory locations: is the storage server running? Please contact an administrator.')
 
     return render(request, 'ingest/grid.html', locals())
+
+class SipsView(View):
+    def post(self, request):
+        """
+        Creates a new stub SIP object, and returns its UUID in a JSON response.
+        """
+        sip = models.SIP.objects.create(uuid=str(uuid.uuid4()), currentpath=None)
+        return helpers.json_response({
+            "success": True,
+            "id": sip.uuid,
+        })
 
 def ingest_status(request, uuid=None):
     # Equivalent to: "SELECT SIPUUID, MAX(createdTime) AS latest FROM Jobs WHERE unitType='unitSIP' GROUP BY SIPUUID

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -219,6 +219,7 @@ class SIP(models.Model):
     """ Information on SIP units. """
     uuid = models.CharField(max_length=36, primary_key=True, db_column='sipUUID')
     createdtime = models.DateTimeField(db_column='createdTime', auto_now_add=True)
+    # If currentpath is null, this SIP is understood to not have been started yet.
     currentpath = models.TextField(db_column='currentPath', null=True, blank=True)
     hidden = models.BooleanField(default=False)
     aip_filename = models.TextField(db_column='aipFilename', null=True, blank=True)


### PR DESCRIPTION
- Adds a new API to create an unstarted SIP object. A SIP is understood to be "unstarted" if its `currentpath` is null.
- Allows the SIP arrange "create SIP" API to accept a SIP UUID. If that UUID points to an unstarted SIP, uses that as the SIP object and updates it with the correct path. If it points to a started SIP, the API returns 400. If it doesn't point to a SIP that exists, then a SIP object is created with that UUID.
