### PR TITLE
Delete unused django-autoslug

### DIFF
--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -1,7 +1,6 @@
 bagit==1.5.2
 Django>=1.8,<1.9
 django-annoying==0.7.7
-django-autoslug==1.7.1
 django-mysqlpool==0.1-9
 django-extensions==1.1.1
 mysqlclient==1.3.9

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -7,7 +7,6 @@ django-model-utils==1.3.1
 logutils==0.3.3
 django-tastypie==0.13.2
 django-extensions==1.1.1
-django-autoslug==1.7.1
 django-annoying==0.7.7
 elasticsearch>=1.0.0,<2.0.0
 git+https://github.com/artefactual/archivematica-fpr-admin.git@v1.6.0#egg=archivematica-fpr-admin


### PR DESCRIPTION
It is used by fpr-admin which has its own requirements file.