### PR TITLE
Delete base64 git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/dashboard/src/external/base64-helpers"]
-	path = src/dashboard/src/external/base64-helpers
-	url = https://github.com/artefactual-labs/base64-helpers.git


### PR DESCRIPTION
In practice we're using src/dashboard/src/media/js/vendor/base64 which was
never replaced with a symlink to the submodule. As we prefer to avoid git
submodules this commit just deletes it. If we need a more recent version of
base64.js in the future we'll just vendor it again or approach the dependency
differently, e.g. bower...

Fixes #585.