### PR TITLE
requirements.txt: Make names & contents more consistent

### DIFF
--- a/src/MCPClient/requirements/dev.txt
+++ b/src/MCPClient/requirements/dev.txt
@@ -1,0 +1,1 @@
+-r test.txt

--- a/src/MCPClient/requirements/test.txt
+++ b/src/MCPClient/requirements/test.txt
@@ -1,1 +1,5 @@
 -r base.txt
+
+pytest>=2,<3
+pytest-django>=2,<3
+pytest-pythonpath

--- a/src/MCPServer/requirements/dev.txt
+++ b/src/MCPServer/requirements/dev.txt
@@ -1,0 +1,1 @@
+-r test.txt

--- a/src/MCPServer/requirements/test.txt
+++ b/src/MCPServer/requirements/test.txt
@@ -1,1 +1,5 @@
 -r base.txt
+
+pytest>=2,<3
+pytest-django>=2,<3
+pytest-pythonpath

--- a/src/archivematicaCommon/requirements/dev.txt
+++ b/src/archivematicaCommon/requirements/dev.txt
@@ -1,0 +1,1 @@
+-r test.txt

--- a/src/archivematicaCommon/requirements/test.txt
+++ b/src/archivematicaCommon/requirements/test.txt
@@ -2,5 +2,5 @@
 
 pytest>=2,<3
 pytest-django>=2,<3
-vcrpy>=1,<2
 pytest-pythonpath
+vcrpy>=1,<2

--- a/src/dashboard/src/requirements/dev.txt
+++ b/src/dashboard/src/requirements/dev.txt
@@ -1,0 +1,3 @@
+-r test.txt
+
+ipython

--- a/src/dashboard/src/requirements/test.txt
+++ b/src/dashboard/src/requirements/test.txt
@@ -1,7 +1,6 @@
 -r base.txt
 
-ipython
 pytest>=2,<3
 pytest-django>=2,<3
-vcrpy>=1,<2
 pytest-pythonpath
+vcrpy>=1,<2


### PR DESCRIPTION
For every project, have a base.txt, test.txt and dev.txt. base.txt contains dependencies required to run the project, test.txt has the testing dependencies, and dev.txt has anything that makes development easier. dev.txt includes test.txt which includes base.txt.

This should also make it easier to update the ansible role to install dev.txt or test.txt when not in production.

I'm not sure if it makes sense to separate put the test.txt dependencies in base.txt (since you should always be able to run tests), or perhaps dev.txt in test.txt (since there's few dev-only non-testing dependencies).
