### PR TITLE
Problem: Dockerfiles cache invalidation happens too often

### DIFF
--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -48,7 +48,6 @@ RUN set -ex \
 		siegfried \
 		sleuthkit \
 		tesseract-ocr \
-		tika \
 		tree \
 		ufraw \
 		unrar-free \
@@ -70,17 +69,16 @@ RUN set -ex \
 		libxslt-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
-ADD archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/
+COPY archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/
+COPY dashboard/src/requirements/ /src/dashboard/src/requirements/
+COPY MCPClient/requirements/ /src/MCPClient/requirements/
 RUN pip install -r /src/archivematicaCommon/requirements/production.txt -r /src/archivematicaCommon/requirements/dev.txt
-ADD archivematicaCommon/ /src/archivematicaCommon/
-
-ADD dashboard/src/requirements/ /src/dashboard/src/requirements/
 RUN pip install -r /src/dashboard/src/requirements/production.txt -r /src/dashboard/src/requirements/dev.txt
-ADD dashboard/ /src/dashboard/
-
-ADD MCPClient/requirements/ /src/MCPClient/requirements/
 RUN pip install -r /src/MCPClient/requirements/production.txt -r /src/MCPClient/requirements/dev.txt
-ADD MCPClient/ /src/MCPClient/
+
+COPY archivematicaCommon/ /src/archivematicaCommon/
+COPY dashboard/ /src/dashboard/
+COPY MCPClient/ /src/MCPClient/
 
 RUN set -ex \
 	&& groupadd --gid 333 --system archivematica \

--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -12,17 +12,16 @@ RUN set -ex \
 		libmysqlclient-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
-ADD archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/
+COPY archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/
+COPY dashboard/src/requirements/ /src/dashboard/src/requirements/
+COPY MCPServer/requirements/ /src/MCPServer/requirements/
 RUN pip install -r /src/archivematicaCommon/requirements/production.txt -r /src/archivematicaCommon/requirements/dev.txt
-ADD archivematicaCommon/ /src/archivematicaCommon/
-
-ADD dashboard/src/requirements/ /src/dashboard/src/requirements/
 RUN pip install -r /src/dashboard/src/requirements/production.txt -r /src/dashboard/src/requirements/dev.txt
-ADD dashboard/ /src/dashboard/
-
-ADD MCPServer/requirements/ /src/MCPServer/requirements/
 RUN pip install -r /src/MCPServer/requirements/production.txt -r /src/MCPServer/requirements/dev.txt
-ADD MCPServer/ /src/MCPServer/
+
+COPY archivematicaCommon/ /src/archivematicaCommon/
+COPY dashboard/ /src/dashboard/
+COPY MCPServer/ /src/MCPServer/
 
 RUN set -ex \
 	&& groupadd --gid 333 --system archivematica \

--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -16,36 +16,32 @@ RUN set -ex \
 		nodejs \
 	&& rm -rf /var/lib/apt/lists/*
 
-ADD archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/
+COPY archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/
+COPY dashboard/src/requirements/ /src/dashboard/src/requirements/
 RUN pip install -r /src/archivematicaCommon/requirements/production.txt -r /src/archivematicaCommon/requirements/dev.txt
-ADD archivematicaCommon/ /src/archivematicaCommon/
-
-ADD dashboard/src/requirements/ /src/dashboard/src/requirements/
 RUN pip install -r /src/dashboard/src/requirements/production.txt -r /src/dashboard/src/requirements/dev.txt
-
-RUN set -ex \
-	&& groupadd --gid 333 --system archivematica \
-	&& useradd --uid 333 --gid 333 --create-home --system archivematica \
-	&& mkdir -p /src/dashboard/src/media \
-	&& chown archivematica:archivematica /src/dashboard/src/media
-
-ADD dashboard/frontend/transfer-browser/ /src/dashboard/frontend/transfer-browser/
-RUN chown -R archivematica:archivematica /src/dashboard/frontend/transfer-browser \
-	&& su -l archivematica -c "cd /src/dashboard/frontend/transfer-browser && npm install"
-
-ADD dashboard/frontend/appraisal-tab/ /src/dashboard/frontend/appraisal-tab/
-RUN chown -R archivematica:archivematica /src/dashboard/frontend/appraisal-tab \
-	&& su -l archivematica -c "cd /src/dashboard/frontend/appraisal-tab && npm install"
-
-ADD dashboard/ /src/dashboard/
-ADD dashboard/install/dashboard.gunicorn-config.py /etc/archivematica/dashboard.gunicorn-config.py
 
 RUN set -ex \
 	&& internalDirs=' \
 		/src/dashboard/src/static \
+		/src/dashboard/src/media \
 	' \
+	&& groupadd --gid 333 --system archivematica \
+	&& useradd --uid 333 --gid 333 --create-home --system archivematica \
 	&& mkdir -p $internalDirs \
 	&& chown -R archivematica:archivematica $internalDirs
+
+COPY dashboard/frontend/transfer-browser/ /src/dashboard/frontend/transfer-browser/
+RUN chown -R archivematica:archivematica /src/dashboard/frontend/transfer-browser \
+	&& su -l archivematica -c "cd /src/dashboard/frontend/transfer-browser && npm install"
+
+COPY dashboard/frontend/appraisal-tab/ /src/dashboard/frontend/appraisal-tab/
+RUN chown -R archivematica:archivematica /src/dashboard/frontend/appraisal-tab \
+	&& su -l archivematica -c "cd /src/dashboard/frontend/appraisal-tab && npm install"
+
+COPY archivematicaCommon/ /src/archivematicaCommon/
+COPY dashboard/ /src/dashboard/
+COPY dashboard/install/dashboard.gunicorn-config.py /etc/archivematica/dashboard.gunicorn-config.py
 
 USER archivematica
 


### PR DESCRIPTION
Each statement in a Dockerfile translates into a layer that is cached. The order matters because Docker brings an invalidation mechanism, if files have changed from the last build the according cached layer is invalidated and the following layers need to be rebuilt. I'm changing the order of these statements so pip requirements and npm builds are executed first and the rest of the source code is copied after that making sure that each time we run `docker-compose build` we don't have to install pip requirements and run npm builds unnecessarily.

Also a couple of minor changes:

- Delete unneeded dependency in MCPClient: tika
- Use COPY instead of ADD because its simplicity