### PR TITLE
Problem: too many Gunicorn workers are being deployed

### DIFF
--- a/src/dashboard/install/dashboard.gunicorn-config.py
+++ b/src/dashboard/install/dashboard.gunicorn-config.py
@@ -13,7 +13,7 @@ group = os.environ.get('AM_GUNICORN_GROUP', 'archivematica')
 bind = os.environ.get('AM_GUNICORN_BIND', '127.0.0.1:8002')
 
 # http://docs.gunicorn.org/en/stable/settings.html#workers
-workers = os.environ.get('AM_GUNICORN_WORKERS', '4')
+workers = os.environ.get('AM_GUNICORN_WORKERS', '1')
 
 # http://docs.gunicorn.org/en/stable/settings.html#worker-class
 worker_class = os.environ.get('AM_GUNICORN_WORKER_CLASS', 'gevent')


### PR DESCRIPTION
With gevent (libevent event loop) we can efficiently process many requests
simultaneously from a single worker. The default value of `worker_connections`
is `1000` so it makes very little sense at this point to deploy four workers.

In development environments, Gunicorn uses a source code reload engine based on
a polling mechanism (os.stat) which is very consuming when the filesystem is
shared with a virtual machine. Each worker run its own reload engine loop so
having just one worker is going to improve the developer experience
significantly too.