### PR TITLE
Fixed message when editing taxonomy, refs #10336

### DIFF
--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -396,7 +396,7 @@ def term_detail(request, term_uuid):
         form = TaxonomyTermForm(request.POST, instance=term)
         if form.is_valid():
             form.save()
-            messages = [{'text': _('Saved.')}]
+            messages.info(request, _('Saved.'))
     else:
         form = TaxonomyTermForm(instance=term)
 

--- a/src/dashboard/src/templates/administration/term_detail.html
+++ b/src/dashboard/src/templates/administration/term_detail.html
@@ -31,7 +31,7 @@
       {% include "_form.html" %}
 
       <div style='float: right'>
-        <input class='btn btn-submit' type='submit' value='{% trans "Save" %}' />
+        <input class='btn btn-primary' type='submit' value='{% trans "Save" %}' />
         <a href='/administration/taxonomy/term/{{ term.pk }}/delete/' class='btn btn-danger'>{% trans "Delete" %}</a>
       </div>
       </form>

--- a/src/dashboard/src/templates/administration/term_detail.html
+++ b/src/dashboard/src/templates/administration/term_detail.html
@@ -31,7 +31,7 @@
       {% include "_form.html" %}
 
       <div style='float: right'>
-        <input type='submit' value='{% trans "Save" %}' />
+        <input class='btn btn-submit' type='submit' value='{% trans "Save" %}' />
         <a href='/administration/taxonomy/term/{{ term.pk }}/delete/' class='btn btn-danger'>{% trans "Delete" %}</a>
       </div>
       </form>


### PR DESCRIPTION
Previous to this, editing a Taxonomy would result in a dict literal `{'text': 'Saved.'}` being displayed in the HTML.
