### PR TITLE
Dashboard: more nuanced job view update logic

### DIFF
--- a/src/dashboard/src/media/js/jobs.js
+++ b/src/dashboard/src/media/js/jobs.js
@@ -119,6 +119,7 @@ Sip = Backbone.Model.extend({
   initialize: function()
     {
       this.loadJobs();
+      this.isInProgress = true;
     },
 
   hasFinished: function(attributes)
@@ -131,16 +132,31 @@ Sip = Backbone.Model.extend({
         });
     },
 
+  shouldUpdateView: function(attributes)
+    {
+      // Return `true` if the view should be updated. Update the view only if the
+      // unit is in progress or if it was in progress and has just now finished.
+      var ret = false;
+      var hasFinished = this.hasFinished(attributes);
+      if (this.hasOwnProperty('view')) {
+        if (hasFinished) {
+          if (this.isInProgress) {
+              ret = true;
+          }
+          this.isInProgress = false;
+        } else {
+            ret = true;
+        }
+      }
+      return ret;
+    },
+
   set: function(attributes, options)
     {
       res = Backbone.Model.prototype.set.call(this, attributes, options);
-
-      // Update the view only if the unit is in progress
-      if (!this.hasFinished(attributes) && this.hasOwnProperty('view'))
-      {
+      if (this.shouldUpdateView(attributes)) {
         this.view.update();
       }
-
       return res;
     },
 


### PR DESCRIPTION
When deciding whether to update its view, the `Sip` Backbone model now
does so if some jobs are in progress or all jobs have just recently finished.
Previously, the update occurred only when there were in-progress jobs.
This fixes issue #774 where "Store DIP" was finished but the GUI was
still displaying "Executing command(s)".