### PR TITLE
Normalization: Use default access rule if normal rule errors

### DIFF
--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -362,9 +362,16 @@ def main(opts):
     cl = transcoder.CommandLinker(rule, command, replacement_dict, opts, once_normalized)
     exitstatus = cl.execute()
 
-    # TODO does this need to check if the file exists? Or can we assume that a verification rule exists?
-    # If the rule failed, run the default access rule
-    if exitstatus != 0 and opts.purpose == 'access':
+    # If the access normalization command has errored AND a derivative was NOT
+    # created, then we run the default access rule. Note that we DO need to
+    # check if the derivative file exists. Even when a verification command
+    # exists for the normalization command, the transcoder.py::Command.execute
+    # method will only run the verification command if the normalization
+    # command returns a 0 exit code.
+    if (    exitstatus != 0 and
+            opts.purpose == 'access' and
+            cl.commandObject.output_location and
+            (not os.path.isfile(cl.commandObject.output_location))):
         # Fall back to default rule
         try:
             fallback_rule = get_default_rule(opts.purpose)

--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -362,14 +362,18 @@ def main(opts):
     cl = transcoder.CommandLinker(rule, command, replacement_dict, opts, once_normalized)
     exitstatus = cl.execute()
 
-    # If the access normalization command has errored AND a derivative was NOT
-    # created, then we run the default access rule. Note that we DO need to
-    # check if the derivative file exists. Even when a verification command
-    # exists for the normalization command, the transcoder.py::Command.execute
-    # method will only run the verification command if the normalization
-    # command returns a 0 exit code.
+    # If the access/thumbnail normalization command has errored AND a
+    # derivative was NOT created, then we run the default access/thumbnail
+    # rule. Note that we DO need to check if the derivative file exists. Even
+    # when a verification command exists for the normalization command, the
+    # transcoder.py::Command.execute method will only run the verification
+    # command if the normalization command returns a 0 exit code.
+    # Errored thumbnail normalization also needs to result in default thumbnail
+    # normalization; if not, then a transfer with a single file that failed
+    # thumbnail normalization will result in a failed SIP at "Prepare DIP: Copy
+    # thumbnails to DIP directory"
     if (    exitstatus != 0 and
-            opts.purpose == 'access' and
+            opts.purpose in ('access', 'thumbnail') and
             cl.commandObject.output_location and
             (not os.path.isfile(cl.commandObject.output_location))):
         # Fall back to default rule

--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -372,7 +372,7 @@ def main(opts):
     # normalization; if not, then a transfer with a single file that failed
     # thumbnail normalization will result in a failed SIP at "Prepare DIP: Copy
     # thumbnails to DIP directory"
-    if (    exitstatus != 0 and
+    if (exitstatus != 0 and
             opts.purpose in ('access', 'thumbnail') and
             cl.commandObject.output_location and
             (not os.path.isfile(cl.commandObject.output_location))):

--- a/src/MCPClient/lib/clientScripts/trimRestructureForCompliance.py
+++ b/src/MCPClient/lib/clientScripts/trimRestructureForCompliance.py
@@ -33,6 +33,7 @@ from archivematicaFunctions import REQUIRED_DIRECTORIES
 from custom_handlers import get_script_logger
 import fileOperations
 
+
 def restructureTRIMForComplianceFileUUIDsAssigned(unitPath, unitIdentifier, unitIdentifierType="transfer", unitPathReplaceWith="%transferDirectory%"):
     # Create required directories
     archivematicaFunctions.create_directories(REQUIRED_DIRECTORIES, unitPath)


### PR DESCRIPTION
If the access normalization rule fails, we should fall back to the default access rule to ensure there is always an access copy. Not needed for preservation, since the original is always in the AIP.

refs redmine 10779