### PR TITLE
File path to clamd scan method is Unicode

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
@@ -34,6 +34,7 @@ from main.models import Event
 # archivematicaCommon
 from custom_handlers import get_script_logger
 from databaseFunctions import insertIntoEvents
+from archivematicaFunctions import cmd_line_arg_to_unicode
 
 from django.conf import settings as mcpclient_settings
 from clamd import ClamdUnixSocket, ClamdNetworkSocket, ClamdError
@@ -113,7 +114,6 @@ def main(fileUUID, target, date):
 
 if __name__ == '__main__':
     fileUUID = sys.argv[1]
-    target = sys.argv[2]
+    target = cmd_line_arg_to_unicode(sys.argv[2])
     date = sys.argv[3]
-
     sys.exit(main(fileUUID, target, date))

--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -24,6 +24,7 @@
 from __future__ import print_function
 import collections
 import hashlib
+import locale
 import os
 import re
 from uuid import uuid4
@@ -93,6 +94,24 @@ def strToUnicode(string, obstinate=False):
             else:
                 raise
     return string
+
+
+def get_locale_encoding():
+    try:
+        return locale.getdefaultlocale()[1]
+    except IndexError:
+        return 'UTF-8'
+
+
+def cmd_line_arg_to_unicode(cmd_line_arg):
+    """Decode a command-line argument (bytestring, type ``str``) to Unicode
+    (type ``unicode``) by decoding it using the default system encoding (if
+    retrievable) or UTF-8 otherwise.
+    """
+    try:
+        return cmd_line_arg.decode(get_locale_encoding())
+    except (LookupError, UnicodeDecodeError):
+        return cmd_line_arg
 
 
 def getTagged(root, tag):


### PR DESCRIPTION
Fixes

- https://github.com/artefactual/archivematica/issues/740
- https://github.com/JiscRDSS/rdss-archivematica/issues/57

See https://gist.github.com/jrwdunham/e445eb1b0eba194ef82d583ac6908835