### PR TITLE
Readd and update django-autoslug to 1.9.3

### DIFF
--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -23,3 +23,7 @@ pyasn1
 requests==2.7.0
 lxml==3.5.0
 django-forms-bootstrap>=3.0.0,<4.0.0
+
+# fpr-admin needs this. fpr-admin has its own requirements but not until AM 1.7
+# the fpr-admin was installed as a Python package.
+django-autoslug==1.9.3


### PR DESCRIPTION
I deleted django-autoslug in 7d0cef673581753379043a070650122b06c9d8d5 because I
wanted to use the version installed by fpr-admin as that's the only app using
it. That's ok in AM 1.7 because fpr-admin is installed as a Python package.
But in AM 1.6, fpr-admin is still a git submodule. We could have packages and
roles using the fpr-admin requirements but at this point this is the easiest
solution.

This closes #661. Only needed in v1.6.