### PR TITLE
Backlog: fix ES query to get all entries

### DIFF
--- a/src/dashboard/src/components/backlog/views.py
+++ b/src/dashboard/src/components/backlog/views.py
@@ -146,7 +146,9 @@ def search(request):
         else:  # Transfer mode
             # Query to transfers/transferfile, but only fetch & aggregrate transfer UUIDs
             # Based on transfer UUIDs, query to transfers/transfer
-            query['aggs'] = {'transfer_uuid': {'terms': {'field': 'sipuuid'}}}
+            # ES query will limit to 10 aggregation results by default, add size parameter in terms to override
+            # (https://stackoverflow.com/questions/22927098/show-all-elasticsearch-aggregation-results-buckets-and-not-just-10)
+            query['aggs'] = {'transfer_uuid': {'terms': {'field': 'sipuuid', 'size': '10000'}}}
             hits = es_client.search(
                 index='transfers',
                 doc_type='transferfile',


### PR DESCRIPTION
Archivematica uses an ES aggregations query to get backlog entries.
Aggregation queries return the top 10 results only, for this reason the
backlog tab was showing only a maximum of 10 items.

Add a size parameter to terms in the ES query in order to get all
the backlog entries.

Refs. #11252

Also needs to be cherry-picked to qa/1.x