### PR TITLE
Requirements: Update for agentarchives & metsrw on PyPI

### DIFF
--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -7,6 +7,6 @@ django-extensions==1.1.1
 mysqlclient==1.3.7
 gearman==2.0.2
 lxml==3.5.0
-git+https://github.com/artefactual-labs/mets-reader-writer#egg=metsrw
+metsrw==0.1.0
 requests==2.7.0
 unidecode==0.04.19

--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -1,7 +1,7 @@
+agentarchives==0.2.2
 bagit==1.5.2
 Django>=1.8,<1.9
 elasticsearch>=1.0.0,<2.0.0
 requests==2.7.0
 python-dateutil==2.4.2
 django-mysqlpool
-git+https://github.com/artefactual-labs/agentarchives.git#egg=agentarchives

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -1,4 +1,5 @@
 # Base requirements - for all installations
+agentarchives==0.2.2
 Django>=1.8,<1.9
 django-braces==1.0.0
 django-model-utils==1.3.1
@@ -11,8 +12,7 @@ elasticsearch>=1.0.0,<2.0.0
 gearman==2.0.2
 gunicorn==19.4.5
 lazy-paged-sequence
-git+https://github.com/artefactual-labs/agentarchives.git#egg=agentarchives
-git+https://github.com/artefactual-labs/mets-reader-writer#egg=metsrw
+metsrw==0.1.0
 mysqlclient==1.3.7
 # Required by storage-service component
 slumber==0.6.0


### PR DESCRIPTION
agentarchives and metsrw are published on PyPI, so update requirements files to use that instead of Github.
