### PR TITLE
MCPClient: update shebangs for parse_mets and parse_external_mets

### DIFF
--- a/src/MCPClient/lib/clientScripts/parse_external_mets.py
+++ b/src/MCPClient/lib/clientScripts/parse_external_mets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 from __future__ import print_function
 import argparse

--- a/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
+++ b/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 from __future__ import print_function
 import argparse


### PR DESCRIPTION
Command parseExternalMETS is failing in CentOS rpm's, due to the use of system's python, instead of the one from the virtualenv.

This updates parse_external_mets.py and parse_mets_to_db.py and aligns them with the other client scripts.