### PR TITLE
Set up elastic search client in manage.py

### DIFF
--- a/src/dashboard/src/manage.py
+++ b/src/dashboard/src/manage.py
@@ -5,6 +5,10 @@ import sys
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.local")
 
+    # Set up Elasticsearch client
+    import elasticSearchFunctions
+    elasticSearchFunctions.setup_reading_from_client_conf()
+
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
When running dashboard using `manage.py` (which I find useful for debugging) some areas of the app complain about elastic search not being set up. This is already done in `wsgi.py` but not here.