### PR TITLE
Look for non-zero exit code, not just > 0

### DIFF
--- a/src/MCPServer/lib/linkTaskManagerFiles.py
+++ b/src/MCPServer/lib/linkTaskManagerFiles.py
@@ -140,7 +140,7 @@ class linkTaskManagerFiles(LinkTaskManager):
             self.jobChainLink.linkProcessingComplete(self.exitCode)
 
     def taskCompletedCallBackFunction(self, task):
-        self.exitCode = max(self.exitCode, task.results["exitCode"])
+        self.exitCode = max(self.exitCode, abs(task.results["exitCode"]))
         databaseFunctions.logTaskCompletedSQL(task)
 
         self.tasksLock.acquire()


### PR DESCRIPTION
Fixes #10354

As suggested by Holly Becker.
This has been tested in a case where some tasks return -1.
