### PR TITLE
Use Format description in premis:formatName

### DIFF
--- a/src/MCPClient/lib/clientScripts/identifyFileFormat.py
+++ b/src/MCPClient/lib/clientScripts/identifyFileFormat.py
@@ -82,7 +82,7 @@ def write_file_id(file_uuid, format=None, output=''):
 
     FileID.objects.create(
         file_id=file_uuid,
-        format_name=format.description,
+        format_name=format.format.description,
         format_version=version,
         format_registry_name=format_registry,
         format_registry_key=key

--- a/src/MCPClient/lib/clientScripts/identifyFileFormat.py
+++ b/src/MCPClient/lib/clientScripts/identifyFileFormat.py
@@ -8,12 +8,12 @@ import django
 django.setup()
 # dashboard
 from fpr.models import IDCommand, IDRule, FormatVersion
-from main.models import FileFormatVersion, File, UnitVariable, Event
+from main.models import FileFormatVersion, File, FileID, UnitVariable
 
 # archivematicaCommon
 from custom_handlers import get_script_logger
 from executeOrRunSubProcess import executeOrRun
-from databaseFunctions import getUTCDate, insertIntoEvents, insertIntoFilesIDs
+from databaseFunctions import getUTCDate, insertIntoEvents
 
 
 def save_idtool(file_, value):
@@ -63,6 +63,13 @@ def write_identification_event(file_uuid, command, format=None, success=True):
 
 
 def write_file_id(file_uuid, format=None, output=''):
+    """
+    Write the identified format to the DB.
+
+    :param str file_uuid: UUID of the file identified
+    :param FormatVersion format: FormatVersion it was identified as
+    :param str output: Text that generated the match
+    """
     if format.pronom_id:
         format_registry = 'PRONOM'
         key = format.pronom_id
@@ -73,11 +80,13 @@ def write_file_id(file_uuid, format=None, output=''):
     # Sometimes, this is null instead of an empty string
     version = format.version or ''
 
-    insertIntoFilesIDs(fileUUID=file_uuid,
-                       formatName=format.description,
-                       formatVersion=version,
-                       formatRegistryName=format_registry,
-                       formatRegistryKey=key)
+    FileID.objects.create(
+        file_id=file_uuid,
+        format_name=format.description,
+        format_version=version,
+        format_registry_name=format_registry,
+        format_registry_key=key
+    )
 
 
 def main(command_uuid, file_path, file_uuid, disable_reidentify):

--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -239,7 +239,7 @@ def once_normalized(command, opts, replacement_dict):
 
         FileID.objects.create(
             file_id=output_file_uuid,
-            format_name=command.fpcommand.output_format.description
+            format_name=command.fpcommand.output_format.format.description
         )
 
 

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -174,18 +174,6 @@ def insertIntoFPCommandOutput(fileUUID="", fitsXMLString="", ruleUUID=""):
     FPCommandOutput.objects.create(file_id=fileUUID, content=fitsXMLString,
                                    rule_id=ruleUUID)
 
-def insertIntoFilesIDs(fileUUID="", formatName="", formatVersion="", formatRegistryName="", formatRegistryKey=""):
-    """
-    Creates a new entry in the FilesIDs table using the provided data.
-    This function, and its associated table, may be removed in the future.
-    """
-    f = FileID(file_id=fileUUID,
-               format_name=formatName,
-               format_version=formatVersion,
-               format_registry_name=formatRegistryName,
-               format_registry_key=formatRegistryKey)
-    f.save()
-
 
 #user approved?
 #client connected/disconnected.


### PR DESCRIPTION
Use the Format's description in `<premis:formatName>` instead of FormatVersion's description.  The Format description is populated from PRONOM's name field, while the FormatVersion is from the version name.

Also, remove insertIntoFilesIDs because it was trivial with Django's ORM.

Redmine 8319
