### PR TITLE
Enable re-login after Shibboleth logout

### DIFF
--- a/src/dashboard/src/components/accounts/urls.py
+++ b/src/dashboard/src/components/accounts/urls.py
@@ -26,7 +26,6 @@ urlpatterns = [
     url(r'(?P<id>\d+)/edit/$', views.edit),
     url(r'profile/$', views.profile, name='profile'),
     url(r'list/$', views.list),
-    url(r'logged-out', views.logged_out, name='logged-out'),
 ]
 
 urlpatterns += [

--- a/src/dashboard/src/components/accounts/views.py
+++ b/src/dashboard/src/components/accounts/views.py
@@ -171,8 +171,3 @@ def delete(request, id):
         return redirect('components.accounts.views.list')
     except:
         raise Http404
-
-
-def logged_out(request):
-    # Display a post-logout message
-    return render(request, 'accounts/logged_out.html')

--- a/src/dashboard/src/main/urls.py
+++ b/src/dashboard/src/main/urls.py
@@ -47,6 +47,14 @@ urlpatterns = [
 ]
 
 if 'shibboleth' in settings.INSTALLED_APPS:
+    # Simulate a shibboleth urls module (so our custom Shibboleth logout view
+    # matches the same namespaced URL name as the standard logout view from
+    # the shibboleth lib)
+    class shibboleth_urls:
+        urlpatterns = [
+            url(r'^logout/$', views.CustomShibbolethLogoutView.as_view(), name='logout'),
+        ]
+
     urlpatterns += [
-        url(r'^shib/', include('shibboleth.urls', namespace='shibboleth')),
+        url(r'^shib/', include(shibboleth_urls, namespace='shibboleth')),
     ]

--- a/src/dashboard/src/main/views.py
+++ b/src/dashboard/src/main/views.py
@@ -23,6 +23,7 @@ from django.utils.translation import get_language, ugettext as _
 from django.views.decorators.cache import cache_page
 from django.views.decorators.http import last_modified
 from django.views.i18n import javascript_catalog
+from shibboleth.views import ShibbolethLogoutView, LOGOUT_SESSION_KEY
 
 from contrib.mcp.client import MCPClient
 from main import models
@@ -323,3 +324,15 @@ def formdata(request, type, parent_id, delete_id=None):
         response['message'] = _('Incorrect type.')
 
     return helpers.json_response(response)
+
+
+class CustomShibbolethLogoutView(ShibbolethLogoutView):
+    def get(self, request, *args, **kwargs):
+        response = super(CustomShibbolethLogoutView, self).get(request, *args, **kwargs)
+        # LOGOUT_SESSION_KEY is set by the standard logout to prevent re-login
+        # which is useful to prevent bouncing straight back to login under
+        # certain setups, but not here where we want the Django session state
+        # to reflect the SP session state
+        if LOGOUT_SESSION_KEY in request.session:
+            del request.session[LOGOUT_SESSION_KEY]
+        return response

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -353,7 +353,6 @@ LOGIN_REDIRECT_URL = '/'
 LOGIN_EXEMPT_URLS = [
     r'^administration/accounts/login',
     r'^api',
-    r'^administration/accounts/logged-out',
 ]
 # Django debug toolbar
 try:
@@ -414,7 +413,6 @@ ALLOW_USER_EDITS = True
 SHIBBOLETH_AUTHENTICATION = config.get('shibboleth_authentication')
 if SHIBBOLETH_AUTHENTICATION:
     SHIBBOLETH_LOGOUT_URL = '/Shibboleth.sso/Logout?target=%s'
-    SHIBBOLETH_LOGOUT_REDIRECT_URL = '/administration/accounts/logged-out'
 
     SHIBBOLETH_REMOTE_USER_HEADER = 'HTTP_EPPN'
     SHIBBOLETH_ATTRIBUTE_MAP = {


### PR DESCRIPTION
django-shibboleth-user sets a session flag to prevent immediate bounce back to logged in state after logout. This is useful in some setups but is unnecessary here, and it prevents logging back in again until cookies are cleared.

I've added a custom logout which unsets that session flag after the standard logout. This should enable users to log back in.

Fixes artefactual/archivematica-storage-service#238

See also artefactual/archivematica-storage-service#247 for SS PR