### PR TITLE
Storage Service: Add API key support

### DIFF
--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -3,6 +3,7 @@ import logging
 import os
 import platform
 import requests
+from requests.auth import AuthBase
 import slumber
 
 from archivematicaFunctions import get_setting
@@ -23,6 +24,16 @@ class StorageServiceError(Exception):
 
 ############# HELPER FUNCTIONS #############
 
+class TastypieApikeyAuth(AuthBase):
+    def __init__(self, username, apikey):
+        self.username = username
+        self.apikey = apikey
+
+    def __call__(self, r):
+        r.headers['Authorization'] = "ApiKey {0}:{1}".format(self.username, self.apikey)
+        return r
+
+
 def _storage_service_url():
     # Get storage service URL from DashboardSetting model
     storage_service_url = get_setting('storage_service_url', None)
@@ -40,7 +51,9 @@ def _storage_service_url():
 def _storage_api():
     """ Returns slumber access to storage API. """
     storage_service_url = _storage_service_url()
-    api = slumber.API(storage_service_url)
+    username = get_setting('storage_service_user', 'test')
+    api_key = get_setting('storage_service_apikey', None)
+    api = slumber.API(storage_service_url, auth=TastypieApikeyAuth(username, api_key))
     return api
 
 def _storage_relative_from_absolute(location_path, space_path):
@@ -72,6 +85,7 @@ def create_pipeline(create_default_locations=False, shared_path=None, api_userna
         LOGGER.warning("Unable to create Archivematica pipeline in storage service from {} because {}".format(pipeline, e.content))
         return False
     except slumber.exceptions.HttpServerError as e:
+        LOGGER.warning("Unable to create Archivematica pipeline in storage service from {} because {}".format(pipeline, e.content), exc_info=True)
         if 'column uuid is not unique' in e.content:
             pass
         else:
@@ -85,6 +99,7 @@ def _get_pipeline(uuid):
     except slumber.exceptions.HttpClientError as e:
         if e.response.status_code == 404:
             LOGGER.warning("This Archivematica instance is not registered with the storage service or has been disabled.")
+        LOGGER.warning('Error fetching pipeline', exc_info=True)
         pipeline = None
     return pipeline
 

--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -69,9 +69,18 @@ class SettingsForm(forms.Form):
 
 
 class StorageSettingsForm(SettingsForm):
-    storage_service_url = forms.URLField(required=False,
-        label="Full URL of the storage service")
-
+    storage_service_url = forms.URLField(
+        label="Storage Service URL",
+        help_text='Full URL of the storage service. E.g. https://192.168.168.192:8000'
+    )
+    storage_service_user = forms.CharField(
+        label='Storage Service User',
+        help_text='User in the storage service to authenticate as. E.g. test'
+    )
+    storage_service_apikey = forms.CharField(
+        label='API key',
+        help_text='API key of the storage service user. E.g. 45f7684483044809b2de045ba59dc876b11b9810'
+    )
 
 class ChecksumSettingsForm(SettingsForm):
     CHOICES = (

--- a/src/dashboard/src/installer/views.py
+++ b/src/dashboard/src/installer/views.py
@@ -156,8 +156,11 @@ def storagesetup(request):
     dashboard_uuid = helpers.get_setting('dashboard_uuid', None)
     assert dashboard_uuid is not None
     # Prefill the storage service URL
-    inital_data = {'storage_service_url':
-        helpers.get_setting('storage_service_url', 'http://localhost:8000')}
+    inital_data = {
+        'storage_service_url': helpers.get_setting('storage_service_url', 'http://localhost:8000'),
+        'storage_service_user': helpers.get_setting('storage_service_user', 'test'),
+        'storage_service_apikey': helpers.get_setting('storage_service_apikey', None)
+    }
     storage_form = StorageSettingsForm(request.POST or None, initial=inital_data)
     if storage_form.is_valid():
         # Set storage service URL

--- a/src/dashboard/src/templates/installer/storagesetup.html
+++ b/src/dashboard/src/templates/installer/storagesetup.html
@@ -9,6 +9,7 @@
     .submit {
       margin-bottom: 1em;
     }
+    label { width: auto; }
   </style>
 {% endblock %}
 
@@ -19,11 +20,13 @@
 
     <form action="#" method="POST">
       <div id="storage" class="well">
-        <p>Dashboard UUID: {{ dashboard_uuid }}</p>
+        <p>
+          <label>Dashboard UUID:</label>
+          <p><code>{{ dashboard_uuid }}</code></p>
+        </p>
 
         {{ storage_form.as_p }}
 
-        <p>Would you like to used the default transfer source and AIP storage locations?</p>
       </div>
       <input class="submit" type="submit" name="use_default" value="Register with the storage service &amp; use default configuration." />
       <input class="submit" type="submit" name="configure" value="Register with the storage service &amp; set up custom configuration." onclick="window.open($('#id_storage_service_url').val());" />


### PR DESCRIPTION
Add an API key auth to the slumber storage service config. Add SS user & api key to the SS config form.

This makes all storage service related fields in the form required - previously the URL was optional.

Adds Archivematica support for artefactual/archivematica-storage-service#124
