### PR TITLE
removing shebangs from config files 

### DIFF
--- a/src/MCPClient/etc/clientConfig.conf
+++ b/src/MCPClient/etc/clientConfig.conf
@@ -1,8 +1,6 @@
-#!/bin/bash
-
 # This file is part of Archivematica.
 #
-# Copyright 2010-2012 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/src/MCPServer/etc/serverConfig.conf
+++ b/src/MCPServer/etc/serverConfig.conf
@@ -1,8 +1,6 @@
-#!/bin/bash
-
 # This file is part of Archivematica.
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by


### PR DESCRIPTION
This closes #587.

config files don't need to be executable, so this commit removes
the interpreter directive from the top line of each config file.