### PR TITLE
Dev/issue 9941 unicode directory names

### DIFF
--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -185,6 +185,21 @@ def copy_files(source_location, destination_location, files, api=None):
         'files': files,
         'pipeline': pipeline['resource_uri'],
     }
+
+    # Here we attempt to decode the 'source' attributes of each move-file to
+    # Unicode prior to passing to Slumber's ``post`` method. Slumber will do
+    # this anyway and will choke in certain specific cases, specifically where
+    # the JavaScript of the dashboard has base-64-encoded a Latin-1-encoded
+    # string.
+    for file_ in move_files['files']:
+        try:
+            file_['source'] = file_['source'].decode('utf8')
+        except UnicodeDecodeError:
+            try:
+                file_['source'] = file_['source'].decode('latin-1')
+            except UnicodeError:
+                pass
+
     try:
         ret = api.location(destination_location['uuid']).post(move_files)
     except slumber.exceptions.HttpClientError as e:

--- a/src/dashboard/src/media/js/transfer/component_form.js
+++ b/src/dashboard/src/media/js/transfer/component_form.js
@@ -157,7 +157,16 @@ var TransferComponentFormView = Backbone.View.extend({
         components = {};
       },
       error: function(error) {
-        alert(error.message);
+        // You need to parse the `responseText` if you want the error message
+        // from `filesystem_ajax/views.py`.
+        error = JSON.parse(error.responseText);
+        if (error.message.indexOf("'utf8' codec can't decode byte") !== -1) {
+          alert('Your transfer could not be started, probably because of an' +
+                ' issue related to non-ASCII (e.g., Unicode) characters in' +
+                ' the name of the directory that you are trying to transfer.');
+        } else {
+          alert(error.message);
+        }
       }
     });
     $('.activity-indicator').hide();


### PR DESCRIPTION
This PR fixes fixes a small bug related to non-ASCII characters in directory 
names. I have the following observations related to the issue of non-ASCII
characters in directory names. Observation #3 and the table at the bottom 
describe the bug that the present PR hopefully fixed.
1. Automation-tools' debugger spits out `UnicodeDecodeError` exceptions
     when non-ASCII characters are in the directory names. However, if you run
     automation-tools with Python 3, this does not happen. (Maybe we ought to
     put the advice to use Python 3 in the documentation.)
2. At some point during its processing, Archivematica removes non-ASCII
     characters from the directory names. Unicode combining characters
     (diacritics) are stripped from their base characters. Other Unicode
     characters (I tested the glottal stop character U+0294) are replaced with
     an underscore. In the transfer METS file (in submissionDocumentation/)
     the diacritics are still viewable and the characters in the higher ranges
     appear to be encoded as HTML entities using their code points in decimal,
     e.g., U+0294 is represented as &#660;
3. I noticed a strange discrepancy between the behaviour of AM with respect
     to non-ASCII characters in transfer directory names and whether you use
     the dashboard or the automation tools. With automation tools it always
     works, both for diacritics and for higher-range Unicode characters. With
     the dashboard, higher-range Unicode characters (e.g., U+0294) work, but
     diacritics (e.g., U+0301) do not. The error returned via the JSON is
     "'utf8' codec can't decode byte 0xe9 in position 16: invalid continuation
     byte".

```
+--------------------------------------+
|                  | filés   | filésʔ  |
+--------------------------------------+
| dashboard        | FAIL    | SUCCESS |
+--------------------------------------+
| automation-tools | SUCCESS | SUCCESS |
+--------------------------------------+

```
