### PR TITLE
Add LDAP deps to Dockerfile

### DIFF
--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -16,6 +16,8 @@ RUN set -ex \
 		git \
 		python-software-properties \
 		software-properties-common \
+		libldap2-dev \
+		libsasl2-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 # OS dependencies

--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -10,6 +10,8 @@ RUN set -ex \
 	&& apt-get install -y --no-install-recommends \
 		gettext \
 		libmysqlclient-dev \
+		libldap2-dev \
+		libsasl2-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/


### PR DESCRIPTION
#766 added the build deps of LDAP to dashboard.Dockerfile. This PR adds the same deps to MCPServer.Dockerfile and MCPClient.Dockerfile. This is necessary because the latter depend on `src/dashboard/requirements/base.txt` which is unfortunate and it'll be eventually fixed but it's beyond the scope of this release.