### PR TITLE
API: unit status handles bad sub-second ordering

### DIFF
--- a/src/dashboard/tests/fixtures/files.json
+++ b/src/dashboard/tests/fixtures/files.json
@@ -1,0 +1,70 @@
+[
+{
+    "pk": "590bd882-7521-498c-8f89-0958218f779d",
+    "model": "main.file",
+    "fields": {
+        "filegrpuuid": "",
+        "sip": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+        "originallocation": "%SIPDirectory%objects/submissionDocumentation/transfer-no-metadata-46260807-ece1-4a0e-b70a-9814c701146b/METS.xml",
+        "transfer": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+        "filegrpuse": "submissionDocumentation",
+        "removedtime": null,
+        "label": "",
+        "checksum": "51132e5ce1b5d2c2c363f05495f447ea924ab29c2cda2c11037b5fca2119e45a",
+        "enteredsystem": "2015-06-24T17:22:09Z",
+        "currentlocation": "%SIPDirectory%objects/submissionDocumentation/transfer-no-metadata-46260807-ece1-4a0e-b70a-9814c701146b/METS.xml",
+        "size": 12222
+    }
+},
+{
+    "pk": "8140ebe5-295c-490b-a34a-83955b7c844e",
+    "model": "main.file",
+    "fields": {
+        "filegrpuuid": "",
+        "sip": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+        "originallocation": "%SIPDirectory%objects/evelyn_s_photo-6383b731-99e0-432d-a911-a0d2dfd1ce76.tif",
+        "transfer": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+        "filegrpuse": "preservation",
+        "removedtime": null,
+        "label": "",
+        "checksum": "d82448f154b9185bc777ecb0a3602760eb76ba85dd3098f073b2c91a03f571e9",
+        "enteredsystem": "2015-06-24T17:22:09Z",
+        "currentlocation": "%SIPDirectory%objects/evelyn_s_photo-6383b731-99e0-432d-a911-a0d2dfd1ce76.tif",
+        "size": 1446772
+    }
+},
+{
+    "pk": "ae8d4290-fe52-4954-b72a-0f591bee2e2f",
+    "model": "main.file",
+    "fields": {
+        "filegrpuuid": "",
+        "sip": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+        "originallocation": "%SIPDirectory%objects/evelyn's photo.jpg",
+        "transfer": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+        "filegrpuse": "original",
+        "removedtime": null,
+        "label": "",
+        "checksum": "d2bed92b73c7090bb30a0b30016882e7069c437488e1513e9deaacbe29d38d92",
+        "enteredsystem": "2015-06-24T17:22:09Z",
+        "currentlocation": "%SIPDirectory%objects/evelyn_s_photo.jpg",
+        "size": 158131
+    }
+},
+{
+    "pk": "66370f14-2f64-4750-9d50-547614be40e8",
+    "model": "main.file",
+    "fields": {
+        "filegrpuuid": "",
+        "sip": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+        "originallocation": "%SIPDirectory%metadata/metadata.csv",
+        "transfer": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+        "filegrpuse": "metadata",
+        "removedtime": null,
+        "label": "",
+        "checksum": "e8121d8a660e2992872f0b67923d2d08dde9a1ba72dfd58e5a31e68fbac3633c",
+        "enteredsystem": "2015-06-24T17:32:09Z",
+        "currentlocation": "%SIPDirectory%objects/metadata/metadata.csv",
+        "size": 154
+    }
+}
+]

--- a/src/dashboard/tests/fixtures/jobs-failed.json
+++ b/src/dashboard/tests/fixtures/jobs-failed.json
@@ -1,0 +1,36 @@
+[
+    {
+        "fields": {
+            "microservicegroup": "Failed transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-05T00:10:53Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.1840100000",
+            "jobtype": "Email fail report"
+        },
+        "model": "main.job",
+        "pk": "a25f789e-57ae-4190-9188-7a22bc0ef1c4"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Failed transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-05T00:10:54Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.3763290000",
+            "jobtype": "Move to the failed directory"
+        },
+        "model": "main.job",
+        "pk": "7d9ba893-08f1-4678-9fe9-294fdc729c55"
+    }
+]

--- a/src/dashboard/tests/fixtures/jobs-processing.json
+++ b/src/dashboard/tests/fixtures/jobs-processing.json
@@ -1,0 +1,767 @@
+[
+    {
+        "fields": {
+            "microservicegroup": "Approve transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:17Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/activeTransfers/standardTransfer/test/",
+            "hidden": false,
+            "createdtimedec": "0.4155370000",
+            "jobtype": "Approve standard transfer"
+        },
+        "model": "main.job",
+        "pk": "6bf94518-3106-453e-abc4-4c719cb7a8da"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:38Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/activeTransfers/standardTransfer/test/",
+            "hidden": false,
+            "createdtimedec": "0.8058570000",
+            "jobtype": "Set file permissions"
+        },
+        "model": "main.job",
+        "pk": "615d5563-9044-4493-a806-e571051817fd"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:38Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/activeTransfers/standardTransfer/test/",
+            "hidden": false,
+            "createdtimedec": "0.8716200000",
+            "jobtype": "Move to processing directory"
+        },
+        "model": "main.job",
+        "pk": "9faf185a-3068-4ade-ae51-9938a6840806"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:39Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test/",
+            "hidden": false,
+            "createdtimedec": "0.6059340000",
+            "jobtype": "Remove hidden files and directories"
+        },
+        "model": "main.job",
+        "pk": "1abdb2a7-c511-42a3-b1fd-3e3cadbfd317"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:39Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test/",
+            "hidden": false,
+            "createdtimedec": "0.2887440000",
+            "jobtype": "Set transfer type: Standard"
+        },
+        "model": "main.job",
+        "pk": "5c4d776c-1d45-4233-b09c-3ede6ef19db4"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:39Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test/",
+            "hidden": false,
+            "createdtimedec": "0.6515340000",
+            "jobtype": "Remove unneeded files"
+        },
+        "model": "main.job",
+        "pk": "81ff6cf8-cb42-45ca-b8fe-654b1f89eceb"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Include default Transfer processingMCP.xml",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:40Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.8457930000",
+            "jobtype": "Include default Transfer processingMCP.xml"
+        },
+        "model": "main.job",
+        "pk": "1dfbe839-9c19-4f1e-8318-98fc4cf72517"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Rename with transfer UUID",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:40Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test/",
+            "hidden": false,
+            "createdtimedec": "0.5093860000",
+            "jobtype": "Rename with transfer UUID"
+        },
+        "model": "main.job",
+        "pk": "2191efa6-0748-4a06-9911-696cade81914"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:40Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.9046090000",
+            "jobtype": "Set file permissions"
+        },
+        "model": "main.job",
+        "pk": "3d5e75d5-73dc-4ab2-8420-fc0d55dab722"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:40Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test/",
+            "hidden": false,
+            "createdtimedec": "0.4806200000",
+            "jobtype": "Verify mets_structmap.xml compliance"
+        },
+        "model": "main.job",
+        "pk": "3ef1a59e-5f47-4937-ab13-0351e31b867d"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:40Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test/",
+            "hidden": false,
+            "createdtimedec": "0.3975920000",
+            "jobtype": "Verify transfer compliance"
+        },
+        "model": "main.job",
+        "pk": "a01813ce-ec09-4b66-a50f-cbdaf71d5f78"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:40Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test/",
+            "hidden": false,
+            "createdtimedec": "0.1517180000",
+            "jobtype": "Attempt restructure for compliance"
+        },
+        "model": "main.job",
+        "pk": "cd8cb1f4-20c7-42bb-90a1-2d803148e2a9"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Reformat metadata files",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:41Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.7053210000",
+            "jobtype": "Process transfer JSON metadata"
+        },
+        "model": "main.job",
+        "pk": "53825202-5c61-4518-af8a-d34dd990c9d2"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:41Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.3362880000",
+            "jobtype": "Assign checksums and file sizes to objects"
+        },
+        "model": "main.job",
+        "pk": "6da52038-d3c9-4072-8802-b44277fc1a60"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Generate METS.xml document",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:41Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.7862900000",
+            "jobtype": "Generate METS.xml document"
+        },
+        "model": "main.job",
+        "pk": "98910778-19ab-4d3f-9016-052502444af3"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:41Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.1868000000",
+            "jobtype": "Assign file UUIDs to objects"
+        },
+        "model": "main.job",
+        "pk": "9d4fc8c6-94dc-40ae-807c-a09841e041a4"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify transfer checksums",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:41Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.7571490000",
+            "jobtype": "Verify metadata directory checksums"
+        },
+        "model": "main.job",
+        "pk": "d1e01430-17dd-4aaa-bad9-761cad6d801c"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Quarantine",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:42Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/quarantineTransfer/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4361980000",
+            "jobtype": "Find type to process as"
+        },
+        "model": "main.job",
+        "pk": "03b5407b-8f47-4c2a-aa20-edb1962baafd"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Quarantine",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:42Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.1151520000",
+            "jobtype": "Move to workFlowDecisions-quarantineSIP directory"
+        },
+        "model": "main.job",
+        "pk": "3dce5aff-3b5e-40b4-9b09-8b2c03ec75e6"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Scan for viruses",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:42Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.8022160000",
+            "jobtype": "Scan for viruses"
+        },
+        "model": "main.job",
+        "pk": "559bb0d7-7ab7-4959-a687-b2c9a319f0c4"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Scan for viruses",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:42Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/quarantineTransfer/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4729460000",
+            "jobtype": "Move to processing directory"
+        },
+        "model": "main.job",
+        "pk": "800bffdf-7f09-4e9f-97ab-379105070664"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Quarantine",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:42Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/quarantineTransfer/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4456800000",
+            "jobtype": "Workflow decision - send transfer to quarantine"
+        },
+        "model": "main.job",
+        "pk": "a310cc47-ffbe-4da2-99a3-6f72e9964d26"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Quarantine",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:42Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.1008350000",
+            "jobtype": "Designate to process as a standard transfer"
+        },
+        "model": "main.job",
+        "pk": "af2e08c4-a297-4a53-b235-2c93a6d1202b"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Generate transfer structure report",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:43Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.5095610000",
+            "jobtype": "Move to generate transfer tree"
+        },
+        "model": "main.job",
+        "pk": "10af6eb8-7d9c-463c-8065-71bbe4ed39fd"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Clean up names",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:44Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.8298590000",
+            "jobtype": "Sanitize object's file and directory names"
+        },
+        "model": "main.job",
+        "pk": "8c66a191-3d5d-4f60-9179-7200f4f04000"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Generate transfer structure report",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:44Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.7965480000",
+            "jobtype": "Generate transfer structure report"
+        },
+        "model": "main.job",
+        "pk": "9b8b0638-42b0-4c4e-8049-44c82a087da3"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Generate transfer structure report",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:44Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/createTree/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4898710000",
+            "jobtype": "Move to processing directory"
+        },
+        "model": "main.job",
+        "pk": "bfb72604-ebd5-443b-9e58-2cbf964fb0f5"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Identify file format",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:45Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4615070000",
+            "jobtype": "Move to select file ID tool"
+        },
+        "model": "main.job",
+        "pk": "539126ec-0cd3-4fd5-82ab-071a54104a54"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Clean up names",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:45Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.1601980000",
+            "jobtype": "Sanitize Transfer name"
+        },
+        "model": "main.job",
+        "pk": "9483fb19-42b6-4997-a285-50ec51040475"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Identify file format",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:46Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolTransfer/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4190500000",
+            "jobtype": "Select file format identification command"
+        },
+        "model": "main.job",
+        "pk": "166a5bab-b26c-4193-be01-b484697fbff5"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Identify file format",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:46Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolTransfer/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4387120000",
+            "jobtype": "Identify file format"
+        },
+        "model": "main.job",
+        "pk": "2583f129-fb13-4505-a0ac-969c6cd26cb8"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Extract packages",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:46Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolTransfer/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.9587440000",
+            "jobtype": "Move to extract packages"
+        },
+        "model": "main.job",
+        "pk": "2e358bb9-0cb6-47e6-b7d3-5ce35d09ed5f"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Identify file format",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:46Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolTransfer/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4334650000",
+            "jobtype": "Determine which files to identify"
+        },
+        "model": "main.job",
+        "pk": "c40a7c98-62af-44bd-b0eb-772b8a7a22a4"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Extract packages",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:47Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4336080000",
+            "jobtype": "Determine if transfer contains packages"
+        },
+        "model": "main.job",
+        "pk": "1292f7ea-2082-48ae-8cd7-b6917701b881"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Update METS.xml document",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:47Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.7387820000",
+            "jobtype": "Add processed structMap to METS.xml document"
+        },
+        "model": "main.job",
+        "pk": "e6afed55-0515-4eab-9f13-b94b29b0a9f7"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Characterize and extract metadata",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:48Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.1534420000",
+            "jobtype": "Characterize and extract metadata"
+        },
+        "model": "main.job",
+        "pk": "d3188c35-ef00-4908-96d1-34cb4c0bf5bb"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Validation",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:53Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.3611920000",
+            "jobtype": "Validate formats"
+        },
+        "model": "main.job",
+        "pk": "8b91b8a5-2427-46ff-8b79-284de4915ae0"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Characterize and extract metadata",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:53Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.7601000000",
+            "jobtype": "Load labels from metadata/file_labels.csv"
+        },
+        "model": "main.job",
+        "pk": "938c9e6b-a8f9-4b15-80a0-6b608e6b42b0"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Examine contents",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:55Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.3745480000",
+            "jobtype": "Move to examine contents"
+        },
+        "model": "main.job",
+        "pk": "ff51be12-98bc-4e9d-9417-6602bbf77245"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Examine contents",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:56Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.5187020000",
+            "jobtype": "Check for specialized processing"
+        },
+        "model": "main.job",
+        "pk": "c722e558-a6d4-4f08-a386-ef25b4f37d22"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Complete transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:56Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.5258070000",
+            "jobtype": "Create transfer metadata XML"
+        },
+        "model": "main.job",
+        "pk": "e40aebf5-214c-46b5-9892-1ee4c20982c1"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Complete transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:56Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.8767640000",
+            "jobtype": "Move to SIP creation directory for completed transfers"
+        },
+        "model": "main.job",
+        "pk": "e4d55e9e-9061-4939-9d43-b05fef6f2fbe"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Examine contents",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:56Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4876810000",
+            "jobtype": "Examine contents?"
+        },
+        "model": "main.job",
+        "pk": "ee3b39f6-2d57-431d-bdd6-6d38f50de371"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:57Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4846150000",
+            "jobtype": "Load options to create SIPs"
+        },
+        "model": "main.job",
+        "pk": "3ed5ec03-ee7d-4ddc-bdfc-3b1e07170c2b"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Executing command(s)",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:57Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4440550000",
+            "jobtype": "Check transfer directory for objects"
+        },
+        "model": "main.job",
+        "pk": "7bd82bc3-0694-4182-8f72-48fb13f0e8e8"
+    }
+]

--- a/src/dashboard/tests/fixtures/jobs-rejected.json
+++ b/src/dashboard/tests/fixtures/jobs-rejected.json
@@ -1,0 +1,36 @@
+[
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:48:17Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.8561500000",
+            "jobtype": "Create SIP(s)"
+        },
+        "model": "main.job",
+        "pk": "59ace00b-4830-4314-a7d9-38fdbef64896"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Reject transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:48:27Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.1582580000",
+            "jobtype": "Move to the rejected directory"
+        },
+        "model": "main.job",
+        "pk": "b7902aae-ec5f-4290-a3d7-c47f844e8774"
+    }
+]

--- a/src/dashboard/tests/fixtures/jobs-sip-complete.json
+++ b/src/dashboard/tests/fixtures/jobs-sip-complete.json
@@ -1,0 +1,1413 @@
+[
+    {
+        "fields": {
+            "microservicegroup": "Verify SIP compliance",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:56Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/system/autoProcessSIP/test/",
+            "hidden": false,
+            "createdtimedec": "0.4254590000",
+            "jobtype": "Move to processing directory"
+        },
+        "model": "main.job",
+        "pk": "40554613-5bd1-4d51-87ac-9f15b4a59c6c"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify SIP compliance",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:56Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test/",
+            "hidden": false,
+            "createdtimedec": "0.7398420000",
+            "jobtype": "Verify SIP compliance"
+        },
+        "model": "main.job",
+        "pk": "85942c06-b028-429c-bb67-2b17537ceb65"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Rename SIP directory with SIP UUID",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:56Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test/",
+            "hidden": false,
+            "createdtimedec": "0.8845960000",
+            "jobtype": "Rename SIP directory with SIP UUID"
+        },
+        "model": "main.job",
+        "pk": "86249e4d-7d23-4b76-b105-4c63293a96be"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Rename SIP directory with SIP UUID",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:56Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test/",
+            "hidden": false,
+            "createdtimedec": "0.8116700000",
+            "jobtype": "Check if SIP is from Maildir Transfer"
+        },
+        "model": "main.job",
+        "pk": "adeb24bd-c1ec-48f0-b961-0312014fb5f5"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify SIP compliance",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:56Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/system/autoProcessSIP/test/",
+            "hidden": false,
+            "createdtimedec": "0.3372020000",
+            "jobtype": "Set file permissions"
+        },
+        "model": "main.job",
+        "pk": "b9b23554-1fc4-496f-b8a6-8f6d5dd5b15a"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:56Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test/",
+            "hidden": false,
+            "createdtimedec": "0.7839960000",
+            "jobtype": "Verify mets_structmap.xml compliance"
+        },
+        "model": "main.job",
+        "pk": "bc296d61-b8b3-44cb-80cb-fd48e9836eac"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Clean up names",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:57Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.9721070000",
+            "jobtype": "Load Dublin Core metadata from disk"
+        },
+        "model": "main.job",
+        "pk": "02b12c64-74bb-46ce-ab55-4e9de7494e39"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Clean up names",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:57Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.5839220000",
+            "jobtype": "Set file permissions"
+        },
+        "model": "main.job",
+        "pk": "66115eff-931a-48e6-916b-60649586085c"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Remove cache files",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:57Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.2731300000",
+            "jobtype": "Remove cache files"
+        },
+        "model": "main.job",
+        "pk": "bedc5bec-bc01-4736-afa9-eeb78c39afbf"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Include default SIP processingMCP.xml",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:57Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.2204110000",
+            "jobtype": "Include default SIP processingMCP.xml"
+        },
+        "model": "main.job",
+        "pk": "c967f32e-90f2-4952-92c2-b281ab278f71"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Clean up names",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:57Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6769300000",
+            "jobtype": "Sanitize SIP name"
+        },
+        "model": "main.job",
+        "pk": "ef9498c1-418d-4c28-9b73-30c38f0c3476"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:58Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.2809660000",
+            "jobtype": "Identify manually normalized files"
+        },
+        "model": "main.job",
+        "pk": "00f244db-6890-46a2-bb08-fa0f673dca02"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:58Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.9485720000",
+            "jobtype": "Grant normalization options for no pre-existing DIP"
+        },
+        "model": "main.job",
+        "pk": "6d8d3e67-9a95-4c65-a9ce-bb3fece6b11f"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:58Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.9244260000",
+            "jobtype": "Set remove preservation and access normalized files to renormalize link."
+        },
+        "model": "main.job",
+        "pk": "78223479-e4fe-4a4b-b765-7c83ac117dd1"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:58Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.9709600000",
+            "jobtype": "Move to select file ID tool"
+        },
+        "model": "main.job",
+        "pk": "94cd4dd0-a547-4bee-999c-6b5b256b218c"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:58Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.3109450000",
+            "jobtype": "Check for Service directory"
+        },
+        "model": "main.job",
+        "pk": "bc7d9217-732f-4f59-89c6-150a4559d8fd"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:58Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6265520000",
+            "jobtype": "Check for Access directory"
+        },
+        "model": "main.job",
+        "pk": "de2cfc4d-c9f9-4ac8-8e08-22ec21bec63d"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:59Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6288920000",
+            "jobtype": "Normalize"
+        },
+        "model": "main.job",
+        "pk": "160c875c-2f9c-4753-8edc-ae9f26c6ce3c"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:59Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.2992880000",
+            "jobtype": "Select pre-normalize file format identification command"
+        },
+        "model": "main.job",
+        "pk": "1a607cab-0ef7-420e-8235-123862e1eee4"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:59Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6229210000",
+            "jobtype": "Resume after normalization file identification tool selected."
+        },
+        "model": "main.job",
+        "pk": "9a2ae052-dce3-43d8-ab48-e94dab8f1cc6"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:59Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.3102850000",
+            "jobtype": "Identify file format"
+        },
+        "model": "main.job",
+        "pk": "bc54f710-527d-44ba-81bc-298e9fdf4f44"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:33Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.7844440000",
+            "jobtype": "Move to processing directory"
+        },
+        "model": "main.job",
+        "pk": "104994f9-d19f-46d2-a29c-504eed790c18"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:34Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.1301330000",
+            "jobtype": "Create thumbnails directory"
+        },
+        "model": "main.job",
+        "pk": "21ae4db2-291e-4dfb-8521-714bba3abbbe"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:34Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.1651430000",
+            "jobtype": "Normalize for thumbnails"
+        },
+        "model": "main.job",
+        "pk": "9313747d-9fba-4004-a2b1-24642dff9be7"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:35Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.2927860000",
+            "jobtype": "Normalize for preservation"
+        },
+        "model": "main.job",
+        "pk": "1a418733-14c6-475e-8ba4-4c3da1d0c6e7"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:35Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.9806470000",
+            "jobtype": "Set file permissions"
+        },
+        "model": "main.job",
+        "pk": "c1cb2b23-f559-4b3b-bcee-0b1738c4fe7d"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:36Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.4360160000",
+            "jobtype": "Normalization report"
+        },
+        "model": "main.job",
+        "pk": "6b57312a-2f53-49fa-8ae2-912b797a76b2"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:36Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.9409570000",
+            "jobtype": "Move to approve normalization directory"
+        },
+        "model": "main.job",
+        "pk": "7adbdbc8-4dcf-4a92-b572-00a383f1558c"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:36Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.1560990000",
+            "jobtype": "Remove files without linking information (failed normalization artifacts etc.)"
+        },
+        "model": "main.job",
+        "pk": "c8f1df62-87c9-4568-96c4-9a3975126de2"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:38Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/approveNormalization/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.7764100000",
+            "jobtype": "Move to processing directory"
+        },
+        "model": "main.job",
+        "pk": "2a177a92-d84c-4865-9d66-a9d0b0395843"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process manually normalized files",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:38Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.4940630000",
+            "jobtype": "Check for manual normalized files"
+        },
+        "model": "main.job",
+        "pk": "791af1b1-721c-44f8-896a-0db29b788693"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Add final metadata",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:38Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.5252800000",
+            "jobtype": "Move to metadata reminder"
+        },
+        "model": "main.job",
+        "pk": "e2e7a23a-ffd4-4ee5-8130-f6587478f1d4"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:38Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.4169400000",
+            "jobtype": "Set file permissions"
+        },
+        "model": "main.job",
+        "pk": "e9921e00-ffaf-4ea3-8c6f-f6579bab9d2d"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Normalize",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:38Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/approveNormalization/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.4256900000",
+            "jobtype": "Approve normalization"
+        },
+        "model": "main.job",
+        "pk": "ee19af5c-1681-43a2-826b-5f24726e0ebd"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Add final metadata",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:39Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.3326300000",
+            "jobtype": "Reminder: add metadata if desired"
+        },
+        "model": "main.job",
+        "pk": "09137a8b-b194-4110-a102-dc3975785310"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Transcribe SIP contents",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:39Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.1813980000",
+            "jobtype": "Transcribe"
+        },
+        "model": "main.job",
+        "pk": "0d65e0e9-ff63-490a-8186-4a8ccc420640"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:39Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6143940000",
+            "jobtype": "Copy transfer submission documentation"
+        },
+        "model": "main.job",
+        "pk": "51616819-1a1c-45e3-a026-ba2cc52c00a7"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Add final metadata",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:39Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6723500000",
+            "jobtype": "Set file permissions"
+        },
+        "model": "main.job",
+        "pk": "52e24a73-a06c-4c6d-9320-744c54bd7b3a"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Transcribe SIP contents",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:39Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.1687770000",
+            "jobtype": "Transcribe SIP contents"
+        },
+        "model": "main.job",
+        "pk": "d8970119-aa44-4735-8ee1-c7a10b58863f"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:39Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.9643760000",
+            "jobtype": "Move submission documentation into objects directory"
+        },
+        "model": "main.job",
+        "pk": "e4e31c6c-e73e-4254-b670-644a0cc8d416"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:39Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.9145590000",
+            "jobtype": "Check for submission documentation"
+        },
+        "model": "main.job",
+        "pk": "ef1d2cea-1887-48cb-b7b7-ab2fc8836c9b"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:40Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.3356390000",
+            "jobtype": "Assign checksums and file sizes to submissionDocumentation"
+        },
+        "model": "main.job",
+        "pk": "4cfa3b32-7fac-419b-8431-094329fd7aaf"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:40Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.1389600000",
+            "jobtype": "Assign file UUIDs to submission documentation"
+        },
+        "model": "main.job",
+        "pk": "535400a0-0716-4e55-83dc-9faa1112ba7c"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:40Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.9827810000",
+            "jobtype": "Scan for viruses in submission documentation"
+        },
+        "model": "main.job",
+        "pk": "73fecbc6-390d-4f52-8772-14af736e0d70"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:40Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6613570000",
+            "jobtype": "Sanitize file and directory names in submission documentation"
+        },
+        "model": "main.job",
+        "pk": "c8a0b535-6020-4db3-87b7-317b6bc3e11e"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:41Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.3232770000",
+            "jobtype": "Select file format identification command"
+        },
+        "model": "main.job",
+        "pk": "cf49edb4-9ac5-4e76-b291-a913a1f21c09"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:41Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.3349100000",
+            "jobtype": "Identify file format"
+        },
+        "model": "main.job",
+        "pk": "e99ed349-8f19-41c6-a89b-7cc69e936bbd"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:41Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.7937940000",
+            "jobtype": "Characterize and extract metadata on submission documentation"
+        },
+        "model": "main.job",
+        "pk": "f1b39ec0-4d44-43f7-afee-09bf0a8178a5"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:44Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.9302990000",
+            "jobtype": "Copy transfers metadata and logs"
+        },
+        "model": "main.job",
+        "pk": "4f01a1d4-2f95-42b4-b664-988075747245"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:44Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.8445500000",
+            "jobtype": "Remove files without linking information (failed normalization artifacts etc.)"
+        },
+        "model": "main.job",
+        "pk": "b1b4a2b8-f453-4c61-8dc4-58d3b33dcb9b"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:45Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.7355400000",
+            "jobtype": "Assign file UUIDs to metadata"
+        },
+        "model": "main.job",
+        "pk": "133f5d84-031f-4fee-8dd6-ad16a07d979f"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:45Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6214690000",
+            "jobtype": "Move metadata to objects directory"
+        },
+        "model": "main.job",
+        "pk": "4ed7cb76-73c6-478a-b0e6-aa86ee9330ed"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:45Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.5688830000",
+            "jobtype": "Process JSON metadata"
+        },
+        "model": "main.job",
+        "pk": "ddcb9a1a-e97a-4103-a599-943f765f5827"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:46Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.3955900000",
+            "jobtype": "Sanitize file and directory names in metadata"
+        },
+        "model": "main.job",
+        "pk": "2cea6ae1-6d77-4783-9356-5b323f7353cc"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:46Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.4354600000",
+            "jobtype": "Assign checksums and file sizes to metadata "
+        },
+        "model": "main.job",
+        "pk": "54a374bd-24bf-4b81-85c1-f381335bed36"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:46Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6809020000",
+            "jobtype": "Scan for viruses in metadata"
+        },
+        "model": "main.job",
+        "pk": "ff09e8be-857e-4fc6-bb8d-3eea0aaa6617"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:47Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.1273600000",
+            "jobtype": "Identify file format of metadata files"
+        },
+        "model": "main.job",
+        "pk": "a112499c-4a28-4353-a467-263d9a44eaa9"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:47Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.4731440000",
+            "jobtype": "Characterize and extract metadata on metadata files"
+        },
+        "model": "main.job",
+        "pk": "c6bbdd5a-4631-4f30-a50e-32b9ee859370"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Verify checksums",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:48Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.3812910000",
+            "jobtype": "Verify checksums generated on ingest"
+        },
+        "model": "main.job",
+        "pk": "07ac6065-f99f-4ffb-abd9-918e082e1c1d"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:48Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.9896800000",
+            "jobtype": "Remove empty manual normalization directories"
+        },
+        "model": "main.job",
+        "pk": "b174745a-2a31-46bb-90d4-831a716800d5"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:49Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.9121750000",
+            "jobtype": "Prepare AIP"
+        },
+        "model": "main.job",
+        "pk": "69d7482d-9341-402e-9026-f9eb34dacf92"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Generate AIP METS",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:49Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.2085550000",
+            "jobtype": "Generate METS.xml document"
+        },
+        "model": "main.job",
+        "pk": "b7332819-9801-4ede-bd0e-fa8c369f1e3c"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:49Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6852380000",
+            "jobtype": "Check if DIP should be generated"
+        },
+        "model": "main.job",
+        "pk": "ce6ea740-20ab-4d6b-b7b6-2daf8e10efdc"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:49Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.7148690000",
+            "jobtype": "Set file permissions"
+        },
+        "model": "main.job",
+        "pk": "f22cc800-566a-42bb-8605-11bce3ad06a0"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:50Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.8267920000",
+            "jobtype": "Move to compressionAIPDecisions directory"
+        },
+        "model": "main.job",
+        "pk": "260bf6fe-6c26-45d1-8448-43b450448d9c"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:52Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.4031700000",
+            "jobtype": "Select compression algorithm"
+        },
+        "model": "main.job",
+        "pk": "63249f92-0e96-4811-9ff1-7209ec88d7b9"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:52Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.5285000000",
+            "jobtype": "Select compression level"
+        },
+        "model": "main.job",
+        "pk": "6709f4a8-fa07-4b27-9ba9-6f68b43fd3f7"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:52Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6275900000",
+            "jobtype": "Compress AIP"
+        },
+        "model": "main.job",
+        "pk": "6cbc7e06-d992-4c5f-8aa1-3d3021ec9c6c"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:54Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.7604130000",
+            "jobtype": "Create AIP Pointer File"
+        },
+        "model": "main.job",
+        "pk": "bdabea26-5f13-4190-8e23-19bea31451c4"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:54Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.5572260000",
+            "jobtype": "Copy submission documentation"
+        },
+        "model": "main.job",
+        "pk": "d43c8cd6-ab9e-46af-ac27-127260b24147"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:55Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.2347570000",
+            "jobtype": "Set bag file permissions"
+        },
+        "model": "main.job",
+        "pk": "1d7a180c-1c9f-4598-b27c-26012811964f"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Store AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:55Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.3707780000",
+            "jobtype": "Move to the store AIP approval directory"
+        },
+        "model": "main.job",
+        "pk": "83813dd2-5805-46cc-b134-8ba3360e2ffb"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:55Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.2989980000",
+            "jobtype": "Removed bagged files"
+        },
+        "model": "main.job",
+        "pk": "a0f028dd-6b9d-4365-a7ec-2a237e7fc224"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:55Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.2664410000",
+            "jobtype": "Check if AIP is a file or directory"
+        },
+        "model": "main.job",
+        "pk": "c230dff2-16ce-418c-8d28-6671580eecc3"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Store AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:17:56Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/storeAIP/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.5513000000",
+            "jobtype": "Store AIP"
+        },
+        "model": "main.job",
+        "pk": "6148627c-1607-43ae-b9de-3eba70f48cc0"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Store AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:18:10Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/storeAIP/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6377300000",
+            "jobtype": "Retrieve AIP Storage Locations"
+        },
+        "model": "main.job",
+        "pk": "795d967e-3aaf-41e0-b4bb-7327eacf0b96"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Store AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:18:10Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/storeAIP/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.7662470000",
+            "jobtype": "Store AIP location"
+        },
+        "model": "main.job",
+        "pk": "cf59ef57-fb9e-4904-a305-09517eb4c43f"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Store AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:18:37Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%watchedDirectories/storeAIP/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.8078550000",
+            "jobtype": "Move to processing directory"
+        },
+        "model": "main.job",
+        "pk": "4f91f6bf-e19a-467d-a5ab-f9932fbab502"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Store AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:18:38Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.2112580000",
+            "jobtype": "Verify AIP"
+        },
+        "model": "main.job",
+        "pk": "af18a688-9a37-4d41-b792-046258a5b40b"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Store AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:18:41Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.6074080000",
+            "jobtype": "Store the AIP"
+        },
+        "model": "main.job",
+        "pk": "0c1e9d06-c5dd-4f08-8978-7b112f3c9e4d"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Store AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:18:43Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.5373670000",
+            "jobtype": "Index AIP"
+        },
+        "model": "main.job",
+        "pk": "cffc99be-06a8-4179-ae07-e3ec45b659c8"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Store AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:18:46Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.2700590000",
+            "jobtype": "Clean up after storing AIP"
+        },
+        "model": "main.job",
+        "pk": "c3e2f1de-5cd2-4543-89de-e49a75a54dc4"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Store AIP",
+            "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:18:46Z",
+            "unittype": "unitSIP",
+            "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+            "hidden": false,
+            "createdtimedec": "0.8202620000",
+            "jobtype": "Remove the processing directory"
+        },
+        "model": "main.job",
+        "pk": "299c727c-e72b-4070-ae0a-a78a5aa0cfd3"
+    }
+]

--- a/src/dashboard/tests/fixtures/jobs-transfer-backlog.json
+++ b/src/dashboard/tests/fixtures/jobs-transfer-backlog.json
@@ -1,0 +1,87 @@
+[
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:39:49Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.3093370000",
+            "jobtype": "Check transfer directory for objects"
+        },
+        "model": "main.job",
+        "pk": "d2f99030-26b9-4746-b100-856779624934"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:39:49Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.7631970000",
+            "jobtype": "Create SIP(s)"
+        },
+        "model": "main.job",
+        "pk": "c763fa11-0e36-4b93-a8c8-6f008b74a96a"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:40:11Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.5184330000",
+            "jobtype": "Index transfer contents"
+        },
+        "model": "main.job",
+        "pk": "624581dc-ec01-4195-9da3-db0ab0ad1cc3"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:40:12Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.2427270000",
+            "jobtype": "Move transfer to backlog"
+        },
+        "model": "main.job",
+        "pk": "a39d74e4-c42e-404b-8c29-dde873ca48ad"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:40:14Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.3749170000",
+            "jobtype": "Create placement in backlog PREMIS events"
+        },
+        "model": "main.job",
+        "pk": "bac0675d-44fe-4047-9713-f9ba9fe46eff"
+    }
+]

--- a/src/dashboard/tests/fixtures/jobs-transfer-complete.json
+++ b/src/dashboard/tests/fixtures/jobs-transfer-complete.json
@@ -1,0 +1,104 @@
+[
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:57Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4440550000",
+            "jobtype": "Check transfer directory for objects"
+        },
+        "model": "main.job",
+        "pk": "7bd82bc3-0694-4182-8f72-48fb13f0e8e8"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:57Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4903070000",
+            "jobtype": "Create SIP(s)"
+        },
+        "model": "main.job",
+        "pk": "b9390fbf-8c00-434c-ab4b-eb501ed2f490"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:55Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.1605070000",
+            "jobtype": "Move to processing directory"
+        },
+        "model": "main.job",
+        "pk": "c395c111-2671-4b15-9c31-fe1694acb9a2"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:55Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4931960000",
+            "jobtype": "Serialize Dublin Core metadata to disk"
+        },
+        "model": "main.job",
+        "pk": "5572058f-8a3d-4806-9c88-a633e5f33fe4"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:55Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.8095790000",
+            "jobtype": "Create SIP from transfer objects"
+        },
+        "model": "main.job",
+        "pk": "d51f6915-ae7f-4c23-8a02-fcec49941168"
+    },
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Completed successfully",
+            "subjobof": "",
+            "createdtime": "2016-10-04T23:05:56Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.1215710000",
+            "jobtype": "Move to SIP creation directory for completed transfers"
+        },
+        "model": "main.job",
+        "pk": "e7775bc2-613f-4fb7-abba-738dfa799c99"
+    }
+]

--- a/src/dashboard/tests/fixtures/jobs-user-input.json
+++ b/src/dashboard/tests/fixtures/jobs-user-input.json
@@ -1,0 +1,19 @@
+[
+    {
+        "fields": {
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
+            "microservicechainlink": null,
+            "currentstep": "Awaiting decision",
+            "subjobof": "",
+            "createdtime": "2016-10-04T22:50:57Z",
+            "unittype": "unitTransfer",
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+            "hidden": false,
+            "createdtimedec": "0.4903070000",
+            "jobtype": "Create SIP(s)"
+        },
+        "model": "main.job",
+        "pk": "b9390fbf-8c00-434c-ab4b-eb501ed2f490"
+    }
+]

--- a/src/dashboard/tests/fixtures/sip.json
+++ b/src/dashboard/tests/fixtures/sip.json
@@ -1,0 +1,15 @@
+[
+{
+    "pk": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
+    "model": "main.sip",
+    "fields": {
+        "aip_filename": null,
+        "magiclink": null,
+        "magiclinkexitmessage": null,
+        "currentpath": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
+        "sip_type": "AIP",
+        "createdtime": "2015-06-24T17:22:02Z",
+        "hidden": false
+    }
+}
+]

--- a/src/dashboard/tests/fixtures/transfer.json
+++ b/src/dashboard/tests/fixtures/transfer.json
@@ -1,0 +1,19 @@
+[
+{
+    "fields": {
+        "accessionid": "",
+        "magiclink": null,
+        "description": "",
+        "magiclinkexitmessage": null,
+        "transfermetadatasetrow": null,
+        "notes": "",
+        "typeoftransfer": "",
+        "hidden": false,
+        "type": "Standard",
+        "currentlocation": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
+        "sourceofacquisition": ""
+    },
+    "model": "main.transfer",
+    "pk": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"
+}
+]

--- a/src/dashboard/tests/test_api.py
+++ b/src/dashboard/tests/test_api.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python2
+
+import os
+
+from django.core.management import call_command
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from main import models
+
+from components.api import views
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_fixture(fixtures):
+    fixtures = [os.path.join(THIS_DIR, 'fixtures', p) for p in fixtures]
+    call_command('loaddata', *fixtures, **{'verbosity': 0})
+
+
+class TestAPI(TestCase):
+    """Test API endpoints."""
+    fixture_files = ['transfer.json', 'sip.json']
+    fixtures = [os.path.join(THIS_DIR, 'fixtures', p) for p in fixture_files]
+
+    def test_get_unit_status_processing(self):
+        """It should return PROCESSING."""
+        # Setup fixtures
+        load_fixture(['jobs-processing.json'])
+        # Test
+        status = views.get_unit_status('3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e', 'unitTransfer')
+        # Verify
+        assert len(status) == 2
+        assert 'microservice' in status
+        assert status['status'] == 'PROCESSING'
+
+    def test_get_unit_status_user_input(self):
+        """It should return USER_INPUT."""
+        # Setup fixtures
+        load_fixture(['job-processing.json', 'jobs-user-input.json'])
+        # Test
+        status = views.get_unit_status('3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e', 'unitTransfer')
+        # Verify
+        assert len(status) == 2
+        assert 'microservice' in status
+        assert status['status'] == 'USER_INPUT'
+
+    def test_get_unit_status_failed(self):
+        """It should return FAILED."""
+        # Setup fixtures
+        load_fixture(['jobs-processing.json', 'jobs-failed.json'])
+        # Test
+        status = views.get_unit_status('3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e', 'unitTransfer')
+        # Verify
+        assert len(status) == 2
+        assert 'microservice' in status
+        assert status['status'] == 'FAILED'
+
+    def test_get_unit_status_rejected(self):
+        """It should return REJECTED."""
+        # Setup fixtures
+        load_fixture(['jobs-processing.json', 'jobs-rejected.json'])
+        # Test
+        status = views.get_unit_status('3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e', 'unitTransfer')
+        # Verify
+        assert len(status) == 2
+        assert 'microservice' in status
+        assert status['status'] == 'REJECTED'
+
+    def test_get_unit_status_completed_transfer(self):
+        """It should return COMPLETE and the new SIP UUID."""
+        # Setup fixtures
+        load_fixture(['jobs-processing.json', 'jobs-transfer-complete.json', 'files.json'])
+        # Test
+        status = views.get_unit_status('3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e', 'unitTransfer')
+        # Verify
+        assert len(status) == 3
+        assert 'microservice' in status
+        assert status['status'] == 'COMPLETE'
+        assert status['sip_uuid'] == '4060ee97-9c3f-4822-afaf-ebdf838284c3'
+
+    def test_get_unit_status_backlog(self):
+        """It should return COMPLETE and in BACKLOG."""
+        # Setup fixtures
+        load_fixture(['jobs-processing.json', 'jobs-transfer-backlog.json'])
+        # Test
+        status = views.get_unit_status('3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e', 'unitTransfer')
+        # Verify
+        assert len(status) == 3
+        assert 'microservice' in status
+        assert status['status'] == 'COMPLETE'
+        assert status['sip_uuid'] == 'BACKLOG'
+
+    def test_get_unit_status_completed_sip(self):
+        """It should return COMPLETE."""
+        # Setup fixtures
+        load_fixture(['jobs-processing.json', 'jobs-transfer-complete.json', 'jobs-sip-complete.json'])
+        # Test
+        status = views.get_unit_status('4060ee97-9c3f-4822-afaf-ebdf838284c3', 'unitSIP')
+        # Verify
+        assert len(status) == 2
+        assert 'microservice' in status
+        assert status['status'] == 'COMPLETE'


### PR DESCRIPTION
For fast microservices & small transfers it can take less than a second to run and the createdtimedec can be set wrong. To handle this, check for existence of a matching Job, instead of assuming it's the most recent.

Add tests and fixtures for jobs.
