### PR TITLE
Migration: Empty checksums are '' not None

### DIFF
--- a/src/dashboard/src/main/migrations/0021_checksum_algorithms.py
+++ b/src/dashboard/src/main/migrations/0021_checksum_algorithms.py
@@ -9,7 +9,7 @@ def data_migration(apps, schema_editor):
     DashboardSetting = apps.get_model('main', 'DashboardSetting')
     StandardTaskConfig = apps.get_model('main', 'StandardTaskConfig')
 
-    File.objects.filter(checksumtype=None).update(checksumtype='sha256')
+    File.objects.filter(checksumtype='').update(checksumtype='sha256')
     DashboardSetting.objects.create(name='checksum_type', value='sha256')
     StandardTaskConfig.objects.filter(id='045f84de-2669-4dbc-a31b-43a4954d0481').update(arguments='create "%SIPDirectory%%SIPName%-%SIPUUID%" "%SIPDirectory%" "logs/" "objects/" "METS.%SIPUUID%.xml" "thumbnails/" "metadata/" --writer filesystem')
 


### PR DESCRIPTION
When setting the default value for old rows, check against '' not None, since the column is blank=True but null=False.

refs redmine 10966

Will be cherry-picked to qa/1.x