### PR TITLE
Update fido to v1.3.7

### DIFF
--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -10,4 +10,4 @@ lxml==3.5.0
 metsrw==0.2.0
 requests==2.18.4
 unidecode==0.04.19
-opf-fido==1.3.6
+opf-fido==1.3.7

--- a/src/archivematicaCommon/lib/externals/fiwalk_plugins/pronom_ident.py
+++ b/src/archivematicaCommon/lib/externals/fiwalk_plugins/pronom_ident.py
@@ -30,7 +30,7 @@ class FiwalkFido(fido.Fido):
             f = open(filename, 'rb')
             size = os.stat(filename)[6]
             self.current_filesize = size
-            bofbuffer, eofbuffer = self.get_buffers(f, size, seekable=True)
+            bofbuffer, eofbuffer, __ = self.get_buffers(f, size, seekable=True)
             matches = self.match_formats(bofbuffer, eofbuffer)
             # from here is also repeated in walk_zip
             # we should make this uniform in next version!


### PR DESCRIPTION
Also taking this opportunity to fix #755 which relates to fido (see ecd3aab).

---

The build fails because opf-fido has not been published yet.
See https://github.com/openpreserve/fido/pull/115 - needs CR @jrwdunham.