### PR TITLE
Made copyright status a controlled vocabulary.

### DIFF
--- a/src/dashboard/src/components/rights/forms.py
+++ b/src/dashboard/src/components/rights/forms.py
@@ -65,7 +65,7 @@ class RightsCopyrightForm(forms.ModelForm):
         model = models.RightsStatementCopyright
         fields = ('copyrightstatus', 'copyrightjurisdiction', 'copyrightstatusdeterminationdate', 'copyrightapplicablestartdate', 'copyrightapplicableenddate', 'copyrightenddateopen')
         widgets = {
-            'copyrightstatus': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "A coded designation of the copyright status of the object at the time the rights statement is recorded. E.g. Copyrighted, Public Domain, Unknown"}),
+            'copyrightstatus': forms.widgets.Select(attrs={'class': 'span11', 'title': "A coded designation of the copyright status of the object at the time the rights statement is recorded. Available options: Copyrighted, Public Domain, Unknown"}),
             'copyrightjurisdiction': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The country whose copyright laws apply [ISO 3166]"}),
             'copyrightstatusdeterminationdate': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The date that the copyright status recorded in 'copyright status' was determined."}),
             'copyrightapplicablestartdate': forms.widgets.TextInput(attrs={'class': 'span11', 'title': "The date when the particular copyright applies or is applied to the content."}),

--- a/src/dashboard/src/main/migrations/0025_copyrightstatus_controlled_vocab.py
+++ b/src/dashboard/src/main/migrations/0025_copyrightstatus_controlled_vocab.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0024_agenttype'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='rightsstatementcopyright',
+            name='copyrightstatus',
+            field=models.TextField(default=b'unknown', verbose_name=b'Copyright status', db_column=b'copyrightStatus', choices=[(b'copyrighted', b'copyrighted'), (b'public domain', b'public domain'), (b'unknown', b'unknown')]),
+        ),
+    ]

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -468,7 +468,12 @@ class RightsStatement(models.Model):
 class RightsStatementCopyright(models.Model):
     id = models.AutoField(primary_key=True, db_column='pk', editable=False)
     rightsstatement = models.ForeignKey(RightsStatement, db_column='fkRightsStatement')
-    copyrightstatus = models.TextField(db_column='copyrightStatus', verbose_name='Copyright status')
+    PREMIS_COPYRIGHT_STATUSES = (
+        ('copyrighted', 'copyrighted'),
+        ('public domain', 'public domain'),
+        ('unknown', 'unknown'),
+    )
+    copyrightstatus = models.TextField(db_column='copyrightStatus', blank=False, verbose_name='Copyright status', choices=PREMIS_COPYRIGHT_STATUSES, default='unknown')
     copyrightjurisdiction = models.TextField(db_column='copyrightJurisdiction', verbose_name='Copyright jurisdiction')
     copyrightstatusdeterminationdate = models.TextField(db_column='copyrightStatusDeterminationDate', blank=True, null=True, verbose_name='Copyright determination date', help_text='Use ISO 8061 (YYYY-MM-DD)')
     copyrightapplicablestartdate = models.TextField(db_column='copyrightApplicableStartDate', blank=True, null=True, verbose_name='Copyright start date', help_text='Use ISO 8061 (YYYY-MM-DD)')


### PR DESCRIPTION
Given 4.1.3.1 copyrightStatus of PREMIS v. 3.0, I used "copyrighted", "publicdomain", and "unknown" as the underlying values with their human-readable counterparts displayed in the <select>.
