### PR TITLE
copyToNetX: handle multiple Jobs when fetching DIP path

### DIFF
--- a/src/MCPClient/lib/clientScripts/copyToNetX.py
+++ b/src/MCPClient/lib/clientScripts/copyToNetX.py
@@ -96,9 +96,9 @@ def copyToNetX(sip_uuid):
 
 def get_dip_path(sip_uuid):
     try:
-        job = models.Job.objects.get(jobtype='Upload DIP', sipuuid=sip_uuid)
+        job = models.Job.objects.filter(jobtype='Upload DIP', sipuuid=sip_uuid)[0]
         return job.directory.rstrip('/').replace('%sharedPath%', SHARED_DIR)
-    except (django.core.exceptions.MultipleObjectsReturned, django.core.exceptions.ObjectDoesNotExist):
+    except IndexError:
         print >>sys.stderr, "Job directory not found in database."
         sys.exit(1)
 


### PR DESCRIPTION
Since we're uploading to multiple systems, there are multiple Upload DIP jobs, all with the same path. Take the first one instead of erroring.