### PR TITLE
Templates: Hide 'show files' in backlog search

### DIFF
--- a/src/dashboard/src/templates/backlog/backlog.html
+++ b/src/dashboard/src/templates/backlog/backlog.html
@@ -28,7 +28,7 @@
 {% endblock %}
 
 {% block content %}
-  {% include "ingest/backlog/_search_form.html" %}
+  {% include "ingest/backlog/_search_form.html" with show_files=True %}
   <table id="backlog-entries">
   </table>
 {% endblock %}

--- a/src/dashboard/src/templates/ingest/backlog/_search_form.html
+++ b/src/dashboard/src/templates/ingest/backlog/_search_form.html
@@ -3,8 +3,10 @@
     <div id='search_form_container'></div>
     <div id='search_form_submit_container'>
       <input type='button' class='form-control btn-primary' id='search_submit' value='Search transfer backlog'>
+      {% if show_files %}
       <span style='margin-left: 10px'>Show files?</span>
       <span style='margin-left: 5px'><input id='id_show_files' type='checkbox' /></span>
+      {% endif %}
     </div>
   </div>
 </form>

--- a/src/dashboard/src/templates/ingest/grid.html
+++ b/src/dashboard/src/templates/ingest/grid.html
@@ -63,7 +63,7 @@
 
 {% block content %}
 
-  {% include "ingest/backlog/_search_form.html" %}
+  {% include "ingest/backlog/_search_form.html" with show_files=False %}
   <div class="activity-indicator">
     <img src='/media/images/ajax-loader.gif' />
   </div>


### PR DESCRIPTION
Show files was added for the backlog tab, but since the code is reused in the ingest tab it also appeared there, without being functional.  Update the template to hide the non-functional checkbox.

refs Redmine #10502