### PR TITLE
Allow notes to be copied without a label

### DIFF
--- a/src/archivematicaCommon/lib/archivesspace/client.py
+++ b/src/archivematicaCommon/lib/archivesspace/client.py
@@ -506,11 +506,11 @@ class ArchivesSpaceClient(object):
                 content = [subnote["content"] for subnote in pnote["subnotes"]]
             else:
                 content = pnote["content"]
-
+        
             new_object["notes"].append({
                 "jsonmodel_type": "note_digital_object",
                 "type": dnote,
-                "label": pnote["label"],
+                "label": pnote.get("label", ""),
                 "content": content,
                 "publish": pnote["publish"],
             })


### PR DESCRIPTION
refs #9446

When inheriting notes from an Archival Object to a Digital Object, if the note does not have a label, this change allows the note to still be copied, instead of thorwing an error.
