### PR TITLE
Access: accept notes array unmodified

### DIFF
--- a/src/dashboard/src/components/access/views.py
+++ b/src/dashboard/src/components/access/views.py
@@ -199,14 +199,13 @@ def record_children(client, request, system='', record_id=''):
         new_record_data = json.load(request)
         try:
             notes = new_record_data.get('notes', [])
-            note = notes[0] if notes else {}
             new_id = client.add_child(record_id,
                                       title=new_record_data.get('title', ''),
                                       level=new_record_data.get('level', ''),
                                       start_date=new_record_data.get('start_date', ''),
                                       end_date=new_record_data.get('end_date', ''),
                                       date_expression=new_record_data.get('date_expression', ''),
-                                      note=note)
+                                      notes=notes)
         except ArchivesSpaceError as e:
             response = {
                 'success': False,


### PR DESCRIPTION
This allows multiple notes to be specified by callers. This depends on artefactual-labs/agentarchives#23.

Refs #9428.
