### PR TITLE
Remove 'slumber' dependency

### DIFF
--- a/src/MCPClient/lib/clientScripts/failedSIPCleanup.py
+++ b/src/MCPClient/lib/clientScripts/failedSIPCleanup.py
@@ -22,9 +22,10 @@ def main(fail_type, sip_uuid):
     models.SIPArrange.objects.filter(sip_id=sip_uuid).delete()
 
     # Update storage service that reingest failed
-    api = storage_service._storage_api()
+    session = storage_service._storage_api_session()
+    url = storage_service._storage_service_url() + 'file/' + sip_uuid + '/'
     try:
-        api.file(sip_uuid).patch({'reingest': None})
+        session.patch(url, json={'reingest': None})
     except Exception:
         # Ignore errors, as this may not be reingest
         pass

--- a/src/MCPClient/lib/clientScripts/failedTransferCleanup.py
+++ b/src/MCPClient/lib/clientScripts/failedTransferCleanup.py
@@ -18,7 +18,7 @@ FAILED = 'fail'
 
 def main(fail_type, transfer_uuid, transfer_path):
     # Update storage service that reingest failed
-    api = storage_service._storage_api()
+    session = storage_service._storage_api_session()
     aip_uuid = None
     # Get aip_uuid from reingest METS name
     if os.path.isdir(os.path.join(transfer_path, 'data')):
@@ -32,11 +32,13 @@ def main(fail_type, transfer_uuid, transfer_path):
             aip_uuid = item.replace('METS.', '').replace('.xml', '')
 
     print('AIP UUID for this Transfer is', aip_uuid)
-    try:
-        api.file(aip_uuid).patch({'reingest': None})
-    except Exception:
-        # Ignore errors, as this may not be reingest
-        pass
+    if aip_uuid:
+        url = storage_service._storage_service_url() + 'file/' + aip_uuid + '/'
+        try:
+            session.patch(url, json={'reingest': None})
+        except Exception:
+            # Ignore errors, as this may not be reingest
+            pass
 
     # Delete files for reingest transfer
     # A new reingest doesn't know to delete this because the UUID is different from the AIP, and it causes problems when re-parsing these files

--- a/src/MCPClient/lib/clientScripts/storeAIP.py
+++ b/src/MCPClient/lib/clientScripts/storeAIP.py
@@ -91,12 +91,11 @@ def store_aip(aip_destination_uri, aip_path, sip_uuid, sip_name, sip_type):
         # created if if AIP has been stored. If the AIP hasn't yet been stored
         # take note of the DIP's UUID so it the relationship can later be
         # created when the AIP is stored.
-        api = storage_service._storage_api()
         try:
-            api.file(sip_uuid).get()
+            storage_service.get_file_info(uuid=sip_uuid)[0]  # Check existence
             related_package_uuid = sip_uuid
             print('Parent AIP exists so relationship can be created.')
-        except requests.exceptions.RequestException:
+        except IndexError:
             UnitVariable.objects.create(unittype='SIP', unituuid=sip_uuid, variable='relatedPackage', variablevalue=uuid)
             print('Noting DIP UUID {} related to AIP so relationship can be created when AIP is stored.'.format(uuid))
     else:

--- a/src/MCPClient/lib/clientScripts/storeAIP.py
+++ b/src/MCPClient/lib/clientScripts/storeAIP.py
@@ -25,7 +25,6 @@ from annoying.functions import get_object_or_None
 import argparse
 import logging
 import os
-import slumber
 import sys
 from uuid import uuid4
 
@@ -97,7 +96,7 @@ def store_aip(aip_destination_uri, aip_path, sip_uuid, sip_name, sip_type):
             api.file(sip_uuid).get()
             related_package_uuid = sip_uuid
             print('Parent AIP exists so relationship can be created.')
-        except slumber.exceptions.HttpClientError:
+        except requests.exceptions.RequestException:
             UnitVariable.objects.create(unittype='SIP', unituuid=sip_uuid, variable='relatedPackage', variablevalue=uuid)
             print('Noting DIP UUID {} related to AIP so relationship can be created when AIP is stored.'.format(uuid))
     else:

--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -229,35 +229,6 @@ def get_files_from_backlog(files):
     return copy_files(backlog, processing, files)
 
 
-############# SPACES #############
-
-def get_space(access_protocol=None, path=None):
-    """ Returns a list of storage spaces, optionally filtered by parameters.
-
-    Queries the storage service and returns a list of storage spaces,
-    optionally filtered by access_protocol or path.
-
-    access_protocol: How the storage is accessed.  Should reference storage
-        service purposes, in storage_service.locations.models.py
-    """
-    return_spaces = []
-    url = _storage_service_url() + 'space/'
-    params = {
-        'access_protocol': access_protocol,
-        'path': path,
-        'offset': 0,
-    }
-    while True:
-        response = _storage_api_session().get(url, params=params)
-        spaces = response.json()
-        return_spaces += spaces['objects']
-        if not spaces['meta']['next']:
-            break
-        params['offset'] += spaces['meta']['limit']
-
-    LOGGER.debug("Storage spaces returned: {}".format(return_spaces))
-    return return_spaces
-
 ############# FILES #############
 
 def create_file(uuid, origin_location, origin_path, current_location,

--- a/src/archivematicaCommon/lib/utilities/FPRClient/getFromRestAPI.py
+++ b/src/archivematicaCommon/lib/utilities/FPRClient/getFromRestAPI.py
@@ -72,8 +72,6 @@ def _get_from_rest_api(resource="", params=None, url="https://fpr.archivematica.
     should be checked. This is on by default, but can be disabled to connect
     to test FPR servers which may not have valid SSL certificates.
     """
-    # TOOD make this use slumber
-    # How to dynamically set resource in api.resource.get()
     parsed_url = urlparse.urlparse(url)
 
     if resource and not resource.endswith('/'):

--- a/src/dashboard/src/components/archival_storage/atom.py
+++ b/src/dashboard/src/components/archival_storage/atom.py
@@ -19,10 +19,11 @@ import logging
 import os
 import tempfile
 
+import requests
+
 from agentarchives.atom.client import AtomClient, AtomError, CommunicationError
 from metsrw import METSDocument
 from storageService import extract_file
-from slumber.exceptions import SlumberHttpBaseException
 
 from components import helpers
 
@@ -52,7 +53,7 @@ def upload_dip_metadata_to_atom(aip_name, aip_uuid, parent_slug):
         logger.debug('Extracting file %s into %s', mets_path, temp.name)
         try:
             extract_file(aip_uuid, mets_path, temp.name)
-        except SlumberHttpBaseException:
+        except requests.exceptions.RequestException:
             raise AtomMetadataUploadError
 
         client = get_atom_client()

--- a/src/dashboard/src/components/backlog/views.py
+++ b/src/dashboard/src/components/backlog/views.py
@@ -26,7 +26,6 @@ from django.shortcuts import render, redirect
 from django.template import RequestContext
 
 import elasticSearchFunctions
-import slumber
 import storageService as storage_service
 
 # This project, alphabetical by import source
@@ -228,7 +227,7 @@ def delete(request, uuid):
     except requests.exceptions.ConnectionError:
         error_message = 'Unable to connect to storage server. Please contact your administrator.'
         messages.warning(request, error_message)
-    except slumber.exceptions.HttpClientError:
+    except requests.exceptions.RequestException:
         raise Http404
 
     return redirect('backlog_index')

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -14,8 +14,6 @@ gunicorn==19.4.5
 lazy-paged-sequence
 metsrw==0.1.1
 mysqlclient==1.3.7
-# Required by storage-service component
-slumber==0.6.0
 pytz
 pyopenssl
 python-dateutil==2.4.2


### PR DESCRIPTION
Remove `slumber` as a dependency.  Slumber is a wrapper around `requests`, but doesn't provide much additional use, is less standard in it's API than stock requests, and adds another dependency to keep up to date.  Removing to help make Python 3 support easier as well.