### PR TITLE
Set filepath for zip files correctly when starting transfer

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -246,7 +246,9 @@ def start_transfer(transfer_name, transfer_type, accession, paths, row_ids):
 
         if helpers.file_is_an_archive(path):
             transfer_dir = temp_dir
-            filepath = os.path.join(temp_dir, os.path.basename(path))
+            p = path.split(':', 1)[1]
+            logger.debug('found a zip file, splitting path ' + p)
+            filepath = os.path.join(temp_dir, os.path.basename(p))
         else:
             path = os.path.join(path, '.')  # Copy contents of dir but not dir
             transfer_dir = os.path.join(temp_dir, target)


### PR DESCRIPTION
fixes #625 

refs #11224

When using the dashboard rest api to start a transfer, if the contents
of the new transfer contain a zip file, the start_transfer rest api
endpoint was returning a 500 server error, because the path to the
zip file was not getting set correctly.

This commit resolves this issue.