### PR TITLE
MCPServer: Fix microsecond job ordering

### DIFF
--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -251,7 +251,9 @@ def logJobCreatedSQL(job):
     :returns None:    
     """
     unitUUID =  job.unit.UUID
-    decDate = getDeciDate("." + str(job.createdDate.microsecond))
+    # microseconds are always 6 digits
+    # The number returned may have a leading 0 which needs to be preserved
+    decDate = getDeciDate("." + str(job.createdDate.microsecond).zfill(6))
     if job.unit.owningUnit != None:
         unitUUID = job.unit.owningUnit.UUID 
     Job.objects.create(jobuuid=job.UUID,


### PR DESCRIPTION
Microseconds with a leading 0 were having the leading 0 dropped.  This meant that if several microservices ran within a second, sometimes the first ones were reordered to the end.  Use zfill to preserve leading 0.
#510 may not be needed now.
