### PR TITLE
clientScripts: use python provided by environment

### DIFF
--- a/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
+++ b/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 from __future__ import print_function
 import datetime

--- a/src/MCPServer/debian/control
+++ b/src/MCPServer/debian/control
@@ -19,7 +19,8 @@ Depends:
 	python-mysqldb,
 	python-lxml,
 	gearman,
-	uuid
+	uuid,
+	rsync
 Description: MCP Server for Archivematica
   Workflow manager for Archivematica 
   

--- a/src/dashboard/debian/control
+++ b/src/dashboard/debian/control
@@ -19,7 +19,10 @@ Depends:
 	python-simplejson,
 	libffi-dev,
 	libssl-dev,
-	python-dev
+	python-dev,
+	libxml2-dev,
+	libxslt1-dev,
+	libmysqlclient-dev
 Description: Web Dashboard for Archivematica
   Web based dashboard interface used to control an Archivematica pipeline.
   


### PR DESCRIPTION
In the rpm packages the reingest aip feature doesn't work, due to the use of a different virtualenv for each service. This script was using the python provided by the system, instead of the one from the virtualenv
