### PR TITLE
Allow 'object count' from SS to be string

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -83,7 +83,14 @@ def _prepare_browse_response(response):
         if 'levelOfDescription' in prop:
             prop['display_string'] = prop['levelOfDescription']
         elif 'object count' in prop:
-            prop['display_string'] = ungettext("%(count)d object", "%(count)d objects", prop['object count']) % {'count': prop['object count']}
+            try:
+                prop['display_string'] = ungettext(
+                    "%(count)d object",
+                    "%(count)d objects",
+                    prop['object count']) % {'count': prop['object count']}
+            except TypeError:  # 'object_count' val can be a string, see SS:space.py
+                prop['display_string'] = _(
+                    "%(count)s objects") % {'count': prop['object count']}
         elif 'size' in prop:
             prop['display_string'] = django.template.defaultfilters.filesizeformat(prop['size'])
 


### PR DESCRIPTION
Fixes #636. If a transfer source location contains over 5000 files, then
filesystem_ajax/views.py will trigger a TypeError because the call to
ungettext assumes that the value of the 'object count' attribute
returned by the SS will always be an integer. In fact, in this case the
value will be a string, i.e., '5000+'. This change catches the
``TypeError`` and uses ``ugettext`` with ``%(...)s``.