### PR TITLE
Problem: "Generate AIP METS" fails to manage dspace transfers

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -773,11 +773,9 @@ def createFileSec(directoryPath, parentDiv, baseDirectoryPath, baseDirectoryName
                     "filegrpuse": "original",
                     "originallocation__startswith": os.path.dirname(f.originallocation)
                 }
-                try:
-                    original_file = File.objects.get(**kwargs)
+                original_file = File.objects.filter(**kwargs).first()
+                if original_file is not None:
                     GROUPID = 'Group-' + original_file.uuid
-                except (File.DoesNotExist, File.MultipleObjectsReturned):
-                    pass
 
             elif use in ("preservation", "text/ocr"):
                 # Derived files should be in the original file's group


### PR DESCRIPTION
`Generate AIP METS` may fail with DSpace transfers (error: "No groupID for file") because of an ORM query that is failing to handle multiple results gracefully - it seems to be a regression introduced in 34fd87382020d27f9dfdc40e4853e5dbb1ce6280 when we moved away from SQL, e.g.:

```
mysql> SELECT originalLocation FROM Files WHERE removedTime IS NULL AND fileGrpUse = "original" AND sipUUID = "aa8b1944-3304-404a-9439-f2e940cb6c19" AND originalLocation LIKE '%%transferDirectory%%objects/ITEM_12345.zip-2017-07-18T18:33:06.426589+00:00/%';
+-----------------------------------------------------------------------------------------------+
| originalLocation                                                                              |
+-----------------------------------------------------------------------------------------------+
| %transferDirectory%objects/ITEM_12345.zip-2017-07-18T18:33:06.426589+00:00/bitstream_1086.m4v |
| %transferDirectory%objects/ITEM_12345.zip-2017-07-18T18:33:06.426589+00:00/bitstream_1089.mp4 |
| %transferDirectory%objects/ITEM_12345.zip-2017-07-18T18:33:06.426589+00:00/bitstream_1011.rdf |
+-----------------------------------------------------------------------------------------------+
3 rows in set (0.00 sec)
```

The solution suggested in this PR is to accept the fact that a situation with multiple matches is possible and use the first one in the list.