### PR TITLE
Remove unused MCP Server dependencies

### DIFF
--- a/src/MCPServer/debian/control
+++ b/src/MCPServer/debian/control
@@ -14,7 +14,6 @@ Depends:
 	archivematica-common(>=1.6.0),
 	dbconfig-common,
 	mysql-server,
-	gearman,
-	uuid
+	gearman
 Description: MCP Server for Archivematica
   Workflow manager for Archivematica 

--- a/src/MCPServer/osdeps/CentOS-7.json
+++ b/src/MCPServer/osdeps/CentOS-7.json
@@ -8,6 +8,5 @@
   "osdeps_repos": [
   ],
   "osdeps_packages": [
-  { "name": "uuid", "state": "latest"}
   ]
 }

--- a/src/MCPServer/osdeps/Ubuntu-14.json
+++ b/src/MCPServer/osdeps/Ubuntu-14.json
@@ -8,8 +8,5 @@
   "osdeps_repos": [
   ],
   "osdeps_packages": [
-  { "name": "dbconfig-common", "state": "latest"},
-  { "name": "logapp", "state": "latest"},
-  { "name": "uuid", "state": "latest"}
   ]
 }


### PR DESCRIPTION
fixes #590

update the debian control file and osdeps files to remove
os dependencies not used by the MCP Server.