### PR TITLE
Add coverage requirement / config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit = **/migrations/*,**/settings/*,**/wsgi.py,**/tests/*,**/manage.py
+source = .

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,16 @@
 [run]
-omit = **/migrations/*,**/settings/*,**/wsgi.py,**/tests/*,**/manage.py
-source = .
+
+omit =
+	src/archivematicaCommon/lib/externals/
+	**/migrations/*
+	**/settings/*
+	**/wsgi.py
+	**/tests/*
+	**/manage.py
+
+source =
+	src/archivematicaCommon/lib/
+	src/dashboard/src/
+	src/MCPClient/lib/
+	src/MCPClient/lib/clientScripts/
+	src/MCPServer/lib/

--- a/.coveragerc
+++ b/.coveragerc
@@ -14,3 +14,5 @@ source =
 	src/MCPClient/lib/
 	src/MCPClient/lib/clientScripts/
 	src/MCPServer/lib/
+
+branch = True

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ mysql_dev.complete
 .project
 .pydevproject
 .settings/
+
+# coverage data file
+.coverage

--- a/src/dashboard/src/requirements/test.txt
+++ b/src/dashboard/src/requirements/test.txt
@@ -2,6 +2,7 @@
 
 pytest>=2,<3
 pytest-cov==2.4.0
+coverage==4.2
 pytest-django>=2,<3
 pytest-pythonpath
 vcrpy>=1,<2

--- a/src/dashboard/src/requirements/test.txt
+++ b/src/dashboard/src/requirements/test.txt
@@ -1,6 +1,7 @@
 -r base.txt
 
 pytest>=2,<3
+pytest-cov==2.4.0
 pytest-django>=2,<3
 pytest-pythonpath
 vcrpy>=1,<2


### PR DESCRIPTION
Thinking about Python 3 compatibility, I wanted to see what coverage was like so set up the pytest-cov plugin. (It's reporting 42%)

At the moment, it can just be run manually (`py.test --cov`) but could be part of a future CI.