### PR TITLE
MCPClient: Fix fetching FPCommand in extract

### DIFF
--- a/src/MCPClient/lib/clientScripts/extractContents.py
+++ b/src/MCPClient/lib/clientScripts/extractContents.py
@@ -84,8 +84,11 @@ def main(transfer_uuid, sip_directory, date, task_uuid, delete=False):
         # Extraction commands are defined in the FPR just like normalization
         # commands
         try:
-            command = FPCommand.active.get(fprule__format=format_id.format_version,
-            fprule__purpose='extract')
+            command = FPCommand.active.get(
+                fprule__format=format_id.format_version,
+                fprule__purpose='extract',
+                fprule__enabled=True,
+            )
         except FPCommand.DoesNotExist:
             print('Not extracting contents from',
                 os.path.basename(file_.currentlocation),


### PR DESCRIPTION
Filtering on a FPRule uses all Rules, not just the active ones, because the filter doesn't use the 'active' manager. Update to explicitly filter on enabled FPR rules.

Refs Redmine https://projects.artefactual.com/issues/10604