### PR TITLE
Decode Task stderr to Unicode prior to db save.

### DIFF
--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -77,9 +77,17 @@ def unicodeToStr(string):
         string = string.encode("utf-8")
     return string
 
-def strToUnicode(string):
+def strToUnicode(string, obstinate=False):
     if isinstance(string, str):
-        string = string.decode("utf-8")
+        try:
+            string = string.decode('utf8')
+        except UnicodeDecodeError:
+            if obstinate:
+                # Obstinately get a Unicode instance by replacing
+                # indecipherable bytes.
+                string = string.decode('utf8', 'replace')
+            else:
+                raise
     return string
 
 

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -28,6 +28,8 @@ import string
 import sys
 import uuid
 
+from archivematicaFunctions import strToUnicode
+
 sys.path.append("/usr/share/archivematica/dashboard")
 from django.db.models import Q
 from django.utils import timezone
@@ -233,9 +235,13 @@ def logTaskCompletedSQL(task):
     task = Task.objects.get(taskuuid=taskUUID)
     task.endtime = getUTCDate()
     task.exitcode = exitCode
-    task.stdout = stdOut
-    task.stderror = stdError
+    # ``strToUnicode`` here prevents the MCP server from crashing when, e.g.,
+    # stderr contains Latin-1-encoded chars such as \xa9, i.e., the copyright
+    # symbol, cf. #9967.
+    task.stdout = strToUnicode(stdOut, obstinate=True)
+    task.stderror = strToUnicode(stdError, obstinate=True)
     task.save()
+
 
 def logJobCreatedSQL(job):
     """


### PR DESCRIPTION
Fixes bug (cf. #9967) where `logTaskCompletedSQL` in databaseFunctions.py can
receive Latin-1-encoded stderr output (e.g., from GhostScript normalization),
triggering an exception from MySQLdb/Django's ORM. Note: this issue doesn't
arise in newer versions (e.g., qa/1.x), probably because of newer versions of
Django or MySQL-python.
