### PR TITLE
Reorder migrations

### DIFF
--- a/src/dashboard/src/main/migrations/0019_normalization_report.py
+++ b/src/dashboard/src/main/migrations/0019_normalization_report.py
@@ -30,7 +30,7 @@ def data_migration(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('main', '0022_blob_fields'),
+        ('main', '0018_archivesspace_sip_arrange'),
     ]
 
     operations = [

--- a/src/dashboard/src/main/migrations/0020_index_after_processing_decision.py
+++ b/src/dashboard/src/main/migrations/0020_index_after_processing_decision.py
@@ -46,7 +46,7 @@ def data_migration(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('main', '0018_archivesspace_sip_arrange'),
+        ('main', '0019_normalization_report'),
     ]
 
     operations = [

--- a/src/dashboard/src/main/migrations/0021_checksum_algorithms.py
+++ b/src/dashboard/src/main/migrations/0021_checksum_algorithms.py
@@ -16,7 +16,7 @@ def data_migration(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('main', '0019_index_after_processing_decision'),
+        ('main', '0020_index_after_processing_decision'),
     ]
 
     operations = [

--- a/src/dashboard/src/main/migrations/0022_email_report_args.py
+++ b/src/dashboard/src/main/migrations/0022_email_report_args.py
@@ -11,7 +11,7 @@ def data_migration(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('main', '0020_checksum_algorithms'),
+        ('main', '0021_checksum_algorithms'),
     ]
 
     operations = [

--- a/src/dashboard/src/main/migrations/0023_blob_fields.py
+++ b/src/dashboard/src/main/migrations/0023_blob_fields.py
@@ -8,7 +8,7 @@ import main.models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('main', '0021_email_report_args'),
+        ('main', '0022_email_report_args'),
     ]
 
     operations = [

--- a/src/dashboard/src/main/migrations/0024_agenttype.py
+++ b/src/dashboard/src/main/migrations/0024_agenttype.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('main', '0023_normalization_report'),
+        ('main', '0023_blob_fields'),
     ]
 
     operations = [

--- a/src/dashboard/src/main/migrations/0026_agent_m2m_event.py
+++ b/src/dashboard/src/main/migrations/0026_agent_m2m_event.py
@@ -25,8 +25,10 @@ def data_migration(apps, schema_editor):
     org_agent = Agent.objects.get(pk=2)
     for e in Event.objects.all():
         e.agents.add(system_agent, org_agent)
-        user_agent = Agent.objects.get(userprofile__user_id=e.linking_agent)
-        e.agents.add(user_agent)
+        #linking_agent is nullable, can't link an event to an agent with no linking_agent id
+        if e.linking_agent is not None:
+            user_agent = Agent.objects.get(userprofile__user_id=e.linking_agent)
+            e.agents.add(user_agent)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
refs #10830

This puts the dashboards django migrations in the same order, in qa/1.6.x as the order in stable/1.5.x
to avoid problems when upgrading.

This change will be needed in qa/1.x as well.