### PR TITLE
MCPServer: prioritize currentpath over UUID in path

### DIFF
--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -50,6 +50,8 @@ import django
 sys.path.append("/usr/share/archivematica/dashboard")
 django.setup()
 
+from django.db.models import Q
+
 # This project, alphabetical by import source
 import watchDirectory
 import RPCServer
@@ -106,35 +108,49 @@ def findOrCreateSipInDB(path, waitSleep=dbWaitSleep, unit_type='SIP'):
     """Matches a directory to a database sip by it's appended UUID, or path. If it doesn't find one, it will create one"""
     path = path.replace(config.get('MCPServer', "sharedDirectory"), "%sharedPath%", 1)
 
+    query = Q(currentpath=path)
+
     # Find UUID on end of SIP path
     UUID = fetchUUIDFromPath(path)
+    sip = None
     if UUID:
-        try:
-            sip = SIP.objects.get(uuid=UUID)
-        except SIP.DoesNotExist:
-            databaseFunctions.createSIP(path, UUID=UUID)
-        else:
-            current_path = sip.currentpath
-            if current_path != path and unit_type == 'SIP':
-                # Ensure path provided matches path in DB
-                sip.currentpath = path
-                sip.save()
-    else:
-        #Find it in the database
-        sips = SIP.objects.filter(currentpath=path)
-        count = sips.count()
-        if count > 1:
-            logger.warning('More than one SIP for path %s, using first result', path)
-        if count > 0:
-            UUID = sips[0].uuid
-            logger.info('Using existing SIP %s at %s', UUID, path)
-        else:
-            logger.info('Not using existing SIP %s at %s', UUID, path)
+        query = query | Q(uuid=UUID)
 
-    #Create it
-    if not UUID:
-        UUID = databaseFunctions.createSIP(path)
+    sips = SIP.objects.filter(query)
+    count = sips.count()
+    if count > 1:
+        # This might have happened because the UUID at the end of the directory
+        # name corresponds to a different SIP in the database.
+        # Try refiltering the queryset on path alone, and see if that brought us
+        # down to a single SIP.
+        sips = sips.filter(currentpath=path)
+        count = sips.count()
+
+        # Darn: we must have multiple SIPs with the same path in the database.
+        # We have no reasonable way to recover from this condition.
+        if count > 1:
+            logger.error('More than one SIP for path %s and/or UUID %s, using first result', path, UUID)
+    if count > 0:
+        sip = sips[0]
+        UUID = sip.uuid
+        logger.info('Using existing SIP %s at %s', UUID, path)
+    else:
+        logger.info('Not using existing SIP %s at %s', UUID, path)
+
+    if sip is None:
+        # Create it
+        # Note that if UUID is None here, a new UUID will be generated
+        # and returned by the function; otherwise it returns the
+        # value that was passed in.
+        UUID = databaseFunctions.createSIP(path, UUID=UUID)
         logger.info('Creating SIP %s at %s', UUID, path)
+    else:
+        current_path = sip.currentpath
+        if current_path != path and unit_type == 'SIP':
+            # Ensure path provided matches path in DB
+            sip.currentpath = path
+            sip.save()
+
     return UUID
 
 @log_exceptions


### PR DESCRIPTION
This rewrites the SIP lookup by path and alters the prioritizatation of options.

There are three possible outcomes of this route:
1. If the path name ends in a UUID, looks that up in the database, creating
   a SIP if nothing is found.
2. Looks up any SIPs with `currentpath` and uses the first located.
3. If nothing was found from the first two options, creates a new SIP.

The prioritization of options here leads to a possible bug in the case that a directory ends in a UUID, or any string which can be read as a UUID, where that UUID is not the UUID of the SIP in question. If this happens, Archivematica tries to look up a SIP using that UUID and creates one if necessary - even if the SIP already exists in the database under a different UUID.

This rewrites the lookup, prioritizing path lookups over UUID. It also brings the two paths a bit closer to each other, and merges the database query so that the path and UUID lookups happen in a simultaneous OR clause.

Fixes #9417.
