### PR TITLE
Elasticsearch: force str type in some date fields

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -276,7 +276,6 @@ def set_up_mapping(conn, index):
             'name': _sortable_string_field_specification('name'),
             'size': {'type': 'double'},
             'uuid': machine_readable_field_spec,
-            # Prevent autodetection for dc:date
             'mets': aip_mets_mapping,
         }
 
@@ -293,7 +292,6 @@ def set_up_mapping(conn, index):
             'FILEUUID': machine_readable_field_spec,
             'isPartOf': machine_readable_field_spec,
             'AICID': machine_readable_field_spec,
-            # Prevent autodetection for dc:date
             'METS': aipfile_mets_mapping,
         }
 

--- a/src/archivematicaCommon/lib/elasticsearch/aip_mets_mapping.json
+++ b/src/archivematicaCommon/lib/elasticsearch/aip_mets_mapping.json
@@ -516,8 +516,14 @@
                 },
                 "ns0:xmlData_dict_list": {
                   "properties": {
+                    "date_available": {
+                        "type": "string"
+                    },
                     "ns2:dublincore_dict_list": {
                       "properties": {
+                        "dc:available": {
+                          "type": "string"
+                        },
                         "dc:contributor": {
                           "type": "string"
                         },

--- a/src/archivematicaCommon/lib/elasticsearch/aipfile_mets_mapping.json
+++ b/src/archivematicaCommon/lib/elasticsearch/aipfile_mets_mapping.json
@@ -15,6 +15,9 @@
             },
             "ns1:dublincore_dict_list": {
               "properties": {
+                "dc:available": {
+                  "type": "string"
+                },
                 "dc:provenance": {
                   "type": "string"
                 },


### PR DESCRIPTION
Against `qa/1.5.x`.
