### PR TITLE
MCPClient: fixes in normalization process

### DIFF
--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -284,10 +284,6 @@ def main(opts):
 
     setup_dicts(mcpclient_settings)
 
-    # If no explicit return happens earlier, this returns `status`.
-    # This allows default rules to define a non-zero exit status.
-    status = SUCCESS
-
     # Find the file and it's FormatVersion (file identification)
     try:
         file_ = File.objects.get(uuid=opts.file_uuid)
@@ -355,7 +351,6 @@ def main(opts):
                 rule = get_default_rule(opts.purpose)
                 print("No rule for", os.path.basename(file_.currentlocation),
                       "falling back to default", opts.purpose, "rule")
-                status = NO_RULE_FOUND
             except FPRule.DoesNotExist:
                 print('Not normalizing', os.path.basename(file_.currentlocation),
                       ' - No rule or default rule found to normalize for', opts.purpose,
@@ -387,7 +382,6 @@ def main(opts):
         try:
             fallback_rule = get_default_rule(opts.purpose)
             print(opts.purpose, 'normalization failed, falling back to default', opts.purpose, 'rule')
-            status = RULE_FAILED  # TODO what status should this return?
         except FPRule.DoesNotExist:
             print('Not retrying normalizing for', os.path.basename(file_.currentlocation), ' - No default rule found to normalize for', opts.purpose, file=sys.stderr)
             fallback_rule = None
@@ -431,7 +425,7 @@ def main(opts):
         return RULE_FAILED
     else:
         print('Successfully normalized ', os.path.basename(opts.file_path), 'for', opts.purpose)
-        return status
+        return SUCCESS
 
 
 if __name__ == '__main__':

--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -355,8 +355,7 @@ def main(opts):
                   "- Falling back to default", opts.purpose, "rule")
         except FPRule.DoesNotExist:
             print('Not normalizing', os.path.basename(file_.currentlocation),
-                  ' - No rule or default rule found to normalize for', opts.purpose,
-                  file=sys.stderr)
+                  ' - No rule or default rule found to normalize for', opts.purpose)
             return NO_RULE_FOUND
 
     print('Format Policy Rule:', rule)
@@ -386,7 +385,7 @@ def main(opts):
             fallback_rule = get_default_rule(opts.purpose)
             print(opts.purpose, 'normalization failed, falling back to default', opts.purpose, 'rule')
         except FPRule.DoesNotExist:
-            print('Not retrying normalizing for', os.path.basename(file_.currentlocation), ' - No default rule found to normalize for', opts.purpose, file=sys.stderr)
+            print('Not retrying normalizing for', os.path.basename(file_.currentlocation), ' - No default rule found to normalize for', opts.purpose)
             fallback_rule = None
         # Don't re-run the same command
         if fallback_rule and fallback_rule.command != command:

--- a/src/MCPClient/lib/clientScripts/normalizeReport.py
+++ b/src/MCPClient/lib/clientScripts/normalizeReport.py
@@ -120,7 +120,7 @@ def report(uuid):
         except IndexError:
             logger.info('No normalization failures have been detected in type "%s"', jobtype)
             continue
-        tasks = Task.objects.filter(job=job).exclude(exitcode=0)
+        tasks = Task.objects.filter(job=job).exclude(exitcode__in=[0, 2])
         if not tasks.exists():
             logger.info('No normalization failures have been detected in type "%s"', jobtype)
             continue


### PR DESCRIPTION
- Don't return NO_RULE_FOUND or RULE_FAILED when exists and doesn't fail
- Avoid exception getting default rule
- Don't output to stderr when no rule was found
- Don't report normalization failures when no rule was found


