### PR TITLE
Switch to Django persistent connections from django-mysqlpool

### DIFF
--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -50,8 +50,7 @@ from django.conf import settings as django_settings
 
 from main.models import Task
 
-from django_mysqlpool import auto_close_db
-import databaseFunctions
+from databaseFunctions import auto_close_db, getUTCDate
 from executeOrRunSubProcess import executeOrRun
 
 
@@ -90,7 +89,7 @@ def executeCommand(gearman_worker, gearman_job):
         execute = gearman_job.task
         logger.info('Executing %s (%s)', execute, gearman_job.unique)
         data = cPickle.loads(gearman_job.data)
-        utcDate = databaseFunctions.getUTCDate()
+        utcDate = getUTCDate()
         arguments = data["arguments"]  # .encode("utf-8")
         if isinstance(arguments, unicode):
             arguments = arguments.encode("utf-8")

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -51,7 +51,6 @@ CONFIG_MAPPING = {
     'db_password': {'section': 'client', 'option': 'password', 'type': 'string'},
     'db_host': {'section': 'client', 'option': 'host', 'type': 'string'},
     'db_port': {'section': 'client', 'option': 'port', 'type': 'string'},
-    'db_pool_max_overflow': {'section': 'client', 'option': 'max_overflow', 'type': 'string'},
 }
 
 CONFIG_DEFAULTS = """[MCPClient]
@@ -81,9 +80,8 @@ user = archivematica
 password = demo
 host = localhost
 database = MCP
-max_overflow = 40
 port = 3306
-engine = django_mysqlpool.backends.mysqlpool
+engine = django.db.backends.mysql
 """
 
 config = Config(env_prefix='ARCHIVEMATICA_MCPCLIENT', attrs=CONFIG_MAPPING)
@@ -102,16 +100,14 @@ DATABASES = {
         'PASSWORD': config.get('db_password'),
         'HOST': config.get('db_host'),
         'PORT': config.get('db_port'),
+
+        # Recycling connections in MCPClient is not an option because this is
+        # a threaded application. We need a connection pool but we don't have
+        # one we can rely on at the moment - django_mysqlpool does not support
+        # Py3 and seems abandoned.
+        'CONN_MAX_AGE': 0,
     }
 }
-
-MYSQLPOOL_BACKEND = 'QueuePool'
-MYSQLPOOL_ARGUMENTS = {
-    'use_threadlocal': False,
-    'max_overflow': config.get('db_pool_max_overflow'),
-}
-
-CONN_MAX_AGE = 14400
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = config.get('secret_key', default='e7b-$#-3fgu)j1k01)3tp@^e0=yv1hlcc4k-b6*ap^zezv2$48')

--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -3,7 +3,6 @@ bagit==1.5.2
 clamd==1.0.2
 Django>=1.8,<1.9
 django-annoying==0.7.7
-django-mysqlpool==0.1-9
 django-extensions==1.1.1
 mysqlclient==1.3.9
 gearman==2.0.2

--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -60,9 +60,8 @@ from unitTransfer import unitTransfer
 from utils import isUUID
 import RPCServer
 
-from django_mysqlpool import auto_close_db
-import databaseFunctions
 from archivematicaFunctions import unicodeToStr
+from databaseFunctions import auto_close_db, createSIP, getUTCDate
 import dicts
 
 from main.models import Job, SIP, Task, WatchedDirectory
@@ -394,7 +393,7 @@ def findOrCreateSipInDB(path, waitSleep=dbWaitSleep, unit_type='SIP'):
         # Note that if UUID is None here, a new UUID will be generated
         # and returned by the function; otherwise it returns the
         # value that was passed in.
-        UUID = databaseFunctions.createSIP(path, UUID=UUID)
+        UUID = createSIP(path, UUID=UUID)
         logger.info('Creating SIP %s at %s', UUID, path)
     else:
         current_path = sip.currentpath
@@ -512,7 +511,7 @@ def debugMonitor():
     """Periodically prints out status of MCP, including whether the database lock is locked, thread count, etc."""
     global countOfCreateUnitAndJobChainThreaded
     while True:
-        logger.debug('Debug monitor: datetime: %s', databaseFunctions.getUTCDate())
+        logger.debug('Debug monitor: datetime: %s', getUTCDate())
         logger.debug('Debug monitor: thread count: %s', threading.activeCount())
         logger.debug('Debug monitor: created job chain threaded: %s', countOfCreateUnitAndJobChainThreaded)
         time.sleep(3600)

--- a/src/MCPServer/lib/jobChainLink.py
+++ b/src/MCPServer/lib/jobChainLink.py
@@ -35,8 +35,7 @@ from linkTaskManagerGetUserChoiceFromMicroserviceGeneratedList import linkTaskMa
 from linkTaskManagerSetUnitVariable import linkTaskManagerSetUnitVariable
 from linkTaskManagerUnitVariableLinkPull import linkTaskManagerUnitVariableLinkPull
 
-from django_mysqlpool import auto_close_db
-from databaseFunctions import logJobCreatedSQL, getUTCDate
+from databaseFunctions import auto_close_db, logJobCreatedSQL, getUTCDate
 
 from main.models import Job, MicroServiceChainLink, MicroServiceChainLinkExitCode, TaskType
 

--- a/src/MCPServer/lib/linkTaskManagerChoice.py
+++ b/src/MCPServer/lib/linkTaskManagerChoice.py
@@ -35,8 +35,8 @@ from utils import log_exceptions
 choicesAvailableForUnits = {}
 choicesAvailableForUnitsLock = threading.Lock()
 
-from django_mysqlpool import auto_close_db
 from archivematicaFunctions import unicodeToStr
+from databaseFunctions import auto_close_db
 
 from main.models import MicroServiceChainChoice, UserProfile, Job
 from django.conf import settings as django_settings

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -45,7 +45,6 @@ CONFIG_MAPPING = {
     'db_password': {'section': 'client', 'option': 'password', 'type': 'string'},
     'db_host': {'section': 'client', 'option': 'host', 'type': 'string'},
     'db_port': {'section': 'client', 'option': 'port', 'type': 'string'},
-    'db_pool_max_overflow': {'section': 'client', 'option': 'max_overflow', 'type': 'string'},
 }
 
 
@@ -71,9 +70,8 @@ user = archivematica
 password = demo
 host = localhost
 database = MCP
-max_overflow = 40
 port = 3306
-engine = django_mysqlpool.backends.mysqlpool
+engine = django.db.backends.mysql
 """
 
 
@@ -93,16 +91,14 @@ DATABASES = {
         'PASSWORD': config.get('db_password'),
         'HOST': config.get('db_host'),
         'PORT': config.get('db_port'),
+
+        # CONN_MAX_AGE is irrelevant in MCPServer because Django's database
+        # connection reciclyng mechanism is only used in the web context, i.e.
+        # see `signals.request_started` and `signals.request_finished` in
+        # Django's source code.
+        'CONN_MAX_AGE': 0,
     }
 }
-
-MYSQLPOOL_BACKEND = 'QueuePool'
-MYSQLPOOL_ARGUMENTS = {
-    'use_threadlocal': False,
-    'max_overflow': config.get('db_pool_max_overflow'),
-}
-
-CONN_MAX_AGE = 14400
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = config.get('secret_key', default='e7b-$#-3fgu)j1k01)3tp@^e0=yv1hlcc4k-b6*ap^zezv2$48')

--- a/src/MCPServer/lib/taskStandard.py
+++ b/src/MCPServer/lib/taskStandard.py
@@ -34,7 +34,7 @@ from utils import log_exceptions
 from django.conf import settings as django_settings
 from django.utils import timezone
 
-from django_mysqlpool import auto_close_db
+from databaseFunctions import auto_close_db
 from fileOperations import writeToFile
 
 LOGGER = logging.getLogger('archivematica.mcp.server')

--- a/src/MCPServer/lib/watchDirectory.py
+++ b/src/MCPServer/lib/watchDirectory.py
@@ -26,8 +26,8 @@ import os
 import time
 import threading
 
-from django_mysqlpool import auto_close_db
 from archivematicaFunctions import unicodeToStr
+from databaseFunctions import auto_close_db
 
 from utils import log_exceptions
 

--- a/src/MCPServer/requirements/base.txt
+++ b/src/MCPServer/requirements/base.txt
@@ -1,5 +1,4 @@
 Django>=1.8,<1.9
-django-mysqlpool==0.1-9
 django-extensions==1.1.1
 mysqlclient==1.3.7
 gearman==2.0.2

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -22,6 +22,7 @@
 # @author Joseph Perry <joseph@artefactual.com>
 from __future__ import print_function
 
+from functools import wraps
 import logging
 import os
 import string
@@ -30,11 +31,23 @@ import uuid
 
 from archivematicaFunctions import strToUnicode
 
+from django.db import close_old_connections
 from django.db.models import Q
 from django.utils import timezone
 from main.models import Agent, Derivation, Event, File, FPCommandOutput, Job, SIP, Task, Transfer, UnitVariable
 
 LOGGER = logging.getLogger('archivematica.common')
+
+
+def auto_close_db(f):
+    """Decorator to ensure the db connection is closed when the function returns."""
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        finally:
+            close_old_connections()
+    return wrapper
 
 
 def getUTCDate():

--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -4,4 +4,3 @@ Django>=1.8,<1.9
 elasticsearch>=1.0.0,<2.0.0
 requests==2.18.4
 python-dateutil==2.4.2
-django-mysqlpool==0.1-9

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -48,7 +48,7 @@ CONFIG_MAPPING = {
     'db_password': {'section': 'client', 'option': 'password', 'type': 'string'},
     'db_host': {'section': 'client', 'option': 'host', 'type': 'string'},
     'db_port': {'section': 'client', 'option': 'port', 'type': 'string'},
-    'db_pool_max_overflow': {'section': 'client', 'option': 'max_overflow', 'type': 'string'},
+    'db_conn_max_age': {'section': 'client', 'option': 'conn_max_age', 'type': 'string'},
 }
 
 CONFIG_DEFAULTS = """[Dashboard]
@@ -67,9 +67,9 @@ user = archivematica
 password = demo
 host = localhost
 database = MCP
-max_overflow = 40
 port = 3306
-engine = django_mysqlpool.backends.mysqlpool
+engine = django.db.backends.mysql
+conn_max_age = 0
 """
 
 config = Config(env_prefix='ARCHIVEMATICA_DASHBOARD', attrs=CONFIG_MAPPING)
@@ -105,6 +105,11 @@ DATABASES = {
         'PASSWORD': config.get('db_password'),
         'HOST': config.get('db_host'),
         'PORT': config.get('db_port'),
+
+        # If the web server uses greenlets (e.g. gevent) it is not safe to give
+        # CONN_MAX_AGE a value different than 0 - unless you're using a
+        # thread-safe connection pool. More here: https://git.io/vd9qq.
+        'CONN_MAX_AGE': config.get('db_conn_max_age'),
     }
 }
 


### PR DESCRIPTION
As described in https://projects.artefactual.com/issues/10355

This PR removes django-mysqlpool, in favour of the built in connection pooling functionality available in Django >= 1.6.

The MCP Client changes in here have been tested, but the MCP Server changes have not.
