### PR TITLE
Logging: restore GroupWriteRotatingFileHandler

### DIFF
--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -2,8 +2,9 @@
 
 This directory contains the following files:
 
-- [`clientConfig.conf`](./clientConfig.conf) - a sample configuration file that the user can place in
-`/etc/archivematica/clientConfig.conf` to tweak the configuration of MCPClient.
+- [`clientConfig.conf`](./clientConfig.conf) - a sample configuration file that
+the user can place in `/etc/archivematica/clientConfig.conf` to tweak the
+configuration of MCPClient.
 
 - [`clientConfig.logging.json`](./clientConfig.logging.json) - read the
 [logging configuration section](#logging-configuration) for more details.
@@ -27,5 +28,6 @@ The MCPClient will look in `/etc/archivematica` for a file called
 `clientConfig.logging.json`, and if found, this file will override the default
 behaviour described above.
 
-The [`clientConfig.logging.json`](./clientConfig.logging.json) file in this directory provides an example
-that implements the logging behaviour used in Archivematica 1.6.1 and earlier.
+The [`clientConfig.logging.json`](./clientConfig.logging.json) file in this
+directory provides an example that implements the logging behaviour used in
+Archivematica 1.6.1 and earlier.

--- a/src/MCPServer/install/README.md
+++ b/src/MCPServer/install/README.md
@@ -2,8 +2,9 @@
 
 This directory contains the following files:
 
-- [`serverConfig.conf`](./serverConfig.conf) - a sample configuration file that the user can place in
-`/etc/archivematica/serverConfig.conf` to tweak the configuration of MCPServer.
+- [`serverConfig.conf`](./serverConfig.conf) - a sample configuration file that
+the user can place in `/etc/archivematica/serverConfig.conf` to tweak the
+configuration of MCPServer.
 
 - [`serverConfig.logging.json`](./serverConfig.logging.json) - read the
 [logging configuration section](#logging-configuration) for more details.
@@ -27,5 +28,6 @@ The MCPServer will look in `/etc/archivematica` for a file called
 `serverConfig.logging.json`, and if found, this file will override the default
 behaviour described above.
 
-The [`logging.json`](./logging.json) file in this directory provides an example
-that implements the logging behaviour used in Archivematica 1.6.1 and earlier.
+The [`serverConfig.logging.json`](./serverConfig.logging.json) file in this
+directory provides an example that implements the logging behaviour used in
+Archivematica 1.6.1 and earlier.

--- a/src/archivematicaCommon/lib/custom_handlers.py
+++ b/src/archivematicaCommon/lib/custom_handlers.py
@@ -1,7 +1,18 @@
 import logging
 import logging.config
+import logging.handlers
 import os
 import sys
+
+
+class GroupWriteRotatingFileHandler(logging.handlers.RotatingFileHandler):
+    def _open(self):
+        prevumask = os.umask(0o002)
+        try:
+            rtv = logging.handlers.RotatingFileHandler._open(self)
+            return rtv
+        finally:
+            os.umask(prevumask)
 
 
 STANDARD_FORMAT = "%(levelname)-8s  %(asctime)s  %(name)s.%(funcName)s:%(lineno)d  %(message)s"

--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -2,11 +2,13 @@
 
 This directory contains the following files:
 
-- [`archivematica-dashboard.conf`](./archivematica-dashboard.conf) - systemd unit file sample.
+- [`archivematica-dashboard.conf`](./archivematica-dashboard.conf) -
+systemd unit file sample.
 
-- [`dashboard.conf`](./dashboard.conf) - nginx server block sample. 
+- [`dashboard.conf`](./dashboard.conf) - nginx server block sample.
 
-- [`dashboard.gunicorn-config.py`](./dashboard.gunicorn-config.py) - gunicorn configuration file sample.
+- [`dashboard.gunicorn-config.py`](./dashboard.gunicorn-config.py) -
+gunicorn configuration file sample.
 
 - [`dashboard.logging.json`](./dashboard.logging.json) - read the
 [logging configuration section](#logging-configuration) for more details.
@@ -30,5 +32,6 @@ The dashboard will look in `/etc/archivematica` for a file called
 `dashboard.logging.json`, and if found, this file will override the default
 behaviour described above.
 
-The [`dashboard.logging.json`](./dashboard.logging.json) file in this directory provides an example
-that implements the logging behaviour used in Archivematica 1.6.1 and earlier.
+The [`dashboard.logging.json`](./dashboard.logging.json) file in this directory
+provides an example that implements the logging behaviour used in Archivematica
+1.6.1 and earlier.


### PR DESCRIPTION
Deleted in 9a810ad9b81627760d57ee01bbdf667dd318fae7.
Needed because of #776 and #782.