### PR TITLE
Upgrade to Django 1.8

### DIFF
--- a/src/archivematicaCommon/lib/utilities/FPRClient/client.py
+++ b/src/archivematicaCommon/lib/utilities/FPRClient/client.py
@@ -61,8 +61,9 @@ class FPRClient(object):
             fields['format'] = fields.pop('fmt')
 
         # Only keep fields that are in the model
+        model_field_names = [f.name for f in model._meta.get_fields()]
         valid_fields = {k: v for k, v in fields.iteritems()
-                        if k in model._meta.get_all_field_names()}
+                        if k in model_field_names}
 
         # Convert foreign keys from URIs to just UUIDs
         for field, value in valid_fields.iteritems():
@@ -134,8 +135,8 @@ class FPRClient(object):
         for table, resource in resources:
             print 'resource:', resource
             try:
-                table._meta.get_field_by_name('lastmodified')
-            except django.db.models.fields.FieldDoesNotExist:
+                table._meta.get_field('lastmodified')
+            except django.core.exceptions.FieldDoesNotExist:
                 start_at = None
             else:
                 start_at = maxLastUpdateAtStart

--- a/src/dashboard/src/components/access/urls.py
+++ b/src/dashboard/src/components/access/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from components.access import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'(?P<system>archivesspace|atk)/$', views.all_records),
     url(r'(?P<system>archivesspace|atk)/levels/$', views.get_levels_of_description),
     url(r'(?P<system>archivesspace|atk)/(?P<record_id>[A-Za-z0-9-_]+)/$', views.record),
@@ -14,4 +14,4 @@ urlpatterns = patterns('',
     url(r'(?P<system>archivesspace|atk)/(?P<record_id>.+)/children/$', views.record_children),
     # this API exists only for ArchivesSpace, not ATK
     url(r'archivesspace/(?P<record_id>.+)/digital_object_components/$', views.digital_object_components, {'system': 'archivesspace'}),
-)
+]

--- a/src/dashboard/src/components/accounts/urls.py
+++ b/src/dashboard/src/components/accounts/urls.py
@@ -15,20 +15,20 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 import django.contrib.auth.views
 from components.accounts import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', views.list),
     url(r'add/$', views.add),
     url(r'(?P<id>\d+)/delete/$', views.delete),
     url(r'(?P<id>\d+)/edit/$', views.edit),
     url(r'profile/$', views.edit),
     url(r'list/$', views.list)
-)
+]
 
-urlpatterns += patterns('',
+urlpatterns += [
     url(r'login/$', django.contrib.auth.views.login, { 'template_name': 'accounts/login.html' }),
     url(r'logout/$', django.contrib.auth.views.logout_then_login)
-)
+]

--- a/src/dashboard/src/components/administration/urls.py
+++ b/src/dashboard/src/components/administration/urls.py
@@ -15,12 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.conf import settings
 from components.administration import views
 from components.administration import views_processing
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', views.administration),
     url(r'reports/failures/delete/(?P<report_id>\w+)/$', views.failure_report_delete),
     url(r'reports/failures/(?P<report_id>\w+)/$', views.failure_report),
@@ -45,4 +45,4 @@ urlpatterns = patterns('',
     url(r'taxonomy/term/(?P<term_uuid>' + settings.UUID_REGEX + ')/delete/$', views.term_delete),
     url(r'taxonomy/(?P<taxonomy_uuid>' + settings.UUID_REGEX + ')/$', views.terms),
     url(r'taxonomy/$', views.taxonomy),
-)
+]

--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -15,12 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.conf import settings
 
 from components.api import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'transfer/approve', views.approve_transfer),
     url(r'transfer/unapproved', views.unapproved_transfers),
     url(r'transfer/status/(?P<unit_uuid>' + settings.UUID_REGEX + ')', views.status, {'unit_type': 'unitTransfer'}),
@@ -36,4 +36,4 @@ urlpatterns = patterns('',
     url(r'filesystem/metadata/$', views.path_metadata),
 
     url(r'processing-configuration/(?P<name>\w{1,16})', views.processing_configuration),
-)
+]

--- a/src/dashboard/src/components/appraisal/urls.py
+++ b/src/dashboard/src/components/appraisal/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from components.appraisal import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', views.appraisal, name='appraisal_index')
-)
+]

--- a/src/dashboard/src/components/archival_storage/urls.py
+++ b/src/dashboard/src/components/archival_storage/urls.py
@@ -15,12 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.conf import settings
 from components.archival_storage import views
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/$', views.view_aip, name='view_aip'),
     url(r'^download/aip/file/(?P<uuid>' + settings.UUID_REGEX + ')/$', views.aip_file_download),
     url(r'^download/aip/(?P<uuid>' + settings.UUID_REGEX + ')/pointer_file/$', views.aip_pointer_file_download),
@@ -31,4 +31,4 @@ urlpatterns = patterns('',
     url(r'^search/$', views.search, name='archival_storage_search'),
     url(r'^thumbnail/(?P<fileuuid>' + settings.UUID_REGEX + ')/$', views.send_thumbnail),
     url(r'^$', views.overview, name='archival_storage_index')
-)
+]

--- a/src/dashboard/src/components/backlog/urls.py
+++ b/src/dashboard/src/components/backlog/urls.py
@@ -15,15 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.conf import settings
 from components.backlog import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', views.execute, name='backlog_index'),
     url(r'search/$', views.search, name='backlog_search'),
     url(r'delete/(?P<uuid>' + settings.UUID_REGEX + ')/$', views.delete, name='backlog_delete'),
     url(r'download/(?P<uuid>' + settings.UUID_REGEX + ')/$', views.download, name='backlog_download'),
-
-)
+]

--- a/src/dashboard/src/components/file/urls.py
+++ b/src/dashboard/src/components/file/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.conf import settings
 from components.file import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'(?P<fileuuid>' + settings.UUID_REGEX + ')/$', views.file_details),
     url(r'(?P<fileuuid>' + settings.UUID_REGEX + ')/tags/$', views.TransferFileTags.as_view()),
     url(r'(?P<fileuuid>' + settings.UUID_REGEX + ')/bulk_extractor/$', views.bulk_extractor),
-)
+]

--- a/src/dashboard/src/components/filesystem_ajax/urls.py
+++ b/src/dashboard/src/components/filesystem_ajax/urls.py
@@ -15,11 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.conf import settings
 from components.filesystem_ajax import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^download_ss/$', views.download_ss),
     url(r'^download_fs/$', views.download_fs),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/download/$', views.download_by_uuid),
@@ -32,4 +32,4 @@ urlpatterns = patterns('',
     url(r'^transfer/$', views.start_transfer_logged_in),
     url(r'^copy_from_arrange/$', views.copy_from_arrange_to_completed),
     url(r'^copy_metadata_files/$', views.copy_metadata_files),
-)
+]

--- a/src/dashboard/src/components/ingest/urls.py
+++ b/src/dashboard/src/components/ingest/urls.py
@@ -15,13 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.conf import settings
 from components.ingest import views
 from components.ingest import views_atk
 from components.ingest import views_as
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', views.ingest_grid,
         name='ingest_index'),
     url(r'^sips/$', views.SipsView.as_view()),
@@ -42,10 +42,10 @@ urlpatterns = patterns('',
     url(r'^backlog/file/download/(?P<uuid>' + settings.UUID_REGEX + ')/', views.transfer_file_download),
     url(r'^backlog/$', views.transfer_backlog, {'ui': 'legacy'}),
     url(r'^appraisal_list/$', views.transfer_backlog, {'ui': 'appraisal'}),
-)
+]
 
 # Archivists Toolkit
-urlpatterns += patterns('',
+urlpatterns += [
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/atk/match/resource/(?P<resource_id>\d+)/$', views_atk.ingest_upload_atk_match_dip_objects_to_resource_levels),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/atk/match/resourcecomponent/(?P<resource_component_id>\d+)/$', views_atk.ingest_upload_atk_match_dip_objects_to_resource_component_levels),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/atk/resource/(?P<resource_id>\d+)/$', views_atk.ingest_upload_atk_resource),
@@ -53,10 +53,10 @@ urlpatterns += patterns('',
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/atk/save/$', views_atk.ingest_upload_atk_save),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/atk/reset/$', views_atk.ingest_upload_atk_reset),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/atk/$', views_atk.ingest_upload_atk)
-)
+]
 
 # ArchivesSpace
-urlpatterns = urlpatterns + patterns('components.ingest.views_as',
+urlpatterns += [
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/as/match/resource/(?P<resource_id>.+)/$', views_as.ingest_upload_as_match_dip_objects_to_resource_levels),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/as/match/resourcecomponent/(?P<resource_component_id>.+)/$', views_as.ingest_upload_as_match_dip_objects_to_resource_component_levels),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/as/resource/(?P<resource_id>.+)/$', views_as.ingest_upload_as_resource),
@@ -66,4 +66,4 @@ urlpatterns = urlpatterns + patterns('components.ingest.views_as',
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/as/reset/$', views_as.ingest_upload_as_reset),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/as/review/$', views_as.ingest_upload_as_review_matches),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/as/$', views_as.ingest_upload_as)
-)
+]

--- a/src/dashboard/src/components/mcp/urls.py
+++ b/src/dashboard/src/components/mcp/urls.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from components.mcp import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'execute/$', views.execute),
     url(r'list/$', views.list),
-)
+]

--- a/src/dashboard/src/components/rights/ingest_urls.py
+++ b/src/dashboard/src/components/rights/ingest_urls.py
@@ -15,14 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from components.rights import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', views.ingest_rights_list),
     url(r'^add/$', views.ingest_rights_edit),
     url(r'^delete/(?P<id>\d+)/$', views.ingest_rights_delete),
     url(r'^grants/(?P<id>\d+)/delete/$', views.ingest_rights_grant_delete),
     url(r'^grants/(?P<id>\d+)/$', views.ingest_rights_grants_edit),
     url(r'^(?P<id>\d+)/$', views.ingest_rights_edit)
-)
+]

--- a/src/dashboard/src/components/rights/transfer_urls.py
+++ b/src/dashboard/src/components/rights/transfer_urls.py
@@ -15,14 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from components.rights import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', views.transfer_rights_list),
     url(r'^add/$', views.transfer_rights_edit),
     url(r'^delete/(?P<id>\d+)/$', views.transfer_rights_delete),
     url(r'^grants/(?P<id>\d+)/delete/$', views.transfer_rights_grant_delete),
     url(r'^grants/(?P<id>\d+)/$', views.transfer_rights_grants_edit),
     url(r'^(?P<id>\d+)/$', views.transfer_rights_edit)
-)
+]

--- a/src/dashboard/src/components/transfer/urls.py
+++ b/src/dashboard/src/components/transfer/urls.py
@@ -15,11 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.conf import settings
 from components.transfer import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', views.grid),
 
     # Transfer metadata set functions
@@ -34,4 +34,4 @@ urlpatterns = patterns('',
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/metadata/$', views.transfer_metadata_list),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/metadata/add/$', views.transfer_metadata_edit),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/metadata/(?P<id>\d+)/$', views.transfer_metadata_edit),
-)
+]

--- a/src/dashboard/src/components/unit/urls.py
+++ b/src/dashboard/src/components/unit/urls.py
@@ -15,14 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.conf import settings
 from components.unit import views
 
 # The first segment of these urls is '^(?P<unit_type>transfer|ingest)/'
 # All views should expect a first parameter of unit_type, with a value of 'transfer' or 'ingest'
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^(?P<unit_uuid>' + settings.UUID_REGEX + ')/$', views.detail),
     url(r'^(?P<unit_uuid>' + settings.UUID_REGEX + ')/microservices/$', views.microservices),
     url(r'^(?P<unit_uuid>' + settings.UUID_REGEX + ')/delete/$', views.mark_hidden),
-)
+]

--- a/src/dashboard/src/installer/urls.py
+++ b/src/dashboard/src/installer/urls.py
@@ -15,13 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from installer import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'welcome/$', views.welcome),
     url(r'fprconnect/$', views.fprconnect),
     url(r'fprupload/$', views.fprupload),
     url(r'fprdownload/$', views.fprdownload),
     url(r'storagesetup/$', views.storagesetup),
-)
+]

--- a/src/dashboard/src/main/urls.py
+++ b/src/dashboard/src/main/urls.py
@@ -15,11 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.conf import settings
 from main import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     # Index
     url(r'^$', views.home),
 
@@ -40,4 +40,4 @@ urlpatterns = patterns('',
     url(r'status/$', views.status),
     url(r'formdata/(?P<type>\w+)/(?P<parent_id>\d+)/(?P<delete_id>\d+)/$', views.formdata_delete),
     url(r'formdata/(?P<type>\w+)/(?P<parent_id>\d+)/$', views.formdata),
-)
+]

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -1,5 +1,5 @@
 # Base requirements - for all installations
-Django>=1.7,<1.8
+Django>=1.8,<1.9
 django-braces==1.0.0
 django-model-utils==1.3.1
 logutils==0.3.3

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -3,7 +3,7 @@ Django>=1.8,<1.9
 django-braces==1.0.0
 django-model-utils==1.3.1
 logutils==0.3.3
-django-tastypie>=0.12.0
+django-tastypie==0.13.2
 django-extensions==1.1.1
 django-autoslug==1.7.1
 django-annoying==0.7.7

--- a/src/dashboard/src/settings/common.py
+++ b/src/dashboard/src/settings/common.py
@@ -25,7 +25,6 @@ BASE_PATH = os.path.abspath(os.path.join(path_of_this_file, os.pardir))
 # Django settings for app project.
 
 DEBUG = False
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@domain.com'),
@@ -113,23 +112,25 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'e7b-$#-3fgu)j1k01)3tp@^e0=yv1hlcc4k-b6*ap^zezv2$48'
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-    # 'django.template.loaders.eggs.Loader',
-)
-
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    # 'django.core.context_processors.csrf',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.request',
-    'django.contrib.messages.context_processors.messages',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(BASE_PATH, 'templates'),],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.request',
+                'django.contrib.messages.context_processors.messages',
+            ],
+            'debug': DEBUG,
+        },
+    },
+]
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
@@ -144,13 +145,6 @@ MIDDLEWARE_CLASSES = (
 )
 
 ROOT_URLCONF = 'urls'
-
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    os.path.join(BASE_PATH, 'templates'),
-)
 
 INSTALLED_APPS = (
     # Django basics

--- a/src/dashboard/src/settings/local.py
+++ b/src/dashboard/src/settings/local.py
@@ -18,7 +18,7 @@
 from .common import *
 
 DEBUG = True
-TEMPLATE_DEBUG = True
+TEMPLATES[0]['OPTIONS']['debug'] = True
 FPR_URL = 'https://fpr-qa.archivematica.org/fpr/api/v2/'
 FPR_VERIFY_CERT = False
 

--- a/src/dashboard/src/urls.py
+++ b/src/dashboard/src/urls.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import url, include, patterns
+from django.conf.urls import url, include
 from django.conf import settings
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^mcp/', include('components.mcp.urls')),
     url(r'^installer/', include('installer.urls')),
     url(r'^administration/accounts/', include('components.accounts.urls')),
@@ -37,4 +37,4 @@ urlpatterns = patterns('',
     url(r'^access/', include('components.access.urls')),
     url(r'^backlog/', include('components.backlog.urls')),
     url(r'', include('main.urls'))
-)
+]


### PR DESCRIPTION
Changes to upgrade to Django 1.8
- Use new URLs syntax
- Use new _meta API calls
- Use new TEMPLATES setting
- Update fpr-admin version to fix URLs bug artefactual/archivematica-fpr-admin#24
