### PR TITLE
Update django-autoslug to v1.7.1.post1

### DIFF
--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -1,7 +1,7 @@
 bagit==1.5.2
 Django>=1.8,<1.9
 django-annoying==0.7.7
-django-autoslug==1.7.1
+git+https://github.com/artefactual-labs/django-autoslug@v1.7.1.post1#egg=django-autoslug
 django-mysqlpool==0.1-9
 django-extensions==1.1.1
 mysqlclient==1.3.9

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -6,7 +6,7 @@ django-model-utils==1.3.1
 logutils==0.3.3
 django-tastypie==0.13.2
 django-extensions==1.1.1
-django-autoslug==1.7.1
+git+https://github.com/artefactual-labs/django-autoslug@v1.7.1.post1#egg=django-autoslug
 django-annoying==0.7.7
 elasticsearch>=1.0.0,<2.0.0
 gearman==2.0.2


### PR DESCRIPTION
fpr-admin brings PRONOM 90 but the database migration fails because of an
incompatibility with Django 1.8. We need to make sure that these requirements
are not using an older version.

See https://github.com/artefactual/archivematica-fpr-admin/pull/51 for more
details.