### PR TITLE
update Fido to version 1.3.6

### DIFF
--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -10,4 +10,4 @@ lxml==3.5.0
 metsrw==0.1.0
 requests==2.7.0
 unidecode==0.04.19
-opf-fido==1.3.5
+opf-fido==1.3.6


### PR DESCRIPTION
Update FIDO to the most recent version, that supports PRONOM v90.