### PR TITLE
Rights: Handle cascade delete of RightsStatementRightsGranted

### DIFF
--- a/src/dashboard/src/main/signals.py
+++ b/src/dashboard/src/main/signals.py
@@ -1,7 +1,7 @@
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 
-from main.models import RightsStatementRightsGranted
+from main.models import RightsStatementRightsGranted, RightsStatement
 
 
 @receiver(post_delete, sender=RightsStatementRightsGranted)
@@ -13,5 +13,10 @@ def delete_rights_statement(sender, **kwargs):
     When a RightsGranted is deleted, also delete the RightsStatement if this was the last RightsGranted.
     """
     instance = kwargs.get('instance')
-    if not instance.rightsstatement.rightsstatementrightsgranted_set.all():
-        instance.rightsstatement.delete()
+    try:
+        # If the statement has no other RightsGranted delete the RightsStatement
+        if not instance.rightsstatement.rightsstatementrightsgranted_set.all():
+            instance.rightsstatement.delete()
+    except RightsStatement.DoesNotExist:
+        # The RightsGranted is being deleted as part of a cascasde delete from the RightsStatement
+        pass

--- a/src/dashboard/tests/fixtures/metadata_type.json
+++ b/src/dashboard/tests/fixtures/metadata_type.json
@@ -1,0 +1,29 @@
+[
+{
+    "fields": {
+        "lastmodified": "2012-10-02T00:25:05Z",
+        "replaces": null,
+        "description": "SIP"
+    },
+    "model": "main.metadataappliestotype",
+    "pk": "3e48343d-e2d2-4956-aaa3-b54d26eb9761"
+},
+{
+    "fields": {
+        "lastmodified": "2012-10-02T00:25:05Z",
+        "replaces": null,
+        "description": "Transfer"
+    },
+    "model": "main.metadataappliestotype",
+    "pk": "45696327-44c5-4e78-849b-e027a189bf4d"
+},
+{
+    "fields": {
+        "lastmodified": "2012-10-02T00:25:05Z",
+        "replaces": null,
+        "description": "File"
+    },
+    "model": "main.metadataappliestotype",
+    "pk": "7f04d9d4-92c2-44a5-93dc-b7bfdf0c1f17"
+}
+]

--- a/src/dashboard/tests/fixtures/rights.json
+++ b/src/dashboard/tests/fixtures/rights.json
@@ -1,0 +1,37 @@
+[
+{
+    "fields": {
+        "status": "ORIGINAL",
+        "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
+        "metadataappliestoidentifier": "d64b0f43-f6d3-42ac-9821-c559dca13786",
+        "rightsholder": 0,
+        "rightsstatementidentifiervalue": "",
+        "rightsbasis": "Copyright",
+        "rightsstatementidentifiertype": ""
+    },
+    "model": "main.rightsstatement",
+    "pk": 1
+},
+{
+    "fields": {
+        "startdate": "2000",
+        "act": "Disseminate",
+        "enddate": null,
+        "enddateopen": true,
+        "rightsstatement": 1
+    },
+    "model": "main.rightsstatementrightsgranted",
+    "pk": 1
+},
+{
+    "fields": {
+        "startdate": "2016",
+        "act": "Access",
+        "enddate": "",
+        "enddateopen": false,
+        "rightsstatement": 1
+    },
+    "model": "main.rightsstatementrightsgranted",
+    "pk": 2
+}
+]

--- a/src/dashboard/tests/test_signals.py
+++ b/src/dashboard/tests/test_signals.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python2
+
+import os
+
+from django.test import TestCase
+
+from main import models
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestSignals(TestCase):
+    fixture_files = ['metadata_type.json', 'rights.json']
+    fixtures = [os.path.join(THIS_DIR, 'fixtures', p) for p in fixture_files]
+
+    def test_delete_rights_statement(self):
+        """It should delete all children."""
+        # Verify exist
+        assert models.RightsStatement.objects.count() == 1
+        assert models.RightsStatementRightsGranted.objects.count() == 2
+        # Delete
+        models.RightsStatement.objects.filter(pk=1).delete()
+        # Verify children deleted
+        assert models.RightsStatement.objects.count() == 0
+        assert models.RightsStatementRightsGranted.objects.count() == 0
+
+    def test_delete_rights_granted(self):
+        """It should delete RightsStatements with no RightsGranted."""
+        # Verify exist
+        assert models.RightsStatement.objects.count() == 1
+        assert models.RightsStatementRightsGranted.objects.count() == 2
+        # Delete RightsGranted
+        models.RightsStatementRightsGranted.objects.filter(pk=1).delete()
+        # Verify Statement still exists
+        assert models.RightsStatement.objects.count() == 1
+        assert models.RightsStatementRightsGranted.objects.count() == 1
+        # Delete last RightsGranted
+        models.RightsStatementRightsGranted.objects.filter(pk=2).delete()
+        # Verify statement deleted
+        assert models.RightsStatement.objects.count() == 0
+        assert models.RightsStatementRightsGranted.objects.count() == 0
+


### PR DESCRIPTION
When a RightsStatement is deleted, it cascade deletes anything with a foreign key to it. However, RightsStatementRightsGranted checks to see if its RightsStatement had any other RightsGranted, so it can delete Statements with no Rights.  When the RightsStatement had already been deleted, this raised an exception. Also, add tests.

Refs redmine 9938