### PR TITLE
django-mysqlpool: unlimited max_overflow #10622

### DIFF
--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -36,6 +36,7 @@ DATABASES = {
 MYSQLPOOL_BACKEND = 'QueuePool'
 MYSQLPOOL_ARGUMENTS = {
     'use_threadlocal': False,
+    'max_overflow': -1,
 }
 
 CONN_MAX_AGE = 14400

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -19,7 +19,7 @@ import os, sys, ConfigParser
 import django_mysqlpool
 
 # Get DB settings from main configuration file
-config = ConfigParser.SafeConfigParser()
+config = ConfigParser.SafeConfigParser({'max_overflow': 40})
 config.read('/etc/archivematica/archivematicaCommon/dbsettings')
 
 DATABASES = {
@@ -36,7 +36,7 @@ DATABASES = {
 MYSQLPOOL_BACKEND = 'QueuePool'
 MYSQLPOOL_ARGUMENTS = {
     'use_threadlocal': False,
-    'max_overflow': -1,
+    'max_overflow': config.get('client', 'max_overflow'),
 }
 
 CONN_MAX_AGE = 14400

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -36,6 +36,7 @@ DATABASES = {
 MYSQLPOOL_BACKEND = 'QueuePool'
 MYSQLPOOL_ARGUMENTS = {
     'use_threadlocal': False,
+    'max_overflow': -1,
 }
 
 CONN_MAX_AGE = 14400

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -19,7 +19,7 @@ import os, sys, ConfigParser
 import django_mysqlpool
 
 # Get DB settings from main configuration file
-config = ConfigParser.SafeConfigParser()
+config = ConfigParser.SafeConfigParser({'max_overflow': 40})
 config.read('/etc/archivematica/archivematicaCommon/dbsettings')
 
 DATABASES = {
@@ -36,7 +36,7 @@ DATABASES = {
 MYSQLPOOL_BACKEND = 'QueuePool'
 MYSQLPOOL_ARGUMENTS = {
     'use_threadlocal': False,
-    'max_overflow': -1,
+    'max_overflow': config.get('client', 'max_overflow'),
 }
 
 CONN_MAX_AGE = 14400

--- a/src/archivematicaCommon/etc/dbsettings
+++ b/src/archivematicaCommon/etc/dbsettings
@@ -3,3 +3,4 @@ user=archivematica
 password=demo
 host=localhost
 database=MCP
+max_overflow=40


### PR DESCRIPTION
Add parameter "max_overflow: -1" to MYSQLPOOL_ARGUMENTS in both MCPServer and MCPClient configuration, to avoid hitting a limit in the total number of mysql concurrent connections (default value is 10), that causes some scalability issues.