### PR TITLE
MCPServer: Fix typo in ChoiceFromMicroserviceGeneratedList

### DIFF
--- a/src/MCPServer/lib/linkTaskManagerGetUserChoiceFromMicroserviceGeneratedList.py
+++ b/src/MCPServer/lib/linkTaskManagerGetUserChoiceFromMicroserviceGeneratedList.py
@@ -73,7 +73,7 @@ class linkTaskManagerGetUserChoiceFromMicroserviceGeneratedList(LinkTaskManager)
         preConfiguredIndex = self.checkForPreconfiguredXML()
         if preConfiguredIndex is not None:
             self.jobChainLink.setExitMessage("Completed successfully")
-            self.proceedWithChoice(index=preConfiguredIndex, agent=None)
+            self.proceedWithChoice(index=preConfiguredIndex, user_id=None)
         else:
             choicesAvailableForUnitsLock.acquire()
             self.jobChainLink.setExitMessage('Awaiting decision')


### PR DESCRIPTION
Fix typo from #346 that prevents automating GetUserChoiceFromMicroserviceGeneratedList (eg Store AIP location)
