### PR TITLE
Dashboard: GUI reflects DISABLE_SEARCH_INDEXING

### DIFF
--- a/src/MCPClient/lib/clientScripts/elasticSearchIndexProcessTransfer.py
+++ b/src/MCPClient/lib/clientScripts/elasticSearchIndexProcessTransfer.py
@@ -36,7 +36,7 @@ logger = get_script_logger('archivematica.mcp.client.elasticSearchIndexProcessTr
 
 
 if __name__ == '__main__':
-    if mcpclient_settings.DISABLE_SEARCH_INDEXING is True:
+    if not mcpclient_settings.SEARCH_ENABLED:
         logger.info('Skipping indexing: indexing is currently disabled.')
         sys.exit(0)
 

--- a/src/MCPClient/lib/clientScripts/indexAIP.py
+++ b/src/MCPClient/lib/clientScripts/indexAIP.py
@@ -47,7 +47,7 @@ def index_aip():
     sip_path = sys.argv[3]  # %SIPDirectory%
     sip_type = sys.argv[4]  # %SIPType%
 
-    if mcpclient_settings.DISABLE_SEARCH_INDEXING is True:
+    if not mcpclient_settings.SEARCH_ENABLED:
         logger.info('Skipping indexing: indexing is currently disabled.')
         return 0
 

--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -89,7 +89,7 @@ def post_store_hook(sip_uuid):
     """
     Hook for doing any work after an AIP is stored successfully.
     """
-    if mcpclient_settings.DISABLE_SEARCH_INDEXING is True:
+    if not mcpclient_settings.SEARCH_ENABLED:
         logger.info('Skipping indexing: indexing is currently disabled.')
         return 0
 

--- a/src/MCPClient/lib/clientScripts/removeAIPFilesFromIndex.py
+++ b/src/MCPClient/lib/clientScripts/removeAIPFilesFromIndex.py
@@ -38,7 +38,7 @@ logger = get_script_logger("archivematica.mcp.client.removeAIPFilesFromIndex")
 if __name__ == '__main__':
     aip_uuid = sys.argv[1]
 
-    if mcpclient_settings.DISABLE_SEARCH_INDEXING is True:
+    if not mcpclient_settings.SEARCH_ENABLED:
         logger.info('Skipping. Indexing is currently disabled.')
 
     elasticSearchFunctions.setup_reading_from_conf(mcpclient_settings)

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -38,7 +38,10 @@ CONFIG_MAPPING = {
     'client_modules_file': {'section': 'MCPClient', 'option': 'archivematicaClientModules', 'type': 'string'},
     'elasticsearch_server': {'section': 'MCPClient', 'option': 'elasticsearchServer', 'type': 'string'},
     'elasticsearch_timeout': {'section': 'MCPClient', 'option': 'elasticsearchTimeout', 'type': 'float'},
-    'disable_search_indexing': {'section': 'MCPClient', 'option': 'disableElasticsearchIndexing', 'type': 'boolean'},
+    'search_enabled': [
+        {'section': 'MCPClient', 'option': 'disableElasticsearchIndexing', 'type': 'boolean'},
+        {'section': 'MCPClient', 'option': 'search_enabled', 'type': 'iboolean'},
+    ],
     'removable_files': {'section': 'MCPClient', 'option': 'removableFiles', 'type': 'string'},
     'temp_directory': {'section': 'MCPClient', 'option': 'temp_dir', 'type': 'string'},
     'secret_key': {'section': 'MCPClient', 'option': 'django_secret_key', 'type': 'string'},
@@ -58,6 +61,8 @@ CONFIG_MAPPING = {
     'db_port': {'section': 'client', 'option': 'port', 'type': 'string'},
 }
 
+SEARCH_ENABLED_DEFAULT = False
+
 CONFIG_DEFAULTS = """[MCPClient]
 MCPArchivematicaServer = localhost:4730
 sharedDirectoryMounted = /var/archivematica/sharedDirectory/
@@ -71,7 +76,7 @@ LoadSupportedCommandsSpecial = True
 numberOfTasks = 0
 elasticsearchServer = localhost:9200
 elasticsearchTimeout = 10
-disableElasticsearchIndexing = True
+search_enabled = {search_enabled_default}
 temp_dir = /var/archivematica/sharedDirectory/tmp
 removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
 clamav_server = /var/run/clamav/clamd.ctl
@@ -88,7 +93,7 @@ host = localhost
 database = MCP
 port = 3306
 engine = django.db.backends.mysql
-"""
+""".format(search_enabled_default=SEARCH_ENABLED_DEFAULT)
 
 config = Config(env_prefix='ARCHIVEMATICA_MCPCLIENT', attrs=CONFIG_MAPPING)
 config.read_defaults(StringIO.StringIO(CONFIG_DEFAULTS))
@@ -184,7 +189,6 @@ LOAD_SUPPORTED_COMMANDS_SPECIAL = config.get('load_supported_commands_special')
 GEARMAN_SERVER = config.get('gearman_server')
 NUMBER_OF_TASKS = config.get('number_of_tasks')
 CLIENT_MODULES_FILE = config.get('client_modules_file')
-DISABLE_SEARCH_INDEXING = config.get('disable_search_indexing')
 REMOVABLE_FILES = config.get('removable_files')
 TEMP_DIRECTORY = config.get('temp_directory')
 ELASTICSEARCH_SERVER = config.get('elasticsearch_server')
@@ -195,3 +199,4 @@ CLAMAV_CLIENT_TIMEOUT = config.get('clamav_client_timeout')
 CLAMAV_CLIENT_THRESHOLD = config.get('clamav_client_threshold')
 STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
 AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
+SEARCH_ENABLED = config.get('search_enabled')

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -61,8 +61,6 @@ CONFIG_MAPPING = {
     'db_port': {'section': 'client', 'option': 'port', 'type': 'string'},
 }
 
-SEARCH_ENABLED_DEFAULT = False
-
 CONFIG_DEFAULTS = """[MCPClient]
 MCPArchivematicaServer = localhost:4730
 sharedDirectoryMounted = /var/archivematica/sharedDirectory/
@@ -76,7 +74,7 @@ LoadSupportedCommandsSpecial = True
 numberOfTasks = 0
 elasticsearchServer = localhost:9200
 elasticsearchTimeout = 10
-search_enabled = {search_enabled_default}
+search_enabled = false
 temp_dir = /var/archivematica/sharedDirectory/tmp
 removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
 clamav_server = /var/run/clamav/clamd.ctl
@@ -93,7 +91,7 @@ host = localhost
 database = MCP
 port = 3306
 engine = django.db.backends.mysql
-""".format(search_enabled_default=SEARCH_ENABLED_DEFAULT)
+"""
 
 config = Config(env_prefix='ARCHIVEMATICA_MCPCLIENT', attrs=CONFIG_MAPPING)
 config.read_defaults(StringIO.StringIO(CONFIG_DEFAULTS))

--- a/src/MCPServer/lib/linkTaskManagerChoice.py
+++ b/src/MCPServer/lib/linkTaskManagerChoice.py
@@ -57,6 +57,9 @@ class linkTaskManagerChoice(LinkTaskManager):
 
         choices = MicroServiceChainChoice.objects.filter(choiceavailableatlink_id=str(jobChainLink.pk))
         for choice in choices:
+            if (django_settings.DISABLE_SEARCH_INDEXING and
+                    choice.chainavailable.description == 'Send to backlog'):
+                continue
             self.choices.append((choice.chainavailable_id, choice.chainavailable.description))
 
         preConfiguredChain = self.checkForPreconfiguredXML()

--- a/src/MCPServer/lib/linkTaskManagerChoice.py
+++ b/src/MCPServer/lib/linkTaskManagerChoice.py
@@ -37,6 +37,7 @@ choicesAvailableForUnitsLock = threading.Lock()
 
 from archivematicaFunctions import unicodeToStr
 from databaseFunctions import auto_close_db
+from abilities import choice_is_available
 
 from main.models import MicroServiceChainChoice, UserProfile, Job
 from django.conf import settings as django_settings
@@ -54,14 +55,12 @@ class linkTaskManagerChoice(LinkTaskManager):
         self.choices = []
         self.delayTimerLock = threading.Lock()
         self.delayTimer = None
-
-        choices = MicroServiceChainChoice.objects.filter(choiceavailableatlink_id=str(jobChainLink.pk))
+        choices = MicroServiceChainChoice.objects.filter(
+            choiceavailableatlink_id=str(jobChainLink.pk))
         for choice in choices:
-            if (django_settings.DISABLE_SEARCH_INDEXING and
-                    choice.chainavailable.description == 'Send to backlog'):
-                continue
-            self.choices.append((choice.chainavailable_id, choice.chainavailable.description))
-
+            if choice_is_available(choice, django_settings):
+                self.choices.append((choice.chainavailable_id,
+                                     choice.chainavailable.description))
         preConfiguredChain = self.checkForPreconfiguredXML()
         if preConfiguredChain is not None:
             time.sleep(django_settings.WAIT_ON_AUTO_APPROVE)

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -35,6 +35,7 @@ CONFIG_MAPPING = {
     'wait_on_auto_approve': {'section': 'MCPServer', 'option': 'waitOnAutoApprove', 'type': 'int'},
     'watch_directory_interval': {'section': 'MCPServer', 'option': 'watchDirectoriesPollInterval', 'type': 'int'},
     'secret_key': {'section': 'MCPServer', 'option': 'django_secret_key', 'type': 'string'},
+    'disable_search_indexing': {'section': 'MCPServer', 'option': 'disable_search_indexing', 'type': 'boolean'},
 
     # [Protocol]
     'limit_task_threads': {'section': 'Protocol', 'option': 'limitTaskThreads', 'type': 'int'},
@@ -61,6 +62,7 @@ rejectedDirectory = %%sharedPath%%rejected/
 watchDirectoriesPollInterval = 1
 processingXMLFile = processingMCP.xml
 waitOnAutoApprove = 0
+disable_search_indexing = True
 
 [Protocol]
 delimiter = <!&\delimiter/&!>
@@ -163,3 +165,4 @@ LIMIT_TASK_THREADS = config.get('limit_task_threads')
 LIMIT_TASK_THREADS_SLEEP = config.get('limit_task_threads_sleep')
 LIMIT_GEARMAN_CONNS = config.get('limit_gearman_conns')
 RESERVED_AS_TASK_PROCESSING_THREADS = config.get('reserved_as_task_processing_threads')
+DISABLE_SEARCH_INDEXING = config.get('disable_search_indexing')

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -55,8 +55,6 @@ CONFIG_MAPPING = {
     'db_port': {'section': 'client', 'option': 'port', 'type': 'string'},
 }
 
-SEARCH_ENABLED_DEFAULT = False
-
 CONFIG_DEFAULTS = """[MCPServer]
 MCPArchivematicaServer = localhost:4730
 watchDirectoryPath = /var/archivematica/sharedDirectory/watchedDirectories/
@@ -66,7 +64,7 @@ rejectedDirectory = %%sharedPath%%rejected/
 watchDirectoriesPollInterval = 1
 processingXMLFile = processingMCP.xml
 waitOnAutoApprove = 0
-search_enabled = {search_enabled_default}
+search_enabled = false
 
 [Protocol]
 delimiter = <!&\delimiter/&!>
@@ -82,7 +80,7 @@ host = localhost
 database = MCP
 port = 3306
 engine = django.db.backends.mysql
-""".format(search_enabled_default=SEARCH_ENABLED_DEFAULT)
+"""
 
 
 config = Config(env_prefix='ARCHIVEMATICA_MCPSERVER', attrs=CONFIG_MAPPING)

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -35,7 +35,10 @@ CONFIG_MAPPING = {
     'wait_on_auto_approve': {'section': 'MCPServer', 'option': 'waitOnAutoApprove', 'type': 'int'},
     'watch_directory_interval': {'section': 'MCPServer', 'option': 'watchDirectoriesPollInterval', 'type': 'int'},
     'secret_key': {'section': 'MCPServer', 'option': 'django_secret_key', 'type': 'string'},
-    'disable_search_indexing': {'section': 'MCPServer', 'option': 'disable_search_indexing', 'type': 'boolean'},
+    'search_enabled': [
+        {'section': 'MCPServer', 'option': 'disable_search_indexing', 'type': 'boolean'},
+        {'section': 'MCPServer', 'option': 'search_enabled', 'type': 'iboolean'},
+    ],
 
     # [Protocol]
     'limit_task_threads': {'section': 'Protocol', 'option': 'limitTaskThreads', 'type': 'int'},
@@ -52,6 +55,7 @@ CONFIG_MAPPING = {
     'db_port': {'section': 'client', 'option': 'port', 'type': 'string'},
 }
 
+SEARCH_ENABLED_DEFAULT = False
 
 CONFIG_DEFAULTS = """[MCPServer]
 MCPArchivematicaServer = localhost:4730
@@ -62,7 +66,7 @@ rejectedDirectory = %%sharedPath%%rejected/
 watchDirectoriesPollInterval = 1
 processingXMLFile = processingMCP.xml
 waitOnAutoApprove = 0
-disable_search_indexing = True
+search_enabled = {search_enabled_default}
 
 [Protocol]
 delimiter = <!&\delimiter/&!>
@@ -78,7 +82,7 @@ host = localhost
 database = MCP
 port = 3306
 engine = django.db.backends.mysql
-"""
+""".format(search_enabled_default=SEARCH_ENABLED_DEFAULT)
 
 
 config = Config(env_prefix='ARCHIVEMATICA_MCPSERVER', attrs=CONFIG_MAPPING)
@@ -165,4 +169,4 @@ LIMIT_TASK_THREADS = config.get('limit_task_threads')
 LIMIT_TASK_THREADS_SLEEP = config.get('limit_task_threads_sleep')
 LIMIT_GEARMAN_CONNS = config.get('limit_gearman_conns')
 RESERVED_AS_TASK_PROCESSING_THREADS = config.get('reserved_as_task_processing_threads')
-DISABLE_SEARCH_INDEXING = config.get('disable_search_indexing')
+SEARCH_ENABLED = config.get('search_enabled')

--- a/src/archivematicaCommon/lib/abilities.py
+++ b/src/archivematicaCommon/lib/abilities.py
@@ -1,0 +1,35 @@
+"""The abilities module allows for the description of abilities and their
+dependencies across Archivematica components (i.e., dashboard, MCPServer, and
+MCPClient).
+"""
+
+
+ABILITIES = (
+    # The (elastic)search ability must be enabled in order for Archivematica's
+    # transfer backlog to work. Therefore, the "Send to backlog" choice at the
+    # "Create SIP(s)" decision point should not be available when the search
+    # ability is disabled.
+    {
+        'name': 'search',
+        'enabled_attr': 'SEARCH_ENABLED',
+        'dependencies': (
+            ('Create SIP(s)', 'Send to backlog'),
+        )
+    },
+)
+
+
+def choice_is_available(choice, settings):
+    """Return ``True`` if the ``MicroServiceChainChoice`` instance ``choice``
+    should be presented to the user, given ``ABILITIES`` and the configuration
+    object ``settings``.
+    """
+    for ability in ABILITIES:
+        feature_enabled = getattr(settings, ability['enabled_attr'], False)
+        if not feature_enabled:
+            choice_tuple = (
+                choice.choiceavailableatlink.currenttask.description,
+                choice.chainavailable.description)
+            if choice_tuple in ability['dependencies']:
+                return False
+    return True

--- a/src/archivematicaCommon/lib/abilities.py
+++ b/src/archivematicaCommon/lib/abilities.py
@@ -25,7 +25,8 @@ def choice_is_available(choice, settings):
     object ``settings``.
     """
     for ability in ABILITIES:
-        feature_enabled = getattr(settings, ability['enabled_attr'], False)
+        enabled_attr = ability['enabled_attr']
+        feature_enabled = getattr(settings, enabled_attr, False)
         if not feature_enabled:
             choice_tuple = (
                 choice.choiceavailableatlink.currenttask.description,

--- a/src/archivematicaCommon/lib/appconfig.py
+++ b/src/archivematicaCommon/lib/appconfig.py
@@ -12,11 +12,18 @@ class Config(object):
 
         - MCPClient/lib/settings/common.py
         - MCPServer/lib/settings/common.py
-        - Dashboard/src/settings/common.py
+        - Dashboard/src/settings/base.py
     """
     def __init__(self, env_prefix, attrs):
         self.config = EnvConfigParser(prefix=env_prefix)
         self.attrs = attrs
+
+    INVALID_ATTR_MSG = ('Invalid attribute: %s. Make sure the entry in the'
+                        ' attribute has all the fields needed (section, option,'
+                        ' type).')
+
+    UNDEFINED_ATTR_MSG = (
+        'The following configuration attribute must be defined: %s.')
 
     def read_defaults(self, fp):
         self.config.readfp(fp)
@@ -31,11 +38,10 @@ class Config(object):
                                        'attribute list.' % attr)
 
         attr_opts = self.attrs[attr]
+        if isinstance(attr_opts, list):
+            return self.get_from_opts_list(attr, attr_opts, default=default)
         if not all(k in attr_opts for k in ('section', 'option', 'type')):
-            raise ImproperlyConfigured('Invalid attribute: %s. Make sure the '
-                                       'entry in the attribute has all the '
-                                       'fields needed (section, option, '
-                                       'type).' % attr)
+            raise ImproperlyConfigured(self.INVALID_ATTR_MSG % attr)
 
         getter = 'get{}'.format('' if attr_opts['type'] == 'string' else attr_opts['type'])
         kwargs = {'section': attr_opts['section'], 'option': attr_opts['option']}
@@ -47,5 +53,29 @@ class Config(object):
         try:
             return getattr(self.config, getter)(**kwargs)
         except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
-            raise ImproperlyConfigured('The following configuration attribute '
-                                       'must be defined: %s.' % attr)
+            raise ImproperlyConfigured(self.UNDEFINED_ATTR_MSG % attr)
+
+    def get_from_opts_list(self, attr, attr_opts_list, default=None):
+        if not all(all(
+                k in attr_opts for k in ('section', 'option', 'type'))
+                for attr_opts in attr_opts_list):
+            raise ImproperlyConfigured(self.INVALID_ATTR_MSG % attr)
+        opts = []
+        for attr_opts in attr_opts_list:
+            opt_type = attr_opts['type']
+            getter = 'get{}'.format({'string': ''}.get(opt_type, opt_type))
+            kwargs = {'section': attr_opts['section'],
+                      'option': attr_opts['option']}
+            if default is not None:
+                kwargs['fallback'] = default
+            elif 'default' in attr_opts:
+                kwargs['fallback'] = attr_opts['default']
+            try:
+                opt = getattr(self.config, getter)(**kwargs)
+            except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+                pass
+            else:
+                opts.append(opt)
+        if opts:
+            return opts[0]
+        raise ImproperlyConfigured(self.UNDEFINED_ATTR_MSG % attr)

--- a/src/archivematicaCommon/lib/env_configparser.py
+++ b/src/archivematicaCommon/lib/env_configparser.py
@@ -70,3 +70,7 @@ class EnvConfigParser(ConfigParser.SafeConfigParser):
     @fallback_option
     def getboolean(self, *args, **kwargs):
         return ConfigParser.SafeConfigParser.getboolean(self, *args, **kwargs)
+
+    @fallback_option
+    def getiboolean(self, *args, **kwargs):
+        return not self.getboolean(*args, **kwargs)

--- a/src/archivematicaCommon/tests/test_appconfig.py
+++ b/src/archivematicaCommon/tests/test_appconfig.py
@@ -1,0 +1,65 @@
+from __future__ import absolute_import
+import os
+import StringIO
+
+from django.core.exceptions import ImproperlyConfigured
+import pytest
+
+from appconfig import Config
+
+
+CONFIG_MAPPING = {
+    'search_enabled': [
+        {'section': 'Dashboard', 'option': 'disable_search_indexing', 'type': 'iboolean'},
+        {'section': 'Dashboard', 'option': 'search_enabled', 'type': 'boolean'},
+    ],
+}
+
+
+@pytest.mark.parametrize('option, value, expect', [
+    ('search_enabled', 'true', True),
+    ('search_enabled', 'false', False),
+    ('disable_search_indexing', 'true', False),
+    ('disable_search_indexing', 'false', True),
+])
+def test_mapping_list_config_file(option, value, expect):
+    config = Config(env_prefix='ARCHIVEMATICA_DASHBOARD', attrs=CONFIG_MAPPING)
+    config.read_defaults(StringIO.StringIO(
+        '[Dashboard]\n'
+        '{option} = {value}'.format(option=option, value=value)))
+    assert config.get('search_enabled') is expect
+
+
+@pytest.mark.parametrize('envvars, expect', [
+    ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED': 'true'}, True),
+    ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED': 'false'}, False),
+    ({'ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED': 'true'}, True),
+    ({'ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED': 'false'}, False),
+    ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_DISABLE_SEARCH_INDEXING': 'true'},
+     False),
+    ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_DISABLE_SEARCH_INDEXING': 'false'},
+     True),
+    ({'ARCHIVEMATICA_DASHBOARD_DISABLE_SEARCH_INDEXING': 'true'}, False),
+    ({'ARCHIVEMATICA_DASHBOARD_DISABLE_SEARCH_INDEXING': 'false'}, True),
+    ({}, ImproperlyConfigured),
+    # Following two show that the DISABLE env var overrides the ENABLE one
+    # because of the ordering in CONFIG_MAPPING.
+    ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED': 'true',
+      'ARCHIVEMATICA_DASHBOARD_DASHBOARD_DISABLE_SEARCH_INDEXING': 'true'},
+     False),
+    ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED': 'false',
+      'ARCHIVEMATICA_DASHBOARD_DASHBOARD_DISABLE_SEARCH_INDEXING': 'false'},
+     True),
+])
+def test_mapping_list_env_var(envvars, expect):
+    for var, val in envvars.items():
+        os.environ[var] = val
+    config = Config(env_prefix='ARCHIVEMATICA_DASHBOARD', attrs=CONFIG_MAPPING)
+    if bool(expect) is expect:
+        search_enabled = config.get('search_enabled')
+        assert search_enabled is expect
+    else:
+        with pytest.raises(expect):
+            config.get('search_enabled')
+    for var in envvars:
+        del os.environ[var]

--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -298,11 +298,14 @@ class ProcessingConfigurationForm(forms.Form):
         'name': 'examine',
         'label': _('Examine contents'),
     }
+    create_sip_ignored_choices = ['Reject transfer']
+    if settings.DISABLE_SEARCH_INDEXING:
+        create_sip_ignored_choices.append('Send to backlog')
     processing_fields['bb194013-597c-4e4a-8493-b36d190f8717'] = {
         'type': 'chain_choice',
         'name': 'create_sip',
         'label': _('Create SIP(s)'),
-        'ignored_choices': ['Reject transfer'],
+        'ignored_choices': create_sip_ignored_choices,
     }
     processing_fields['7a024896-c4f7-4808-a240-44c87c762bc5'] = {
         'type': 'replace_dict',

--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -29,6 +29,7 @@ from django.utils.translation import ugettext_lazy as _
 from components import helpers
 from main import models
 
+from abilities import choice_is_available
 import storageService as storage_service
 
 
@@ -298,14 +299,11 @@ class ProcessingConfigurationForm(forms.Form):
         'name': 'examine',
         'label': _('Examine contents'),
     }
-    create_sip_ignored_choices = ['Reject transfer']
-    if settings.DISABLE_SEARCH_INDEXING:
-        create_sip_ignored_choices.append('Send to backlog')
     processing_fields['bb194013-597c-4e4a-8493-b36d190f8717'] = {
         'type': 'chain_choice',
         'name': 'create_sip',
         'label': _('Create SIP(s)'),
-        'ignored_choices': create_sip_ignored_choices,
+        'ignored_choices': ['Reject transfer'],
     }
     processing_fields['7a024896-c4f7-4808-a240-44c87c762bc5'] = {
         'type': 'replace_dict',
@@ -442,7 +440,8 @@ class ProcessingConfigurationForm(forms.Form):
                     ignored_choices = field.get('ignored_choices', [])
                     for item in chain_choices:
                         chain = item.chainavailable
-                        if chain.description in ignored_choices:
+                        if ((chain.description in ignored_choices) or
+                                (not choice_is_available(item, settings))):
                             continue
                         choices.append((chain.pk, chain.description))
                 elif ftype == 'replace_dict':

--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -458,7 +458,6 @@ def general(request):
     else:
         if not pipeline:
             messages.warning(request, _("This pipeline is not registered with the storage service or has been disabled in the storage service. Please contact an administrator."))
-    disable_search_indexing = django_settings.DISABLE_SEARCH_INDEXING
     return render(request, 'administration/general.html', locals())
 
 

--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -458,6 +458,7 @@ def general(request):
     else:
         if not pipeline:
             messages.warning(request, _("This pipeline is not registered with the storage service or has been disabled in the storage service. Please contact an administrator."))
+    disable_search_indexing = django_settings.DISABLE_SEARCH_INDEXING
     return render(request, 'administration/general.html', locals())
 
 

--- a/src/dashboard/src/components/appraisal/views.py
+++ b/src/dashboard/src/components/appraisal/views.py
@@ -2,7 +2,6 @@
 import logging
 
 # Django Core, alphabetical by import source
-from django.conf import settings as django_settings
 from django.shortcuts import render
 
 # External dependencies, alphabetical
@@ -17,6 +16,4 @@ logger = logging.getLogger('archivematica.dashboard')
 
 
 def appraisal(request):
-    return render(request, 'appraisal/appraisal.html',
-                  {'disable_search_indexing':
-                   django_settings.DISABLE_SEARCH_INDEXING})
+    return render(request, 'appraisal/appraisal.html')

--- a/src/dashboard/src/components/appraisal/views.py
+++ b/src/dashboard/src/components/appraisal/views.py
@@ -2,6 +2,7 @@
 import logging
 
 # Django Core, alphabetical by import source
+from django.conf import settings as django_settings
 from django.shortcuts import render
 
 # External dependencies, alphabetical
@@ -16,4 +17,6 @@ logger = logging.getLogger('archivematica.dashboard')
 
 
 def appraisal(request):
-    return render(request, 'appraisal/appraisal.html')
+    return render(request, 'appraisal/appraisal.html',
+                  {'disable_search_indexing':
+                   django_settings.DISABLE_SEARCH_INDEXING})

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -435,6 +435,10 @@ def total_size_of_aips(es_client):
 
 
 def list_display(request):
+
+    if settings.DISABLE_SEARCH_INDEXING:
+        return render(request, 'archival_storage/list.html',
+                      {'disable_search_indexing': True})
     current_page_number = int(request.GET.get('page', 1))
     logger.debug('Current page: %s', current_page_number)
 
@@ -559,6 +563,7 @@ def list_display(request):
 
     return render(request, 'archival_storage/list.html',
                   {
+                      'disable_search_indexing': False,
                       'total_size': total_size,
                       'aip_indexed_file_count': aip_indexed_file_count,
                       'aips': aips,

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -436,7 +436,7 @@ def total_size_of_aips(es_client):
 
 def list_display(request):
 
-    if settings.DISABLE_SEARCH_INDEXING:
+    if not settings.SEARCH_ENABLED:
         return render(request, 'archival_storage/list.html')
     current_page_number = int(request.GET.get('page', 1))
     logger.debug('Current page: %s', current_page_number)

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -437,8 +437,7 @@ def total_size_of_aips(es_client):
 def list_display(request):
 
     if settings.DISABLE_SEARCH_INDEXING:
-        return render(request, 'archival_storage/list.html',
-                      {'disable_search_indexing': True})
+        return render(request, 'archival_storage/list.html')
     current_page_number = int(request.GET.get('page', 1))
     logger.debug('Current page: %s', current_page_number)
 
@@ -563,7 +562,6 @@ def list_display(request):
 
     return render(request, 'archival_storage/list.html',
                   {
-                      'disable_search_indexing': False,
                       'total_size': total_size,
                       'aip_indexed_file_count': aip_indexed_file_count,
                       'aips': aips,

--- a/src/dashboard/src/components/backlog/views.py
+++ b/src/dashboard/src/components/backlog/views.py
@@ -18,6 +18,7 @@
 import logging
 import requests
 
+from django.conf import settings as django_settings
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, Http404
@@ -85,8 +86,10 @@ def execute(request):
     :param request: The Django request object
     :return: The main backlog page rendered
     """
-    es_client = elasticSearchFunctions.get_client()
-    check_and_remove_deleted_transfers(es_client)
+    disable_search_indexing = django_settings.DISABLE_SEARCH_INDEXING
+    if not disable_search_indexing:
+        es_client = elasticSearchFunctions.get_client()
+        check_and_remove_deleted_transfers(es_client)
     return render(request, 'backlog/backlog.html', locals())
 
 

--- a/src/dashboard/src/components/backlog/views.py
+++ b/src/dashboard/src/components/backlog/views.py
@@ -86,8 +86,7 @@ def execute(request):
     :param request: The Django request object
     :return: The main backlog page rendered
     """
-    disable_search_indexing = django_settings.DISABLE_SEARCH_INDEXING
-    if not disable_search_indexing:
+    if not django_settings.DISABLE_SEARCH_INDEXING:
         es_client = elasticSearchFunctions.get_client()
         check_and_remove_deleted_transfers(es_client)
     return render(request, 'backlog/backlog.html', locals())

--- a/src/dashboard/src/components/backlog/views.py
+++ b/src/dashboard/src/components/backlog/views.py
@@ -86,7 +86,7 @@ def execute(request):
     :param request: The Django request object
     :return: The main backlog page rendered
     """
-    if not django_settings.DISABLE_SEARCH_INDEXING:
+    if django_settings.SEARCH_ENABLED:
         es_client = elasticSearchFunctions.get_client()
         check_and_remove_deleted_transfers(es_client)
     return render(request, 'backlog/backlog.html', locals())

--- a/src/dashboard/src/main/context_processors.py
+++ b/src/dashboard/src/main/context_processors.py
@@ -1,5 +1,5 @@
 from django.conf import settings
 
 
-def disable_search_indexing(request):
-    return {'DISABLE_SEARCH_INDEXING': settings.DISABLE_SEARCH_INDEXING}
+def search_enabled(request):
+    return {'search_enabled': settings.SEARCH_ENABLED}

--- a/src/dashboard/src/main/context_processors.py
+++ b/src/dashboard/src/main/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def disable_search_indexing(request):
+    return {'DISABLE_SEARCH_INDEXING': settings.DISABLE_SEARCH_INDEXING}

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -222,6 +222,7 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.request',
                 'django.contrib.messages.context_processors.messages',
+                'main.context_processors.disable_search_indexing',
             ],
             'debug': DEBUG,
         },

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -27,6 +27,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from appconfig import Config
 
+SEARCH_ENABLED_DEFAULT = False
 
 CONFIG_MAPPING = {
     # [Dashboard]
@@ -34,7 +35,10 @@ CONFIG_MAPPING = {
     'watch_directory': {'section': 'Dashboard', 'option': 'watch_directory', 'type': 'string'},
     'elasticsearch_server': {'section': 'Dashboard', 'option': 'elasticsearch_server', 'type': 'string'},
     'elasticsearch_timeout': {'section': 'Dashboard', 'option': 'elasticsearch_timeout', 'type': 'float'},
-    'disable_search_indexing': {'section': 'Dashboard', 'option': 'disable_search_indexing', 'type': 'boolean'},
+    'search_enabled': [
+        {'section': 'Dashboard', 'option': 'disable_search_indexing', 'type': 'boolean'},
+        {'section': 'Dashboard', 'option': 'search_enabled', 'type': 'iboolean'},
+    ],
     'gearman_server': {'section': 'Dashboard', 'option': 'gearman_server', 'type': 'string'},
     'shibboleth_authentication': {'section': 'Dashboard', 'option': 'shibboleth_authentication', 'type': 'boolean'},
     'ldap_authentication': {'section': 'Dashboard', 'option': 'ldap_authentication', 'type': 'boolean'},
@@ -61,7 +65,7 @@ shared_directory = /var/archivematica/sharedDirectory/
 watch_directory = /var/archivematica/sharedDirectory/watchedDirectories/
 elasticsearch_server = 127.0.0.1:9200
 elasticsearch_timeout = 10
-disable_search_indexing = True
+search_enabled = {search_enabled_default}
 gearman_server = 127.0.0.1:4730
 shibboleth_authentication = False
 ldap_authentication = False
@@ -77,7 +81,7 @@ database = MCP
 port = 3306
 engine = django.db.backends.mysql
 conn_max_age = 0
-"""
+""".format(search_enabled_default=SEARCH_ENABLED_DEFAULT)
 
 config = Config(env_prefix='ARCHIVEMATICA_DASHBOARD', attrs=CONFIG_MAPPING)
 config.read_defaults(StringIO.StringIO(CONFIG_DEFAULTS))
@@ -222,7 +226,7 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.request',
                 'django.contrib.messages.context_processors.messages',
-                'main.context_processors.disable_search_indexing',
+                'main.context_processors.search_enabled',
             ],
             'debug': DEBUG,
         },
@@ -430,7 +434,7 @@ SHARED_DIRECTORY = config.get('shared_directory')
 WATCH_DIRECTORY = config.get('watch_directory')
 ELASTICSEARCH_SERVER = config.get('elasticsearch_server')
 ELASTICSEARCH_TIMEOUT = config.get('elasticsearch_timeout')
-DISABLE_SEARCH_INDEXING = config.get('disable_search_indexing')
+SEARCH_ENABLED = config.get('search_enabled')
 STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
 AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
 

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -27,8 +27,6 @@ from django.utils.translation import ugettext_lazy as _
 
 from appconfig import Config
 
-SEARCH_ENABLED_DEFAULT = False
-
 CONFIG_MAPPING = {
     # [Dashboard]
     'shared_directory': {'section': 'Dashboard', 'option': 'shared_directory', 'type': 'string'},
@@ -65,7 +63,7 @@ shared_directory = /var/archivematica/sharedDirectory/
 watch_directory = /var/archivematica/sharedDirectory/watchedDirectories/
 elasticsearch_server = 127.0.0.1:9200
 elasticsearch_timeout = 10
-search_enabled = {search_enabled_default}
+search_enabled = false
 gearman_server = 127.0.0.1:4730
 shibboleth_authentication = False
 ldap_authentication = False
@@ -81,7 +79,7 @@ database = MCP
 port = 3306
 engine = django.db.backends.mysql
 conn_max_age = 0
-""".format(search_enabled_default=SEARCH_ENABLED_DEFAULT)
+"""
 
 config = Config(env_prefix='ARCHIVEMATICA_DASHBOARD', attrs=CONFIG_MAPPING)
 config.read_defaults(StringIO.StringIO(CONFIG_DEFAULTS))

--- a/src/dashboard/src/templates/administration/general.html
+++ b/src/dashboard/src/templates/administration/general.html
@@ -42,6 +42,14 @@
 
         {% include "_form.html" with form=checksum_form %}
 
+        <h4>Elasticsearch Indexing</h4>
+
+        {% if disable_search_indexing %}
+          <p class="es-indexing-configuration">Elasticsearch indexing has been disabled in this Archivematica installation</p>
+        {% else %}
+          <p class="es-indexing-configuration">Elasticsearch indexing is enabled in this Archivematica installation</p>
+        {% endif %}
+
         <div>
           <input type="submit" value="{% trans 'Save' %}" class="btn btn-primary">
         </div>

--- a/src/dashboard/src/templates/administration/general.html
+++ b/src/dashboard/src/templates/administration/general.html
@@ -42,12 +42,12 @@
 
         {% include "_form.html" with form=checksum_form %}
 
-        <h4>Elasticsearch Indexing</h4>
+        <h4>{% trans "Elasticsearch Indexing" %}</h4>
 
         {% if disable_search_indexing %}
-          <p class="es-indexing-configuration">Elasticsearch indexing has been disabled in this Archivematica installation</p>
+          <p class="es-indexing-configuration">{% trans "Elasticsearch indexing has been disabled in this Archivematica installation" %}</p>
         {% else %}
-          <p class="es-indexing-configuration">Elasticsearch indexing is enabled in this Archivematica installation</p>
+          <p class="es-indexing-configuration">{% trans "Elasticsearch indexing is enabled in this Archivematica installation" %}</p>
         {% endif %}
 
         <div>

--- a/src/dashboard/src/templates/appraisal/appraisal.html
+++ b/src/dashboard/src/templates/appraisal/appraisal.html
@@ -20,9 +20,14 @@
 {% endblock %}
 
 {% block content %}
-{% verbatim %}
-<div ng-app="appraisalTab">
-    <ng-include src="'front_page/content.html'"></ng-include>
-</div>
-{% endverbatim %}
+  {% if disable_search_indexing %}
+    <h1>Elasticsearch Indexing Disabled</h1>
+    <p class="es-indexing-disabled">Sorry, Elasticsearch indexing has been disabled in this Archivematica installation. The appraisal tab is non-functional when indexing is turned off.</p>
+  {% else %}
+    {% verbatim %}
+    <div ng-app="appraisalTab">
+          <ng-include src="'front_page/content.html'"></ng-include>
+    </div>
+    {% endverbatim %}
+  {% endif %}
 {% endblock %}

--- a/src/dashboard/src/templates/appraisal/appraisal.html
+++ b/src/dashboard/src/templates/appraisal/appraisal.html
@@ -20,14 +20,14 @@
 {% endblock %}
 
 {% block content %}
-  {% if disable_search_indexing %}
-    <h1>Elasticsearch Indexing Disabled</h1>
-    <p class="es-indexing-disabled">Sorry, Elasticsearch indexing has been disabled in this Archivematica installation. The appraisal tab is non-functional when indexing is turned off.</p>
-  {% else %}
-    {% verbatim %}
-    <div ng-app="appraisalTab">
-          <ng-include src="'front_page/content.html'"></ng-include>
-    </div>
-    {% endverbatim %}
-  {% endif %}
+{% if disable_search_indexing %}
+  <h1>{% trans "Elasticsearch Indexing Disabled" %}</h1>
+  <p class="es-indexing-disabled">{% trans "Sorry, Elasticsearch indexing has been disabled in this Archivematica installation. The appraisal tab is non-functional when indexing is turned off." %}</p>
+{% else %}
+  {% verbatim %}
+  <div ng-app="appraisalTab">
+    <ng-include src="'front_page/content.html'"></ng-include>
+  </div>
+  {% endverbatim %}
+{% endif %}
 {% endblock %}

--- a/src/dashboard/src/templates/archival_storage/list.html
+++ b/src/dashboard/src/templates/archival_storage/list.html
@@ -25,103 +25,110 @@
 
 {% block content %}
 
-  <ul class="breadcrumb">
-    {% trans "Archival storage" as archival_storage_label %}
-    {% trans "Search" as search_label %}
-    {% breadcrumb_url archival_storage_label 'components.archival_storage.views.overview' %}
-    {% breadcrumb search_label %}
-  </ul>
-
-  {% include "archival_storage/_archival_storage_search_form.html" %}
-
-  {% if aips %}
-
-    <h1>
-      {% trans "Browse archival storage" %}<br/>
-      <small>
-
-        {% blocktrans with size=total_size %}
-          Total size: {{ size }} MB
-        {% endblocktrans %}
-
-        {% if aip_indexed_file_count %}
-          |
-          {% blocktrans with count=aip_indexed_file_count %}
-            Files indexed: {{ count }}
-          {% endblocktrans %}
-        {% endif %}
-
-      </small>
-    </h1>
-
-    <table class="table">
-      <thead>
-        <th>
-          <div>
-            {% trans "AIP" %}
-            <a class="up {% if order_by == 'name_unanalyzed' and sort_by == 'up' %} selected_up{% endif %}" href="?order_by=name_unanalyzed&sort_by=up">{% trans "Sort" %}</a>
-            <a class="down {% if order_by == 'name_unanalyzed' and sort_by == 'down' %} selected_down{% endif %}" href="?order_by=name_unanalyzed&sort_by=down">{% trans "Sort" %}</a>
-          </div>
-        </th>
-        <th>
-          <div>
-            {% trans "Size" %}
-            <a class="up {% if order_by == 'size' and sort_by == 'up' %} selected_up"{% endif %}" href="?order_by=size&amp;sort_by=up">{% trans "Sort" %}</a>
-            <a class="down {% if order_by == 'size' and sort_by == 'down' %} selected_down"{% endif %}" href="?order_by=size&amp;sort_by=down">{% trans "Sort" %}</a>
-          </div>
-        </th>
-        <th>
-          <div>
-            {% trans "UUID" %}
-          </div>
-        </th>
-        <th>
-          <div>
-            {% trans "Date stored" %}
-            <a class="up {% if order_by == 'created' and sort_by == 'up' %} selected_up{% endif %}" href="?order_by=created&amp;sort_by=up">{% trans "Sort" %}</a>
-            <a class="down {% if order_by == 'created' and sort_by == 'down' %} selected_down{% endif %}" href="?order_by=created&amp;sort_by=down">{% trans "Sort" %}</a>
-          </div>
-        </th>
-        <th>
-          <div>
-            {% trans "Status" %}
-          </div>
-        </th>
-        <th>
-          <div>
-            {% trans "Encrypted" %}
-          </div>
-        </th>
-        <th>
-          <div>
-            {% trans "Actions" %}
-          </div>
-        </th>
-      </thead>
-      <tbody>
-        {% for item in aips %}
-          <tr>
-            <td><a href="{% url 'view_aip' item.uuid %}">{{ item.name }}</a></td>
-            <td class="size">{{ item.size }}</td>
-            <td class="uuid"><a href="{% url 'view_aip' item.uuid %}">{{ item.uuid }}</a></td>
-            <td><span class="timestamp">{{ item.date }}</span></td>
-            <td>{{ item.status }}</td>
-            <td>{{ item.encrypted }}</td>
-            <td><a href="{% url 'view_aip' item.uuid %}">{% trans "View" %}</a></td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-
-    <div style='clear: both' class='search-summary'>
-      {% include "_pager.html" %}
-    </div>
-
+  {% if disable_search_indexing %}
+    <h1>Elasticsearch Indexing Disabled</h1>
+    <p class="es-indexing-disabled">Sorry, Elasticsearch indexing has been disabled in this Archivematica installation. The archival storage tab is non-functional when indexing is turned off.</p>
   {% else %}
 
-    <div class="alert alert-info">
-      <p>{% trans "Archival storage is empty." %}</p>
-    </div>
+    <ul class="breadcrumb">
+      {% trans "Archival storage" as archival_storage_label %}
+      {% trans "Search" as search_label %}
+      {% breadcrumb_url archival_storage_label 'components.archival_storage.views.overview' %}
+      {% breadcrumb search_label %}
+    </ul>
+
+    {% include "archival_storage/_archival_storage_search_form.html" %}
+
+    {% if aips %}
+
+      <h1>
+        {% trans "Browse archival storage" %}<br/>
+        <small>
+
+          {% blocktrans with size=total_size %}
+            Total size: {{ size }} MB
+          {% endblocktrans %}
+
+          {% if aip_indexed_file_count %}
+            |
+            {% blocktrans with count=aip_indexed_file_count %}
+              Files indexed: {{ count }}
+            {% endblocktrans %}
+          {% endif %}
+
+        </small>
+      </h1>
+
+      <table class="table">
+        <thead>
+          <th>
+            <div>
+              {% trans "AIP" %}
+              <a class="up {% if order_by == 'name_unanalyzed' and sort_by == 'up' %} selected_up{% endif %}" href="?order_by=name_unanalyzed&sort_by=up">{% trans "Sort" %}</a>
+              <a class="down {% if order_by == 'name_unanalyzed' and sort_by == 'down' %} selected_down{% endif %}" href="?order_by=name_unanalyzed&sort_by=down">{% trans "Sort" %}</a>
+            </div>
+          </th>
+          <th>
+            <div>
+              {% trans "Size" %}
+              <a class="up {% if order_by == 'size' and sort_by == 'up' %} selected_up"{% endif %}" href="?order_by=size&amp;sort_by=up">{% trans "Sort" %}</a>
+              <a class="down {% if order_by == 'size' and sort_by == 'down' %} selected_down"{% endif %}" href="?order_by=size&amp;sort_by=down">{% trans "Sort" %}</a>
+            </div>
+          </th>
+          <th>
+            <div>
+              {% trans "UUID" %}
+            </div>
+          </th>
+          <th>
+            <div>
+              {% trans "Date stored" %}
+              <a class="up {% if order_by == 'created' and sort_by == 'up' %} selected_up{% endif %}" href="?order_by=created&amp;sort_by=up">{% trans "Sort" %}</a>
+              <a class="down {% if order_by == 'created' and sort_by == 'down' %} selected_down{% endif %}" href="?order_by=created&amp;sort_by=down">{% trans "Sort" %}</a>
+            </div>
+          </th>
+          <th>
+            <div>
+              {% trans "Status" %}
+            </div>
+          </th>
+          <th>
+            <div>
+              {% trans "Encrypted" %}
+            </div>
+          </th>
+          <th>
+            <div>
+              {% trans "Actions" %}
+            </div>
+          </th>
+        </thead>
+        <tbody>
+          {% for item in aips %}
+            <tr>
+              <td><a href="{% url 'view_aip' item.uuid %}">{{ item.name }}</a></td>
+              <td class="size">{{ item.size }}</td>
+              <td class="uuid"><a href="{% url 'view_aip' item.uuid %}">{{ item.uuid }}</a></td>
+              <td><span class="timestamp">{{ item.date }}</span></td>
+              <td>{{ item.status }}</td>
+              <td>{{ item.encrypted }}</td>
+              <td><a href="{% url 'view_aip' item.uuid %}">{% trans "View" %}</a></td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+
+      <div style='clear: both' class='search-summary'>
+        {% include "_pager.html" %}
+      </div>
+
+    {% else %}
+
+      <div class="alert alert-info">
+        <p>{% trans "Archival storage is empty." %}</p>
+      </div>
+
+    {% endif %}
 
   {% endif %}
 

--- a/src/dashboard/src/templates/archival_storage/list.html
+++ b/src/dashboard/src/templates/archival_storage/list.html
@@ -26,8 +26,8 @@
 {% block content %}
 
   {% if disable_search_indexing %}
-    <h1>Elasticsearch Indexing Disabled</h1>
-    <p class="es-indexing-disabled">Sorry, Elasticsearch indexing has been disabled in this Archivematica installation. The archival storage tab is non-functional when indexing is turned off.</p>
+    <h1>{% trans "Elasticsearch Indexing Disabled" %}</h1>
+    <p class="es-indexing-disabled">{% trans "Sorry, Elasticsearch indexing has been disabled in this Archivematica installation. The archival storage tab is non-functional when indexing is turned off." %}</p>
   {% else %}
 
     <ul class="breadcrumb">

--- a/src/dashboard/src/templates/backlog/backlog.html
+++ b/src/dashboard/src/templates/backlog/backlog.html
@@ -22,7 +22,12 @@
 {% endblock %}
 
 {% block content %}
-  {% include "ingest/backlog/_search_form.html" with show_files=True %}
-  <table id="backlog-entries">
-  </table>
+  {% if disable_search_indexing %}
+    <h1>Elasticsearch Indexing Disabled</h1>
+    <p class="es-indexing-disabled">Sorry, Elasticsearch indexing has been disabled in this Archivematica installation. The backlog tab is non-functional when indexing is turned off.</p>
+  {% else %}
+    {% include "ingest/backlog/_search_form.html" with show_files=True %}
+    <table id="backlog-entries">
+    </table>
+  {% endif %}
 {% endblock %}

--- a/src/dashboard/src/templates/backlog/backlog.html
+++ b/src/dashboard/src/templates/backlog/backlog.html
@@ -23,8 +23,8 @@
 
 {% block content %}
   {% if disable_search_indexing %}
-    <h1>Elasticsearch Indexing Disabled</h1>
-    <p class="es-indexing-disabled">Sorry, Elasticsearch indexing has been disabled in this Archivematica installation. The backlog tab is non-functional when indexing is turned off.</p>
+    <h1>{% trans "Elasticsearch Indexing Disabled" %}</h1>
+    <p class="es-indexing-disabled">{% trans "Sorry, Elasticsearch indexing has been disabled in this Archivematica installation. The backlog tab is non-functional when indexing is turned off." %}</p>
   {% else %}
     {% include "ingest/backlog/_search_form.html" with show_files=True %}
     <table id="backlog-entries">

--- a/src/dashboard/src/templates/ingest/grid.html
+++ b/src/dashboard/src/templates/ingest/grid.html
@@ -65,29 +65,31 @@
 
 {% block content %}
 
-  {% include "ingest/backlog/_search_form.html" with show_files=False %}
-  <div class="activity-indicator">
-    <img src='/media/images/ajax-loader.gif' />
-  </div>
+  {% if not DISABLE_SEARCH_INDEXING %}
+    {% include "ingest/backlog/_search_form.html" with show_files=False %}
+    <div class="activity-indicator">
+      <img src='/media/images/ajax-loader.gif' />
+    </div>
 
-  <div style='float:left;'>
-    <div id='originals' class='backbone-file-explorer' style='float:left; width: 460px; margin-bottom: 10px;'></div>
-    <div id='originals_controls'>
-      <span id='open_originals_file_button' class='btn btn-default'>{% trans "View file" %}</span>
-      <span id='originals_hide_button' class='btn btn-default'>{% trans "Hide" %}</span>
+    <div style='float:left;'>
+      <div id='originals' class='backbone-file-explorer' style='float:left; width: 460px; margin-bottom: 10px;'></div>
+      <div id='originals_controls'>
+        <span id='open_originals_file_button' class='btn btn-default'>{% trans "View file" %}</span>
+        <span id='originals_hide_button' class='btn btn-default'>{% trans "Hide" %}</span>
+      </div>
     </div>
-  </div>
-  <div style='margin-left: 30px; float:left;'>
-    <div id='arrange' class='backbone-file-explorer' style='float:left; width: 460px; margin-bottom: 10px;'></div>
-    <div id='arrange_controls'>
-      <span id='arrange_create_directory_button' class='btn btn-default'>{% trans "Add directory" %}</span>
-      <span id='arrange_edit_metadata_button' class='btn btn-default'>{% trans "Edit metadata" %}</span>
-      <span id='arrange_delete_button' class='btn btn-default'>{% trans "Delete" %}</span>
-      <span id='arrange_create_sip_button' class='btn btn-primary'>{% trans "Create SIP" %}</span>
+    <div style='margin-left: 30px; float:left;'>
+      <div id='arrange' class='backbone-file-explorer' style='float:left; width: 460px; margin-bottom: 10px;'></div>
+      <div id='arrange_controls'>
+        <span id='arrange_create_directory_button' class='btn btn-default'>{% trans "Add directory" %}</span>
+        <span id='arrange_edit_metadata_button' class='btn btn-default'>{% trans "Edit metadata" %}</span>
+        <span id='arrange_delete_button' class='btn btn-default'>{% trans "Delete" %}</span>
+        <span id='arrange_create_sip_button' class='btn btn-primary'>{% trans "Create SIP" %}</span>
+      </div>
     </div>
-  </div>
-  <br clear='all' />
-  <br />
+    <br clear='all' />
+    <br />
+  {% endif %}
 
   <div id="sip-container">
     <div>

--- a/src/dashboard/src/templates/layout.html
+++ b/src/dashboard/src/templates/layout.html
@@ -55,10 +55,14 @@
             <ul class="nav navbar-nav">
 
               <li class="{% active request url_transfer %}"><a href="{{ url_transfer }}">{% trans "Transfer" %}</a></li>
-              <li class="{% active request url_backlog %}"><a href="{{ url_backlog }}">{% trans "Backlog" %}</a></li>
-              <li class="{% active request url_appraisal %}"><a href="{{ url_appraisal }}">{% trans "Appraisal" %}</a></li>
+              {% if not DISABLE_SEARCH_INDEXING %}
+                <li class="{% active request url_backlog %}"><a href="{{ url_backlog }}">{% trans "Backlog" %}</a></li>
+                <li class="{% active request url_appraisal %}"><a href="{{ url_appraisal }}">{% trans "Appraisal" %}</a></li>
+              {% endif %}
               <li class="{% active request url_ingest %}"><a href="{{ url_ingest }}">{% trans "Ingest" %}</a></li>
-              <li class="{% active request url_archival_storage %}"><a href="{{ url_archival_storage }}">{% trans "Archival storage" %}</a></li>
+              {% if not DISABLE_SEARCH_INDEXING %}
+                <li class="{% active request url_archival_storage %}"><a href="{{ url_archival_storage }}">{% trans "Archival storage" %}</a></li>
+              {% endif %}
               <li class="{% active request url_fpr %}"><a href="{{ url_fpr }}">{% trans "Preservation planning" %}</a></li>
               <li class="{% active request url_access %}"><a href="{{ url_access }}">{% trans "Access" %}</a></li>
               <li class="{% active request url_administration %}"><a href="{{ url_administration }}">{% trans "Administration" %}</a></li>


### PR DESCRIPTION
If Archivematica has been deployed with Elasticsearch indexing disabled, then the following changes will result:

1. The Backlog, Appraisal, and Archival storage tabs will now no longer be displayed in the navigation bar. If the user navigates to them using their URLs, the pages will indicate their non-operationality.
2. The SIP Arrange pane of the Ingest tab will no longer be displayed.
3. The disabled status of ES indexing will be indicated under Administration > General.
4. The "Send to backlog" option of "Create SIP(s)" will not be available in the Processing Configuration edit pages.
5. When the "Create SIP(s)" choice is displayed to the user during transfer, it will no longer contain a "Send to backlog" option.

Fixes https://github.com/artefactual/archivematica/issues/803 and implements feature file at https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/50.

Possible TODO: If the user supplies a processingConfig.xml file in a transfer that causes "Create SIP(s)" to default to "Send to backlog", then MCPServer should silently ignore this.