### PR TITLE
Normalize: fix preservation file UUID to match path on disk

### DIFF
--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -183,7 +183,7 @@ def once_normalized(command, opts, replacement_dict):
             continue
 
         today = timezone.now()
-        output_file_uuid = str(uuid.uuid4())
+        output_file_uuid = opts.task_uuid  # Match the UUID on disk
         # TODO Add manual normalization for files of same name mapping?
         #Add the new file to the SIP
         path_relative_to_sip = ef.replace(opts.sip_path, "%SIPDirectory%", 1)


### PR DESCRIPTION
Preservation files have the taskUUID appended to the output name. Instead of generating a new UUID, use the existing task UUID as the file UUID in the database, to match the path on disk.

Access & thumbnail copies use the original file UUID.
