### PR TITLE
osdeps CentOS-7 correction

### DIFF
--- a/src/dashboard/osdeps/CentOS-7.json
+++ b/src/dashboard/osdeps/CentOS-7.json
@@ -15,7 +15,7 @@
   { "name": "policycoreutils-python", "state": "latest"},
   { "name": "libffi-devel", "state": "latest"},
   { "name": "libxml2-devel", "state": "latest"},
-  { "name": "libxslt1-devel", "state": "latest"},
+  { "name": "libxslt-devel", "state": "latest"},
   { "name": "openssl-devel", "state": "latest"},
   { "name": "python-devel", "state": "latest"}
   ]


### PR DESCRIPTION

In updating Denver test site, discovered error with dependency of libxslt1-devel - no such package, but libxslt-devel was present and worked when changed in CentOS-7.json.

Discussed in issue [#683](https://github.com/artefactual/archivematica/issues/683) and Justin has subsequently acknowledged he added the line being replaced, and it is a typo.

Change in [commit 40e354ea2477fbb87468a98370143d62fd9867fc](https://github.com/artefactual/archivematica/commit/40e354ea2477fbb87468a98370143d62fd9867fc) of branch dev/issue-11231-CentOS-try.