### PR TITLE
Sanitize Names: Handle unicode transfer names

### DIFF
--- a/src/MCPClient/lib/clientScripts/sanitizeNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeNames.py
@@ -26,7 +26,9 @@ import string
 import os
 from shutil import move as rename
 import sys
+import unicodedata
 from unidecode import unidecode
+from archivematicaFunctions import unicodeToStr
 
 VERSION = "1.10." + "$Id$".split(" ")[1]
 valid = "-_.()" + string.ascii_letters + string.digits
@@ -74,7 +76,9 @@ def sanitizeRecursively(path):
 
     sanitizedName = sanitizePath(path)
     if sanitizedName != path:
-        sanitizations[path] = sanitizedName
+        path_key = unicodeToStr(
+            unicodedata.normalize('NFC', path.decode('utf8')))
+        sanitizations[path_key] = sanitizedName
     if os.path.isdir(sanitizedName):
         for f in os.listdir(sanitizedName):
             sanitizations.update(sanitizeRecursively(os.path.join(sanitizedName, f)))

--- a/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 import logging
 import sys
 import os
+import unicodedata
 
 import django
 django.setup()
@@ -57,7 +58,9 @@ def sanitize_object_names(objectsDirectory, sipUUID, date, groupType, groupSQL, 
     }
     for f in File.objects.filter(**kwargs):
         # Check all files to see if any parent directory had a sanitization event
-        current_location = unicodeToStr(f.currentlocation).replace(groupType, sipPath)
+        current_location = unicodeToStr(
+            unicodedata.normalize('NFC', f.currentlocation)).replace(
+                groupType, sipPath)
         sanitized_location = unicodeToStr(current_location)
         logger.info('Checking %s', current_location)
 

--- a/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeObjectNames.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
     }
     for f in File.objects.filter(**kwargs):
         # Check all files to see if any parent directory had a sanitization event
-        current_location = f.currentlocation.replace(groupType, sipPath)
+        current_location = unicodeToStr(f.currentlocation).replace(groupType, sipPath)
         sanitized_location = unicodeToStr(current_location)
         logger.info('Checking %s', current_location)
 

--- a/src/MCPClient/lib/clientScripts/sanitizeSIPName.py
+++ b/src/MCPClient/lib/clientScripts/sanitizeSIPName.py
@@ -22,7 +22,6 @@
 # @author Joseph Perry <joseph@artefactual.com>
 
 from __future__ import print_function
-from archivematicaMoveSIP import moveSIP
 import sys
 
 import django
@@ -35,24 +34,21 @@ from custom_handlers import get_script_logger
 
 from sanitizeNames import sanitizePath
 
-DetoxDic={}
 
 if __name__ == '__main__':
     logger = get_script_logger("archivematica.mcp.client.sanitizeSIPName")
 
     SIPDirectory = sys.argv[1]
-    sipUUID =  sys.argv[2]
+    sipUUID = sys.argv[2]
     date = sys.argv[3]
     sharedDirectoryPath = sys.argv[4]
     unitType = sys.argv[5]
-    #os.path.abspath(SIPDirectory)
 
-    #remove trailing slash
+    # Remove trailing slash
     if SIPDirectory[-1] == "/":
         SIPDirectory = SIPDirectory[:-1]
-    
-    
-    if unitType == "SIP": 
+
+    if unitType == "SIP":
         klass = SIP
         locationColumn = 'currentpath'
     elif unitType == "Transfer":

--- a/src/MCPClient/tests/fixtures/files-transfer-unicode.json
+++ b/src/MCPClient/tests/fixtures/files-transfer-unicode.json
@@ -1,0 +1,74 @@
+[
+{
+    "fields": {
+        "filegrpuuid": "",
+        "sip": null,
+        "checksumtype": "sha256",
+        "originallocation": "%transferDirectory%objects/\u305f\u304f\u3055\u3093 directories/need sanitization/checking here/ev\u00e9lyn's photo.jpg",
+        "transfer": "e95ab50f-9c84-45d5-a3ca-1b0b3f58d9b6",
+        "filegrpuse": "original",
+        "removedtime": null,
+        "label": "",
+        "checksum": "d2bed92b73c7090bb30a0b30016882e7069c437488e1513e9deaacbe29d38d92",
+        "enteredsystem": "2017-01-04T19:35:20Z",
+        "currentlocation": "%transferDirectory%objects/\u305f\u304f\u3055\u3093 directories/need sanitization/checking here/ev\u00e9lyn's photo.jpg",
+        "size": 158131
+    },
+    "model": "main.file",
+    "pk": "47813453-6872-442b-9d65-6515be3c5aa1"
+},
+{
+    "fields": {
+        "filegrpuuid": "",
+        "sip": null,
+        "checksumtype": "sha256",
+        "originallocation": "%transferDirectory%objects/no_sanitization/needed_here/lion.svg",
+        "transfer": "e95ab50f-9c84-45d5-a3ca-1b0b3f58d9b6",
+        "filegrpuse": "original",
+        "removedtime": null,
+        "label": "",
+        "checksum": "f78615cd834f7fb84832177e73f13e3479f5b5b22ae7a9506c7fa0a14fd9df9e",
+        "enteredsystem": "2017-01-04T19:35:20Z",
+        "currentlocation": "%transferDirectory%objects/no_sanitization/needed_here/lion.svg",
+        "size": 18324
+    },
+    "model": "main.file",
+    "pk": "60e5c61b-14ef-4e92-89ec-9b9201e68adb"
+},
+{
+    "fields": {
+        "filegrpuuid": "",
+        "sip": null,
+        "checksumtype": "sha256",
+        "originallocation": "%transferDirectory%objects/\u305f\u304f\u3055\u3093 directories/need sanitization/checking here/lion\u5199\u771f.svg",
+        "transfer": "e95ab50f-9c84-45d5-a3ca-1b0b3f58d9b6",
+        "filegrpuse": "original",
+        "removedtime": null,
+        "label": "",
+        "checksum": "f78615cd834f7fb84832177e73f13e3479f5b5b22ae7a9506c7fa0a14fd9df9e",
+        "enteredsystem": "2017-01-04T19:35:20Z",
+        "currentlocation": "%transferDirectory%objects/\u305f\u304f\u3055\u3093 directories/need sanitization/checking here/lion\u5199\u771f.svg",
+        "size": 18324
+    },
+    "model": "main.file",
+    "pk": "791e07ea-ad44-4315-b55b-44ec771e95cf"
+},
+{
+    "fields": {
+        "filegrpuuid": "",
+        "sip": null,
+        "checksumtype": "sha256",
+        "originallocation": "%transferDirectory%objects/has space/lion.svg",
+        "transfer": "e95ab50f-9c84-45d5-a3ca-1b0b3f58d9b6",
+        "filegrpuse": "original",
+        "removedtime": null,
+        "label": "",
+        "checksum": "f78615cd834f7fb84832177e73f13e3479f5b5b22ae7a9506c7fa0a14fd9df9e",
+        "enteredsystem": "2017-01-04T19:35:20Z",
+        "currentlocation": "%transferDirectory%objects/has space/lion.svg",
+        "size": 18324
+    },
+    "model": "main.file",
+    "pk": "8a1f0b59-cf94-47ef-8078-647b77c8a147"
+}
+]

--- a/src/MCPClient/tests/fixtures/transfer.json
+++ b/src/MCPClient/tests/fixtures/transfer.json
@@ -1,0 +1,19 @@
+[
+{
+    "fields": {
+        "accessionid": "",
+        "magiclink": null,
+        "description": "",
+        "magiclinkexitmessage": null,
+        "transfermetadatasetrow": null,
+        "notes": "",
+        "typeoftransfer": "",
+        "hidden": false,
+        "type": "Standard",
+        "currentlocation": "%sharedPath%currentlyProcessing/ユニコード-e95ab50f-9c84-45d5-a3ca-1b0b3f58d9b6/",
+        "sourceofacquisition": ""
+    },
+    "model": "main.transfer",
+    "pk": "e95ab50f-9c84-45d5-a3ca-1b0b3f58d9b6"
+}
+]

--- a/src/MCPClient/tests/test_sanitize.py
+++ b/src/MCPClient/tests/test_sanitize.py
@@ -1,0 +1,76 @@
+# -*- coding: utf8
+from __future__ import print_function
+
+import os
+import shutil
+import sys
+
+from django.test import TestCase
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(THIS_DIR, '../lib/clientScripts')))
+
+from main.models import Event, File, Transfer
+
+import sanitizeObjectNames
+
+
+class TestSanitize(TestCase):
+    """Test sanitizeNames, sanitizeObjectNames & sanitizeSipName."""
+
+    fixture_files = ['transfer.json', 'files-transfer-unicode.json']
+    fixtures = [os.path.join(THIS_DIR, 'fixtures', p) for p in fixture_files]
+
+    transfer_uuid = 'e95ab50f-9c84-45d5-a3ca-1b0b3f58d9b6'
+
+    def test_sanitize_object_names(self):
+        """Test sanitizeObjectNames.
+
+        It should sanitize files.
+        It should sanitize a directory & update the files in it.
+        It should handle unicode unit names.
+        It should not change a name that is already sanitized.
+        """
+        # Create files
+        transfer = Transfer.objects.get(uuid=self.transfer_uuid)
+        transfer_path = transfer.currentlocation.replace('%sharedPath%currentlyProcessing', THIS_DIR)
+        for f in File.objects.filter(transfer_id=self.transfer_uuid):
+            path = f.currentlocation.replace('%transferDirectory%', transfer_path)
+            dirname = os.path.dirname(path)
+            if not os.path.exists(dirname):
+                os.makedirs(dirname)
+            with open(path, 'w') as f:
+                f.write(path.encode('utf8'))
+
+        try:
+            # Sanitize
+            sanitizeObjectNames.sanitize_object_names(
+                objectsDirectory=os.path.join(transfer_path, 'objects', '').encode('utf8'),
+                sipUUID=self.transfer_uuid,
+                date='2017-01-04 19:35:22',
+                groupType='%transferDirectory%',
+                groupSQL='transfer_id',
+                sipPath=os.path.join(transfer_path, '').encode('utf8'),
+            )
+
+            # Assert files have expected name
+            # Assert DB has been updated
+            # Assert events created
+            assert os.path.exists(os.path.join(transfer_path, 'objects', 'takusan_directories', 'need_sanitization', 'checking_here', 'evelyn_s_photo.jpg'))
+            assert File.objects.get(currentlocation='%transferDirectory%objects/takusan_directories/need_sanitization/checking_here/evelyn_s_photo.jpg')
+            assert Event.objects.filter(file_uuid='47813453-6872-442b-9d65-6515be3c5aa1', event_type='name cleanup').exists()
+
+            assert os.path.exists(os.path.join(transfer_path, 'objects', 'no_sanitization/needed_here/lion.svg'))
+            assert File.objects.get(currentlocation='%transferDirectory%objects/no_sanitization/needed_here/lion.svg')
+            assert not Event.objects.filter(file_uuid='60e5c61b-14ef-4e92-89ec-9b9201e68adb', event_type='name cleanup').exists()
+
+            assert os.path.exists(os.path.join(transfer_path, 'objects', 'takusan_directories', 'need_sanitization', 'checking_here', 'lionXie_Zhen_.svg'))
+            assert File.objects.get(currentlocation='%transferDirectory%objects/takusan_directories/need_sanitization/checking_here/lionXie_Zhen_.svg')
+            assert Event.objects.filter(file_uuid='791e07ea-ad44-4315-b55b-44ec771e95cf', event_type='name cleanup').exists()
+
+            assert os.path.exists(os.path.join(transfer_path, 'objects', 'has_space', 'lion.svg'))
+            assert File.objects.get(currentlocation='%transferDirectory%objects/has_space/lion.svg')
+            assert Event.objects.filter(file_uuid='8a1f0b59-cf94-47ef-8078-647b77c8a147', event_type='name cleanup').exists()
+        finally:
+            # Delete files
+            shutil.rmtree(transfer_path)


### PR DESCRIPTION
The transfer name coming from the database was unicode, which forced the (byte)strings to also be promoted to unicode, which failed with a `UnicodeDecodeError`.  Converting the transfer name to a bytestring by encoding as utf8 solves the problem.

Added tests to the sanitize object names code.

This should be cherry-picked to qa/1.x when merged.