### PR TITLE
Requests: attach timeout to avoid hanging forever

### DIFF
--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -53,7 +53,7 @@ def dspace_handle_to_archivesspace(sip_uuid):
     url = archivesspace_url + '/users/' + config.user + '/login'
     params = {'password': config.passwd}
     logger.debug('Log in to ArchivesSpace URL: %s', url)
-    response = requests.post(url, params=params)
+    response = requests.post(url, params=params, timeout=60)
     logger.debug('Response: %s %s', response, response.content)
     session_id = response.json()['session']
     headers = {'X-ArchivesSpace-Session': session_id}
@@ -61,7 +61,7 @@ def dspace_handle_to_archivesspace(sip_uuid):
     # Get Digital Object from ArchivesSpace
     url = archivesspace_url + digital_object.remoteid
     logger.debug('Get Digital Object info URL: %s', url)
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, timeout=120)
     logger.debug('Response: %s %s', response, response.content)
     body = response.json()
 
@@ -75,7 +75,7 @@ def dspace_handle_to_archivesspace(sip_uuid):
     }
     body['file_versions'].append(file_version)
     logger.debug('Modified Digital Object: %s', body)
-    response = requests.post(url, headers=headers, json=body)
+    response = requests.post(url, headers=headers, json=body, timeout=120)
     print('Update response:', response, response.content)
     logger.debug('Response: %s %s', response, response.content)
     if response.status_code != 200:

--- a/src/MCPClient/lib/clientScripts/upload-qubit.py
+++ b/src/MCPClient/lib/clientScripts/upload-qubit.py
@@ -210,7 +210,7 @@ def start(data):
     auth = requests.auth.HTTPBasicAuth(data.email, data.password)
 
     # Disable redirects: AtoM returns 302 instead of 202, but Location header field is valid
-    response = requests.request('POST', data.url, auth=auth, headers=headers, allow_redirects=False)
+    response = requests.request('POST', data.url, auth=auth, headers=headers, allow_redirects=False, timeout=5)
 
     # response.{content,headers,status_code}
     log("> Response code: %s" % response.status_code)

--- a/src/dashboard/src/components/file/views.py
+++ b/src/dashboard/src/components/file/views.py
@@ -170,7 +170,7 @@ def bulk_extractor(request, fileuuid):
     for report in reports:
         relative_path = os.path.join('logs', 'bulk-' + fileuuid, report + '.txt')
         url = storage_service.extract_file_url(f.transfer_id, relative_path)
-        response = requests.get(url)
+        response = requests.get(url, timeout=5)
 
         if response.status_code != 200:
             message = 'Unable to retrieve ' + report + ' report for file with UUID ' + fileuuid

--- a/src/dashboard/src/components/helpers.py
+++ b/src/dashboard/src/components/helpers.py
@@ -232,7 +232,7 @@ def get_atom_levels_of_description(clear=True):
 
     # taxonomy 34 is "level of description"
     dest = urljoin(url, 'api/taxonomies/34')
-    response = requests.get(dest, params={'culture': 'en'}, auth=auth)
+    response = requests.get(dest, params={'culture': 'en'}, auth=auth, timeout=5)
     if response.status_code == 200:
         base = 1
         if clear:
@@ -319,7 +319,7 @@ def processing_config_path():
     )
 
 def stream_file_from_storage_service(url, error_message='Remote URL returned {}'):
-    stream = requests.get(url, stream=True)
+    stream = requests.get(url, stream=True, timeout=5)
     if stream.status_code == 200:
         content_type = stream.headers.get('content-type', 'text/plain')
         return StreamingHttpResponse(stream, content_type=content_type)

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -292,7 +292,7 @@ def ingest_upload_destination_url_check(request):
     url = urljoin(url, request.GET.get('target', ''))
 
     # make request for URL
-    response = requests.request('GET', url)
+    response = requests.request('GET', url, timeout=5)
 
     # return resulting status code from request
     return HttpResponse(response.status_code)

--- a/src/dashboard/src/installer/views.py
+++ b/src/dashboard/src/installer/views.py
@@ -129,7 +129,7 @@ def fprupload(request):
               }
     headers = {'Content-Type': 'application/json'}
     try: 
-        r = requests.post(url, data=json.dumps(payload), headers=headers, timeout=10, verify=True)
+        r = requests.post(url, data=json.dumps(payload), headers=headers, timeout=5, verify=True)
         if r.status_code == 201:
             response_data['result'] = 'success'
         else:


### PR DESCRIPTION
Redmine: https://projects.artefactual.com/issues/10575

See http://docs.python-requests.org/en/latest/user/advanced/#timeouts:
> Most requests to external servers should have a timeout attached, in case the
> server is not responding in a timely manner. By default, requests do not time
> out unless a timeout value is set explicitly. Without a timeout, your code
> may hang for minutes or more.

This is particularly important in the Dashboard when it's deployed using synchronous workers because these workers can process only one request at a time.

Try for example to fetch the level of descriptions in the AtoM settings. If the AtoM server is not available your request will hang for a long time (in the order of minutes). With this change, it will hang only for five seconds (probably too generous, but much better) and return an error if AtoM didn't make it in time. This example is particularly annoying because [the XHR call is not asynchronous](https://github.com/artefactual/archivematica/blob/stable/1.5.x/src/dashboard/src/media/js/administration/atom_levels_of_description.js#L11), completely blocking the whole browser tab, i.e. the user interface.