### PR TITLE
Reingest: Do not use formatversion.description to try and match a premis:formatRegistryKey entry

### DIFF
--- a/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
+++ b/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
@@ -62,11 +62,6 @@ def parse_files(root):
                 key = amdsec.findtext('.//premis:formatRegistryKey', namespaces=ns.NSMAP)
                 print('FPR key', key)
                 format_version = fpr_models.IDRule.active.get(command_output=key).format
-            # If not, look for formatName
-            if not format_version:
-                name = amdsec.findtext('.//premis:formatName', namespaces=ns.NSMAP)
-                print('Format name', name)
-                format_version = fpr_models.FormatVersion.active.get(description=name)
         except fpr_models.FormatVersion.DoesNotExist:
             pass
         print('format_version', format_version)


### PR DESCRIPTION
refs #9926

Do not use formatversion.description to try and match a premis:formatRegistryKey entry.

See the notes on the redmine ticket.  https://projects.artefactual.com/issues/9926
