### PR TITLE
Backward-compatible logging

### DIFF
--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -1,0 +1,31 @@
+## Configuration files
+
+This directory contains the following files:
+
+- [`config.ini`](./config.ini) - a sample configuration file that the user can place in
+`/etc/archivematica/clientConfig.conf` to tweak the configuration of MCPClient.
+
+- [`logging.json`](./logging.json) - read the
+[logging configuration section](#logging-configuration) for more details.
+
+## Logging configuration
+
+Archivematica 1.6.1 and earlier releases are configured by default to log to
+subdirectories in `/var/log/archivematica`, such as
+`/var/log/archivematica/MCPClient/MCPClient.debug.log`. Starting with
+Archivematica 1.7.0, logging configuration defaults to using stdout and stderr
+for all logs. If no changes are made to the new default configuration logs
+will be handled by whichever process is managing Archivematica's services. For
+example on Ubuntu 16.04 or Centos 7, Archivematica's processes are managed by
+systemd. Logs for the MCPClient can be accessed using
+`sudo journalctl -u archivematica-mcp-client`. On Ubuntu 14.04, upstart is used
+instead of systemd, so logs are usually found in `/var/log/upstart`. When
+running Archivematica using docker, `docker-compose logs` commands can be used
+to access the logs from different containers.
+
+The MCPClient will look in `/etc/archivematica` for a file called
+`clientConfig.logging.json`, and if found, this file will override the default
+behaviour described above.
+
+The [`logging.json`](./logging.json) file in this directory provides an example
+that implements the logging behaviour used in Archivematica 1.6.1 and earlier.

--- a/src/MCPClient/install/config.ini
+++ b/src/MCPClient/install/config.ini
@@ -1,0 +1,29 @@
+[MCPClient]
+MCPArchivematicaServer = localhost:4730
+sharedDirectoryMounted = /var/archivematica/sharedDirectory/
+watchDirectoryPath = /var/archivematica/sharedDirectory/watchedDirectories/
+processingDirectory = /var/archivematica/sharedDirectory/currentlyProcessing/
+rejectedDirectory = %%sharedPath%%rejected/
+archivematicaClientModules = /usr/lib/archivematica/MCPClient/archivematicaClientModules
+clientScriptsDirectory = /usr/lib/archivematica/MCPClient/clientScripts/
+clientAssetsDirectory = /usr/lib/archivematica/MCPClient/assets/
+LoadSupportedCommandsSpecial = True
+numberOfTasks = 0
+elasticsearchServer = localhost:9200
+elasticsearchTimeout = 10
+disableElasticsearchIndexing = False
+temp_dir = /var/archivematica/sharedDirectory/tmp
+removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
+clamav_server = /var/run/clamav/clamd.ctl
+clamav_pass_by_reference = False
+storage_service_client_timeout = 86400
+agentarchives_client_timeout = 300
+clamav_client_timeout = 86400
+
+[client]
+user = archivematica
+password = demo
+host = localhost
+database = MCP
+port = 3306
+engine = django.db.backends.mysql

--- a/src/MCPClient/install/logging.json
+++ b/src/MCPClient/install/logging.json
@@ -1,0 +1,40 @@
+{
+  "disable_existing_loggers": false,
+  "formatters": {
+    "detailed": {
+      "datefmt": "%Y-%m-%d %H:%M:%S",
+      "format": "%(levelname)-8s  %(asctime)s  %(name)s:%(module)s:%(funcName)s:%(lineno)d:  %(message)s"
+    }
+  },
+  "handlers": {
+    "logfile": {
+      "backupCount": 5,
+      "class": "custom_handlers.GroupWriteRotatingFileHandler",
+      "filename": "/var/log/archivematica/MCPClient/MCPClient.log",
+      "formatter": "detailed",
+      "level": "INFO",
+      "maxBytes": 4194304
+    },
+    "verboselogfile": {
+      "backupCount": 5,
+      "class": "custom_handlers.GroupWriteRotatingFileHandler",
+      "filename": "/var/log/archivematica/MCPClient/MCPClient.debug.log",
+      "formatter": "detailed",
+      "level": "DEBUG",
+      "maxBytes": 4194304
+    }
+  },
+  "loggers": {
+    "archivematica": {
+      "level": "DEBUG"
+    }
+  },
+  "root": {
+    "handlers": [
+      "logfile",
+      "verboselogfile"
+    ],
+    "level": "WARNING"
+  },
+  "version": 1
+}

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -16,6 +16,10 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 import StringIO
+import json
+import logging
+import logging.config
+import os
 
 from appconfig import Config
 
@@ -129,6 +133,13 @@ INSTALLED_APPS = (
     'fpr',
 )
 
+# Configure logging manually
+LOGGING_CONFIG = None
+
+# Location of the logging configuration file that we're going to pass to
+# `logging.config.fileConfig` unless it doesn't exist.
+LOGGING_CONFIG_FILE = '/etc/archivematica/clientConfig.logging.json'
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -155,6 +166,12 @@ LOGGING = {
         'level': 'WARNING',
     }
 }
+
+if os.path.isfile(LOGGING_CONFIG_FILE):
+    with open(LOGGING_CONFIG_FILE, 'rt') as f:
+        LOGGING = logging.config.dictConfig(json.load(f))
+else:
+    logging.config.dictConfig(LOGGING)
 
 
 SHARED_DIRECTORY = config.get('shared_directory')

--- a/src/MCPServer/install/README.md
+++ b/src/MCPServer/install/README.md
@@ -1,0 +1,31 @@
+## Configuration files
+
+This directory contains the following files:
+
+- [`config.ini`](./config.ini) - a sample configuration file that the user can place in
+`/etc/archivematica/serverConfig.conf` to tweak the configuration of MCPServer.
+
+- [`logging.json`](./logging.json) - read the
+[logging configuration section](#logging-configuration) for more details.
+
+## Logging configuration
+
+Archivematica 1.6.1 and earlier releases are configured by default to log to
+subdirectories in `/var/log/archivematica`, such as
+`/var/log/archivematica/MCPServer/MCPServer.debug.log`. Starting with
+Archivematica 1.7.0, logging configuration defaults to using stdout and stderr
+for all logs. If no changes are made to the new default configuration logs
+will be handled by whichever process is managing Archivematica's services. For
+example on Ubuntu 16.04 or Centos 7, Archivematica's processes are managed by
+systemd. Logs for the MCPServer can be accessed using
+`sudo journalctl -u archivematica-mcp-server`. On Ubuntu 14.04, upstart is used
+instead of systemd, so logs are usually found in `/var/log/upstart`. When
+running Archivematica using docker, `docker-compose logs` commands can be used
+to access the logs from different containers.
+
+The MCPServer will look in `/etc/archivematica` for a file called
+`serverConfig.logging.json`, and if found, this file will override the default
+behaviour described above.
+
+The [`logging.json`](./logging.json) file in this directory provides an example
+that implements the logging behaviour used in Archivematica 1.6.1 and earlier.

--- a/src/MCPServer/install/config.ini
+++ b/src/MCPServer/install/config.ini
@@ -1,0 +1,24 @@
+[MCPServer]
+MCPArchivematicaServer = localhost:4730
+watchDirectoryPath = /var/archivematica/sharedDirectory/watchedDirectories/
+sharedDirectory = /var/archivematica/sharedDirectory/
+processingDirectory = /var/archivematica/sharedDirectory/currentlyProcessing/
+rejectedDirectory = %%sharedPath%%rejected/
+watchDirectoriesPollInterval = 1
+processingXMLFile = processingMCP.xml
+waitOnAutoApprove = 0
+
+[Protocol]
+delimiter = <!&\delimiter/&!>
+limitGearmanConnections = 10000
+limitTaskThreads = 75
+limitTaskThreadsSleep = 0.2
+reservedAsTaskProcessingThreads = 8
+
+[client]
+user = archivematica
+password = demo
+host = localhost
+database = MCP
+port = 3306
+engine = django.db.backends.mysql

--- a/src/MCPServer/install/logging.json
+++ b/src/MCPServer/install/logging.json
@@ -1,0 +1,40 @@
+{
+  "disable_existing_loggers": false,
+  "formatters": {
+    "detailed": {
+      "datefmt": "%Y-%m-%d %H:%M:%S",
+      "format": "%(levelname)-8s  %(asctime)s  %(name)s:%(module)s:%(funcName)s:%(lineno)d:  %(message)s"
+    }
+  },
+  "handlers": {
+    "logfile": {
+      "backupCount": 5,
+      "class": "custom_handlers.GroupWriteRotatingFileHandler",
+      "filename": "/var/log/archivematica/MCPServer/MCPServer.log",
+      "formatter": "detailed",
+      "level": "INFO",
+      "maxBytes": 4194304
+    },
+    "verboselogfile": {
+      "backupCount": 5,
+      "class": "custom_handlers.GroupWriteRotatingFileHandler",
+      "filename": "/var/log/archivematica/MCPServer/MCPServer.debug.log",
+      "formatter": "detailed",
+      "level": "DEBUG",
+      "maxBytes": 4194304
+    }
+  },
+  "loggers": {
+    "archivematica": {
+      "level": "DEBUG"
+    }
+  },
+  "root": {
+    "handlers": [
+      "logfile",
+      "verboselogfile"
+    ],
+    "level": "WARNING"
+  },
+  "version": 1
+}

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -16,6 +16,10 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 import StringIO
+import json
+import logging
+import logging.config
+import os
 
 from appconfig import Config
 
@@ -106,6 +110,13 @@ SECRET_KEY = config.get('secret_key', default='e7b-$#-3fgu)j1k01)3tp@^e0=yv1hlcc
 USE_TZ = True
 TIME_ZONE = 'UTC'
 
+# Configure logging manually
+LOGGING_CONFIG = None
+
+# Location of the logging configuration file that we're going to pass to
+# `logging.config.fileConfig` unless it doesn't exist.
+LOGGING_CONFIG_FILE = '/etc/archivematica/serverConfig.logging.json'
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -132,6 +143,12 @@ LOGGING = {
         'level': 'WARNING',
     },
 }
+
+if os.path.isfile(LOGGING_CONFIG_FILE):
+    with open(LOGGING_CONFIG_FILE, 'rt') as f:
+        LOGGING = logging.config.dictConfig(json.load(f))
+else:
+    logging.config.dictConfig(LOGGING)
 
 
 SHARED_DIRECTORY = config.get('shared_directory')

--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -1,0 +1,34 @@
+## Configuration files
+
+This directory contains the following files:
+
+- [`archivematica-dashboard.conf`](./archivematica-dashboard.conf) - systemd unit file sample.
+
+- [`dashboard.conf`](./dashboard.conf) - nginx server block sample. 
+
+- [`dashboard.gunicorn-config.py`](./dashboard.gunicorn-config.py) - gunicorn configuration file sample.
+
+- [`logging.json`](./logging.json) - read the
+[logging configuration section](#logging-configuration) for more details.
+
+## Logging configuration
+
+Archivematica 1.6.1 and earlier releases are configured by default to log to
+subdirectories in `/var/log/archivematica`, such as
+`/var/log/archivematica/dashboard/dashboard.debug.log`. Starting with
+Archivematica 1.7.0, logging configuration defaults to using stdout and stderr
+for all logs. If no changes are made to the new default configuration logs
+will be handled by whichever process is managing Archivematica's services. For
+example on Ubuntu 16.04 or Centos 7, Archivematica's processes are managed by
+systemd. Logs for the Dashboard can be accessed using
+`sudo journalctl -u archivematica-dashboard`. On Ubuntu 14.04, upstart is used
+instead of systemd, so logs are usually found in `/var/log/upstart`. When
+running Archivematica using docker, `docker-compose logs` commands can be used
+to access the logs from different containers.
+
+The dashboard will look in `/etc/archivematica` for a file called
+`dashboard.logging.json`, and if found, this file will override the default
+behaviour described above.
+
+The [`logging.json`](./logging.json) file in this directory provides an example
+that implements the logging behaviour used in Archivematica 1.6.1 and earlier.

--- a/src/dashboard/install/logging.json
+++ b/src/dashboard/install/logging.json
@@ -1,0 +1,80 @@
+{
+  "disable_existing_loggers": false,
+  "filters": {
+    "require_debug_false": {
+      "()": "django.utils.log.RequireDebugFalse"
+    }
+  },
+  "formatters": {
+    "detailed": {
+      "datefmt": "%Y-%m-%d %H:%M:%S",
+      "format": "%(levelname)-8s  %(asctime)s  %(name)s:%(module)s:%(funcName)s:%(lineno)d:  %(message)s"
+    },
+    "simple": {
+      "format": "%(levelname)-8s  %(name)s.%(funcName)s:  %(message)s"
+    }
+  },
+  "handlers": {
+    "console": {
+      "class": "logging.StreamHandler",
+      "formatter": "simple",
+      "level": "DEBUG"
+    },
+    "logfile": {
+      "backupCount": 5,
+      "class": "custom_handlers.GroupWriteRotatingFileHandler",
+      "filename": "/var/log/archivematica/dashboard/dashboard.log",
+      "formatter": "detailed",
+      "level": "INFO",
+      "maxBytes": 20971520
+    },
+    "mail_admins": {
+      "class": "django.utils.log.AdminEmailHandler",
+      "filters": [
+        "require_debug_false"
+      ],
+      "level": "ERROR"
+    },
+    "null": {
+      "class": "logging.NullHandler",
+      "level": "DEBUG"
+    },
+    "verboselogfile": {
+      "backupCount": 5,
+      "class": "custom_handlers.GroupWriteRotatingFileHandler",
+      "filename": "/var/log/archivematica/dashboard/dashboard.debug.log",
+      "formatter": "detailed",
+      "level": "DEBUG",
+      "maxBytes": 104857600
+    }
+  },
+  "loggers": {
+    "agentarchives": {
+      "level": "INFO"
+    },
+    "archivematica": {
+      "level": "DEBUG"
+    },
+    "archivematica.mcp": {
+      "propagate": false
+    },
+    "django.request": {
+      "handlers": [
+        "mail_admins"
+      ],
+      "level": "ERROR",
+      "propagate": true
+    },
+    "elasticsearch": {
+      "level": "INFO"
+    }
+  },
+  "root": {
+    "handlers": [
+      "logfile",
+      "verboselogfile"
+    ],
+    "level": "WARNING"
+  },
+  "version": 1
+}

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -18,6 +18,9 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 import StringIO
+import json
+import logging
+import logging.config
 import os
 
 from django.utils.translation import ugettext_lazy as _
@@ -291,6 +294,14 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = '127.0.0.1'
 EMAIL_TIMEOUT = 15
 
+# Configure logging manually
+LOGGING_CONFIG = None
+
+# Location of the logging configuration file that we're going to pass to
+# `logging.config.fileConfig` unless it doesn't exist.
+LOGGING_CONFIG_FILE = '/etc/archivematica/dashboard.logging.json'
+
+# This is our default logging configuration.
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -348,6 +359,13 @@ LOGGING = {
         'level': 'WARNING',
     },
 }
+
+if os.path.isfile(LOGGING_CONFIG_FILE):
+    with open(LOGGING_CONFIG_FILE, 'rt') as f:
+        LOGGING = logging.config.dictConfig(json.load(f))
+else:
+    logging.config.dictConfig(LOGGING)
+
 
 CACHES = {
     'default': {


### PR DESCRIPTION
AM 1.7 brought a new simpler logging configuration with less responsibilities -
log writing to files, debugging log file or automatic file rotation are gone
now. The new default is to send the events to the standard streams which is
more convenient when you're running Archivematica in a cluster.

In this pull request I add the ability to change the new logging configuration
defaults via a JSON configuration file. The examples included mimic the old
behaviour - this is important for deb/pkg/ansible installations that still
prefer to have the old defaults in place.

- `/etc/archivematica/dashboard.logging.json` (see
[install/README.md](https://github.com/artefactual/archivematica/blob/dev/backward-compatible-logging/src/dashboard/install/README.md))
- `/etc/archivematica/clientConfig.logging.json` (see
[install/README.md](https://github.com/artefactual/archivematica/blob/dev/backward-compatible-logging/src/MCPClient/install/README.md))
- `/etc/archivematica/serverConfig.logging.json` (see
[install/README.md](https://github.com/artefactual/archivematica/blob/dev/backward-compatible-logging/src/MCPServer/install/README.md))

This closes #776.