### PR TITLE
Administration: Remove hiding certain UI elements

### DIFF
--- a/src/dashboard/src/components/accounts/views.py
+++ b/src/dashboard/src/components/accounts/views.py
@@ -28,13 +28,11 @@ from django.template import RequestContext
 from tastypie.models import ApiKey
 from components.accounts.forms import UserCreationForm
 from components.accounts.forms import UserChangeForm
-from components.helpers import hidden_features
 from components.helpers import get_client_config_value
 
 @user_passes_test(lambda u: u.is_superuser, login_url='/forbidden/')
 def list(request):
     users = User.objects.all()
-    hide_features = hidden_features()
     return render(request, 'accounts/list.html', locals())
 
 @user_passes_test(lambda u: u.is_superuser, login_url='/forbidden/')
@@ -57,7 +55,6 @@ def add(request):
         form = UserCreationForm(initial=data)
 
     return render(request, 'accounts/add.html', {
-        'hide_features': hidden_features(),
         'form': form
     })
 
@@ -130,7 +127,6 @@ def edit(request, id=None):
         api_key = '<no API key generated>'
 
     return render(request, 'accounts/edit.html', {
-      'hide_features': hidden_features(),
       'form': form,
       'user': user,
       'api_key': api_key,

--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -44,33 +44,7 @@ class AgentForm(forms.ModelForm):
         }
 
 
-class SettingsForm(forms.Form):
-    def __init__(self, *args, **kwargs):
-        self.reverse_checkboxes = kwargs.pop('reverse_checkboxes', [])
-        super(SettingsForm, self).__init__(*args, **kwargs)
-
-        for setting in self.reverse_checkboxes:
-            # if it's enabled it shouldn't be checked and visa versa
-            checked = not helpers.get_boolean_setting(setting)
-            self.fields[setting] = forms.BooleanField(
-                required=False,
-                label=self.reverse_checkboxes[setting],
-                initial=checked,
-                widget=CheckboxInput()
-            )
-
-    def save(self, *args, **kwargs):
-        """ Save each of the fields in the form to the Settings table. """
-        for key in self.cleaned_data:
-            # If it's one of the reverse_checkboxes, reverse the checkbox value
-            if key in self.reverse_checkboxes:
-                helpers.set_setting(key, not self.cleaned_data[key])
-            # Otherwise, save the value
-            else:
-                helpers.set_setting(key, self.cleaned_data[key])
-
-
-class StorageSettingsForm(SettingsForm):
+class StorageSettingsForm(forms.Form):
 
     class StripCharField(forms.CharField):
         """
@@ -95,7 +69,7 @@ class StorageSettingsForm(SettingsForm):
         help_text='API key of the storage service user. E.g. 45f7684483044809b2de045ba59dc876b11b9810'
     )
 
-class ChecksumSettingsForm(SettingsForm):
+class ChecksumSettingsForm(forms.Form):
     CHOICES = (
         ('md5', 'MD5'),
         ('sha1', 'SHA-1'),
@@ -148,7 +122,7 @@ class ArchivesSpaceConfigForm(forms.ModelForm):
         }
 
 
-class AtomDipUploadSettingsForm(SettingsForm):
+class AtomDipUploadSettingsForm(forms.Form):
     dip_upload_atom_url = forms.CharField(required=True,
         label="Upload URL",
         help_text="URL where the Qubit index.php frontend lives, SWORD services path will be appended.")

--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -37,7 +37,6 @@ from components.administration.forms import AtomDipUploadSettingsForm
 from components.administration.forms import AgentForm
 from components.administration.forms import ArchivesSpaceConfigForm
 from components.administration.forms import ArchivistsToolkitConfigForm
-from components.administration.forms import SettingsForm
 from components.administration.forms import StorageSettingsForm, ChecksumSettingsForm
 from components.administration.forms import TaxonomyTermForm
 from components.administration.models import ArchivesSpaceConfig, ArchivistsToolkitConfig
@@ -113,11 +112,9 @@ def atom_dips(request):
         form.save()
         messages.info(request, 'Saved.')
 
-    hide_features = helpers.hidden_features()
     return render(request, 'administration/dips_atom_edit.html',
         {
             'form': form,
-            'hide_features': hide_features,
         })
 
 
@@ -480,7 +477,6 @@ def premis_agent(request):
     else:
         form = AgentForm(instance=agent)
 
-    hide_features = helpers.hidden_features()
     return render(request, 'administration/premis_agent.html', locals())
 
 def api(request):
@@ -491,7 +487,6 @@ def api(request):
     else:
         whitelist = helpers.get_setting('api_whitelist', '127.0.0.1')
 
-    hide_features = helpers.hidden_features()
     return render(request, 'administration/api.html', locals())
 
 def taxonomy(request):
@@ -538,22 +533,13 @@ def _intial_settings_data():
         'name', 'value'))
 
 def general(request):
-    toggleableSettings = {
-        'dashboard_administration_atom_dip_enabled':
-            'Hide AtoM DIP upload link',
-        'dashboard_administration_dspace_enabled':
-            'Hide DSpace transfer type',
-    }
     initial_data = _intial_settings_data()
-    interface_form = SettingsForm(request.POST or None, prefix='interface',
-        reverse_checkboxes=toggleableSettings)
     storage_form = StorageSettingsForm(request.POST or None, prefix='storage',
         initial=initial_data)
     checksum_form = ChecksumSettingsForm(request.POST or None, prefix='checksum algorithm',
         initial=initial_data)
 
-    if interface_form.is_valid() and storage_form.is_valid() and checksum_form.is_valid():
-        interface_form.save()
+    if storage_form.is_valid() and checksum_form.is_valid():
         storage_form.save()
         checksum_form.save()
         messages.info(request, 'Saved.')
@@ -566,7 +552,6 @@ def general(request):
     else:
         if not pipeline:
             messages.warning(request, "This pipeline is not registered with the storage service or has been disabled in the storage service.  Please contact an administrator.")
-    hide_features = helpers.hidden_features()
     return render(request, 'administration/general.html', locals())
 
 def version(request):

--- a/src/dashboard/src/components/helpers.py
+++ b/src/dashboard/src/components/helpers.py
@@ -292,23 +292,6 @@ def file_is_an_archive(file):
     file = file.lower()
     return file.endswith('.zip') or file.endswith('.tgz') or file.endswith('.tar.gz')
 
-def feature_settings():
-    return {
-        'atom_dip_admin':      'dashboard_administration_atom_dip_enabled',
-        'dspace':              'dashboard_administration_dspace_enabled'
-    }
-
-def hidden_features():
-    hide_features = {}
-
-    short_forms = feature_settings()
-
-    for short_form, long_form in short_forms.items():
-        # hide feature if setting isn't enabled
-        hide_features[short_form] = not get_boolean_setting(long_form)
-
-    return hide_features
-
 def pad_destination_filepath_if_it_already_exists(filepath, original=None, attempt=0):
     if original == None:
         original = filepath

--- a/src/dashboard/src/components/transfer/views.py
+++ b/src/dashboard/src/components/transfer/views.py
@@ -49,7 +49,6 @@ def grid(request):
     polling_interval = django_settings.POLLING_INTERVAL
     microservices_help = django_settings.MICROSERVICES_HELP
     uid = request.user.id
-    hide_features = helpers.hidden_features()
     return render(request, 'transfer/grid.html', locals())
 
 def transfer_source_locations(request):

--- a/src/dashboard/src/main/views.py
+++ b/src/dashboard/src/main/views.py
@@ -54,8 +54,6 @@ def home(request):
 
     if 'first_login' in request.session and request.session['first_login']:
         request.session.first_login = False
-        for feature_setting in helpers.feature_settings().values():
-            helpers.set_setting(feature_setting, 'True')
         redirectUrl = reverse('components.transfer.views.grid')
     else:
         redirectUrl = reverse('components.transfer.views.grid')

--- a/src/dashboard/src/templates/administration/general.html
+++ b/src/dashboard/src/templates/administration/general.html
@@ -28,12 +28,6 @@
       <h3>General configuration</h3>
 
       <form method='POST'>
-        <h4>Interface options</h4>
-
-        <p>Parts of the interface may be hidden if not needed.</p>
-
-        {% include "_form.html" with form=interface_form %}
-
         <h4>Storage Service options</h4>
 
         {% include "_form.html" with form=storage_form %}

--- a/src/dashboard/src/templates/administration/sidebar.html
+++ b/src/dashboard/src/templates/administration/sidebar.html
@@ -28,9 +28,7 @@
 
     <li class="{% active request url_usage %}"><a href="{{ url_usage }}">Processing storage usage</a></li>
 
-    {% if not hide_features.atom_dip_admin %}
     <li class="{% active request url_dip %}"><a href="{{ url_dip }}">AtoM DIP upload</a></li>
-    {% endif %}
 
     <li class="{% active request url_as_dips %}"><a href="{{ url_as_dips }}">ArchivesSpace DIP upload</a></li>
 

--- a/src/dashboard/src/templates/transfer/grid.html
+++ b/src/dashboard/src/templates/transfer/grid.html
@@ -156,9 +156,7 @@
               <option value='standard'>Standard</option>
               <option value='unzipped bag'>Unzipped Bag</option>
               <option value='zipped bag'>Zipped Bag</option>
-              {% if not hide_features.dspace %}
               <option value='dspace'>DSpace</option>
-              {% endif %}
               {% comment 'Disabled until maildir is better supported' %}
               <option value='maildir'>Maildir</option>
               {% endcomment %}


### PR DESCRIPTION
We had the ability to hide certain parts of the UI if they weren't used. However, this was implemented inconsistently, both in terms of what features could be hidden and hiding the features properly. This removes the feature, since it is straightforward to ignore UI elements unrelated to your current
task.

This also removes SettingsForm, since the reverse_checkboxes it provided were only used in hiding UI elements.

Redmine https://projects.artefactual.com/issues/10447
