### PR TITLE
remove empty bulkextractor logs

### DIFF
--- a/src/MCPClient/lib/clientScripts/examineContents.py
+++ b/src/MCPClient/lib/clientScripts/examineContents.py
@@ -12,11 +12,11 @@ def main(target, output):
     try:
         os.makedirs(output)
         subprocess.call(args)
-	# remove empty BulkExtractor logs
-	for filename in os.listdir(output):
-	    filepath = os.path.join(path,filename)
-	    if os.path.getsize(filepath) == 0:       
-		os.remove(filepath)
+        # remove empty BulkExtractor logs
+        for filename in os.listdir(output):
+            filepath = os.path.join(output,filename)
+            if os.path.getsize(filepath) == 0:
+                os.remove(filepath)
         return 0
     except Exception as e:
         return e

--- a/src/MCPClient/lib/clientScripts/examineContents.py
+++ b/src/MCPClient/lib/clientScripts/examineContents.py
@@ -12,6 +12,11 @@ def main(target, output):
     try:
         os.makedirs(output)
         subprocess.call(args)
+	# remove empty BulkExtractor logs
+	for filename in os.listdir(output):
+	    filepath = os.path.join(path,filename)
+	    if os.path.getsize(filepath) == 0:       
+		os.remove(filepath)
         return 0
     except Exception as e:
         return e


### PR DESCRIPTION
Submitting this PR at the recommendation of @eckardm -- this partially addresses https://github.com/mlibrary/archivematica/issues/2 by drastically cutting down on the number of files that need to be index by removing any empty BulkExtractor logs. The generated `report.xml` still lists any scanners that had no results, so there is still evidence that BulkExtractor ran the scanners.