### PR TITLE
Problem: tests don't run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 
 # coverage data file
 .coverage
+
+# pytest's working directory
+.cache

--- a/src/archivematicaCommon/lib/custom_handlers.py
+++ b/src/archivematicaCommon/lib/custom_handlers.py
@@ -33,7 +33,12 @@ def get_script_logger(name, formatter=SCRIPT_FILE_FORMAT, logfile="/var/log/arch
                 'formatter': 'fmt',
                 'filename': logfile,
                 'maxBytes': logsize,
-            }
+            },
+            'console': {
+                'level': 'DEBUG',
+                'class': 'logging.StreamHandler',
+                'formatter': 'fmt',
+            },
         },
         'loggers': {
             root: {  # 'archivematica'
@@ -49,6 +54,15 @@ def get_script_logger(name, formatter=SCRIPT_FILE_FORMAT, logfile="/var/log/arch
         },
     }
 
+    # Don't use the `logfile` handler during testing so we don't force the
+    # developer to run the suite as the archivematica user.
+    try:
+        if os.environ['DJANGO_SETTINGS_MODULE'] == 'settings.test':
+            del logging_config['handlers']['logfile']
+            logging_config['root']['handlers'] = ['console']
+    except KeyError:
+        pass
+   
     logging.config.dictConfig(logging_config)
     logger = logging.getLogger(name)
     return logger


### PR DESCRIPTION
Problems:
- Permission issue when running tests because logs are written to `/var/log/archivematica` which is owned by `archivematica`. The solution is to log to `stderr` when running tests.
- Fix migration issue that was breaking the test suite, `models.py` was deleted but it turns out that it's important to leave the file there even if it's empty so the migrations are executed. The last migration was to delete the models, which is still important.

This was affecting `qa/1.x` only.