### PR TITLE
Fix FITS XML

### DIFF
--- a/src/archivematicaCommon/lib/dicts.py
+++ b/src/archivematicaCommon/lib/dicts.py
@@ -172,6 +172,7 @@ class ReplacementDict(dict):
             rd['%fileExtension%'] = ext[1:]
             rd['%fileExtensionWithDot%'] = ext
 
+        rd['%tmpDirectory%'] = os.path.join(config['shared_directory'], 'tmp', '')
         rd['%processingDirectory%'] = config['processing_directory']
         rd['%watchDirectoryPath%'] = config['watch_directory']
         rd['%rejectedDirectory%'] = config['rejected_directory']

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -10,7 +10,7 @@ django-tastypie==0.13.2
 django-extensions==1.1.1
 django-annoying==0.7.7
 elasticsearch>=1.0.0,<2.0.0
-git+https://github.com/artefactual/archivematica-fpr-admin.git@v1.7.0#egg=archivematica-fpr-admin
+git+https://github.com/artefactual/archivematica-fpr-admin.git@v1.7.1#egg=archivematica-fpr-admin
 gearman==2.0.2
 gevent==1.2.1  # used by gunicorn's async workers
 gunicorn==19.7.1


### PR DESCRIPTION
- FITS characterization FPR command now no longer pollutes stdout with
  invalid XML.
- %tmpDirectory% variable now made available to commands; points to
  %sharedDirectory%/tmp/.