### PR TITLE
Matching GUI: tweaks and fixes

### DIFF
--- a/src/dashboard/src/components/ingest/pair_matcher.py
+++ b/src/dashboard/src/components/ingest/pair_matcher.py
@@ -102,7 +102,18 @@ def render_resource_component(client, request, resource_component_id, query, pag
             reverse(match_redirect_target, args=[uuid, resource_component_id])
         )
     else:
-        return render(request, resource_detail_template, locals())
+        return render(request, resource_detail_template, {
+            'match_redirect_target': match_redirect_target,
+            'page': page,
+            'query': query,
+            'reset_url': reset_url,
+            'resource_component_data': resource_component_data,
+            'resource_component_id': resource_component_id,
+            'search_params': search_params,
+            'sort_by': sort_by,
+            'sort_direction': sort_direction,
+            'uuid': uuid,
+        })
 
 
 def match_dip_objects_to_resource_levels(client, request, resource_id, match_template, parent_id, parent_url, reset_url, uuid, matches=[]):

--- a/src/dashboard/src/media/js/ingest/as_matcher.js
+++ b/src/dashboard/src/media/js/ingest/as_matcher.js
@@ -160,6 +160,8 @@ var ATKMatcherView = Backbone.View.extend({
     var self = this,
         index = 0;
 
+    // Sort by path
+    this.objectPaths.sort(function (a, b){return a.path.toLowerCase().localeCompare(b.path.toLowerCase())})
     // add each path to object pane
     this.objectPaths.forEach(function(pathData) {
       // create object path representation (checkbox and label)
@@ -321,7 +323,7 @@ var ATKMatcherView = Backbone.View.extend({
     // add comparator
     this.resourceCollection.comparator = function(resource) {
       if (self.resourceCollection.sortAttribute != undefined) {
-        return resource.get(self.resourceCollection.sortAttribute);
+        return resource.get(self.resourceCollection.sortAttribute).toLowerCase();
       } else {
         return resource.id;
       }

--- a/src/dashboard/src/templates/ingest/as/match.html
+++ b/src/dashboard/src/templates/ingest/as/match.html
@@ -16,7 +16,13 @@
   function toggle_objects(source) {
     checkboxes = document.querySelectorAll('.atk-matcher-object-path > input');
     for (var i = 0, n = checkboxes.length; i < n; i++) {
-      checkboxes[i].checked = source.checked;
+      var $cb = $(checkboxes[i]);
+      // Only select if the checkbox is visible and not disabled
+      if ( $cb.is(":visible") && ! $cb.is(":disabled") ) {
+        checkboxes[i].checked = source.checked;
+      } else {
+        checkboxes[i].checked = false;
+      }
     }
   }
   </script>

--- a/src/dashboard/src/templates/ingest/as/match.html
+++ b/src/dashboard/src/templates/ingest/as/match.html
@@ -92,7 +92,7 @@
             <th><a class='atk_resource_sort' id='sort_by_sortPosition'>Level</a></th>
             <th><a class='atk_resource_sort' id='sort_by_title'>Title</a></th>
             <th><a class='atk_resource_sort' id='sort_by_identifier'>Identifier</a></th>
-            <th>Dates</th>
+            <th><a class='atk_resource_sort' id='sort_by_dates'>Dates</a></th>
           </tr>
         </thead>
         <tbody id="resource_pane_items">

--- a/src/dashboard/src/templates/ingest/as/resource_component.html
+++ b/src/dashboard/src/templates/ingest/as/resource_component.html
@@ -10,7 +10,9 @@
 
   <ul class="breadcrumb">
     {% breadcrumb_url 'DIP Upload' 'components.ingest.views_as.ingest_upload_as' uuid %}
-    {% breadcrumb_url 'Collection' 'components.ingest.views_as.ingest_upload_as_resource' uuid resource_id %}
+    {% if resource_id %}
+      {% breadcrumb_url 'Collection' 'components.ingest.views_as.ingest_upload_as_resource' uuid resource_id %}
+    {% endif %}
     {% if parent_id %}
       {% breadcrumb_url 'Parent record' 'components.ingest.views_as.ingest_upload_as_resource_component' parent_id %}
     {% endif %}


### PR DESCRIPTION
When filtering in the matching GUI, don't select checkboxes that aren't visible or are disabled. Also, fix viewing resource component and be explicit about what's sent to the template.

Update: Sorting is now case insensitive.
Update: Add sorting by date. This works best with artefactual-labs/agentarchives#29

This may also be merged into 1.5
