### PR TITLE
Backlog removal event: removed objects/ filterSubDir

### DIFF
--- a/src/MCPClient/lib/clientScripts/createEvent.py
+++ b/src/MCPClient/lib/clientScripts/createEvent.py
@@ -46,10 +46,19 @@ if __name__ == '__main__':
 
     (opts, args) = parser.parse_args()
 
-    insertIntoEvents(fileUUID=opts.fileUUID, \
-                     eventIdentifierUUID=str(uuid.uuid4()), \
-                     eventType=opts.eventType, \
-                     eventDateTime=opts.eventDateTime, \
-                     eventDetail=opts.eventDetail, \
-                     eventOutcome=opts.eventOutcome, \
-                     eventOutcomeDetailNote=opts.eventOutcomeDetailNote)
+    # The "Create removal from backlog PREMIS events" is one of the
+    # micro-services that uses this createEvent client script. It used to
+    # ignore everything not in an objects/ subdirectory. However, this becomes
+    # problematic when you create a SIP from a subdirectory of something in
+    # backlog; in that case there may be no objects/ root directory, in which
+    # case "removal from backlog" events will, contrary to desire, not be
+    # created. Therefore, we make sure that there is a file UUID value prior to
+    # creating an event.
+    if opts.fileUUID and opts.fileUUID != 'None':
+        insertIntoEvents(fileUUID=opts.fileUUID,
+                         eventIdentifierUUID=str(uuid.uuid4()),
+                         eventType=opts.eventType,
+                         eventDateTime=opts.eventDateTime,
+                         eventDetail=opts.eventDetail,
+                         eventOutcome=opts.eventOutcome,
+                         eventOutcomeDetailNote=opts.eventOutcomeDetailNote)

--- a/src/dashboard/src/main/migrations/0029_backlog_removal_event.py
+++ b/src/dashboard/src/main/migrations/0029_backlog_removal_event.py
@@ -1,0 +1,32 @@
+from __future__ import print_function, unicode_literals
+
+from django.db import migrations
+
+
+BCKLG_RMVL_EVT_UUID = '463e5d1c-d680-47fa-a27a-7efd4f702355'
+
+
+def data_migration(apps, schema_editor):
+    """Cause the "Create removal from backlog PREMIS events" micro-service to
+    no longer restrict itself to files in an objects/ directory. Essentially,
+    run this SQL::
+
+        UPDATE StandardTasksConfigs
+            SET filterSubDir=NULL
+            WHERE pk='463e5d1c-d680-47fa-a27a-7efd4f702355';
+    """
+    StandardTaskConfig = apps.get_model('main', 'StandardTaskConfig')
+    StandardTaskConfig.objects\
+        .filter(id=BCKLG_RMVL_EVT_UUID)\
+        .update(filter_subdir=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0028_version_number'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration),
+    ]


### PR DESCRIPTION
The "Create removal from backlog PREMIS events" micro-service was, prior to this PR, ignoring all files not in a root objects/ directory of the transfer. When you re-arrange a backlogged transfer, chances are you are removing that condition, i.e., you are creating a SIP without a root objects/ directory. The solution here implemented is simply to remove the condition that in order to receive a "removal from backlog" event you must be somewhere in objects/.