### PR TITLE
MCPClient: populate archivematica_format_extensions.xml

### DIFF
--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -87,6 +87,9 @@ COPY archivematicaCommon/ /src/archivematicaCommon/
 COPY dashboard/ /src/dashboard/
 COPY MCPClient/ /src/MCPClient/
 
+# Workaround for https://github.com/artefactual/archivematica-fpr-admin/issues/49
+COPY archivematicaCommon/lib/externals/fido/archivematica_format_extensions.xml /usr/lib/archivematica/archivematicaCommon/externals/fido/archivematica_format_extensions.xml
+
 RUN set -ex \
 	&& groupadd --gid 333 --system archivematica \
 	&& useradd --uid 333 --gid 333 --system archivematica


### PR DESCRIPTION
archivematica-fpr-admin brings a IDCommand that expects this file to be
available in a specific location that was not being provided by our Docker
image breaking the file identification process.

This is a port of https://github.com/JiscRDSS/archivematica/pull/31 where you
can find more context about the issue. Ultimately fpr-admin will include a fix
for https://github.com/artefactual/archivematica-fpr-admin/issues/49 making the
changes in this PR not needed anymore.