### PR TITLE
dbsettings: use database instead of db

### DIFF
--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -25,7 +25,7 @@ config.read('/etc/archivematica/archivematicaCommon/dbsettings')
 DATABASES = {
     'default': {
         'ENGINE': 'django_mysqlpool.backends.mysqlpool',
-        'NAME': 'MCP',                                     # Or path to database file if using sqlite3.
+        'NAME': config.get('client', 'database'),          # Or path to database file if using sqlite3.
         'USER': config.get('client', 'user'),              # Not used with sqlite3.
         'PASSWORD': config.get('client', 'password'),      # Not used with sqlite3.
         'HOST': config.get('client', 'host'),              # Set to empty string for localhost. Not used with sqlite3.

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -25,7 +25,7 @@ config.read('/etc/archivematica/archivematicaCommon/dbsettings')
 DATABASES = {
     'default': {
         'ENGINE': 'django_mysqlpool.backends.mysqlpool',
-        'NAME': 'MCP',                                     # Or path to database file if using sqlite3.
+        'NAME': config.get('client', 'database'),          # Or path to database file if using sqlite3.
         'USER': config.get('client', 'user'),              # Not used with sqlite3.
         'PASSWORD': config.get('client', 'password'),      # Not used with sqlite3.
         'HOST': config.get('client', 'host'),              # Set to empty string for localhost. Not used with sqlite3.

--- a/src/archivematicaCommon/etc/dbsettings
+++ b/src/archivematicaCommon/etc/dbsettings
@@ -2,4 +2,4 @@
 user=archivematica
 password=demo
 host=localhost
-db=MCP
+database=MCP

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -41,7 +41,7 @@ config.read('/etc/archivematica/archivematicaCommon/dbsettings')
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',         # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': config.get('client', 'db'),           # Or path to database file if using sqlite3.
+        'NAME': config.get('client', 'database'),     # Or path to database file if using sqlite3.
         'USER': config.get('client', 'user'),         # Not used with sqlite3.
         'PASSWORD': config.get('client', 'password'), # Not used with sqlite3.
         'HOST': config.get('client', 'host'),         # Set to empty string for localhost. Not used with sqlite3.


### PR DESCRIPTION
Note: planning to merge into `qa/1.5.x` and `qa/1.x`.

When using `read_default_file` (as in `databaseInterface.py`), the `db`
parameter seems to be ignored. It's an alternative name for `database` but its
use is not recommended (and apparently abandoned?). See
https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html.

Related: https://github.com/artefactual-labs/ansible-role-archivematica-src/pull/53
