### PR TITLE
Dashboard: add LDAP deps to Dockerfile

### DIFF
--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -13,6 +13,8 @@ RUN set -ex \
 	&& apt-get install -y --no-install-recommends \
 		gettext \
 		libmysqlclient-dev \
+		libldap2-dev \
+		libsasl2-dev \
 		nodejs \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Otherwise the image won't build.

LDAP deps were added in #710.