### PR TITLE
save target slug in dip upload better

### DIFF
--- a/src/dashboard/src/media/js/ingest.js
+++ b/src/dashboard/src/media/js/ingest.js
@@ -381,10 +381,11 @@ $(function()
 
                   if (input.filter(':text').val())
                   {
+                    var v_target = input.filter(':text').val();
                     $('#upload-dip-modal-spinner').show();
                     // get AtoM destination URL (so we can confirm it's up)
                     $.ajax({
-                      url: '/ingest/upload/url/check/?target=' + encodeURIComponent(input.filter(':text').val()),
+                      url: '/ingest/upload/url/check/?target=' + encodeURIComponent(v_target),
                       type: 'GET',
                       success: function(status_code_from_url_check)
                         {
@@ -393,7 +394,7 @@ $(function()
                             alert('There was a problem attempting to reach the destination URL.');
                           } else {
                                   var xhr = $.ajax(url, { type: 'POST', data: {
-                                    'target': input.filter(':text').val() }})
+                                    'target': v_target }})
 
                                     .done(function(data)
                                       {


### PR DESCRIPTION
Fixes issue #10759 https://projects.artefactual.com/issues/10759

For some reason (unknown to me), the value of input.filter(':text').val()
is empty when it is used to populate the form POST data sent to Archivematica.

This commit saves the value to a variable and uses the variable instead.

I'd love to know why this is necessary.  The code here did not change from
the 1.5.1 release, other than the change to a new bootstrap modal.

I assume that is the reason the behaviour has changed, but I am not sure
why it didn't show up until now.