### PR TITLE
Reingest: Clear files from ES index

### DIFF
--- a/src/MCPClient/lib/clientScripts/indexAIP.py
+++ b/src/MCPClient/lib/clientScripts/indexAIP.py
@@ -70,8 +70,9 @@ def index_aip():
     print('Indexing AIP info')
     # Delete ES index before creating new one if reingesting
     if 'REIN' in sip_type:
+        print('Deleting outdated entry for AIP and AIP files with UUID', sip_uuid, 'from archival storage')
         elasticSearchFunctions.delete_aip(sip_uuid)
-        print('Deleted outdated entry for AIP with UUID', sip_uuid, ' from archival storage')
+        elasticSearchFunctions.connect_and_delete_aip_files(sip_uuid)
 
     # Index AIP
     elasticSearchFunctions.connect_and_index_aip(


### PR DESCRIPTION
Delete AIP files from ES index when storing. Since ES is indexed from the METS file, all files will be re-indexed even if they aren't on disk (eg a metadata-only reingest)

Cherry-picked from #391 for 1.5
