### PR TITLE
Configurable timeouts

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
@@ -42,13 +42,11 @@ from clamd import ClamdUnixSocket, ClamdNetworkSocket, ClamdError
 
 logger = get_script_logger("archivematica.mcp.client.clamscan")
 
-DEFAULT_TIMEOUT = 10
-
 
 def get_client(addr):
     if ':' in addr:
         host, port = addr.split(':')
-        return ClamdNetworkSocket(host=host, port=int(port), timeout=DEFAULT_TIMEOUT)
+        return ClamdNetworkSocket(host=host, port=int(port), timeout=mcpclient_settings.CLAMAV_CLIENT_TIMEOUT)
     return ClamdUnixSocket(path=addr)
 
 

--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -8,6 +8,7 @@ import requests
 
 import django
 django.setup()
+from django.conf import settings as mcpclient_settings
 # dashboard
 from main import models
 
@@ -15,8 +16,6 @@ from main import models
 from custom_handlers import get_script_logger
 import elasticSearchFunctions
 import storageService as storage_service
-
-from django.conf import settings as mcpclient_settings
 
 logger = get_script_logger("archivematica.mcp.client.post_store_aip_hook")
 
@@ -55,7 +54,7 @@ def dspace_handle_to_archivesspace(sip_uuid):
     url = archivesspace_url + '/users/' + config['user'] + '/login'
     params = {'password': config['passwd']}
     logger.debug('Log in to ArchivesSpace URL: %s', url)
-    response = requests.post(url, params=params, timeout=120)
+    response = requests.post(url, params=params, timeout=mcpclient_settings.AGENTARCHIVES_CLIENT_TIMEOUT)
     logger.debug('Response: %s %s', response, response.content)
     session_id = response.json()['session']
     headers = {'X-ArchivesSpace-Session': session_id}
@@ -63,7 +62,7 @@ def dspace_handle_to_archivesspace(sip_uuid):
     # Get Digital Object from ArchivesSpace
     url = archivesspace_url + digital_object.remoteid
     logger.debug('Get Digital Object info URL: %s', url)
-    response = requests.get(url, headers=headers, timeout=120)
+    response = requests.get(url, headers=headers, timeout=mcpclient_settings.AGENTARCHIVES_CLIENT_TIMEOUT)
     logger.debug('Response: %s %s', response, response.content)
     body = response.json()
 
@@ -77,7 +76,7 @@ def dspace_handle_to_archivesspace(sip_uuid):
     }
     body['file_versions'].append(file_version)
     logger.debug('Modified Digital Object: %s', body)
-    response = requests.post(url, headers=headers, json=body, timeout=120)
+    response = requests.post(url, headers=headers, json=body, timeout=mcpclient_settings.AGENTARCHIVES_CLIENT_TIMEOUT)
     print('Update response:', response, response.content)
     logger.debug('Response: %s %s', response, response.content)
     if response.status_code != 200:

--- a/src/MCPClient/lib/clientScripts/upload-qubit.py
+++ b/src/MCPClient/lib/clientScripts/upload-qubit.py
@@ -37,6 +37,7 @@ import requests
 
 import django
 django.setup()
+from django.conf import settings as mcpclient_settings
 # dashboard
 import main.models as models
 
@@ -207,7 +208,7 @@ def start(data):
     auth = requests.auth.HTTPBasicAuth(data.email, data.password)
 
     # Disable redirects: AtoM returns 302 instead of 202, but Location header field is valid
-    response = requests.request('POST', data.url, auth=auth, headers=headers, allow_redirects=False, timeout=120)
+    response = requests.request('POST', data.url, auth=auth, headers=headers, allow_redirects=False, timeout=mcpclient_settings.AGENTARCHIVES_CLIENT_TIMEOUT)
 
     # response.{content,headers,status_code}
     log("> Response code: %s" % response.status_code)

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -40,6 +40,9 @@ CONFIG_MAPPING = {
     'secret_key': {'section': 'MCPClient', 'option': 'django_secret_key', 'type': 'string'},
     'clamav_server': {'section': 'MCPClient', 'option': 'clamav_server', 'type': 'string'},
     'clamav_pass_by_reference': {'section': 'MCPClient', 'option': 'clamav_pass_by_reference', 'type': 'boolean'},
+    'storage_service_client_timeout': {'section': 'MCPClient', 'option': 'storage_service_client_timeout', 'type': 'float'},
+    'agentarchives_client_timeout': {'section': 'MCPClient', 'option': 'agentarchives_client_timeout', 'type': 'float'},
+    'clamav_client_timeout': {'section': 'MCPClient', 'option': 'clamav_client_timeout', 'type': 'float'},
 
     # [client]
     'db_engine': {'section': 'client', 'option': 'engine', 'type': 'string'},
@@ -69,6 +72,9 @@ temp_dir = /var/archivematica/sharedDirectory/tmp
 removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
 clamav_server = /var/run/clamav/clamd.ctl
 clamav_pass_by_reference = False
+storage_service_client_timeout = 86400
+agentarchives_client_timeout = 300
+clamav_client_timeout = 86400
 
 [client]
 user = archivematica
@@ -170,3 +176,6 @@ ELASTICSEARCH_SERVER = config.get('elasticsearch_server')
 ELASTICSEARCH_TIMEOUT = config.get('elasticsearch_timeout')
 CLAMAV_SERVER = config.get('clamav_server')
 CLAMAV_PASS_BY_REFERENCE = config.get('clamav_pass_by_reference')
+CLAMAV_CLIENT_TIMEOUT = config.get('clamav_client_timeout')
+STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
+AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')

--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -7,6 +7,8 @@ import requests
 from requests.auth import AuthBase
 import urllib
 
+from django.conf import settings as django_settings
+
 # archivematicaCommon
 from archivematicaFunctions import get_setting
 
@@ -54,7 +56,7 @@ def _storage_service_url():
     return storage_service_url
 
 
-def _storage_api_session(timeout=5):
+def _storage_api_session(timeout=django_settings.STORAGE_SERVICE_CLIENT_TIMEOUT):
     """Return a requests.Session with a customized adapter with timeout support."""
     class HTTPAdapterWithTimeout(requests.adapters.HTTPAdapter):
         def __init__(self, timeout=None, *args, **kwargs):
@@ -263,7 +265,7 @@ def create_file(uuid, origin_location, origin_path, current_location,
 
     LOGGER.info("Creating file with %s", new_file)
     try:
-        session = _storage_api_session(timeout=None)
+        session = _storage_api_session()
         if update:
             new_file['reingest'] = pipeline['uuid']
             url = _storage_service_url() + 'file/' + uuid + '/'

--- a/src/dashboard/src/components/file/views.py
+++ b/src/dashboard/src/components/file/views.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 # Django Core, alphabetical by import source
+from django.conf import settings as django_settings
 from django.views.generic import View
 
 # External dependencies, alphabetical
@@ -170,7 +171,7 @@ def bulk_extractor(request, fileuuid):
     for report in reports:
         relative_path = os.path.join('logs', 'bulk-' + fileuuid, report + '.txt')
         url = storage_service.extract_file_url(f.transfer_id, relative_path)
-        response = requests.get(url, timeout=120)
+        response = requests.get(url, timeout=django_settings.STORAGE_SERVICE_CLIENT_TIMEOUT)
 
         if response.status_code != 200:
             message = 'Unable to retrieve ' + report + ' report for file with UUID ' + fileuuid

--- a/src/dashboard/src/components/helpers.py
+++ b/src/dashboard/src/components/helpers.py
@@ -214,7 +214,7 @@ def get_atom_levels_of_description(clear=True):
 
     # taxonomy 34 is "level of description"
     dest = urljoin(url, 'api/taxonomies/34')
-    response = requests.get(dest, params={'culture': 'en'}, auth=auth, timeout=120)
+    response = requests.get(dest, params={'culture': 'en'}, auth=auth, timeout=django_settings.AGENTARCHIVES_CLIENT_TIMEOUT)
     if response.status_code == 200:
         base = 1
         if clear:
@@ -307,7 +307,7 @@ def processing_config_path():
 
 
 def stream_file_from_storage_service(url, error_message='Remote URL returned {}'):
-    stream = requests.get(url, stream=True, timeout=120)
+    stream = requests.get(url, stream=True, timeout=django_settings.STORAGE_SERVICE_CLIENT_TIMEOUT)
     if stream.status_code == 200:
         content_type = stream.headers.get('content-type', 'text/plain')
         content_disposition = stream.headers.get('content-disposition')

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -314,7 +314,7 @@ def ingest_upload_destination_url_check(request):
     url = urljoin(url, request.GET.get('target', ''))
 
     # make request for URL
-    response = requests.request('GET', url, timeout=120)
+    response = requests.request('GET', url, timeout=django_settings.AGENTARCHIVES_CLIENT_TIMEOUT)
 
     # return resulting status code from request
     return HttpResponse(response.status_code)

--- a/src/dashboard/src/installer/steps.py
+++ b/src/dashboard/src/installer/steps.py
@@ -77,7 +77,7 @@ def submit_fpr_agent():
 
     try:
         logger.info("FPR Server URL: {}".format(django_settings.FPR_URL))
-        r = requests.post(url, data=json.dumps(payload), headers=headers, timeout=120, verify=True)
+        r = requests.post(url, data=json.dumps(payload), headers=headers, timeout=django_settings.FPR_CLIENT_TIMEOUT, verify=True)
         if r.status_code == 201:
             resp['result'] = 'success'
         else:

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -33,6 +33,9 @@ CONFIG_MAPPING = {
     'elasticsearch_timeout': {'section': 'Dashboard', 'option': 'elasticsearch_timeout', 'type': 'float'},
     'gearman_server': {'section': 'Dashboard', 'option': 'gearman_server', 'type': 'string'},
     'shibboleth_authentication': {'section': 'Dashboard', 'option': 'shibboleth_authentication', 'type': 'boolean'},
+    'storage_service_client_timeout': {'section': 'Dashboard', 'option': 'storage_service_client_timeout', 'type': 'float'},
+    'agentarchives_client_timeout': {'section': 'Dashboard', 'option': 'agentarchives_client_timeout', 'type': 'float'},
+    'fpr_client_timeout': {'section': 'Dashboard', 'option': 'fpr_client_timeout', 'type': 'float'},
 
     # [Dashboard] (MANDATORY in production)
     'allowed_hosts': {'section': 'Dashboard', 'option': 'django_allowed_hosts', 'type': 'string'},
@@ -55,6 +58,9 @@ elasticsearch_server = 127.0.0.1:9200
 elasticsearch_timeout = 10
 gearman_server = 127.0.0.1:4730
 shibboleth_authentication = False
+storage_service_client_timeout = 86400
+agentarchives_client_timeout = 300
+fpr_client_timeout = 60
 
 [client]
 user = archivematica
@@ -366,6 +372,7 @@ UUID_REGEX = '[\w]{8}(-[\w]{4}){3}-[\w]{12}'
 
 FPR_URL = 'https://fpr.archivematica.org/fpr/api/v2/'
 FPR_VERIFY_CERT = True
+FPR_CLIENT_TIMEOUT = config.get('fpr_client_timeout')
 
 MICROSERVICES_HELP = {
     'Approve transfer': _('Select "Approve transfer" to begin processing or "Reject transfer" to start over again.'),
@@ -390,6 +397,8 @@ SHARED_DIRECTORY = config.get('shared_directory')
 WATCH_DIRECTORY = config.get('watch_directory')
 ELASTICSEARCH_SERVER = config.get('elasticsearch_server')
 ELASTICSEARCH_TIMEOUT = config.get('elasticsearch_timeout')
+STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
+AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
 
 # Only required in production.py
 ALLOWED_HOSTS = ["*"]


### PR DESCRIPTION
Timeouts were introduced in: https://github.com/artefactual/archivematica/pull/531 ([#10575](https://projects.artefactual.com/issues/10575)). The predetermined elapsed time introduced was too low causing all kind of issues when dealing with large datasets. Some of the timeouts were increased here: https://github.com/artefactual/archivematica/pull/565.

The following issues were filed in regards to the problems caused:
- https://github.com/artefactual/archivematica/issues/645 (starting transfers)
- https://github.com/artefactual/archivematica/issues/712 (starting transfers)
- https://github.com/artefactual/archivematica/issues/739 (clamdscan)
- https://github.com/artefactual/archivematica/issues/745 (meta issue)

Also under JiscRDSS:
- https://github.com/JiscRDSS/rdss-archivematica/issues/56
- https://jiscdev.atlassian.net/browse/RDSSARK-221
- https://jiscdev.atlassian.net/browse/RDSSARK-222

@mamedin submitted a pull request with a tentative fix: https://github.com/artefactual/archivematica/pull/715 - it wasn't merged but it served well as a temporary solution in a production environment.

@helenst introduced a configurable timeout value in the SS client (in the RDSS fork of AM): https://github.com/JiscRDSS/archivematica/pull/30 which solved https://github.com/JiscRDSS/rdss-archivematica/issues/56.

This commit extends the same approach as @helenst's PR to all the places where
timeouts were defined.

In addition to:

```
ARCHIVEMATICA_DASHBOARD_DASHBOARD_ELASTICSEARCH_TIMEOUT=10
ARCHIVEMATICA_DASHBOARD_DASHBOARD_ELASTICSEARCH_TIMEOUT=10
```

This commit adds:

```
ARCHIVEMATICA_DASHBOARD_DASHBOARD_STORAGE_SERVICE_CLIENT_TIMEOUT=86400
ARCHIVEMATICA_DASHBOARD_DASHBOARD_AGENTARCHIVES_TIMEOUT=300
ARCHIVEMATICA_DASHBOARD_DASHBOARD_FPR_CLIENT_TIMEOUT=60
```

And:

```
ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_STORAGE_SERVICE_CLIENT_TIMEOUT=86400
ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_AGENTARCHIVES_TIMEOUT=300
ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_TIMEOUT=86400
```