### PR TITLE
TRIM: update to use Django models

### DIFF
--- a/src/MCPClient/lib/clientScripts/trimCreateRightsEntries.py
+++ b/src/MCPClient/lib/clientScripts/trimCreateRightsEntries.py
@@ -2,7 +2,7 @@
 
 # This file is part of Archivematica.
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -131,7 +131,7 @@ for dir in os.listdir(transferPath):
         if  file == "ContainerMetadata.xml" or file.endswith("Metadata.xml") or not os.path.isfile(filePath):
             continue
 
-        fileUUID = getFileUUIDLike(filePath, transferPath, transferUUID, "transferUUID", "%transferDirectory%")[filePath.replace(transferPath, "%transferDirectory%", 1)]
+        fileUUID = getFileUUIDLike(filePath, transferPath, transferUUID, "transfer", "%transferDirectory%")[filePath.replace(transferPath, "%transferDirectory%", 1)]
         FileMetadataAppliesToType = '7f04d9d4-92c2-44a5-93dc-b7bfdf0c1f17'
 
         # RightsStatement

--- a/src/MCPClient/lib/clientScripts/trimRestructureForCompliance.py
+++ b/src/MCPClient/lib/clientScripts/trimRestructureForCompliance.py
@@ -2,7 +2,7 @@
 
 # This file is part of Archivematica.
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -33,7 +33,7 @@ from archivematicaFunctions import REQUIRED_DIRECTORIES
 from custom_handlers import get_script_logger
 import fileOperations
 
-def restructureTRIMForComplianceFileUUIDsAssigned(unitPath, unitIdentifier, unitIdentifierType="transfer_id", unitPathReplaceWith="%transferDirectory%"):
+def restructureTRIMForComplianceFileUUIDsAssigned(unitPath, unitIdentifier, unitIdentifierType="transfer", unitPathReplaceWith="%transferDirectory%"):
     # Create required directories
     archivematicaFunctions.create_directories(REQUIRED_DIRECTORIES, unitPath)
 

--- a/src/MCPClient/lib/clientScripts/trimVerifyChecksums.py
+++ b/src/MCPClient/lib/clientScripts/trimVerifyChecksums.py
@@ -2,7 +2,7 @@
 
 # This file is part of Archivematica.
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -73,7 +73,7 @@ for transfer_dir in os.listdir(transferPath):
         if objectMD5 == xmlMD5:
             print('File OK: ', xmlMD5, filePath.replace(transferPath, '%TransferDirectory%'))
 
-            fileID = getFileUUIDLike(filePath, transferPath, transferUUID, 'transferUUID', '%transferDirectory%')
+            fileID = getFileUUIDLike(filePath, transferPath, transferUUID, 'transfer', '%transferDirectory%')
             for path, fileUUID in fileID.items():
                 eventDetail = 'program="python"; module="hashlib.md5()"'
                 eventOutcome = 'Pass'

--- a/src/MCPClient/lib/clientScripts/trimVerifyManifest.py
+++ b/src/MCPClient/lib/clientScripts/trimVerifyManifest.py
@@ -2,7 +2,7 @@
 
 # This file is part of Archivematica.
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -86,7 +86,7 @@ for line in open(os.path.join(transferPath, "manifest.txt"),'r'):
         if os.path.isfile(path):
             print("Verified file exists: ", path.replace(transferPath, "%TransferDirectory%"))
             fileCount += 1
-            fileID = getFileUUIDLike(path, transferPath, transferUUID, "transferUUID", "%transferDirectory%")
+            fileID = getFileUUIDLike(path, transferPath, transferUUID, "transfer", "%transferDirectory%")
             if not len(fileID):
                 print("Could not find fileUUID for: ", path.replace(transferPath, "%TransferDirectory%"), file=sys.stderr)
                 exitCode += 1
@@ -108,7 +108,7 @@ for line in open(os.path.join(transferPath, "manifest.txt"),'r'):
             if i != -1 and os.path.isfile(path2):
                 print("Warning, verified file exists, but with implicit extension case: ", path.replace(transferPath, "%TransferDirectory%"), file=sys.stderr)
                 fileCount += 1
-                fileID = getFileUUIDLike(path2, transferPath, transferUUID, "transferUUID", "%transferDirectory%")
+                fileID = getFileUUIDLike(path2, transferPath, transferUUID, "transfer", "%transferDirectory%")
                 if not len(fileID):
                     print("Could not find fileUUID for: ", path.replace(transferPath, "%TransferDirectory%"), file=sys.stderr)
                     exitCode += 1


### PR DESCRIPTION
refs #11161

The TRIM transfer type is normally not available in an Archivematica
dashboard.  If that option is enabled, a workflow is triggered that
uses these four scripts.

These scripts have not been updated since before the 1.4.0 release.
They call getFileUUIDLike(), a method that is defined in
archivematicaCommon/fileOperations.py, and that was updated in
version 1.4.0 to use Django Models.

As a result, the list of permissible values for the 4th parameter
changed.

This commit updates the TRIM workflow to call getFileUUIDLike
correctly.