### PR TITLE
Index Islandora identifier

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -293,6 +293,7 @@ def set_up_mapping(conn, index):
             'isPartOf': machine_readable_field_spec,
             'AICID': machine_readable_field_spec,
             'METS': aipfile_mets_mapping,
+            'identifiers': machine_readable_field_spec,
         }
 
         print 'Creating AIP file mapping...'

--- a/src/archivematicaCommon/lib/identifier_functions.py
+++ b/src/archivematicaCommon/lib/identifier_functions.py
@@ -16,3 +16,16 @@ def extract_identifiers_from_mods(mods_path):
     doc = etree.parse(mods_path)
     elements = doc.findall('//{http://www.loc.gov/mods/v3}identifier')
     return [e.text for e in elements if e.text is not None]
+
+def extract_identifier_from_islandora(islandora_path):
+    """
+    Parse an Islandora identifier from a METS file.
+
+    This typically occurs when using the FEDORA deposit storage service space.
+
+    :return: List of identifiers, possibly empty.
+    """
+    tree = etree.parse(islandora_path)
+    root = tree.getroot()
+    objid = root.attrib.get('OBJID')
+    return [objid] if objid else []

--- a/src/archivematicaCommon/lib/identifier_functions.py
+++ b/src/archivematicaCommon/lib/identifier_functions.py
@@ -1,6 +1,18 @@
+# -*- coding: UTF-8 -*-
+"""
+Functions to fetch identifiers for indexing in ElasticSearch.
+
+See also src/MCPClient/lib/clientScripts/indexAIP.py where these are used.
+"""
+
 from lxml import etree
 
 def extract_identifiers_from_mods(mods_path):
+    """
+    Parse MODS identifiers from a MODS file.
+
+    :return: List of identifiers, possibly empty.
+    """
     doc = etree.parse(mods_path)
     elements = doc.findall('//{http://www.loc.gov/mods/v3}identifier')
-    return [e.text for e in elements]
+    return [e.text for e in elements if e.text is not None]

--- a/src/archivematicaCommon/tests/fixtures/test-identifiers-MODS-METS.xml
+++ b/src/archivematicaCommon/tests/fixtures/test-identifiers-MODS-METS.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <titleInfo>
+    <title>Yamani Weapons</title>
+  </titleInfo>
+  <name>
+    <namePart>Keladry of Mindelan</namePart>
+    <role>
+      <roleTerm type="text">Provenance</roleTerm>
+    </role>
+  </name>
+  <name xmlns="">
+    <marker />
+    <namePart type="personal">Yuki</namePart>
+    <role>
+      <roleTerm type="text" />
+    </role>
+  </name>
+  <name xmlns="">
+    <marker />
+    <namePart type="personal">雪</namePart>
+    <role>
+      <roleTerm type="text" />
+    </role>
+  </name>
+  <identifier xmlns="" type="filename">F_374_18</identifier>
+  <identifier type="local">28475</identifier>
+  <identifier type="fonds">Yamani</identifier>
+  <identifier type="series" />
+  <identifier type="file">Glaive 18</identifier>
+  <identifier type="uri">http://archives.tortall.gov/yamani/permalink/28475</identifier>
+  <accessCondition type="copyrightHolder">Public domain</accessCondition>
+  <accessCondition type="copyrightExpiry" />
+  <accessCondition type="otherReproductionTerms">Researchers must contact the Royal University in Corus, Tortall for permission to use or reproduce.</accessCondition>
+  <accessCondition type="accessRestrictions">There are no restrictions on access.</accessCondition>
+  <note type="originalLocation">Yamani Islands</note>
+  <note type="otherFormats" />
+  <note type="language" />
+  <note type="numbering" />
+  <note type="gennote"></note>
+  <classification authority="digitalproject">Yamani</classification>
+  <subject>
+    <topic xmlns="" authority="aboriginalSubject">Weapons</topic>
+  </subject>
+  <language>
+    <languageTerm type="text" />
+  </language>
+  <genre type="grouping">Archival</genre>
+  <originInfo xmlns="">
+    <dateCreated>400-450</dateCreated>
+    <dateRange encoding="iso-8601"></dateRange>
+  </originInfo>
+  <typeOfResource>Photographs</typeOfResource>
+  <physicalDescription xmlns="">
+    <extent>one photograph</extent>
+    <note type="otherdetails">b&amp;w</note>
+    <note type="dimensions">16 cm x 10 cm</note>
+  </physicalDescription>
+  <abstract type="biohist"></abstract>
+  <abstract type="scopecontent"></abstract>
+  <location>
+    <physicalLocation />
+  </location>
+  <language>
+    <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+  </language>
+</mods>
+

--- a/src/archivematicaCommon/tests/fixtures/test-identifiers-islandora-METS.xml
+++ b/src/archivematicaCommon/tests/fixtures/test-identifiers-islandora-METS.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<METS:mets xmlns:METS="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" EXT_VERSION="1.1" OBJID="yamani:12" LABEL="Yamani Glaive" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.fedora.info/definitions/1/0/mets-fedora-ext1-1.xsd">
+  <METS:metsHdr CREATEDATE="2014-06-20T17:53:07.649Z" LASTMODDATE="2015-02-19T22:29:29.205Z" RECORDSTATUS="Active">
+    <METS:agent ROLE="IPOWNER">
+      <METS:name>fedoraAdmin</METS:name>
+    </METS:agent>
+  </METS:metsHdr>
+  <METS:amdSec ID="AUDIT" STATUS="A" VERSIONABLE="false">
+    <METS:digiprovMD ID="AUDIT.0" CREATED="2014-06-20T17:53:07.649Z">
+      <METS:mdWrap MIMETYPE="text/xml" MDTYPE="OTHER" OTHERMDTYPE="FEDORA-AUDIT" LABEL="Audit Trail for this object" FORMAT_URI="info:fedora/fedora-system:format/xml.fedora.audit">
+        <METS:xmlData>
+          <audit:auditTrail xmlns:audit="info:fedora/fedora-system:def/audit#">
+            <audit:record ID="AUDREC1">
+              <audit:process type="Fedora API-M" />
+              <audit:action>addDatastream</audit:action>
+              <audit:componentID>TN</audit:componentID>
+              <audit:responsibility>fedoraAdmin</audit:responsibility>
+              <audit:date>2014-06-20T17:53:37.872Z</audit:date>
+              <audit:justification>Copied datastream from yamani:12.</audit:justification>
+            </audit:record>
+            <audit:record ID="AUDREC2">
+              <audit:process type="Fedora API-M" />
+              <audit:action>addDatastream</audit:action>
+              <audit:componentID>MEDIUM_SIZE</audit:componentID>
+              <audit:responsibility>fedoraAdmin</audit:responsibility>
+              <audit:date>2014-06-20T17:53:38.082Z</audit:date>
+              <audit:justification>Copied datastream from yamani:12.</audit:justification>
+            </audit:record>
+            <audit:record ID="AUDREC3">
+              <audit:process type="Fedora API-M" />
+              <audit:action>modifyDatastreamByValue</audit:action>
+              <audit:componentID>RELS-EXT</audit:componentID>
+              <audit:responsibility>fedoraAdmin</audit:responsibility>
+              <audit:date>2014-07-31T23:27:59.412Z</audit:date>
+              <audit:justification />
+            </audit:record>
+            <audit:record ID="AUDREC4">
+              <audit:process type="Fedora API-M" />
+              <audit:action>modifyDatastreamByValue</audit:action>
+              <audit:componentID>RELS-EXT</audit:componentID>
+              <audit:responsibility>fedoraAdmin</audit:responsibility>
+              <audit:date>2015-02-19T20:58:15.951Z</audit:date>
+              <audit:justification />
+            </audit:record>
+            <audit:record ID="AUDREC5">
+              <audit:process type="Fedora API-M" />
+              <audit:action>addDatastream</audit:action>
+              <audit:componentID>RELS-INT</audit:componentID>
+              <audit:responsibility>fedoraAdmin</audit:responsibility>
+              <audit:date>2015-02-19T20:59:11.459Z</audit:date>
+              <audit:justification>Copied datastream from yamani:12.</audit:justification>
+            </audit:record>
+            <audit:record ID="AUDREC6">
+              <audit:process type="Fedora API-M" />
+              <audit:action>modifyDatastreamByValue</audit:action>
+              <audit:componentID>RELS-EXT</audit:componentID>
+              <audit:responsibility>fedoraAdmin</audit:responsibility>
+              <audit:date>2015-02-19T22:29:29.205Z</audit:date>
+              <audit:justification />
+            </audit:record>
+          </audit:auditTrail>
+        </METS:xmlData>
+      </METS:mdWrap>
+    </METS:digiprovMD>
+  </METS:amdSec>
+  <METS:amdSec ID="RELS-EXT" STATUS="A" VERSIONABLE="true">
+    <METS:techMD ID="RELS-EXT.0" CREATED="2014-06-20T17:53:07.663Z">
+      <METS:mdWrap MIMETYPE="application/rdf+xml" MDTYPE="OTHER" OTHERMDTYPE="UNSPECIFIED" LABEL="Fedora Object to Object Relationship Metadata." FORMAT_URI="info:fedora/fedora-system:FedoraRELSExt-1.0">
+        <METS:xmlData>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:islandora="http://islandora.ca/ontology/relsext#">
+            <rdf:Description rdf:about="info:fedora/yamani:12">
+              <fedora-model:hasModel rdf:resource="info:fedora/islandora:sp_basic_image" />
+              <fedora:isMemberOfCollection rdf:resource="info:fedora/yamani:images" />
+            </rdf:Description>
+          </rdf:RDF>
+        </METS:xmlData>
+      </METS:mdWrap>
+    </METS:techMD>
+    <METS:techMD ID="RELS-EXT.1" CREATED="2014-07-31T23:27:59.412Z">
+      <METS:mdWrap MIMETYPE="application/rdf+xml" MDTYPE="OTHER" OTHERMDTYPE="UNSPECIFIED" LABEL="Fedora Object to Object Relationship Metadata." FORMAT_URI="info:fedora/fedora-system:FedoraRELSExt-1.0">
+        <METS:xmlData>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:islandora="http://islandora.ca/ontology/relsext#">
+            <rdf:Description rdf:about="info:fedora/yamani:12">
+              <fedora-model:hasModel rdf:resource="info:fedora/islandora:sp_basic_image" />
+              <fedora:isMemberOfCollection rdf:resource="info:fedora/yamani:images" />
+              <edit_media xmlns="http://islandora.ca/archivematica#" rdf:resource="http://142.103.97.135:8000/api/v1/file/d4395054-f752-445e-9aa9-08592641c561/sword/media/" />
+            </rdf:Description>
+          </rdf:RDF>
+        </METS:xmlData>
+      </METS:mdWrap>
+    </METS:techMD>
+    <METS:techMD ID="RELS-EXT.2" CREATED="2015-02-19T20:58:15.951Z">
+      <METS:mdWrap MIMETYPE="application/rdf+xml" MDTYPE="OTHER" OTHERMDTYPE="UNSPECIFIED" LABEL="Fedora Object to Object Relationship Metadata." FORMAT_URI="info:fedora/fedora-system:FedoraRELSExt-1.0">
+        <METS:xmlData>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:islandora="http://islandora.ca/ontology/relsext#">
+            <rdf:Description rdf:about="info:fedora/yamani:12">
+              <fedora-model:hasModel rdf:resource="info:fedora/islandora:sp_basic_image" />
+              <fedora:isMemberOfCollection rdf:resource="info:fedora/yamani:images" />
+              <edit_media xmlns="http://islandora.ca/archivematica#" rdf:resource="http://142.103.97.135:8000/api/v1/file/c9f21bf0-45a8-4cc0-8220-27ce48efca2f/sword/media/" />
+            </rdf:Description>
+          </rdf:RDF>
+        </METS:xmlData>
+      </METS:mdWrap>
+    </METS:techMD>
+    <METS:techMD ID="RELS-EXT.3" CREATED="2015-02-19T22:29:29.205Z">
+      <METS:mdWrap MIMETYPE="application/rdf+xml" MDTYPE="OTHER" OTHERMDTYPE="UNSPECIFIED" LABEL="Fedora Object to Object Relationship Metadata." FORMAT_URI="info:fedora/fedora-system:FedoraRELSExt-1.0">
+        <METS:xmlData>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:islandora="http://islandora.ca/ontology/relsext#">
+            <rdf:Description rdf:about="info:fedora/yamani:12">
+              <fedora-model:hasModel rdf:resource="info:fedora/islandora:sp_basic_image" />
+              <fedora:isMemberOfCollection rdf:resource="info:fedora/yamani:images" />
+              <edit_media xmlns="http://islandora.ca/archivematica#" rdf:resource="http://142.103.97.135:8000/api/v1/file/31cfcbef-ddbd-4e56-ad7e-2c74e95d2159/sword/media/" />
+            </rdf:Description>
+          </rdf:RDF>
+        </METS:xmlData>
+      </METS:mdWrap>
+    </METS:techMD>
+  </METS:amdSec>
+  <METS:amdSec ID="DC" STATUS="A" VERSIONABLE="true">
+    <METS:techMD ID="DC.0" CREATED="2014-06-20T17:53:07.666Z">
+      <METS:mdWrap MIMETYPE="text/xml" MDTYPE="OTHER" OTHERMDTYPE="UNSPECIFIED" LABEL="DC Record">
+        <METS:xmlData>
+          <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+            <dc:identifier>yamani:12</dc:identifier>
+          </oai_dc:dc>
+        </METS:xmlData>
+      </METS:mdWrap>
+    </METS:techMD>
+  </METS:amdSec>
+  <METS:amdSec ID="RELS-INT" STATUS="A" VERSIONABLE="true">
+    <METS:techMD ID="RELS-INT.0" CREATED="2015-02-19T20:59:11.459Z">
+      <METS:mdWrap MIMETYPE="application/rdf+xml" MDTYPE="OTHER" OTHERMDTYPE="UNSPECIFIED" LABEL="Fedora Relationship Metadata." FORMAT_URI="info:fedora/fedora-system:FedoraRELSExt-1.0">
+        <METS:xmlData>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:islandora="http://islandora.ca/ontology/relsint#">
+            <rdf:Description rdf:about="info:fedora/yamani:12/OBJ">
+              <isReadyForDeletion xmlns="http://islandora.ca/archivematica#">TRUE</isReadyForDeletion>
+            </rdf:Description>
+          </rdf:RDF>
+        </METS:xmlData>
+      </METS:mdWrap>
+    </METS:techMD>
+  </METS:amdSec>
+  <METS:fileSec>
+    <METS:fileGrp ID="DATASTREAMS">
+      <METS:fileGrp ID="MODS" STATUS="A" VERSIONABLE="true">
+        <METS:file ID="MODS.0" CREATED="2014-06-20T17:53:07.663Z" MIMETYPE="text/xml" SIZE="5195" OWNERID="M">
+          <METS:FLocat xlink:title="MODS Record" LOCTYPE="URL" xlink:href="http://localhost:8080/fedora/get/yamani:12/MODS/2014-06-20T17:53:07.663Z" />
+        </METS:file>
+      </METS:fileGrp>
+      <METS:fileGrp ID="OBJ" STATUS="A" VERSIONABLE="true">
+        <METS:file ID="OBJ.0" CREATED="2014-06-20T17:53:07.666Z" MIMETYPE="image/jpeg" SIZE="35931" OWNERID="M">
+          <METS:FLocat xlink:title="OBJ datastream" LOCTYPE="URL" xlink:href="http://localhost:8080/fedora/get/yamani:12/OBJ/2014-06-20T17:53:07.666Z" />
+        </METS:file>
+      </METS:fileGrp>
+      <METS:fileGrp ID="TN" STATUS="A" VERSIONABLE="true">
+        <METS:file ID="TN.0" CREATED="2014-06-20T17:53:37.872Z" MIMETYPE="image/jpeg" SIZE="15876" OWNERID="M">
+          <METS:FLocat xlink:title="TN" LOCTYPE="URL" xlink:href="http://localhost:8080/fedora/get/yamani:12/TN/2014-06-20T17:53:37.872Z" />
+        </METS:file>
+      </METS:fileGrp>
+      <METS:fileGrp ID="MEDIUM_SIZE" STATUS="A" VERSIONABLE="true">
+        <METS:file ID="MEDIUM_SIZE.0" CREATED="2014-06-20T17:53:38.082Z" MIMETYPE="image/jpeg" SIZE="47005" OWNERID="M">
+          <METS:FLocat xlink:title="MEDIUM_SIZE" LOCTYPE="URL" xlink:href="http://localhost:8080/fedora/get/yamani:12/MEDIUM_SIZE/2014-06-20T17:53:38.082Z" />
+        </METS:file>
+      </METS:fileGrp>
+    </METS:fileGrp>
+  </METS:fileSec>
+</METS:mets>

--- a/src/archivematicaCommon/tests/test_identifier_functions.py
+++ b/src/archivematicaCommon/tests/test_identifier_functions.py
@@ -19,3 +19,13 @@ class TestIdentifierFunctions(unittest.TestCase):
         assert 'Yamani' in identifiers
         assert 'Glaive 18' in identifiers
         assert 'http://archives.tortall.gov/yamani/permalink/28475' in identifiers
+
+    def test_islandora(self):
+        """It should return the object ID."""
+        path = os.path.join(FIXTURES_DIR, 'test-identifiers-islandora-METS.xml')
+        assert identifier_functions.extract_identifier_from_islandora(path) == ['yamani:12']
+
+    def test_islandora_no_id(self):
+        """It should return an empty list."""
+        path = os.path.join(FIXTURES_DIR, 'test-identifiers-MODS-METS.xml')  # Any XML with no OBJID
+        assert identifier_functions.extract_identifier_from_islandora(path) == []

--- a/src/archivematicaCommon/tests/test_identifier_functions.py
+++ b/src/archivematicaCommon/tests/test_identifier_functions.py
@@ -1,0 +1,21 @@
+# -*- coding: UTF-8 -*-
+import os
+import unittest
+
+import identifier_functions
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+FIXTURES_DIR = os.path.join(THIS_DIR, 'fixtures')
+
+class TestIdentifierFunctions(unittest.TestCase):
+    """Test extracting additional identifiers for indexing."""
+
+    def test_mods(self):
+        """It should return all identifiers."""
+        path = os.path.join(FIXTURES_DIR, 'test-identifiers-MODS-METS.xml')
+        identifiers = identifier_functions.extract_identifiers_from_mods(path)
+        assert len(identifiers) == 4
+        assert '28475' in identifiers
+        assert 'Yamani' in identifiers
+        assert 'Glaive 18' in identifiers
+        assert 'http://archives.tortall.gov/yamani/permalink/28475' in identifiers

--- a/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
+++ b/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
@@ -65,6 +65,7 @@ $(document).ready(function() {
     'fileExtension': 'File extension',
     'AIPUUID': 'AIP UUID',
     'sipName': 'AIP name',
+    'identifiers': 'Identifiers',
     'isPartOf': 'Part of AIC',
     'AICID': 'AIC Identifier',
     'transferMetadata': 'Transfer metadata',


### PR DESCRIPTION
Add the Islandora identifier to the list of identifiers specifically indexed.

This usually happens when using the FEDORA Space in the storage service, which accepts a METS POSTed to it (usually from Islandora).  The METS is parsed and the files listed are fetched, then sent to Archivematica.  The METS originally posted has an OBJID that is the Islandora identifier, that needs to be indexed.

Also, added tests for the identifiers section of code.  Fixtures can be trimmed to a more minimal example if requested.

This will also need to be committed to qa/1.x
