### PR TITLE
Run test suite via tox + Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 sudo: false
 
 language: python
+cache: pip
 
 before_script:
   - pip install tox
@@ -13,6 +14,25 @@ notifications:
   email: false
 
 matrix:
+  fast_finish: true
   include:
+
     - python: "2.7"
-      env: TOXENV=flake8
+      env: TOXENV=py27
+
+    - python: "3.6"
+      env: TOXENV=py36
+
+    - python: "2.7"
+      env: TOXENV=py27-flake8
+
+    - python: "3.6"
+      env: TOXENV=py36-flake8
+
+  allow_failures:
+
+    - python: "3.6"
+      env: TOXENV=py36
+
+    - python: "3.6"
+      env: TOXENV=py36-flake8

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 django_find_projects=false
 python_paths=/usr/share/archivematica/dashboard/;/usr/lib/archivematica/archivematicaCommon/
 DJANGO_SETTINGS_MODULE=settings.test
-norecursedirs = .svn _build tmp* node_modules bower_components share
+norecursedirs = .svn _build tmp* node_modules bower_components share .tox

--- a/src/MCPClient/lib/clientScripts/jsonMetadataToCSV.py
+++ b/src/MCPClient/lib/clientScripts/jsonMetadataToCSV.py
@@ -29,10 +29,10 @@ def fetch_keys(objects):
                     occurrence_count[key] = occurrence
         keys.update(o_keys)
 
-    # Column order is otherwise unimportant, but
+    # Column order is important so the output is consistent.
     # "filename" and "parts" must be column 0.
     # (They are mutually exclusive.)
-    keys = list(keys)
+    keys = sorted(list(keys))
     if 'filename' in keys:
         keys.remove('filename')
         keys.insert(0, 'filename')

--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -9,6 +9,6 @@ mysqlclient==1.3.9
 gearman==2.0.2
 lxml==3.5.0
 metsrw==0.1.1
-requests==2.7.0
+requests==2.18.4
 unidecode==0.04.19
 opf-fido==1.3.6

--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -2,6 +2,6 @@ agentarchives==0.4.0
 bagit==1.5.2
 Django>=1.8,<1.9
 elasticsearch>=1.0.0,<2.0.0
-requests==2.7.0
+requests==2.18.4
 python-dateutil==2.4.2
 django-mysqlpool==0.1-9

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -24,7 +24,7 @@ pyopenssl
 python-dateutil==2.6.0
 ndg-httpsclient
 pyasn1
-requests==2.7.0
+requests==2.18.4
 whitenoise==3.3.0
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
 

--- a/src/dashboard/tests/test_dashboardsetting_manager.py
+++ b/src/dashboard/tests/test_dashboardsetting_manager.py
@@ -49,7 +49,8 @@ def test_dashboardsetting_get_dict():
 
     assert isinstance(ret, dict)
     assert len(ret) == len(data)
-    assert ret.keys() == [u'url', u'key']
+    assert u'url' in ret.keys()
+    assert u'key' in ret.keys()
     assert ret['url'] == unicode(data['url'])
     assert ret['key'] == unicode(data['key'])
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,29 @@
 [tox]
 skipsdist = True
 minversion = 2.7.0
-envlist = flake8
+envlist = {py27,py36}{,-flake8}
 
-[testenv:flake8]
-basepython = python2
-skip_install = true
-deps = flake8
+[testenv]
+skip_install = True
+setenv =
+    PYTHONPATH = src/archivematicaCommon/lib:src/dashboard/src
 commands =
-    flake8 .
+    pip install -q -r src/archivematicaCommon/requirements/test.txt
+    pip install -q -r src/MCPClient/requirements/test.txt
+    pip install -q -r src/dashboard/src/requirements/test.txt
+    py.test {posargs}
+
+[testenv:py27-flake8]
+basepython = python2.7
+envdir = {toxworkdir}/py27
+deps = flake8
+commands = flake8 .
+
+[testenv:py36-flake8]
+basepython = python3.6
+envdir = {toxworkdir}/py36
+deps = flake8
+commands = flake8 .
 
 [flake8]
 exclude = .tox, .git, __pycache__, .cache, build, dist, *.pyc, *.egg-info, .eggs


### PR DESCRIPTION
- Added tox envs: `py27`, `py36`, `py27-flake8`, `py36-flake8`.
- Execute all envs in Travis CI.

This closes #612.