### PR TITLE
Models: Index File.currentlocation

### DIFF
--- a/src/dashboard/src/main/migrations/0027_index_currentlocation.py
+++ b/src/dashboard/src/main/migrations/0027_index_currentlocation.py
@@ -12,9 +12,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
-            model_name='file',
-            name='currentlocation',
-            field=main.models.BlobTextField(null=True, db_column=b'currentLocation', db_index=True),
-        ),
+        migrations.RunSQL('CREATE INDEX Files_currentLocation ON Files(currentLocation(255))')
     ]

--- a/src/dashboard/src/main/migrations/0027_index_currentlocation.py
+++ b/src/dashboard/src/main/migrations/0027_index_currentlocation.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import main.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0026_agent_m2m_event'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='file',
+            name='currentlocation',
+            field=main.models.BlobTextField(null=True, db_column=b'currentLocation', db_index=True),
+        ),
+    ]

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -345,7 +345,7 @@ class File(models.Model):
     transfer = models.ForeignKey(Transfer, db_column='transferUUID', to_field='uuid', null=True, blank=True)
     # both actually `longblob` in the database
     originallocation = BlobTextField(db_column='originalLocation')
-    currentlocation = BlobTextField(db_column='currentLocation', null=True, db_index=True)
+    currentlocation = BlobTextField(db_column='currentLocation', null=True)
     filegrpuse = models.CharField(max_length=50, db_column='fileGrpUse', default='Original')
     filegrpuuid = models.CharField(max_length=36, db_column='fileGrpUUID', blank=True)
     checksum = models.CharField(max_length=128, db_column='checksum', blank=True)

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -345,7 +345,7 @@ class File(models.Model):
     transfer = models.ForeignKey(Transfer, db_column='transferUUID', to_field='uuid', null=True, blank=True)
     # both actually `longblob` in the database
     originallocation = BlobTextField(db_column='originalLocation')
-    currentlocation = BlobTextField(db_column='currentLocation', null=True)
+    currentlocation = BlobTextField(db_column='currentLocation', null=True, db_index=True)
     filegrpuse = models.CharField(max_length=50, db_column='fileGrpUse', default='Original')
     filegrpuuid = models.CharField(max_length=36, db_column='fileGrpUUID', blank=True)
     checksum = models.CharField(max_length=128, db_column='checksum', blank=True)

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -22,5 +22,6 @@ python-dateutil==2.4.2
 ndg-httpsclient
 pyasn1
 requests==2.7.0
+sqlparse==0.2.0
 lxml==3.5.0
 django-forms-bootstrap>=3.0.0,<4.0.0


### PR DESCRIPTION
We often query for a file by it's location, notably in indexAIP. Add an index to improve performance.

Suggested by Aaron Elkiss on the archivematica-tech list  https://groups.google.com/forum/#!msg/archivematica-tech/oYFHiJZ2eis/PZqbF4TLBQAJ

This is connected to https://github.com/archivematica/Issues/issues/75.