### PR TITLE
Change metsrw dependency to v0.2.0

### DIFF
--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -7,7 +7,7 @@ django-extensions==1.1.1
 mysqlclient==1.3.9
 gearman==2.0.2
 lxml==3.5.0
-git+https://github.com/artefactual-labs/mets-reader-writer.git@dev/issue-10908-empty-directories
+metsrw==0.2.0
 requests==2.18.4
 unidecode==0.04.19
 opf-fido==1.3.6

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -17,7 +17,7 @@ gunicorn==19.7.1
 futures==3.0.5  # used by gunicorn's async workers
 lazy-paged-sequence
 lxml==3.5.0
-git+https://github.com/artefactual-labs/mets-reader-writer.git@dev/issue-10908-empty-directories
+metsrw==0.2.0
 mysqlclient==1.3.7
 pytz
 pyopenssl


### PR DESCRIPTION
Using metsrw version 0.2.0 in dashboard and MCPClient.