### PR TITLE
FITS: Use models not databaseInterface

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaFITS.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaFITS.py
@@ -32,14 +32,13 @@ from archivematicaFunctions import getTagged
 from archivematicaFunctions import escapeForCommand
 from custom_handlers import get_script_logger
 from databaseFunctions import insertIntoFPCommandOutput
-from databaseFunctions import insertIntoEvents
-import databaseInterface
 
 # initialize Django (required for Django 1.7)
 import django
 django.setup()
+# dashboard
+from main.models import FPCommandOutput
 
-databaseInterface.printSQL = False
 excludeJhoveProperties = True
 formats = []
 FITSNS = "{http://hul.harvard.edu/ois/xml/ns/fits/fits_output}"
@@ -80,8 +79,7 @@ if __name__ == '__main__':
         print "file's fileGrpUse in exclusion list, skipping"
         exit(0)
 
-    sql = """SELECT fileUUID FROM FPCommandOutput WHERE fileUUID = %s;"""
-    if len(databaseInterface.queryAllSQL(sql, (fileUUID,))):
+    if not FPCommandOutput.objects.filter(file=fileUUID).exists():
         print >>sys.stderr, "Warning: Fits has already run on this file. Not running again."
         exit(0)
 


### PR DESCRIPTION
FPCommandOutput doesn't exist anymore - as part of migrations (#98 and #409 ) it became `main_fpcommandoutput`. Update this to use the models instead of the outdated SQL.  This is already fixed in qa/1.x with #354 
