### PR TITLE
update MicroServiceChoiceReplacementDic for Siegfried 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 dev (1.5.0)
 ===========
 
+* Dashboard: always show arguments in job detail view
+* Tests: Use an in-memory database
+* Specify python2 in shebangs.  Python version choice respects path.
+
+1.4.1
+=====
+
 * Fix "active" templatetag when Django handles an uncaught exception
 * Fix updating AIP records after marking files as deleted in archival storage (#8533)
 * Fix querying for deleted AIPs (#8533)
@@ -8,9 +15,6 @@ dev (1.5.0)
 * MCPServer: log all exceptions (#8509)
 * MCPServer: remove duplicate ReplacementDict code (#8509)
 * Dashboard: use GroupWriteRotatingFileHandler to ensure group-writeability of rotated logs (#8587)
-* Dashboard: always show arguments in job detail view
-* Tests: Use an in-memory database
-* Specify python2 in shebangs.  Python version choice respects path.
 
 1.4.0
 =====

--- a/src/dashboard/src/main/migrations/0017_update_seigfried.py
+++ b/src/dashboard/src/main/migrations/0017_update_seigfried.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+def data_migration(apps, schema_editor):
+    mscrd = apps.get_model('main', 'MicroServiceChoiceReplacementDic')
+    
+    #make the Seigfried replacementDics point at a new IDCommand for sf 1.5.0
+    #see archivematica-fpr-admin branch 1.1.x
+    
+    mscrd.objects.filter(id='bed4eeb1-d654-4d97-b98d-40eb51d3d4bb').update(replacementDic='{"%IDCommand%":"9d2cefc1-2bd2-44e4-8d55-6cf8151eecff"}')
+    
+    mscrd.objects.filter(id='664cbde3-e658-4288-87db-bd28266d83f5').update(replacementDic='{"%IDCommand%":"9d2cefc1-2bd2-44e4-8d55-6cf8151eecff"}')
+    
+    mscrd.objects.filter(id='25a91595-37f0-4373-a89a-56a757353fb8').update(replacementDic='{"%IDCommand%":"9d2cefc1-2bd2-44e4-8d55-6cf8151eecff"}')
+    
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0016_file_currentlocation_nullable'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration),
+    ]
+    


### PR DESCRIPTION
refs #9830

When a new IDCommand is created, the MicroServiceChoiceReplacementDic
entries that linked to the old IDCommand need to be updated.
