### PR TITLE
API: Encode unicode paths

### DIFF
--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -31,6 +31,7 @@ from annoying.functions import get_object_or_None
 from tastypie.authentication import ApiKeyAuthentication
 
 # This project, alphabetical
+import archivematicaFunctions
 from contrib.mcp.client import MCPClient
 from components.filesystem_ajax import views as filesystem_ajax_views
 from components.unit import views as unit_views
@@ -326,6 +327,7 @@ def approve_transfer(request):
 
             directory = request.POST.get('directory', '')
             transfer_type = request.POST.get('type', 'standard')
+            directory = archivematicaFunctions.unicodeToStr(directory)
             error, unit_uuid = approve_transfer_via_mcp(directory, transfer_type, request.user.id)
 
             if error is not None:

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -21,17 +21,12 @@ import os
 import logging
 import re
 import shutil
-import sys
 import tempfile
 import uuid
 
-from django.conf import settings as django_settings
-from django.db import connection, IntegrityError
-from django.db.models import Q
+from django.db import IntegrityError
 import django.http
 import django.template.defaultfilters
-
-import requests
 
 from components import helpers
 import components.filesystem_ajax.helpers as filesystem_ajax_helpers
@@ -259,7 +254,7 @@ def start_transfer(transfer_name, transfer_type, accession, paths, row_ids):
 
         transfer_relative = transfer_dir.replace(SHARED_DIRECTORY_ROOT, '', 1)
         copy_from_transfer_sources([path], transfer_relative)
-
+        filepath = archivematicaFunctions.unicodeToStr(filepath)
         try:
             destination = copy_to_start_transfer(filepath=filepath,
                 type=transfer_type, accession=accession,


### PR DESCRIPTION
When dealing with filesystem paths coming from the API, ensure they're strs.  Otherwise, it generates Unicode exceptions.

There are likely other cases with this problem; these are the ones I found.

refs #9941
