### PR TITLE
Increase timeout to 120 seconds

### DIFF
--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -53,7 +53,7 @@ def dspace_handle_to_archivesspace(sip_uuid):
     url = archivesspace_url + '/users/' + config.user + '/login'
     params = {'password': config.passwd}
     logger.debug('Log in to ArchivesSpace URL: %s', url)
-    response = requests.post(url, params=params, timeout=60)
+    response = requests.post(url, params=params, timeout=120)
     logger.debug('Response: %s %s', response, response.content)
     session_id = response.json()['session']
     headers = {'X-ArchivesSpace-Session': session_id}

--- a/src/MCPClient/lib/clientScripts/upload-qubit.py
+++ b/src/MCPClient/lib/clientScripts/upload-qubit.py
@@ -210,7 +210,7 @@ def start(data):
     auth = requests.auth.HTTPBasicAuth(data.email, data.password)
 
     # Disable redirects: AtoM returns 302 instead of 202, but Location header field is valid
-    response = requests.request('POST', data.url, auth=auth, headers=headers, allow_redirects=False, timeout=5)
+    response = requests.request('POST', data.url, auth=auth, headers=headers, allow_redirects=False, timeout=120)
 
     # response.{content,headers,status_code}
     log("> Response code: %s" % response.status_code)

--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -73,7 +73,7 @@ def _storage_api():
     storage_service_url = _storage_service_url()
     username = get_setting('storage_service_user', 'test')
     api_key = get_setting('storage_service_apikey', None)
-    api = slumber.API(storage_service_url, session=_storage_api_session(auth=TastypieApikeyAuth(username, api_key), timeout=5))
+    api = slumber.API(storage_service_url, session=_storage_api_session(auth=TastypieApikeyAuth(username, api_key), timeout=120))
     return api
 
 def _storage_api_params():

--- a/src/dashboard/src/components/file/views.py
+++ b/src/dashboard/src/components/file/views.py
@@ -170,7 +170,7 @@ def bulk_extractor(request, fileuuid):
     for report in reports:
         relative_path = os.path.join('logs', 'bulk-' + fileuuid, report + '.txt')
         url = storage_service.extract_file_url(f.transfer_id, relative_path)
-        response = requests.get(url, timeout=5)
+        response = requests.get(url, timeout=120)
 
         if response.status_code != 200:
             message = 'Unable to retrieve ' + report + ' report for file with UUID ' + fileuuid

--- a/src/dashboard/src/components/helpers.py
+++ b/src/dashboard/src/components/helpers.py
@@ -232,7 +232,7 @@ def get_atom_levels_of_description(clear=True):
 
     # taxonomy 34 is "level of description"
     dest = urljoin(url, 'api/taxonomies/34')
-    response = requests.get(dest, params={'culture': 'en'}, auth=auth, timeout=5)
+    response = requests.get(dest, params={'culture': 'en'}, auth=auth, timeout=120)
     if response.status_code == 200:
         base = 1
         if clear:
@@ -319,7 +319,7 @@ def processing_config_path():
     )
 
 def stream_file_from_storage_service(url, error_message='Remote URL returned {}'):
-    stream = requests.get(url, stream=True, timeout=5)
+    stream = requests.get(url, stream=True, timeout=120)
     if stream.status_code == 200:
         content_type = stream.headers.get('content-type', 'text/plain')
         return StreamingHttpResponse(stream, content_type=content_type)

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -292,7 +292,7 @@ def ingest_upload_destination_url_check(request):
     url = urljoin(url, request.GET.get('target', ''))
 
     # make request for URL
-    response = requests.request('GET', url, timeout=5)
+    response = requests.request('GET', url, timeout=120)
 
     # return resulting status code from request
     return HttpResponse(response.status_code)

--- a/src/dashboard/src/installer/views.py
+++ b/src/dashboard/src/installer/views.py
@@ -129,7 +129,7 @@ def fprupload(request):
               }
     headers = {'Content-Type': 'application/json'}
     try: 
-        r = requests.post(url, data=json.dumps(payload), headers=headers, timeout=5, verify=True)
+        r = requests.post(url, data=json.dumps(payload), headers=headers, timeout=120, verify=True)
         if r.status_code == 201:
             response_data['result'] = 'success'
         else:


### PR DESCRIPTION
For the storage service, a timeout of 5 isn't always long enough. Since the
values are currently harcoded we're defining larger values for safety reasons.

This is a continuation of #531.