### PR TITLE
Delete unneeded TravisCI env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ sudo: false
 
 language: python
 
-python:
-  - "2.7"
-
 before_script:
   - pip install tox
 


### PR DESCRIPTION
Combining `python: 2.7` and `matrix` was causing TravisCI to create two
different build jobs. One with the `TOXENV` defined and one without
it. We only need the one defined under the `matrix` section.

To clarify that, I'm trying to avoid the following:

![image](https://cloud.githubusercontent.com/assets/606459/25960651/65d79bea-362c-11e7-940b-c65946de523c.png)

The first build in the list is redundant. Having only one job should help to speed up the build.
