### PR TITLE
Give AIP download a filename

### DIFF
--- a/src/dashboard/src/components/helpers.py
+++ b/src/dashboard/src/components/helpers.py
@@ -331,7 +331,11 @@ def stream_file_from_storage_service(url, error_message='Remote URL returned {}'
     stream = requests.get(url, stream=True, timeout=120)
     if stream.status_code == 200:
         content_type = stream.headers.get('content-type', 'text/plain')
-        return StreamingHttpResponse(stream, content_type=content_type)
+        content_disposition = stream.headers.get('content-disposition')
+        response = StreamingHttpResponse(stream, content_type=content_type)
+        if content_disposition:
+            response['Content-Disposition'] = content_disposition
+        return response
     else:
         response = {
             'success': False,


### PR DESCRIPTION
This is a fix for #646 - takes the content disposition (which gives the download filename) from storage service response and passes it on to the streaming Dashboard response (and not doing so if no content disposition is set).