### PR TITLE
METS: handle missing metadata entry in structMap

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -855,7 +855,8 @@ def build_arranged_structmap(original_structmap, sip_uuid):
     # represented in this structMap.
     for label in ('submissionDocumentation', 'metadata'):
         div = objects.find('.mets:div[@LABEL="{}"]'.format(label), namespaces=ns.NSMAP)
-        objects.remove(div)
+        if div is not None:
+            objects.remove(div)
 
     # Handle objects level of description separately, since tag paths are relative to objects
     tag = tag_dict.get('.')

--- a/src/archivematicaCommon/lib/version.py
+++ b/src/archivematicaCommon/lib/version.py
@@ -1,4 +1,4 @@
-ARCHIVEMATICA_VERSION = (1, 3, 2)
+ARCHIVEMATICA_VERSION = (1, 5, 0)
 
 
 def get_version():

--- a/src/dashboard/src/main/migrations/0011_version_number.py
+++ b/src/dashboard/src/main/migrations/0011_version_number.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def data_migration(apps, schema_editor):
+    Agent = apps.get_model('main', 'Agent')
+    Agent.objects.filter(identifiertype='preservation system', name='Archivematica').update(identifiervalue='Archivematica-1.5.0')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0010_dip_upload_store'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration)
+    ]


### PR DESCRIPTION
After deleting empty directories under objects/ (0c7e2947be), ran into this
issue. This commits avoids trying to remove `div` when .find() returned `None`.
Refs #9873.
