### PR TITLE
Dashboard: update fpr-admin to v1.7.3

### DIFF
--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -10,7 +10,7 @@ django-tastypie==0.13.2
 django-extensions==1.1.1
 django-annoying==0.7.7
 elasticsearch>=1.0.0,<2.0.0
-git+https://github.com/artefactual/archivematica-fpr-admin.git@v1.7.2#egg=archivematica-fpr-admin
+git+https://github.com/artefactual/archivematica-fpr-admin.git@v1.7.3#egg=archivematica-fpr-admin
 gearman==2.0.2
 gevent==1.2.1  # used by gunicorn's async workers
 gunicorn==19.7.1


### PR DESCRIPTION
Version 1.7.3 of AM-fpr-admin adds the UUID of a file to its OCR transcription text file so that such tanscription files do not overwrite one another. This fixes https://github.com/artefactual/archivematica-fpr-admin/issues/66 and https://projects.artefactual.com/issues/11651.