### PR TITLE
Problem: RemovedInDjango19Warning's in Dashboard

### DIFF
--- a/src/dashboard/src/components/mcp/views.py
+++ b/src/dashboard/src/components/mcp/views.py
@@ -22,12 +22,12 @@ from lxml import etree
 
 def execute(request):
     result = ''
-    if 'uuid' in request.REQUEST:
+    if request.POST.get('uuid'):
         client = MCPClient()
-        uuid = request.REQUEST.get('uuid', '')
-        choice = request.REQUEST.get('choice', '')
-        uid = request.REQUEST.get('uid', '')
-        result = client.execute(uuid, choice, uid)
+        result = client.execute(
+            request.POST.get('uuid'),
+            request.POST.get('choice', ''),
+            request.POST.get('uid', ''))
     return HttpResponse(result, content_type='text/plain')
 
 

--- a/src/dashboard/src/components/rights/views.py
+++ b/src/dashboard/src/components/rights/views.py
@@ -537,13 +537,7 @@ def rights_holders_lookup(request, id):
 
 
 def rights_holders_autocomplete(request):
-
-    search_text = ''
-
-    try:
-        search_text = request.REQUEST['text']
-    except Exception:
-        pass
+    search_text = request.GET.get('text', '')
 
     response = {}
 

--- a/src/dashboard/src/main/templatetags/breadcrumb.py
+++ b/src/dashboard/src/main/templatetags/breadcrumb.py
@@ -18,7 +18,7 @@ import logging
 
 from django.template import Node, Variable, Library
 from django.utils.encoding import smart_unicode
-from django.templatetags.future import url
+from django.template.defaulttags import url
 from django.template import VariableDoesNotExist
 
 logger = logging.getLogger('archivematica.dashboard')


### PR DESCRIPTION
I was seeing these warnings too often in my logs and it became annoying.

- Loading the `url` tag from the `future` library is deprecated
- Use of `request.REQUEST` is deprecated

`components.rights.views::rights_holder_autocomplete` seems unused but removing
dead code is beyond the scope of this commit.