### PR TITLE
Template: Fix error message styling

### DIFF
--- a/src/dashboard/src/templates/_messages.html
+++ b/src/dashboard/src/templates/_messages.html
@@ -1,3 +1,3 @@
 {% for message in messages %}
-  <div class='alert alert-{{ message.tags }}'>{{ message|safe }}</div>
+  <div class='alert alert-{{ message.tags }} {% if "error" in message.tags %}alert-danger{% endif %}'>{{ message|safe }}</div>
 {% endfor %}


### PR DESCRIPTION
Bootstrap renamed alert-error to alert-danger.  Add a conditional to style error messages correctly.

Related to #488 
