### PR TITLE
Models: File.currentlocation & File.originallocation are longblobs

### DIFF
--- a/src/dashboard/src/main/migrations/0018_blob_fields.py
+++ b/src/dashboard/src/main/migrations/0018_blob_fields.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import main.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0017_update_seigfried'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='file',
+            name='currentlocation',
+            field=main.models.BlobTextField(null=True, db_column=b'currentLocation'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='file',
+            name='originallocation',
+            field=main.models.BlobTextField(db_column=b'originalLocation'),
+            preserve_default=True,
+        ),
+    ]

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -53,6 +53,17 @@ class UUIDPkField(UUIDField):
         super(UUIDPkField, self).__init__(*args, **kwargs)
 
 
+class BlobTextField(models.TextField):
+    """
+    Text field backed by `longblob` instead of `longtext`.
+
+    Used for storing strings that need to match unsanitized paths on disk.
+    """
+
+    def db_type(self, connection):
+        return 'longblob'
+
+
 # MODELS
 
 class DashboardSetting(models.Model):
@@ -294,8 +305,8 @@ class File(models.Model):
     sip = models.ForeignKey(SIP, db_column='sipUUID', to_field='uuid', null=True, blank=True)
     transfer = models.ForeignKey(Transfer, db_column='transferUUID', to_field='uuid', null=True, blank=True)
     # both actually `longblob` in the database
-    originallocation = models.TextField(db_column='originalLocation')
-    currentlocation = models.TextField(db_column='currentLocation', null=True)
+    originallocation = BlobTextField(db_column='originalLocation')
+    currentlocation = BlobTextField(db_column='currentLocation', null=True)
     filegrpuse = models.CharField(max_length=50, db_column='fileGrpUse', default='Original')
     filegrpuuid = models.CharField(max_length=36L, db_column='fileGrpUUID', blank=True)
     checksum = models.CharField(max_length=100, db_column='checksum', blank=True)


### PR DESCRIPTION
Pre-migrations, File paths were stored as blobs so they correctly matched paths on disk in the MCPServer. However, TextFields are represented as longtext, which broke that behaviour. Reverting to longblob in the database.

This may not be the approach we take in 1.6.
