### PR TITLE
ArchivesSpace: optional inheritance of notes

### DIFF
--- a/src/MCPClient/lib/clientScripts/upload-archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload-archivesspace.py
@@ -55,7 +55,7 @@ def delete_pairs(dip_uuid):
     ArchivesSpaceDIPObjectResourcePairing.objects.filter(dipuuid=dip_uuid).delete()
 
 
-def upload_to_archivesspace(files, client, xlink_show, xlink_actuate, object_type, use_statement, uri, dip_uuid, access_conditions, use_conditions, restrictions, dip_location):
+def upload_to_archivesspace(files, client, xlink_show, xlink_actuate, object_type, use_statement, uri, dip_uuid, access_conditions, use_conditions, restrictions, dip_location, inherit_notes):
 
     if not uri.endswith('/'):
         uri += '/'
@@ -131,7 +131,7 @@ def upload_to_archivesspace(files, client, xlink_show, xlink_actuate, object_typ
                 uuid=uuid
             )
         except (File.DoesNotExist, File.MultipleObjectsReturned):
-            original_name=''
+            original_name = ''
             size = format_name = format_version = None
         else:
             # Set some variables based on the original, we will override most
@@ -188,36 +188,40 @@ def upload_to_archivesspace(files, client, xlink_show, xlink_actuate, object_typ
                                   size=size,
                                   format_name=format_name,
                                   format_version=format_version,
+                                  inherit_notes=inherit_notes,
         )
 
         delete_pairs(dip_uuid)
+
 
 if __name__ == '__main__':
     RESTRICTIONS_CHOICES = ['yes', 'no', 'premis']
     EAD_SHOW_CHOICES = ['embed', 'new', 'none', 'other', 'replace']
     EAD_ACTUATE_CHOICES = ['none', 'onLoad', 'other', 'onRequest']
+    INHERIT_NOTES_CHOICES = ['yes', 'y', 'true', '1']
 
-    parser = argparse.ArgumentParser(description="A program to take digital objects from a DIP and upload them to an ArchivesSpace db")
-    parser.add_argument('--host', default="localhost", dest="host",
-        metavar="host", help="hostname of ArchivesSpace")
-    parser.add_argument('--port', type=int, default=8089, dest='port',
-        metavar="port", help="Port used by ArchivesSpace backend API")
-    parser.add_argument('--user', dest='user', metavar="Administrative user")
-    parser.add_argument('--passwd', dest='passwd', metavar="Administrative user password")
-    parser.add_argument('--dip_location', metavar="dip location")
-    parser.add_argument('--dip_name', metavar="dip name")
-    parser.add_argument('--dip_uuid', metavar="dip uuid")
-    parser.add_argument('--restrictions', metavar="restrictions apply", default="premis", choices=RESTRICTIONS_CHOICES)
-    parser.add_argument('--object_type', metavar="object type", default="")
-    parser.add_argument('--xlink_actuate', metavar="xlink actuate", default="onRequest", choices=EAD_ACTUATE_CHOICES)
-    parser.add_argument('--xlink_show', metavar="xlink show", default="new", choices=EAD_SHOW_CHOICES)
-    parser.add_argument('--use_statement', metavar="use statement")
-    parser.add_argument('--uri_prefix', metavar="uri prefix")
-    parser.add_argument('--access_conditions', metavar="conditions governing access", default="")
-    parser.add_argument('--use_conditions', metavar="conditions governing use", default="")
+    parser = argparse.ArgumentParser(description='A program to take digital objects from a DIP and upload them to an ArchivesSpace db')
+    parser.add_argument('--host', default='localhost', dest='host', metavar='host', help='Hostname of ArchivesSpace')
+    parser.add_argument('--port', type=int, default=8089, dest='port', metavar='port', help='Port used by ArchivesSpace backend API')
+    parser.add_argument('--user', dest='user', help='Administrative user')
+    parser.add_argument('--passwd', dest='passwd', help='Administrative user password')
+    parser.add_argument('--dip_location', help='DIP location')
+    parser.add_argument('--dip_name', help='DIP name')
+    parser.add_argument('--dip_uuid', help='DIP UUID')
+    parser.add_argument('--restrictions', help='Restrictions apply', default='premis', choices=RESTRICTIONS_CHOICES)
+    parser.add_argument('--object_type', help='object type', default='')
+    parser.add_argument('--xlink_actuate', help='XLink actuate', default='onRequest', choices=EAD_ACTUATE_CHOICES)
+    parser.add_argument('--xlink_show', help='XLink show', default='new', choices=EAD_SHOW_CHOICES)
+    parser.add_argument('--use_statement', help='USE statement')
+    parser.add_argument('--uri_prefix', help='URI prefix')
+    parser.add_argument('--access_conditions', help='Conditions governing access', default='')
+    parser.add_argument('--use_conditions', help='Conditions governing use', default='')
+    parser.add_argument('--inherit_notes', help='Inherit digital object notes from the parent component', default='no', type=str)
     parser.add_argument('--version', action='version', version='%(prog)s 0.1.0')
     args = parser.parse_args()
 
+    args.inherit_notes = args.inherit_notes.lower() in INHERIT_NOTES_CHOICES
+
     client = ArchivesSpaceClient(host=args.host, user=args.user, passwd=args.passwd)
     files = get_files_from_dip(args.dip_location, args.dip_name, args.dip_uuid)
-    upload_to_archivesspace(files, client, args.xlink_show, args.xlink_actuate, args.object_type, args.use_statement, args.uri_prefix, args.dip_uuid, args.access_conditions, args.use_conditions, args.restrictions, args.dip_location)
+    upload_to_archivesspace(files, client, args.xlink_show, args.xlink_actuate, args.object_type, args.use_statement, args.uri_prefix, args.dip_uuid, args.access_conditions, args.use_conditions, args.restrictions, args.dip_location, args.inherit_notes)

--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -98,7 +98,7 @@ class ArchivistsToolkitConfigForm(ModelForm):
 class ArchivesSpaceConfigForm(ModelForm):
     class Meta:
         model = ArchivesSpaceConfig
-        fields = ('host', 'port', 'user', 'passwd', 'premis', 'xlink_actuate', 'xlink_show', 'use_statement', 'object_type', 'access_conditions', 'use_conditions', 'uri_prefix', 'repository')
+        fields = ('host', 'port', 'user', 'passwd', 'premis', 'xlink_actuate', 'xlink_show', 'use_statement', 'object_type', 'access_conditions', 'use_conditions', 'uri_prefix', 'repository', 'inherit_notes')
         widgets = {
             'host': TextInput(attrs=settings.INPUT_ATTRS),
             'port': TextInput(attrs=settings.INPUT_ATTRS),

--- a/src/dashboard/src/components/administration/migrations/0004_archivesspaceconfig_inherit_notes.py
+++ b/src/dashboard/src/components/administration/migrations/0004_archivesspaceconfig_inherit_notes.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('administration', '0003_archivesspace_help_text'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='archivesspaceconfig',
+            name='inherit_notes',
+            field=models.BooleanField(default=False, verbose_name=b'Inherit digital object notes from the parent component'),
+            preserve_default=True,
+        ),
+    ]

--- a/src/dashboard/src/components/administration/models.py
+++ b/src/dashboard/src/components/administration/models.py
@@ -35,6 +35,7 @@ class ArchivistsToolkitConfig(models.Model):
     access_conditions = models.CharField(max_length=50, blank=True, verbose_name='Conditions governing access')
     use_conditions = models.CharField(max_length=50, blank=True, verbose_name='Conditions governing use')
 
+
 class ArchivesSpaceConfig(models.Model):
     id = UUIDPkField()
     host = models.CharField(max_length=50, verbose_name='ArchivesSpace host', help_text='Do not include http:// or www. Example: aspace.test.org ')
@@ -50,3 +51,4 @@ class ArchivesSpaceConfig(models.Model):
     access_conditions = models.CharField(max_length=50, blank=True, verbose_name='Conditions governing access', help_text='Populates Conditions governing access note')
     use_conditions = models.CharField(max_length=50, blank=True, verbose_name='Conditions governing use', help_text='Populates Conditions governing use note')
     repository = models.IntegerField(default=2, verbose_name='ArchivesSpace repository number', help_text='Default for single repository installation is 2')
+    inherit_notes = models.BooleanField(default=False, verbose_name='Inherit digital object notes from the parent component')

--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -146,6 +146,7 @@ def administration_as_dips(request):
                 "%use_conditions%": new_asconfig.use_conditions,
                 "%use_statement%": new_asconfig.use_statement,
                 "%repository%": str(new_asconfig.repository),
+                "%inherit_notes%": str(new_asconfig.inherit_notes),
             }
 
             logger.debug('New ArchivesSpace settings: %s', (settings,))

--- a/src/dashboard/src/main/migrations/0013_upload_archivesspace_inherit_notes.py
+++ b/src/dashboard/src/main/migrations/0013_upload_archivesspace_inherit_notes.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+def data_migration(apps, schema_editor):
+    arguments = ' '.join([
+        '--host "%host%"',
+        '--port "%port%"',
+        '--user "%user%"',
+        '--passwd "%passwd%"',
+        '--dip_location "%SIPDirectory%"',
+        '--dip_name "%SIPName%"',
+        '--dip_uuid "%SIPUUID%"',
+        '--restrictions "%restrictions%"',
+        '--object_type "%object_type%"',
+        '--xlink_actuate "%xlink_actuate%"',
+        '--xlink_show "%xlink_show%"',
+        '--use_statement "%use_statement%"',
+        '--uri_prefix "%uri_prefix%"',
+        '--access_conditions "%access_conditions%"',
+        '--use_conditions "%use_conditions%"',
+        '--inherit_notes="%inherit_notes%"',
+    ])
+
+    StandardTaskConfig = apps.get_model('main', 'StandardTaskConfig')
+    StandardTaskConfig.objects.filter(pk='10a0f352-aeb7-4c13-8e9e-e81bda9bca29').update(arguments=arguments)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0012_file_id_text'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration),
+    ]


### PR DESCRIPTION
In qa/1.x (without migration): ecb385b51fa53585d09570f50df0f3144d72cccc
It includes two migrations:
- `administration/migrations/0004_archivesspaceconfig_inherit_notes.py`:<br />This migration adds a new field (`inherit_notes`) to the `ArchivesSpaceConfig` model.
- `main/migrations/0013_upload_archivesspace_inherit_notes.py`:<br />This migration updates the task configuration.
