### PR TITLE
ArchivesSpace: Location of originals is DIP UUID (1.5)

### DIFF
--- a/src/MCPClient/lib/clientScripts/upload-archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload-archivesspace.py
@@ -9,7 +9,6 @@ from fpr.models import FormatVersion
 
 # archivematicaCommon
 from archivesspace.client import ArchivesSpaceClient
-from elasticSearchFunctions import getDashboardUUID
 from xml2obj import mets_file
 
 # initialize Django (required for Django 1.7)
@@ -61,7 +60,6 @@ def upload_to_archivesspace(files, client, xlink_show, xlink_actuate, object_typ
     if not uri.endswith('/'):
         uri += '/'
     pairs = get_pairs(dip_uuid)
-    dashboard_uuid = getDashboardUUID()
 
     # get mets object if needed
     mets = None
@@ -174,7 +172,7 @@ def upload_to_archivesspace(files, client, xlink_show, xlink_actuate, object_typ
 
         logger.info("Uploading {} to ArchivesSpace record {}".format(file_name, as_resource))
         client.add_digital_object(as_resource,
-                                  dashboard_uuid,
+                                  location_of_originals=dip_uuid,
                                   # TODO: fetch a title from DC?
                                   #       Use the title of the parent record?
                                   title=original_name,

--- a/src/archivematicaCommon/lib/archivesspace/client.py
+++ b/src/archivematicaCommon/lib/archivesspace/client.py
@@ -515,7 +515,7 @@ class ArchivesSpaceClient(object):
             new_object["notes"].append({
                 "jsonmodel_type": "note_digital_object",
                 "type": dnote,
-                "label": pnote["label"],
+                "label": pnote.get("label", ""),
                 "content": content,
                 "publish": pnote["publish"],
             })

--- a/src/archivematicaCommon/lib/archivesspace/client.py
+++ b/src/archivematicaCommon/lib/archivesspace/client.py
@@ -438,7 +438,7 @@ class ArchivesSpaceClient(object):
 
         return resources_augmented
 
-    def add_digital_object(self, parent_archival_object, dashboard_uuid, title="", identifier=None, uri=None, object_type="text", xlink_show="embed", xlink_actuate="onLoad", restricted=False, use_statement="", use_conditions=None, access_conditions=None, size=None, format_name=None, format_version=None):
+    def add_digital_object(self, parent_archival_object, location_of_originals=None, title="", identifier=None, uri=None, object_type="text", xlink_show="embed", xlink_actuate="onLoad", restricted=False, use_statement="", use_conditions=None, access_conditions=None, size=None, format_name=None, format_version=None):
         """
         Creates a new digital object.
 
@@ -487,7 +487,7 @@ class ArchivesSpaceClient(object):
             "notes": [{
                 "jsonmodel_type": "note_digital_object",
                 "type": "originalsloc",
-                "content": [dashboard_uuid],
+                "content": [location_of_originals],
                 "publish": False,
             }],
             "restrictions": restricted,


### PR DESCRIPTION
Instead of dashboard UUID, location of originals should be the AIP/DIP UUID. 

This also includes #428 and a fix from agentarchives. 
