### PR TITLE
Use UTC in MCPClient and MCPServer

### DIFF
--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -42,3 +42,6 @@ CONN_MAX_AGE = 14400
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'e7b-$#-3fgu)j1k01)3tp@^e0=yv1hlcc4k-b6*ap^zezv2$48'
+
+USE_TZ = True
+TIME_ZONE = 'UTC'

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -42,3 +42,6 @@ CONN_MAX_AGE = 14400
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'e7b-$#-3fgu)j1k01)3tp@^e0=yv1hlcc4k-b6*ap^zezv2$48'
+
+USE_TZ = True
+TIME_ZONE = 'UTC'

--- a/src/dashboard/src/media/js/misc.js
+++ b/src/dashboard/src/media/js/misc.js
@@ -145,13 +145,11 @@ function timestampToLocal(timestamp) {
   return date.getArchivematicaDateString();
 }
 
-function datetimeToLocal(timestamp) {
+function datetimeToLocal(dt) {
   // Converts an ISO formatted string to localtime
-  // Append 'Z' so they are parsed as UTC
   'use strict';
-  var date = new Date(timestamp+'Z');
-
-  return date.toLocaleFormat();
+  var date = new Date(dt);
+  return date.toLocaleString();
 }
 
 function localizeTimestampElements() {


### PR DESCRIPTION
Also, use standard `Date.prototype.toLocaleString()` in the dashboard.
