### PR TITLE
MCPClient: document and reconstruct empty dirs

### DIFF
--- a/src/MCPClient/lib/assets/README/README.html
+++ b/src/MCPClient/lib/assets/README/README.html
@@ -35,8 +35,8 @@
     <p>&lt;mets:dmdSec&gt; (descriptive metadata section): descriptive metadata about the digital objects;</p>
     <p>&lt;mets:amdSec&gt; (administrative metadata section): technical and provenance information about the digital objects;</p>
     <p>&lt;mets:fileSec&gt; (file section): a list of the digital objects and an indication of their role in the AIP (original, preservation, metadata, submission documentation, license etc.);</p>
-    <p>&lt;mets:structMap&gt; (structural map): a physical or logical ordering of the digital objects.</p>
-<p>The technical and provenance information in the METS amdSec is recorded as PREMIS metadata. PREMIS is also a Library of Congress standard, and is described as "the international standard for metadata to support the preservation of digital objects and ensure their long-term usability." The PREMIS entities are wrapped in the METS file as follows:</p>
+    <p>&lt;mets:structMap&gt; (structural map): a physical or logical ordering of the digital objects. As of Archivematica version 1.8, all AIP METS files contain a logical structural map which lists all files and directories including empty directories. The physical structural map accurately documents the final directory structure of the AIP. Because AIPs conform to the BagIt specification and because bags cannot contain empty directories, the logical structural map labelled "Normative Directory Structure" indicates how the AIP should be structured when the empty directories are reconstructed.</p>
+    <p>The technical and provenance information in the METS amdSec is recorded as PREMIS metadata. PREMIS is also a Library of Congress standard, and is described as "the international standard for metadata to support the preservation of digital objects and ensure their long-term usability." The PREMIS entities are wrapped in the METS file as follows:</p>
     <p>&lt;mets:amdSec&gt;</p>
     <p>--&lt;mets:techMD&gt; (technical metadata)</p>
     <p>----&lt;premis:object&gt; e.g. UUID, size, checksum, format, original name, extracted technical metadata</p> 

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -29,6 +29,7 @@ from glob import glob
 from itertools import chain
 import lxml.etree as etree
 import os
+import pprint
 import re
 import sys
 import traceback
@@ -85,6 +86,8 @@ global globalDigiprovMDCounter
 globalDigiprovMDCounter = 0
 global fileNameToFileID  # Used for mapping structMaps included with transfer
 fileNameToFileID = {}
+global globalStructMapCounter
+globalStructMapCounter = 0
 
 global trimStructMap
 trimStructMap = None
@@ -99,6 +102,10 @@ CSV_METADATA = {}
 
 
 logger = get_script_logger("archivematica.mcp.client.createMETS2")
+
+
+FSItem = collections.namedtuple('FSItem', 'type path is_empty')
+FakeDirMdl = collections.namedtuple('FakeDirMdl', 'uuid')
 
 
 def newChild(parent, tag, text=None, tailText=None, sets=[]):
@@ -162,6 +169,8 @@ def getDublinCore(unit, id):
 
 def _get_mdl_identifiers(mdl):
     """Get identifiers of a model as a type-value 2-tuple."""
+    if isinstance(mdl, FakeDirMdl):
+        return []
     return [(idfr.type, idfr.value) for idfr in mdl.identifiers.all()]
 
 
@@ -710,6 +719,7 @@ def getIncludedStructMap(baseDirectoryPath):
 def createFileSec(directoryPath, parentDiv, baseDirectoryPath,
                   baseDirectoryName, fileGroupIdentifier, fileGroupType,
                   directories, includeAmdSec=True):
+
     """Creates fileSec and structMap entries for files on disk recursively.
 
     :param directoryPath: Path to recursively traverse and create METS entries for
@@ -789,10 +799,9 @@ def createFileSec(directoryPath, parentDiv, baseDirectoryPath,
             try:
                 f = File.objects.get(**kwargs)
             except File.DoesNotExist:
-                if os.path.basename(itemdirectoryPath) != '.keep':
-                    print("No uuid for file: \"", directoryPathSTR, "\"", file=sys.stderr)
-                    sharedVariablesAcrossModules.globalErrorCount += 1
-                continue
+                print('No uuid for file: "', directoryPathSTR, '"',
+                      file=sys.stderr)
+                sharedVariablesAcrossModules.globalErrorCount += 1
 
             use = f.filegrpuse
             label = f.label
@@ -1125,6 +1134,63 @@ def write_mets(tree, filename):
         f.write(fileContents)
 
 
+def add_normative_structmap_div(all_fsitems, root_el, directories, index=0,
+                                path_to_el=None):
+    """Recursively document all of the file/dir paths in ``all_fsitems`` in the
+    lxml._Element instance ``root_el``. This constructs the <mets:div> element
+    tree under the TYPE "logical" structMap with LABEL "Normative Directory
+    Structure". Said structural map documents all files and directories,
+    including empty directories, which latter are not documented in the
+    physical structMap.
+    :param list all_fsitems: contains ``FSItem`` instances crucially ordered so
+        that parent directories always precede their children.
+    :param lxml._Element root_el: root element for documenting the directory
+        structure.
+    :param dict directories: maps directory model instance ``currentlocation``
+        values to directories for any and all directory model instances
+        associated to the current SIP.
+    :param int index: index of the ``FSItem()`` to document
+    :param dict path_to_el: maps paths from ``all_fsitems`` to the lxml elements
+        that document them.
+    :returns: None.
+    """
+    global globalDmdSecCounter
+    global dmdSecs
+    path_to_el = path_to_el or {'': root_el}
+    try:
+        fsitem = all_fsitems[index]
+        index += 1
+    except IndexError:
+        return
+    parent_path = os.path.dirname(fsitem.path)
+    basename = os.path.basename(fsitem.path)
+    try:
+        parent_el = path_to_el[parent_path]
+    except KeyError:
+        logger.info('Unable to find parent path {} of item {} in path_to_el\n{}'.format(
+            parent_path, fsitem.path, pprint.pformat(path_to_el)))
+        raise
+    el = etree.SubElement(
+        parent_el,
+        ns.metsBNS + 'div',
+        TYPE={'dir': 'Directory'}.get(fsitem.type, 'Item'),
+        LABEL=basename)
+    if fsitem.is_empty:  # Create dmdSec for empty dirs
+        fsitem_path = '%SIPDirectory%' + fsitem.path
+        dir_mdl = directories.get(
+            fsitem_path, directories.get(
+                fsitem_path.rstrip('/'), FakeDirMdl(uuid=str(uuid4()))))
+        dirDmdSec = getDirDmdSec(dir_mdl, fsitem_path)
+        globalDmdSecCounter += 1
+        dmdSecs.append(dirDmdSec)
+        dir_dmd_id = 'dmdSec_' + str(globalDmdSecCounter)
+        dirDmdSec.set('ID', dir_dmd_id)
+        el.set('DMDID', dir_dmd_id)
+    path_to_el[fsitem.path] = el
+    add_normative_structmap_div(
+        all_fsitems, root_el, directories, index=index, path_to_el=path_to_el)
+
+
 if __name__ == '__main__':
 
     from optparse import OptionParser
@@ -1174,23 +1240,24 @@ if __name__ == '__main__':
     objectsDirectoryPath = os.path.join(baseDirectoryPath, 'objects')
     objectsMetadataDirectoryPath = os.path.join(objectsDirectoryPath, 'metadata')
 
+    # Get all paths in the SIP as ``FSItem`` instances before deleting any
+    # empty directories. These filesystem items are crucially ordered so that
+    # directories always precede the paths of the items they contain.
+    all_fsitems = []
+    for root, dirs, files in os.walk(objectsDirectoryPath):
+        root = root.replace(baseDirectoryPath, '', 1)
+        if files or dirs:
+            all_fsitems.append(FSItem('dir', root, False))
+        else:
+            all_fsitems.append(FSItem('dir', root, True))
+        for file_ in files:
+            all_fsitems.append(FSItem('file', os.path.join(root, file_), False))
+
     # Delete empty directories, see #8427
     for root, dirs, files in os.walk(baseDirectoryPath, topdown=False):
         try:
             os.rmdir(root)
-            # If we just deleted an empty subdirectory of objects/ (but not of
-            # objects/metadata/), then re-create it with a .keep file in it.
-            # (This deletion and re-creation seems more efficient than calling
-            # ``os.listdir`` on every directory to see if it is empty.)
-            if (root.startswith(objectsDirectoryPath) and
-                    root != objectsDirectoryPath and
-                    not root.startswith(objectsMetadataDirectoryPath)):
-                os.makedirs(root)
-                fpath = os.path.join(root, '.keep')
-                with open(fpath, 'a'):
-                    os.utime(fpath, None)
-            else:
-                print("Deleted empty directory", root)
+            print("Deleted empty directory", root)
         except OSError:
             pass
 
@@ -1199,16 +1266,32 @@ if __name__ == '__main__':
     # createSIPfromTransferObjects.py for the association of ``Directory``
     # objects to a ``SIP``.
     directories = {
-        d.currentlocation: d for d in
+        d.currentlocation.rstrip('/'): d for d in
         Directory.objects.filter(sip_id=fileGroupIdentifier).all()}
 
+    globalStructMapCounter += 1
     structMap = etree.Element(
-        ns.metsBNS + "structMap", TYPE='physical', ID='structMap_1',
+        ns.metsBNS + "structMap", TYPE='physical',
+        ID='structMap_{}'.format(globalStructMapCounter),
         LABEL="Archivematica default")
     sip_dir_name = os.path.basename(baseDirectoryPath.rstrip('/'))
     structMapDiv = etree.SubElement(
         structMap, ns.metsBNS + 'div', TYPE="Directory",
         LABEL=sip_dir_name)
+
+    # Create the normative structmap.
+    globalStructMapCounter += 1
+    normativeStructMap = etree.Element(
+        ns.metsBNS + 'structMap',
+        TYPE='logical',
+        ID='structMap_{}'.format(globalStructMapCounter),
+        LABEL='Normative Directory Structure')
+    normativeStructMapDiv = etree.SubElement(
+        normativeStructMap,
+        ns.metsBNS + 'div',
+        TYPE='Directory',
+        LABEL=sip_dir_name)
+    add_normative_structmap_div(all_fsitems, normativeStructMapDiv, directories)
 
     # Get the <dmdSec> for the entire AIP; it is associated to the root
     # <mets:div> in the physical structMap.
@@ -1274,6 +1357,8 @@ if __name__ == '__main__':
 
     root.append(fileSec)
     root.append(structMap)
+    root.append(normativeStructMap)
+
     for structMapIncl in getIncludedStructMap(baseDirectoryPath):
         root.append(structMapIncl)
 

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py
@@ -268,7 +268,8 @@ def add_new_files(mets, sip_uuid, sip_dir):
     """
     # Find new files
     # How tell new file from old with same name? Check hash?
-    # QUESTION should the metadata.csv be parsed and only updated if different even if one already existed?
+    # QUESTION should the metadata.csv be parsed and only updated if different
+    # even if one already existed?
     new_files = []
     old_mets_rel_path = _get_old_mets_rel_path(sip_uuid)
     metadata_csv = None
@@ -276,7 +277,8 @@ def add_new_files(mets, sip_uuid, sip_dir):
     for dirpath, _, filenames in os.walk(objects_dir):
         for filename in filenames:
             # Find in METS
-            current_loc = os.path.join(dirpath, filename).replace(sip_dir, '%SIPDirectory%', 1)
+            current_loc = os.path.join(dirpath, filename).replace(
+                sip_dir, '%SIPDirectory%', 1)
             rel_path = current_loc.replace('%SIPDirectory%', '', 1)
             print('Looking for', rel_path, 'in METS')
             fsentry = mets.get_file(path=rel_path)
@@ -297,9 +299,13 @@ def add_new_files(mets, sip_uuid, sip_dir):
         return mets
 
     # Set global counters so getAMDSec will work
-    createmets2.globalAmdSecCounter = int(mets.tree.xpath('count(mets:amdSec)', namespaces=ns.NSMAP))
-    createmets2.globalTechMDCounter = int(mets.tree.xpath('count(mets:amdSec/mets:techMD)', namespaces=ns.NSMAP))
-    createmets2.globalDigiprovMDCounter = int(mets.tree.xpath('count(mets:amdSec/mets:digiprovMD)', namespaces=ns.NSMAP))
+    createmets2.globalAmdSecCounter = int(
+        mets.tree.xpath('count(mets:amdSec)', namespaces=ns.NSMAP))
+    createmets2.globalTechMDCounter = int(
+        mets.tree.xpath('count(mets:amdSec/mets:techMD)', namespaces=ns.NSMAP))
+    createmets2.globalDigiprovMDCounter = int(
+        mets.tree.xpath('count(mets:amdSec/mets:digiprovMD)',
+                        namespaces=ns.NSMAP))
 
     objects_fsentry = mets.get_file(label='objects', type='Directory')
 

--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -7,7 +7,7 @@ django-extensions==1.1.1
 mysqlclient==1.3.9
 gearman==2.0.2
 lxml==3.5.0
-metsrw==0.1.1
+git+https://github.com/artefactual-labs/mets-reader-writer.git@dev/issue-10908-empty-directories
 requests==2.18.4
 unidecode==0.04.19
 opf-fido==1.3.6

--- a/src/MCPClient/tests/test_reingest_mets.py
+++ b/src/MCPClient/tests/test_reingest_mets.py
@@ -638,14 +638,21 @@ class TestAddingNewFiles(TestCase):
         assert len(mets.tree.findall('mets:amdSec', namespaces=NSMAP)) == 3
         assert len(mets.tree.findall('mets:fileSec//mets:file', namespaces=NSMAP)) == 3
         assert mets.tree.find('mets:fileSec/mets:fileGrp[@USE="metadata"]', namespaces=NSMAP) is None
-        assert len(mets.tree.findall('mets:structMap//mets:div', namespaces=NSMAP)) == 10
+        assert len(mets.tree.findall('mets:structMap[@TYPE="physical"]//mets:div', namespaces=NSMAP)) == 10
 
         mets = archivematicaCreateMETSReingest.add_new_files(mets, self.sip_uuid, sip_dir)
         root = mets.serialize()
         assert len(root.findall('mets:amdSec', namespaces=NSMAP)) == 3
         assert len(root.findall('mets:fileSec//mets:file', namespaces=NSMAP)) == 3
         assert root.find('mets:fileSec/mets:fileGrp[@USE="metadata"]', namespaces=NSMAP) is None
-        assert len(root.findall('mets:structMap//mets:div', namespaces=NSMAP)) == 10
+
+        # There used to be 10 <mets:div> elements under the physical structMap.
+        # However, now metsrw does not list empty directories (or directories
+        # that only contain empty directories) in the physical structMap.
+        # Therefore, the directories in the following path will not be
+        # documented after metsrw has re-serialized:
+        # metadata/transfers/no-metadata-46260807-ece1-4a0e-b70a-9814c701146b/
+        assert len(root.findall('mets:structMap[@TYPE="physical"]//mets:div', namespaces=NSMAP)) == 7
 
         # Reverse deletion
         with open(os.path.join(sip_dir, 'objects', 'metadata', 'transfers', '.gitignore'), 'w'):
@@ -661,7 +668,7 @@ class TestAddingNewFiles(TestCase):
         assert len(mets.tree.findall('mets:amdSec', namespaces=NSMAP)) == 3
         assert len(mets.tree.findall('mets:fileSec//mets:file', namespaces=NSMAP)) == 3
         assert mets.tree.find('mets:fileSec/mets:fileGrp[@USE="metadata"]', namespaces=NSMAP) is None
-        assert len(mets.tree.findall('mets:structMap//mets:div', namespaces=NSMAP)) == 10
+        assert len(mets.tree.findall('mets:structMap[@TYPE="physical"]//mets:div', namespaces=NSMAP)) == 10
 
         mets = archivematicaCreateMETSReingest.add_new_files(mets, self.sip_uuid, sip_dir)
 
@@ -703,7 +710,7 @@ class TestAddingNewFiles(TestCase):
         assert len(mets.tree.findall('mets:amdSec', namespaces=NSMAP)) == 3
         assert len(mets.tree.findall('mets:fileSec//mets:file', namespaces=NSMAP)) == 3
         assert mets.tree.find('mets:fileSec/mets:fileGrp[@USE="metadata"]', namespaces=NSMAP) is None
-        assert len(mets.tree.findall('mets:structMap//mets:div', namespaces=NSMAP)) == 10
+        assert len(mets.tree.findall('mets:structMap[@TYPE="physical"]//mets:div', namespaces=NSMAP)) == 10
 
         mets = archivematicaCreateMETSReingest.add_new_files(mets, self.sip_uuid, sip_dir)
 
@@ -760,7 +767,7 @@ class TestAddingNewFiles(TestCase):
         assert len(mets.tree.findall('mets:amdSec', namespaces=NSMAP)) == 3
         assert len(mets.tree.findall('mets:fileSec//mets:file', namespaces=NSMAP)) == 3
         assert len(mets.tree.find('mets:fileSec/mets:fileGrp[@USE="preservation"]', namespaces=NSMAP)) == 1
-        assert len(mets.tree.findall('mets:structMap//mets:div', namespaces=NSMAP)) == 10
+        assert len(mets.tree.findall('mets:structMap[@TYPE="physical"]//mets:div', namespaces=NSMAP)) == 10
         # Run test
         mets = archivematicaCreateMETSReingest.add_new_files(mets, self.sip_uuid, sip_dir)
         root = mets.serialize()

--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -26,10 +26,14 @@ import collections
 import hashlib
 import locale
 import os
+import pprint
 import re
 from uuid import uuid4
 
+from lxml import etree
+
 from main.models import DashboardSetting
+from namespaces import NSMAP
 
 
 REQUIRED_DIRECTORIES = [
@@ -250,3 +254,67 @@ def str2bool(val):
     if val == 'True':
         return True
     return False
+
+
+NORMATIVE_STRUCTMAP_LABEL = 'Normative Directory Structure'
+
+
+def div_el_to_dir_paths(div_el, parent='', include=True):
+    """Recursively extract the list of filesystem directory paths encoded in
+    <mets:div> element ``div_el``.
+    """
+    paths = []
+    path = parent
+    dir_name = div_el.get('LABEL')
+    if parent == '' and dir_name in ('metadata', 'submissionDocumentation'):
+        return []
+    if include:
+        path = os.path.join(parent, dir_name)
+        paths.append(path)
+    for sub_div_el in div_el.findall('mets:div[@TYPE="Directory"]', NSMAP):
+        paths += div_el_to_dir_paths(sub_div_el, parent=path)
+    return paths
+
+
+def reconstruct_empty_directories(mets_file_path, objects_path, logger=None):
+    """Reconstruct in objects/ path ``objects_path`` the empty directories
+    documented in METS file ``mets_file_path``.
+    :param str mets_file_path: absolute path to an AIP/SIP's METS file.
+    :param str objects_path: absolute path to an AIP/SIP's objects/ directory
+        on disk.
+    :returns None:
+    """
+    if (not os.path.isfile(mets_file_path) or
+            not os.path.isdir(objects_path)):
+        if logger:
+            logger.info('Unable to construct empty directories, either because'
+                        ' there is no METS file at {} or because there is no'
+                        ' objects/ directory at {}'.format(mets_file_path,
+                                                           objects_path))
+        return
+    doc = etree.parse(mets_file_path, etree.XMLParser(remove_blank_text=True))
+    logical_struct_map_el = doc.find(
+        'mets:structMap[@TYPE="logical"][@LABEL="{}"]'.format(
+            NORMATIVE_STRUCTMAP_LABEL), NSMAP)
+    if logical_struct_map_el is None:
+        if logger:
+            logger.info('Unable to locate a logical structMap labelled {}.'
+                        ' Aborting attempt to reconstruct empty'
+                        ' directories.'.format(NORMATIVE_STRUCTMAP_LABEL))
+        return
+    root_div_el = logical_struct_map_el.find(
+        'mets:div/mets:div[@LABEL="objects"]', NSMAP)
+    if root_div_el is None:
+        if logger:
+            logger.info('Unable to locate a logical structMap labelled {}.'
+                        ' Aborting attempt to reconstruct empty'
+                        ' directories.'.format(NORMATIVE_STRUCTMAP_LABEL))
+        return
+    paths = div_el_to_dir_paths(root_div_el, include=False)
+    if logger:
+        logger.info('paths extracted from METS file:')
+        logger.info(pprint.pformat(paths))
+    for path in paths:
+        path = os.path.join(objects_path, path)
+        if not os.path.isdir(path):
+            os.makedirs(path)

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -17,7 +17,7 @@ gunicorn==19.7.1
 futures==3.0.5  # used by gunicorn's async workers
 lazy-paged-sequence
 lxml==3.5.0
-metsrw==0.1.1
+git+https://github.com/artefactual-labs/mets-reader-writer.git@dev/issue-10908-empty-directories
 mysqlclient==1.3.7
 pytz
 pyopenssl


### PR DESCRIPTION
- archivematicaCreateMETS2.py documents empty directories in a logical
  structMap with LABEL "Normative Directory Structure".
- .keep files are no longer placed in empty directories to prevent deletion.
  Instead, we once again delete empty directories in archivematicaCreateMETS2.py
  and document them in the METS file so they can be reconstructed if needed.
- ``reconstruct_empty_directories`` function added to archivematicaCommon's
  archivematicaFunctions; it uses the normative logical structMap of the input
  METS file to reconstruct empty directories under the input objects/
  directory path.
- ``reconstruct_empty_directories`` called in restructureBagAIPToSIP.py and
  restructureForCompliance.py, allowing empty directories to be reconstructed
  during partial and metadata-only re-ingest, and during full re-ingest,
  respectively.
- Uses dev branch dev/issue-10908-empty-directories of metsrw which correctly
  creates normative logical structMaps documenting empty directories during
  re-ingest. Will need to be change to a new metsrw version once the metsrw PR
  is merged.

See [Artefactual-internal estimate doc](https://docs.google.com/a/artefactual.com/document/d/15YbQ6yqQJgC3BBjCrXXuhVcn-nRKBGKlW2t9BXKE1f0/edit?usp=sharing)

See related [metsrw PR 32](https://github.com/artefactual-labs/mets-reader-writer/pull/32)