### PR TITLE
Reingest approval API endpoint

### DIFF
--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     url(r'ingest/waiting', views.waiting_for_user_input),
     url(r'^(?P<unit_type>transfer|ingest)/(?P<unit_uuid>' + settings.UUID_REGEX + ')/delete/', views.mark_hidden),
 
+    url(r'^ingest/reingest/approve', views.reingest_approve),
     url(r'^ingest/reingest', views.reingest, {'target': 'ingest'}),
     url(r'^ingest/completed', views.completed_ingests),
     url(r'^ingest/copy_metadata_files/$', views.copy_metadata_files_api),

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -423,6 +423,58 @@ def approve_transfer_via_mcp(directory, transfer_type, user_id):
 
 
 @_api_endpoint(expected_methods=['POST'])
+def reingest_approve(request):
+    """Approve an AIP partial re-ingest.
+
+    - Method:      POST
+    - URL:         api/ingest/reingest/approve
+    - POST params:
+                   - username -- AM username
+                   - api_key  -- AM API key
+                   - name     -- SIP directory name
+                   - uuid     -- SIP UUID
+
+    TODO: this is just a temporary way of getting the API to do the
+    equivalent of clicking "Approve AIP reingest" in the dashboard when faced
+    with "Approve AIP reingest". This is non-dry given
+    ``approve_transfer_via_mcp`` above and should probably me made congruent
+    with that function and ``approve_transfer``.
+    """
+    if request.method == 'POST':
+        error = authenticate_request(request)
+        if error:
+            response = {'error': True, 'message': error}
+            return helpers.json_response(response, status_code=403)
+        sip_name = request.POST.get('name')
+        sip_uuid = request.POST.get('uuid')
+        if not all([sip_name, sip_uuid]):
+            response = {'error': True,
+                        'message': '"name" and "uuid" are required.'}
+            return helpers.json_response(response, status_code=400)
+        job = models.Job.objects.filter(
+            sipuuid=sip_uuid,
+            microservicegroup='Reingest AIP',
+            currentstep=models.Job.STATUS_AWAITING_DECISION
+        ).first()
+        if job:
+            # Hard-coded UUID. Bad. Don't to this. Temporary.
+            approve_aip_reingest_choice_uuid = \
+                '260ef4ea-f87d-4acf-830d-d0de41e6d2af'
+            MCPClient().execute(
+                job.jobuuid, approve_aip_reingest_choice_uuid, '')
+            response = {'message': 'Approval successful.'}
+            return helpers.json_response(response)
+        else:
+            # No job to be found.
+            response = {'error': True,
+                        'message': ('There is no "Reingest AIP" job awaiting a'
+                                    ' decision for SIP {}'.format(sip_uuid))}
+            return helpers.json_response(response, status_code=400)
+    else:
+        return django.http.HttpResponseNotAllowed(permitted_methods=['POST'])
+
+
+@_api_endpoint(expected_methods=['POST'])
 def reingest(request, target):
     """
     Endpoint to approve reingest of an AIP to the beginning of transfer or ingest.

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -440,38 +440,31 @@ def reingest_approve(request):
     ``approve_transfer_via_mcp`` above and should probably me made congruent
     with that function and ``approve_transfer``.
     """
-    if request.method == 'POST':
-        error = authenticate_request(request)
-        if error:
-            response = {'error': True, 'message': error}
-            return helpers.json_response(response, status_code=403)
-        sip_name = request.POST.get('name')
-        sip_uuid = request.POST.get('uuid')
-        if not all([sip_name, sip_uuid]):
-            response = {'error': True,
-                        'message': '"name" and "uuid" are required.'}
-            return helpers.json_response(response, status_code=400)
-        job = models.Job.objects.filter(
-            sipuuid=sip_uuid,
-            microservicegroup='Reingest AIP',
-            currentstep=models.Job.STATUS_AWAITING_DECISION
-        ).first()
-        if job:
-            # Hard-coded UUID. Bad. Don't to this. Temporary.
-            approve_aip_reingest_choice_uuid = \
-                '260ef4ea-f87d-4acf-830d-d0de41e6d2af'
-            MCPClient().execute(
-                job.jobuuid, approve_aip_reingest_choice_uuid, '')
-            response = {'message': 'Approval successful.'}
-            return helpers.json_response(response)
-        else:
-            # No job to be found.
-            response = {'error': True,
-                        'message': ('There is no "Reingest AIP" job awaiting a'
-                                    ' decision for SIP {}'.format(sip_uuid))}
-            return helpers.json_response(response, status_code=400)
+    sip_name = request.POST.get('name')
+    sip_uuid = request.POST.get('uuid')
+    if not all([sip_name, sip_uuid]):
+        response = {'error': True,
+                    'message': '"name" and "uuid" are required.'}
+        return helpers.json_response(response, status_code=400)
+    job = models.Job.objects.filter(
+        sipuuid=sip_uuid,
+        microservicegroup='Reingest AIP',
+        currentstep=models.Job.STATUS_AWAITING_DECISION
+    ).first()
+    if job:
+        # Hard-coded UUID. Bad. Don't to this. Temporary.
+        approve_aip_reingest_choice_uuid = \
+            '260ef4ea-f87d-4acf-830d-d0de41e6d2af'
+        MCPClient().execute(
+            job.jobuuid, approve_aip_reingest_choice_uuid, '')
+        response = {'message': 'Approval successful.'}
+        return helpers.json_response(response)
     else:
-        return django.http.HttpResponseNotAllowed(permitted_methods=['POST'])
+        # No job to be found.
+        response = {'error': True,
+                    'message': ('There is no "Reingest AIP" job awaiting a'
+                                ' decision for SIP {}'.format(sip_uuid))}
+        return helpers.json_response(response, status_code=400)
 
 
 @_api_endpoint(expected_methods=['POST'])


### PR DESCRIPTION
Based on @jrwdunham 's work here: https://github.com/artefactual/archivematica/tree/dev/issue-10180-little-jisc

* Rebased onto qa/1.x
* Adapted to use new `api_endpoint` decorator
* Look up choice UUID instead of hard coding
* Pass in user ID to MCP `execute()`

It could still use some tidying up and integrating with `approve_transfer_via_mcp` as per TODO comments.