### PR TITLE
metadata/ and logs/ dirs viewable in SIP arrange

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -56,9 +56,9 @@ MATCH_ALL_QUERY = {
         "match_all": {}
     }
 }
-# Returns files which are in the backlog, omitting files without UUIDs,
+# Returns files which are in the backlog; *omits* files without UUIDs,
 # e.g. administrative files (AM metadata and logs directories).
-BACKLOG_FILTER = {
+BACKLOG_FILTER_NO_MD_LOGS = {
     'bool': {
         'must': {
             'term': {
@@ -71,6 +71,18 @@ BACKLOG_FILTER = {
             }
         }
     },
+}
+
+# Returns files which are in the backlog; *includes* files without UUIDs,
+# e.g. administrative files (AM metadata and logs directories).
+BACKLOG_FILTER = {
+    'bool': {
+        'must': {
+            'term': {
+                'status': 'backlog',
+            },
+        }
+    }
 }
 
 MACHINE_READABLE_FIELD_SPEC = {

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -504,9 +504,16 @@ def transfer_backlog(request, ui):
     # Get search parameters from request
     results = None
 
+    # GET params in SIP arrange can control whether files in metadata/ and
+    # logs/ are returned. Appraisal tab always hides these dirs and their files
+    # (for now).
+    backlog_filter = elasticSearchFunctions.BACKLOG_FILTER
+    if ui == 'appraisal' or request.GET.get('hidemetadatalogs'):
+        backlog_filter = elasticSearchFunctions.BACKLOG_FILTER_NO_MD_LOGS
+
     if not 'query' in request.GET:
         query = elasticSearchFunctions.MATCH_ALL_QUERY.copy()
-        query['filter'] = elasticSearchFunctions.BACKLOG_FILTER
+        query['filter'] = backlog_filter
     else:
         queries, ops, fields, types = advanced_search.search_parameter_prep(request)
 
@@ -517,7 +524,7 @@ def transfer_backlog(request, ui):
                 ops,
                 fields,
                 types,
-                filters=elasticSearchFunctions.BACKLOG_FILTER,
+                filters=backlog_filter,
             )
         except:
             logger.exception('Error accessing index.')

--- a/src/dashboard/src/media/js/ingest/backlog.js
+++ b/src/dashboard/src/media/js/ingest/backlog.js
@@ -61,6 +61,9 @@ function renderBacklogSearchForm(search_uri, on_success, on_error) {
     function backlogSearchSubmit() {
       // Query Django, which queries ElasticSearch, to get the backlog file info
       var query_url = search_uri + '?' + search.toUrlParams();
+      if (!$('#id_show_metadata_logs').is(':checked')) {
+          query_url = query_url + '&' + $.param({hidemetadatalogs: 1});
+      }
 
       $.ajax({
         type: 'GET',

--- a/src/dashboard/src/templates/ingest/backlog/_search_form.html
+++ b/src/dashboard/src/templates/ingest/backlog/_search_form.html
@@ -6,6 +6,9 @@
       {% if show_files %}
       <span style='margin-left: 10px'>Show files?</span>
       <span style='margin-left: 5px'><input id='id_show_files' type='checkbox' /></span>
+      {% else %}
+      <span style='margin-left: 10px'>Show metadata &amp; logs directories?</span>
+      <span style='margin-left: 5px'><input id='id_show_metadata_logs' type='checkbox' checked/></span>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
UI has "Show metadata & logs directories?" checkbox to control whether
these directories will be displayed when browsing transfers in backlog.