### PR TITLE
Fix display of transfer rights

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRights.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRights.py
@@ -213,7 +213,7 @@ def getrightsGranted(statement, parent):
         etree.SubElement(rightsGranted, ns.premisBNS + "act").text = granted.act
         
         restriction = "Undefined"
-        for restriction in granted.rightsstatementrightsgrantedrestriction_set.all():
+        for restriction in granted.restrictions.all():
             restriction = restriction.restriction
             if not restriction.lower() in ["disallow", "conditional", "allow"]:
                 print >>sys.stderr, "The value of element restriction must be: 'Allow', 'Disallow', or 'Conditional':", restriction
@@ -238,5 +238,5 @@ def getrightsGranted(statement, parent):
                 etree.SubElement(termOfGrant, ns.premisBNS + "endDate").text = formatDate(granted.enddate)
 
         # 4.1.6.4 rightsGrantedNote (O, R)
-        for note in granted.rightsstatementrightsgrantednote_set.all():
+        for note in granted.notes.all():
             etree.SubElement(rightsGranted, ns.premisBNS + "rightsGrantedNote").text = note.rightsgrantednote

--- a/src/dashboard/src/components/rights/views.py
+++ b/src/dashboard/src/components/rights/views.py
@@ -15,17 +15,22 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+import re
+
 from django.core.urlresolvers import reverse
 from django.forms.models import inlineformset_factory
-from django.shortcuts import redirect, render
 from django.http import HttpResponse
-from contrib import utils
-from components.rights import forms
-from main import models
-from components import helpers
-import re
-from components import decorators
+from django.shortcuts import redirect, render
 from django.template import RequestContext
+
+from components import decorators
+from components import helpers
+from components.rights import forms
+from contrib import utils
+from main import models
+
+LOGGER = logging.getLogger('archivematica.dashboard')
 
 """ @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
       Rights-related
@@ -553,12 +558,12 @@ def rights_list(request, uuid, section):
     # The only way I've found to get the related transfer of a SIP is looking into the File table
     if section is "ingest":
         try:
-            transfer_uuid = models.File.objects.filter(sip__uuid__exact=uuid)[0].transfer.uuid
+            transfer_uuids = models.File.objects.filter(sip_id=uuid, removedtime__isnull=True, transfer_id__isnull=False).values_list('transfer', flat=True).distinct()
             transfer_grants = models.RightsStatementRightsGranted.objects.filter(
-                rightsstatement__metadataappliestotype=types['transfer'],
-                rightsstatement__metadataappliestoidentifier__exact=transfer_uuid
+                rightsstatement__metadataappliestotype__description=types['transfer'],
+                rightsstatement__metadataappliestoidentifier__in=transfer_uuids
             )
-        except:
-            pass
+        except Exception:
+            LOGGER.exception('Error fetching Transfer rights')
 
     return render(request, 'rights/rights_list.html', locals())

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -532,7 +532,7 @@ class RightsStatementRightsGranted(models.Model):
 
 class RightsStatementRightsGrantedNote(models.Model):
     id = models.AutoField(primary_key=True, db_column='pk', editable=False)
-    rightsgranted = models.ForeignKey(RightsStatementRightsGranted, db_column='fkRightsStatementRightsGranted')
+    rightsgranted = models.ForeignKey(RightsStatementRightsGranted, related_name='notes', db_column='fkRightsStatementRightsGranted')
     rightsgrantednote = models.TextField(db_column='rightsGrantedNote', verbose_name='Rights note')
 
     class Meta:
@@ -541,7 +541,7 @@ class RightsStatementRightsGrantedNote(models.Model):
 
 class RightsStatementRightsGrantedRestriction(models.Model):
     id = models.AutoField(primary_key=True, db_column='pk')
-    rightsgranted = models.ForeignKey(RightsStatementRightsGranted, db_column='fkRightsStatementRightsGranted')
+    rightsgranted = models.ForeignKey(RightsStatementRightsGranted, related_name='restrictions', db_column='fkRightsStatementRightsGranted')
     restriction = models.TextField(db_column='restriction')
 
     class Meta:

--- a/src/dashboard/src/templates/rights/rights_list.html
+++ b/src/dashboard/src/templates/rights/rights_list.html
@@ -31,14 +31,14 @@
           {% for grant in grants %}
             <tr>
               <td>{{ grant.act }}</td>
-              <td>{{ grant.basis }}</td>
+              <td>{{ grant.rightsstatement.rightsbasis }}</td>
               <td>
-                {% for restriction in grant.restrictions %}
-                  <div>{{ restriction }}</div>
+                {% for restriction in grant.restrictions.all %}
+                  <div>{{ restriction.restriction }}</div>
                 {% endfor %}
               </td>
               <td>{{ grant.startdate }}</td>
-              <td>{{ grant.enddate }}</td>
+              <td>{% if grant.enddateopen %}(open){% else %}{{ grant.enddate}}{% endif %}</td>
               <td>
                 {% if section == 'ingest' %}
                   <a href="{% url 'components.rights.views.ingest_rights_edit' uuid grant.rightsstatement.id %}">Edit</a>
@@ -53,14 +53,14 @@
           {% for grant in transfer_grants %}
             <tr>
               <td>{{ grant.act }}</td>
-              <td>{{ grant.basis }}</td>
+              <td>{{ grant.rightsstatement.rightsbasis }}</td>
               <td>
-                {% for restriction in grant.restrictions %}
-                  <div>{{ restriction }}</div>
+                {% for restriction in grant.restrictions.all %}
+                  <div>{{ restriction.restriction }}</div>
                 {% endfor %}
               </td>
               <td>{{ grant.startdate }}</td>
-              <td>{{ grant.enddate }}</td>
+              <td>{% if grant.enddateopen %}(open){% else %}{{ grant.enddate}}{% endif %}</td>
               <td>Transfer</td>
             </tr>
           {% endfor %}


### PR DESCRIPTION
- Fix the query that fetches rights associated with a transfer for display with the SIP rights. Also works with multiple transfers now.
- Rename related query, update caller & add tests
- Remove second parse to format rights information, update template
