### PR TITLE
Remove symlinks

### DIFF
--- a/src/MCPClient/osdeps/RedHat-7.json
+++ b/src/MCPClient/osdeps/RedHat-7.json
@@ -1,1 +1,65 @@
-CentOS-7.json
+{
+  "_comments": [
+    "Add any comments here",
+    "Include here keys, repos, and packages required by this component not already in archivematicaCommon osdeps file",
+    "consider to put clamav related pkgs separately (install with a different playbook, like ES or the mysql server)",
+    "epel-release nux-dextop-release cert-forensic-tools on top of package list because they enable repos to be able to install other packages",
+    "archivematica-extras: siegfried fits bagit-java atool jhove",
+    "nux-dextop-release: ffmpeg ufraw",
+    "cert-forensic-tools: bulk_extractor sleuthkit libewf",
+    "fido is not required here anymore, it is installed with pip (opf-fido)"
+  ],
+  "osdeps_repokeys": [
+  ],
+  "osdeps_repos": [
+    { "name": "archivematica-extras",
+      "description": "archivematica extras",
+      "baseurl": "https://packages.archivematica.org/1.6.x/centos-extras",
+      "gpgcheck": "no",
+      "enabled": "yes"
+    }
+  ],
+  "osdeps_packages": [
+  { "name": "epel-release", "state": "latest"}
+  ],
+    "osdeps_packages_2": [
+  { "name": "https://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm", "state": "present"},
+  { "name": "https://forensics.cert.org/cert-forensics-tools-release-el7.rpm", "state": "present"}
+  ],
+  "osdeps_packages_3": [
+  { "name": "atool", "state": "latest"},
+  { "name": "bagit-java", "state": "latest"},
+  { "name": "bulk_extractor", "state": "latest"},
+  { "name": "ffmpeg", "state": "latest"},
+  { "name": "fits", "state": "latest"},
+  { "name": "gearmand", "state": "latest"},
+  { "name": "ghostscript", "state": "latest"},
+  { "name": "ImageMagick", "state": "latest"},
+  { "name": "inkscape", "state": "latest"},
+  { "name": "jhove", "state": "latest"},
+  { "name": "libewf", "state": "latest"},
+  { "name": "libxml2", "state": "latest"},
+  { "name": "libpst", "state": "latest"},
+  { "name": "libraw1394", "state": "latest"},
+  { "name": "libvpx", "state": "latest"},
+  { "name": "md5deep", "state": "latest"},
+  { "name": "mediainfo", "state": "latest"},
+  { "name": "nfs-utils", "state": "latest"},
+  { "name": "java-1.7.0-openjdk-headless", "state": "latest"},
+  { "name": "openjpeg", "state": "latest"},
+  { "name": "p7zip", "state": "latest"},
+  { "name": "p7zip-plugins", "state": "latest"},
+  { "name": "pbzip2", "state": "latest"},
+  { "name": "perl-Image-ExifTool", "state": "latest"},
+  { "name": "postfix", "state": "latest"},
+  { "name": "python-unidecode", "state": "latest"},
+  { "name": "rsync", "state": "latest"},
+  { "name": "siegfried", "state": "latest"},
+  { "name": "sleuthkit", "state": "latest"},
+  { "name": "tesseract", "state": "latest"},
+  { "name": "tree", "state": "latest"},
+  { "name": "ufraw", "state": "latest"},
+  { "name": "uuid", "state": "latest"}
+  ]
+}
+

--- a/src/MCPServer/osdeps/RedHat-7.json
+++ b/src/MCPServer/osdeps/RedHat-7.json
@@ -1,1 +1,12 @@
-CentOS-7.json
+{
+  "_comments": [
+    "Add any comments here",
+    "Include here keys, repos, and packages required by this component not already in archivematicaCommon osdeps file"
+  ],
+  "osdeps_repokeys": [
+  ],
+  "osdeps_repos": [
+  ],
+  "osdeps_packages": [
+  ]
+}

--- a/src/MCPServer/osdeps/Ubuntu-16.json
+++ b/src/MCPServer/osdeps/Ubuntu-16.json
@@ -1,1 +1,12 @@
-Ubuntu-14.json
+{
+  "_comments": [
+    "Add any comments here",
+    "Include here keys, repos, and packages required by this component not already in archivematicaCommon osdeps file"
+  ],
+  "osdeps_repokeys": [
+  ],
+  "osdeps_repos": [
+  ],
+  "osdeps_packages": [
+  ]
+}

--- a/src/archivematicaCommon/osdeps/RedHat-7.json
+++ b/src/archivematicaCommon/osdeps/RedHat-7.json
@@ -1,1 +1,21 @@
-CentOS-7.json
+{
+  "_comments": [
+    "Add any comments here",
+    "(ref. http://stackoverflow.com/questions/244777/can-comments-be-used-in-json)",
+    "(ref. http://stackoverflow.com/questions/2392766/multiline-strings-in-json)",
+    "epel-release: required for some dependencies (TODO: specify )",
+    "gcc: required to build some pip dependencies"
+  ],
+  "osdeps_repokeys": [
+  ],
+  "osdeps_repos": [
+  ],
+  "osdeps_packages": [
+   { "name": "epel-release", "state": "latest"}
+  ],
+  "osdeps_packages_2": [
+   { "name": "gcc", "state": "latest"},
+   { "name": "mariadb-devel", "state": "latest"}
+  ]
+
+}

--- a/src/archivematicaCommon/osdeps/Ubuntu-16.json
+++ b/src/archivematicaCommon/osdeps/Ubuntu-16.json
@@ -1,1 +1,14 @@
-Ubuntu-14.json
+{
+  "_comments": [
+    "Add any comments here",
+    "http://stackoverflow.com/questions/244777/can-comments-be-used-in-json",
+    "http://stackoverflow.com/questions/2392766/multiline-strings-in-json"
+  ],
+  "osdeps_repokeys": [
+  ],
+  "osdeps_repos": [
+  ],
+  "osdeps_packages": [
+   { "name": "libmysqlclient-dev", "state": "latest"}
+   ]
+}

--- a/src/dashboard/osdeps/RedHat-7.json
+++ b/src/dashboard/osdeps/RedHat-7.json
@@ -1,1 +1,22 @@
-CentOS-7.json
+{
+  "_comments": [
+    "Add any comments here",
+    "Include here keys, repos, and packages required by this component not already in archivematicaCommon osdeps file",
+    "gettext is only required in development environments (used to make string translateable)",
+    "policycoreutils-python is for redhat/centos only?"
+  ],
+  "osdeps_repokeys": [
+  ],
+  "osdeps_repos": [
+  ],
+  "osdeps_packages": [
+  { "name": "gettext", "state": "latest"},
+  { "name": "nginx", "state": "latest"},
+  { "name": "policycoreutils-python", "state": "latest"},
+  { "name": "libffi-devel", "state": "latest"},
+  { "name": "libxml2-devel", "state": "latest"},
+  { "name": "libxslt-devel", "state": "latest"},
+  { "name": "openssl-devel", "state": "latest"},
+  { "name": "python-devel", "state": "latest"}
+  ]
+}

--- a/src/dashboard/osdeps/Ubuntu-16.json
+++ b/src/dashboard/osdeps/Ubuntu-16.json
@@ -1,1 +1,20 @@
-Ubuntu-14.json
+{
+  "_comments": [
+    "Add any comments here",
+    "Include here keys, repos, and packages required by this component not already in archivematicaCommon osdeps file"
+  ],
+  "osdeps_repokeys": [
+  ],
+  "osdeps_repos": [
+  ],
+  "osdeps_packages": [
+  { "name": "gettext", "state": "latest"},
+  { "name": "nginx", "state": "latest"},
+  { "name": "libffi-dev", "state": "latest"},
+  { "name": "libxml2-dev", "state": "latest"},
+  { "name": "libxslt1-dev", "state": "latest"},
+  { "name": "libssl-dev", "state": "latest"},
+  { "name": "python-dev", "state": "latest"}
+  ]
+}
+


### PR DESCRIPTION
Using symlinks cause Windows deployments to become much harder.
See #704 for more details.