### PR TITLE
MCPClient: add alternate dependency for libavcodec

### DIFF
--- a/src/MCPClient/debian/control
+++ b/src/MCPClient/debian/control
@@ -18,7 +18,7 @@ Depends:
 	clamav,
 	clamav-daemon,
 	ffmpeg (>= 7:3.0),
-	libavcodec-extra-56,
+	libavcodec-extra-56|libavcodec-extra57,
 	fits (>= 0.8.4),
 	gearman,
 	imagemagick (>=8:6.7.7.10),


### PR DESCRIPTION
This way, the same package can be built for 14.04 and 16.04