### PR TITLE
Problem: ES client timeout is not configurable

### DIFF
--- a/src/MCPClient/etc/clientConfig.conf
+++ b/src/MCPClient/etc/clientConfig.conf
@@ -33,6 +33,7 @@ LoadSupportedCommandsSpecial = True
 #numberOfTasks 0 means detect number of cores, and use that.
 numberOfTasks = 0
 elasticsearchServer = localhost:9200
+elasticsearchTimeout = 10
 disableElasticsearchIndexing = False
 temp_dir = /var/archivematica/sharedDirectory/tmp
 kioskMode = False

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -105,9 +105,10 @@ class TooManyResultsError(ElasticsearchError):
 
 _es_hosts = None
 _es_client = None
+DEFAULT_TIMEOUT = 10
 
 
-def setup(hosts):
+def setup(hosts, timeout=DEFAULT_TIMEOUT):
     """
     Initialize Elasticsearch client and share it as the attribute _es_client in
     the current module. An additional attribute _es_hosts is defined containing
@@ -119,6 +120,7 @@ def setup(hosts):
     _es_hosts = hosts
     _es_client = Elasticsearch(**{
         'hosts': _es_hosts,
+        'timeout': timeout,
         'dead_timeout': 2
     })
 
@@ -137,7 +139,12 @@ def setup_reading_from_client_conf(config=None):
         hosts = config.get('MCPClient', "elasticsearchServer")
     except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
         hosts = '127.0.0.1:9200'
-    setup(hosts)
+    try:
+        timeout = config.getfloat('MCPClient', "elasticsearchTimeout")
+    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+        timeout = DEFAULT_TIMEOUT
+
+    setup(hosts, timeout)
 
 
 def get_host():


### PR DESCRIPTION
With big METs files, 10 seconds might not be enough. This creates a configuration parameter in order to configure it.

I went for the conservative approach of only changing the ES aip index call, but this can also be handled at connection level, with something like:

    es_client = Elasticsearch(**{
        'hosts': _es_hosts,
        'timeout': request_timeout,
        'dead_timeout': 2,
    })



Refs: #10734