### PR TITLE
Dockerfile: stop cp shareDirectoryStructure

### DIFF
--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -30,7 +30,6 @@ RUN set -ex \
 
 RUN set -ex \
 	&& mkdir -p /var/archivematica/sharedDirectory \
-	&& cp -R /src/MCPServer/share/sharedDirectoryStructure/* /var/archivematica/sharedDirectory/ \
 	&& chown -R archivematica:archivematica /var/archivematica
 
 USER archivematica


### PR DESCRIPTION
This command fails because the source folder was deleted from MCPServer. The
shared directory structure is now populated from code.

Verify with: `docker build -f src/MCPServer.Dockerfile src/` - should fail before c0e27b5 is applied.