### PR TITLE
AIC fixes

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -1047,7 +1047,6 @@ if __name__ == '__main__':
 
     baseDirectoryPath = os.path.join(baseDirectoryPath, '')
     objectsDirectoryPath = os.path.join(baseDirectoryPath, 'objects')
-    metadataDirectoryPath = os.path.join(objectsDirectoryPath, 'metadata')
 
     # Delete empty directories, see #8427
     for root, dirs, files in os.walk(objectsDirectoryPath, topdown=False):
@@ -1065,6 +1064,8 @@ if __name__ == '__main__':
     if el:
         amdSecs.append(el)
 
+    # In an AIC, the metadata dir is not inside the objects dir
+    metadataDirectoryPath = os.path.join(baseDirectoryPath, 'metadata')
     createFileSec(metadataDirectoryPath, structMapDiv, baseDirectoryPath, baseDirectoryPathString, fileGroupIdentifier, fileGroupType, includeAmdSec)
 
     fileSec = etree.Element(ns.metsBNS + "fileSec")

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -1087,7 +1087,13 @@ if __name__ == '__main__':
     dc = createDublincoreDMDSecFromDBData(SIPMetadataAppliesToType, fileGroupIdentifier, baseDirectoryPath)
     if dc != None:
         (dmdSec, ID) = dc
-        structMapDivObjects.set("DMDID", ID)
+        if structMapDivObjects is not None:
+            structMapDivObjects.set("DMDID", ID)
+        else:
+            # AICs have no objects directory but do have DC metadata
+            # Attach the DC metadata to the top level SIP div
+            # See #9822 for details
+            structMapDiv.set('DMDID', ID)
         root.append(dmdSec)
 
     for dmdSec in dmdSecs:

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -1049,7 +1049,7 @@ if __name__ == '__main__':
     objectsDirectoryPath = os.path.join(baseDirectoryPath, 'objects')
 
     # Delete empty directories, see #8427
-    for root, dirs, files in os.walk(objectsDirectoryPath, topdown=False):
+    for root, dirs, files in os.walk(baseDirectoryPath, topdown=False):
         try:
             os.rmdir(root)
             print "Deleted empty directory", root

--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -144,7 +144,7 @@ def escapeForCommand(string):
 # and is primarily used for arbitrary strings (e.g. filenames, paths)
 # that might not be valid unicode to begin with.
 def escape(string):
-    if isinstance(string, basestring):
+    if isinstance(string, str):
         string = string.decode('utf-8', errors='replace')
     return string
 

--- a/src/dashboard/src/main/migrations/0014_aic_fixes.py
+++ b/src/dashboard/src/main/migrations/0014_aic_fixes.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+def data_migration(apps, schema_editor):
+    MicroServiceChainLink = apps.get_model('main', 'MicroServiceChainLink')
+    # Update delete bagged files to continue processing if there's an error
+    MicroServiceChainLink.objects.filter(id='63f35161-ba76-4a43-8cfa-c38c6a2d5b2f').update(defaultnextchainlink='7c44c454-e3cc-43d4-abe0-885f93d693c6')
+    MicroServiceChainLink.objects.filter(id='746b1f47-2dad-427b-8915-8b0cb7acccd8').update(defaultnextchainlink='7c44c454-e3cc-43d4-abe0-885f93d693c6')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0013_upload_archivesspace_inherit_notes'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration),
+    ]

--- a/src/dashboard/src/manage.py
+++ b/src/dashboard/src/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.common")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
Fixes for bugs relating to #440 and deleting empty directories.
- Add DMDID to the top-level structMap div, instead of the objects directory, since it no longer exists
- Deleting bagged files continues processing if it has an error, which happens for AICs since there's no objects directory
- Add the metadata directory explicitly to the structMap when it's not in the objects dir
- Delete empty directories anywhere in the AIP, not just the objects directory.

And other minor fixes
- Only try to decode `str` not `unicode` strings. Fixes displaying unicode in the task detail view
- Set default project settings, instead of the boilerplate
