### PR TITLE
Fixes for unicode in transfer names

### DIFF
--- a/src/MCPServer/lib/unit.py
+++ b/src/MCPServer/lib/unit.py
@@ -25,6 +25,8 @@ import logging
 import os
 import sys
 
+import archivematicaFunctions
+
 import archivematicaMCP
 from unitFile import unitFile
 
@@ -60,9 +62,10 @@ class unit:
             else:
                 files = File.objects.filter(sip_id=self.UUID)
             for f in files:
-                if f.currentlocation in self.fileList:
-                    self.fileList[f.currentlocation].UUID = f.uuid
-                    self.fileList[f.currentlocation].fileGrpUse = f.filegrpuse
+                currentlocation = archivematicaFunctions.unicodeToStr(f.currentlocation)
+                if currentlocation in self.fileList:
+                    self.fileList[currentlocation].UUID = f.uuid
+                    self.fileList[currentlocation].fileGrpUse = f.filegrpuse
                 else:
                     LOGGER.warning('%s %s has file (%s) %s in the database, but file does not exist in the file system',
                         self.unitType, self.UUID, f.uuid, f.currentlocation)

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -768,7 +768,7 @@ def copy_from_transfer_sources(paths, relative_destination):
             logger.debug('Location %s is not associated with this pipeline.', location)
             continue
 
-        source = path.replace(files[location]['location']['path'], '', 1).lstrip('/')
+        source = path.replace(files[location]['location']['path'].encode('utf8'), '', 1).lstrip('/')
         # Use the last segment of the path for the destination - basename for a
         # file, or the last folder if not. Keep the trailing / for folders.
         last_segment = os.path.basename(source.rstrip('/')) + '/' if source.endswith('/') else os.path.basename(source)

--- a/src/dashboard/src/media/js/vendor/base64.js
+++ b/src/dashboard/src/media/js/vendor/base64.js
@@ -2,42 +2,13 @@
 
 var Base64 =
 {
-    // Returns true if the passed string consists of codepoints between 0 and 255
-    // which are valid within UTF-8.
-    all_bytes_valid_utf8: function (str) {
-        var invalid_chars = [0xc0, 0xc1, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9,
-                             0xF0, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF];
-
-        for (var i in str) {
-            var cp = str.codePointAt(i);
-            if (cp > 255 || invalid_chars.indexOf(cp) !== -1) {
-                return false
-            }
-        }
-
-        return true;
-    },
-
     // Decodes the string before base64-encoding.
-    encode_escaped: function (str) {
-        return window.btoa(unescape(encodeURIComponent(str)));
-    },
-
-    // If passed string is not UTF-8, decodes to bytes first before encoding.
     encode: function (str) {
-        if (this.all_bytes_valid_utf8(str)) {
-            return window.btoa(str);
-        } else {
-            return this.encode_escaped(str);
-        }
+        return window.btoa(unescape(encodeURIComponent(str)));
     },
 
     // Returns a UTF-8 string if input is UTF-8, raw bytes otherwise.
     decode: function (str) {
-        try {
-            return decodeURIComponent(escape(window.atob(str)));
-        } catch (URIError) {
-            return window.atob(str);
-        }
+        return decodeURIComponent(escape(window.atob(str)));
     }
 };

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -15,7 +15,7 @@ git+https://github.com/artefactual-labs/agentarchives.git#egg=agentarchives
 git+https://github.com/artefactual-labs/mets-reader-writer#egg=metsrw
 mysqlclient==1.3.7
 # Required by storage-service component
-slumber==0.6.0
+slumber
 pytz
 pyopenssl
 python-dateutil==2.4.2


### PR DESCRIPTION
- Upgrade slumber so it doesn't use deprecated simplejson library (Edit: This won't be needed with #550)
- Encode filesystem paths as bytestrings
- In JS, assume strings are unicode and can be utf8 encoded.  Note that this probably removes support for non-unicode transfer names and paths, but needs further testing

refs #9234

Edit:
- Add MCPServer bugfix for unicode (from database) vs str (from disk) paths (Edit: Merged as part of #545)
