### PR TITLE
Fixing typo in xlst-devel package name

### DIFF
--- a/src/dashboard/osdeps/CentOS-7.json
+++ b/src/dashboard/osdeps/CentOS-7.json
@@ -15,7 +15,7 @@
   { "name": "policycoreutils-python", "state": "latest"},
   { "name": "libffi-devel", "state": "latest"},
   { "name": "libxml2-devel", "state": "latest"},
-  { "name": "libxslt1-devel", "state": "latest"},
+  { "name": "libxslt-devel", "state": "latest"},
   { "name": "openssl-devel", "state": "latest"},
   { "name": "python-devel", "state": "latest"}
   ]


### PR DESCRIPTION
Fixes #683

This is a bug introduced in #613 

This change will need to be cherry-picked into stable/1.6.x as well.