### PR TITLE
Dashboard: delete media block from nginx sample

### DIFF
--- a/src/dashboard/install/dashboard.conf
+++ b/src/dashboard/install/dashboard.conf
@@ -22,8 +22,4 @@ server {
     proxy_pass http://archivematica_dashboard_backend;
   }
 
-  location /media {
-    alias /usr/share/archivematica/dashboard/media;
-  }
-
 }


### PR DESCRIPTION
That block was unnecessary since we started using WhiteNoise.