### PR TITLE
Requirements: use https instead of git transport

### DIFF
--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -4,4 +4,4 @@ elasticsearch>=1.0.0,<2.0.0
 requests==2.7.0
 python-dateutil==2.4.2
 django-mysqlpool
-git+git://github.com/artefactual-labs/agentarchives.git#egg=agentarchives
+git+https://github.com/artefactual-labs/agentarchives.git#egg=agentarchives

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -11,8 +11,8 @@ elasticsearch>=1.0.0,<2.0.0
 gearman==2.0.2
 gunicorn==19.4.5
 lazy-paged-sequence
-git+git://github.com/artefactual-labs/agentarchives.git#egg=agentarchives
-git+git://github.com/artefactual-labs/mets-reader-writer#egg=metsrw
+git+https://github.com/artefactual-labs/agentarchives.git#egg=agentarchives
+git+https://github.com/artefactual-labs/mets-reader-writer#egg=metsrw
 mysqlclient==1.3.7
 # Required by storage-service component
 slumber==0.6.0


### PR DESCRIPTION
Avoid potential issues with corporate firewalls.
