### PR TITLE
ArchivesSpace client: Handle notes with no content

### DIFF
--- a/src/archivematicaCommon/lib/archivesspace/client.py
+++ b/src/archivematicaCommon/lib/archivesspace/client.py
@@ -503,9 +503,14 @@ class ArchivesSpaceClient(object):
             else:
                 dnote = "note"
             if "subnotes" in pnote:
-                content = [subnote["content"] for subnote in pnote["subnotes"]]
+                content = []
+                for subnote in pnote['subnotes']:
+                    if 'content' in subnote:
+                        content.append(subnote['content'])
+                    else:
+                        LOGGER.info('No content fiel in %s, skipping adding to child digital object.', subnote)
             else:
-                content = pnote["content"]
+                content = pnote.get("content", '')
 
             new_object["notes"].append({
                 "jsonmodel_type": "note_digital_object",


### PR DESCRIPTION
When creating a digital object, handle notes from the parent that don't have a content attribute.  Print an error if notes are being skipped.

refs #9464

Edit: This is also artefactual-labs/agentarchives#30 for the 1.6 release
