### PR TITLE
sanitizeNames: Run on files, not sanitization events

### DIFF
--- a/src/MCPClient/lib/clientScripts/sanitizeNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeNames.py
@@ -70,14 +70,14 @@ def sanitizePath(path):
 
 def sanitizeRecursively(path):
     path = os.path.abspath(path)
-    sanitizations = []
+    sanitizations = {}
 
     sanitizedName = sanitizePath(path)
     if sanitizedName != path:
-        sanitizations.append((path, sanitizedName))
+        sanitizations[path] = sanitizedName
     if os.path.isdir(sanitizedName):
         for f in os.listdir(sanitizedName):
-            sanitizations.extend(sanitizeRecursively(os.path.join(sanitizedName, f)))
+            sanitizations.update(sanitizeRecursively(os.path.join(sanitizedName, f)))
 
     return sanitizations
 
@@ -88,6 +88,6 @@ if __name__ == '__main__':
         sys.exit(-1)
     print("Scanning: ", path)
     sanitizations = sanitizeRecursively(path)
-    for oldfile, newfile in sanitizations:
+    for oldfile, newfile in sanitizations.items():
         print(oldfile, " -> ", newfile)
     print("TEST DEBUG CLEAR DON'T INCLUDE IN RELEASE", file=sys.stderr)

--- a/src/MCPClient/lib/clientScripts/sanitizeNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeNames.py
@@ -59,20 +59,11 @@ def sanitizePath(path):
         return path
     else:
         n = 1
-        s = sanitizedName
-        index = s.rfind('.')
-        fileTitle = sanitizedName
-        if index != -1:
-            fileTitle = s[:index]
-        fileExtension = s.split(".")[-1]
-        if fileExtension != sanitizedName:
-            fileExtension = "." + fileExtension
-        else:
-            fileExtension = ""
-        sanitizedName = dirname + "/" + fileTitle + fileExtension
+        fileTitle, fileExtension = os.path.splitext(sanitizedName)
+        sanitizedName = os.path.join(dirname, fileTitle + fileExtension)
 
         while os.path.exists(sanitizedName):
-            sanitizedName = dirname + "/" + fileTitle + replacementChar + n.__str__() + fileExtension
+            sanitizedName = os.path.join(dirname, fileTitle + replacementChar + str(n) + fileExtension)
             n += 1
         rename(path, sanitizedName)
         return sanitizedName

--- a/src/MCPClient/lib/clientScripts/sanitizeNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeNames.py
@@ -39,7 +39,7 @@ def transliterate(basename):
         return unidecode(basename.decode('utf-8'))
     except UnicodeDecodeError:
         return unidecode(basename)
-    
+
 def sanitizeName(basename):
     ret = ""
     basename = transliterate(basename)
@@ -54,12 +54,7 @@ def sanitizePath(path):
     basename = os.path.basename(path)
     dirname = os.path.dirname(path)
     sanitizedName = sanitizeName(basename)
-    if False:
-        print("path: " + path)
-        print("dirname: " + dirname)
-        print("basename: " + basename)
-        print("sanitizedName: " + sanitizedName)
-        print("renamed:", basename != sanitizedName)
+
     if basename == sanitizedName:
         return path
     else:
@@ -78,7 +73,7 @@ def sanitizePath(path):
 
         while os.path.exists(sanitizedName):
             sanitizedName = dirname + "/" + fileTitle + replacementChar + n.__str__() + fileExtension
-            n+=1
+            n += 1
         rename(path, sanitizedName)
         return sanitizedName
 
@@ -91,22 +86,16 @@ def sanitizeRecursively(path):
         sanitizations.append((path, sanitizedName))
     if os.path.isdir(sanitizedName):
         for f in os.listdir(sanitizedName):
-            sanitizations.extend(sanitizeRecursively(sanitizedName + "/" + f))
+            sanitizations.extend(sanitizeRecursively(os.path.join(sanitizedName, f)))
 
     return sanitizations
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        print("Error, sanitizeNames takes one agrument PATH or -V (version)", file=sys.stderr)
-        quit(-1)
     path = sys.argv[1]
-    if path == "-V":
-        print(VERSION)
-        quit(0)
     if not os.path.isdir(path):
         print("Not a directory: " + path, file=sys.stderr)
-        quit(-1)
-    print("Scanning: " + path)
+        sys.exit(-1)
+    print("Scanning: ", path)
     sanitizations = sanitizeRecursively(path)
     for oldfile, newfile in sanitizations:
         print(oldfile, " -> ", newfile)

--- a/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
@@ -22,9 +22,7 @@
 # @author Joseph Perry <joseph@artefactual.com>
 from __future__ import print_function
 import sys
-import subprocess
 import os
-import uuid
 
 import django
 django.setup()
@@ -40,23 +38,21 @@ import sanitizeNames
 if __name__ == '__main__':
     logger = get_script_logger("archivematica.mcp.client.sanitizeObjectNames")
 
-    objectsDirectory = sys.argv[1] #the directory to run sanitization on.
-    sipUUID =  sys.argv[2]
+    objectsDirectory = sys.argv[1]  # directory to run sanitization on.
+    sipUUID = sys.argv[2]
     date = sys.argv[3]
     taskUUID = sys.argv[4]
     groupType = sys.argv[5]
     groupType = "%%%s%%" % (groupType)
     groupSQL = sys.argv[6]
-    sipPath =  sys.argv[7] #the unit path
+    sipPath = sys.argv[7]  # unit path
     groupID = sipUUID
 
-    #relativeReplacement = "%sobjects/" % (groupType) #"%SIPDirectory%objects/"
-    relativeReplacement = objectsDirectory.replace(sipPath, groupType, 1) #"%SIPDirectory%objects/"
-
+    relativeReplacement = objectsDirectory.replace(sipPath, groupType, 1)  # "%SIPDirectory%objects/"
 
     sanitizations = sanitizeNames.sanitizeRecursively(objectsDirectory)
 
-    eventDetail= "program=\"sanitizeNames\"; version=\"" + sanitizeNames.VERSION + "\""
+    eventDetail = 'program="sanitizeNames"; version="' + sanitizeNames.VERSION + '"'
     for oldfile, newfile in sanitizations:
         if os.path.isfile(newfile):
             oldfile = oldfile.replace(objectsDirectory, relativeReplacement, 1)

--- a/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
@@ -39,56 +39,67 @@ if __name__ == '__main__':
     logger = get_script_logger("archivematica.mcp.client.sanitizeObjectNames")
 
     objectsDirectory = sys.argv[1]  # directory to run sanitization on.
-    sipUUID = sys.argv[2]
-    date = sys.argv[3]
-    taskUUID = sys.argv[4]
-    groupType = sys.argv[5]
-    groupType = "%%%s%%" % (groupType)
-    groupSQL = sys.argv[6]
-    sipPath = sys.argv[7]  # unit path
-    groupID = sipUUID
+    sipUUID = sys.argv[2]  # %SIPUUID%
+    date = sys.argv[3]  # %date%
+    taskUUID = sys.argv[4]  # %taskUUID%, unused
+    groupType = sys.argv[5]  # SIPDirectory or transferDirectory
+    groupType = "%%%s%%" % (groupType)  # %SIPDirectory% or %transferDirectory%
+    groupSQL = sys.argv[6]  # transfer_id or sip_id
+    sipPath = sys.argv[7]  # %SIPDirectory%
 
     relativeReplacement = objectsDirectory.replace(sipPath, groupType, 1)  # "%SIPDirectory%objects/"
 
     sanitizations = sanitizeNames.sanitizeRecursively(objectsDirectory)
+    for oldfile, newfile in sanitizations.items():
+        logger.info('sanitizations: %s -> %s', oldfile, newfile)
 
     eventDetail = 'program="sanitizeNames"; version="' + sanitizeNames.VERSION + '"'
-    for oldfile, newfile in sanitizations:
-        if os.path.isfile(newfile):
-            oldfile = oldfile.replace(objectsDirectory, relativeReplacement, 1)
-            newfile = newfile.replace(objectsDirectory, relativeReplacement, 1)
-            print(oldfile, " -> ", newfile)
 
+    kwargs = {
+        groupSQL: sipUUID,
+        "removedtime__isnull": True,
+    }
+    for f in File.objects.filter(**kwargs):
+        # Check all files to see if any parent directory had a sanitization event
+        current_location = f.currentlocation.replace(groupType, sipPath)
+        sanitized_location = unicodeToStr(current_location)
+        logger.info('Checking %s', current_location)
+
+        # Check parent directories
+        # Since directory keys are a mix of sanitized and unsanitized, this is a little complicated
+        # Directories keys are in the form sanitized/sanitized/unsanitized
+        # When a match is found (eg 'unsanitized' -> 'sanitized') reset the search
+        # This will find 'sanitized/unsanitized2' -> 'sanitized/sanitized2' on the next pass
+        # TODO This should be checked for a more efficient solution
+        dirpath = sanitized_location
+        while objectsDirectory in dirpath:  # Stay within unit
+            if dirpath in sanitizations:  # Make replacement
+                sanitized_location = sanitized_location.replace(dirpath, sanitizations[dirpath])
+                dirpath = sanitized_location  # Reset search
+            else:  # Check next level up
+                dirpath = os.path.dirname(dirpath)
+
+        if current_location != sanitized_location:
+            oldfile = current_location.replace(objectsDirectory, relativeReplacement, 1)
+            newfile = sanitized_location.replace(objectsDirectory, relativeReplacement, 1)
+            kwargs = {
+                'src': oldfile,
+                'dst': newfile,
+                'eventType': 'name cleanup',
+                'eventDateTime': date,
+                'eventDetail': "prohibited characters removed:" + eventDetail,
+                'fileUUID': None,
+            }
             if groupType == "%SIPDirectory%":
-                updateFileLocation(oldfile, newfile, "name cleanup", date, "prohibited characters removed:" + eventDetail, fileUUID=None, sipUUID=sipUUID)
+                kwargs['sipUUID'] = sipUUID
             elif groupType == "%transferDirectory%":
-                updateFileLocation(oldfile, newfile, "name cleanup", date, "prohibited characters removed:" + eventDetail, fileUUID=None, transferUUID=sipUUID)
+                kwargs['transferUUID'] = sipUUID
             else:
                 print("bad group type", groupType, file=sys.stderr)
-                exit(3)
-
-        elif os.path.isdir(newfile):
-            oldfile = oldfile.replace(objectsDirectory, relativeReplacement, 1) + "/"
-            newfile = newfile.replace(objectsDirectory, relativeReplacement, 1) + "/"
-            directoryContents = []
-
-            kwargs = {
-                "removedtime__isnull": True,
-                "currentlocation__startswith": oldfile,
-                groupSQL: groupID
-            }
-            files = File.objects.filter(**kwargs)
-
-            print(oldfile, " -> ", newfile)
-
-            for f in files:
-                new_path = unicodeToStr(f.currentlocation).replace(oldfile, newfile, 1)
-                updateFileLocation(f.currentlocation,
-                                   new_path,
-                                   fileUUID=f.uuid,
-                                   # Don't create sanitization events for each
-                                   # file, since it's only a parent directory
-                                   # somewhere up that changed.
-                                   # Otherwise, extra amdSecs will be generated
-                                   # from the resulting METS.
-                                   createEvent=False)
+                sys.exit(3)
+            logger.info('Sanitized name: %s -> %s', oldfile, newfile)
+            print('Sanitized name:', oldfile, " -> ", newfile)
+            updateFileLocation(**kwargs)
+        else:
+            logger.info('No sanitization for %s', current_location)
+            print('No sanitization found for', current_location)


### PR DESCRIPTION
Previous behaviour generated name cleanup events based on which files had been sanitized. This missed files that were in a sanitized directory but that didn't need filename sanitization.

This iterates through all files in the unit and checks for sanitization on all directories in the path.  If found, it generates a single sanitization event from the totally unsanitized path to the completely sanitized path.

Also, some PEP8 & cleanup.