### PR TITLE
GPG encryption: encrypted AIPs identified

### DIFF
--- a/src/MCPClient/lib/clientScripts/indexAIP.py
+++ b/src/MCPClient/lib/clientScripts/indexAIP.py
@@ -91,7 +91,8 @@ def index_aip():
         mets_path,
         size=aip_info['size'],
         aips_in_aic=aips_in_aic,
-        identifiers=identifiers)
+        identifiers=identifiers,
+        encrypted=aip_info['encrypted'])
 
     # Index AIP files
     print('Indexing AIP files')

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -390,7 +390,8 @@ def set_up_mapping(client, index):
         set_up_mapping_aip_index(client)
 
 
-def index_aip(client, uuid, name, filePath, pathToMETS, size=None, aips_in_aic=None, identifiers=[]):
+def index_aip(client, uuid, name, filePath, pathToMETS, size=None, aips_in_aic=None, identifiers=[], encrypted=False):
+
     tree = ElementTree.parse(pathToMETS)
 
     # TODO add a conditional to toggle this
@@ -424,6 +425,7 @@ def index_aip(client, uuid, name, filePath, pathToMETS, size=None, aips_in_aic=N
         'countAIPsinAIC': aips_in_aic,
         'identifiers': identifiers,
         'transferMetadata': _extract_transfer_metadata(root),
+        'encrypted': encrypted
     }
     wait_for_cluster_yellow_status(client)
     try_to_index(client, aipData, 'aips', 'aip')

--- a/src/dashboard/src/templates/archival_storage/list.html
+++ b/src/dashboard/src/templates/archival_storage/list.html
@@ -89,6 +89,11 @@
         </th>
         <th>
           <div>
+            {% trans "Encrypted" %}
+          </div>
+        </th>
+        <th>
+          <div>
             {% trans "Actions" %}
           </div>
         </th>
@@ -101,6 +106,7 @@
             <td class="uuid"><a href="{% url 'view_aip' item.uuid %}">{{ item.uuid }}</a></td>
             <td><span class="timestamp">{{ item.date }}</span></td>
             <td>{{ item.status }}</td>
+            <td>{{ item.encrypted }}</td>
             <td><a href="{% url 'view_aip' item.uuid %}">{% trans "View" %}</a></td>
           </tr>
         {% endfor %}

--- a/src/dashboard/src/templates/archival_storage/search.html
+++ b/src/dashboard/src/templates/archival_storage/search.html
@@ -61,6 +61,7 @@
           <th>{% trans "Files" %}</th>
           <th>{% trans "Date stored" %}</th>
           <th>{% trans "Status" %}</th>
+          <th>{% trans "Encrypted" %}</th>
           <th>{% trans "Actions" %}</th>
         </thead>
         <tbody>
@@ -94,6 +95,7 @@
             <td>{{ term_usage.count }} file{{term_usage.count|pluralize}}</td>
             <td><span class='timestamp'>{{ term_usage.created }}</a></td>
             <td>{{ term_usage.status }}</td>
+            <td>{{ term_usage.encrypted }}</td>
             <td><a href="{% url 'view_aip' term_usage.uuid %}">{% trans "View" %}</a></td>
           </tr>
         {% endfor %}

--- a/src/dashboard/src/templates/archival_storage/view.html
+++ b/src/dashboard/src/templates/archival_storage/view.html
@@ -76,6 +76,10 @@
         <td>{{ status }}</td>
       </tr>
       <tr>
+        <th>{% trans "Encrypted" %}</th>
+        <td>{{ encrypted }}</td>
+      </tr>
+      <tr>
         <th>{% trans "Location" %}</th>
         <td>
           <a class="btn btn-default btn-sm" href="{% url 'components.archival_storage.views.aip_download' uuid %}">{% trans "Download" %}</a>


### PR DESCRIPTION
AIPs in GPG-encrypted spaces are marked as "encrypted" in the archival storage tab.

See https://github.com/artefactual/archivematica-storage-service/pull/192