### PR TITLE
URLs: fix trailing $ with no /

### DIFF
--- a/src/dashboard/src/components/administration/urls.py
+++ b/src/dashboard/src/components/administration/urls.py
@@ -36,7 +36,7 @@ urlpatterns = [
     url(r'processing/$', views_processing.list),
     url(r'processing/add/$', views_processing.edit),
     url(r'processing/edit/(?P<name>\w{1,16})/$', views_processing.edit),
-    url(r'processing/delete/(?P<name>\w{1,16})$', views_processing.delete),
+    url(r'processing/delete/(?P<name>\w{1,16})/$', views_processing.delete),
     url(r'premis/agent/$', views.premis_agent),
     url(r'api/$', views.api),
     url(r'general/$', views.general),

--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -21,7 +21,7 @@ from django.conf import settings
 from components.api import views
 
 urlpatterns = [
-    url(r'transfer/approve$', views.approve_transfer),
+    url(r'transfer/approve', views.approve_transfer),
     url(r'transfer/unapproved', views.unapproved_transfers),
     url(r'transfer/completed', views.completed_transfers),
     url(r'transfer/status/(?P<unit_uuid>' + settings.UUID_REGEX + ')', views.status, {'unit_type': 'unitTransfer'}),


### PR DESCRIPTION
Django's APPEND_SLASH setting can handle URLs that end in `/$`, `/` or nothing, but not just `$`.  This causes the version of the url with a trailing / to not exist.  Notably, this fixes `api/transfer/approve/` to not return a 404.

refs redmine 10707