### PR TITLE
Set up email settings via config

### DIFF
--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -1,4 +1,4 @@
-# MCPClient Configuration 
+# MCPClient Configuration
 
 ## Table of contents
 
@@ -10,21 +10,21 @@
 
 ## Introduction
 
-Archivematica components can be configured using multipe methods.  All 
+Archivematica components can be configured using multipe methods.  All
 components follow the same pattern:
 
-1. **Environment variables** - setting a configuration parameter with an 
+1. **Environment variables** - setting a configuration parameter with an
    environment variable will override all other methods.
-1. **Configuration file** - if the parameter is not set by an environment 
+1. **Configuration file** - if the parameter is not set by an environment
    variable, the component will look for a setting in its default configuration file.
-1. **Application defaults**  - if the parameter is not set in an environment 
+1. **Application defaults**  - if the parameter is not set in an environment
    variable or the config file, the application default is used.
 
 Logging behaviour is configured differently, and provides two methods:
 
 1. **`logging.json` file** - if a JSON file is present in the default location,
     the contents of the JSON file will control the components logging behaviour.
-1. **Application default** - if no JSON file is present, the default logging 
+1. **Application default** - if no JSON file is present, the default logging
    behaviour is to write to standard streams (standard out and standard error).
 
 MCPClient specific details are provided below.
@@ -51,7 +51,7 @@ of these settings or provide values to mandatory fields.
 
 ## Configuration file
 
-There is an example configuration file for MCPClient included in the source 
+There is an example configuration file for MCPClient included in the source
 code: (see [`the example`](./clientConfig.conf))
 
 MCPClient will look for a configuration file in one of two locations:
@@ -59,9 +59,9 @@ MCPClient will look for a configuration file in one of two locations:
 - `/etc/archivematica/archivematicaCommon/dbsettings`
 - `/etc/archivematica/MCPClient/clientConfig.conf`
 
-Traditionally, the dbsettings file was used to hold mysql login credentials, 
-which are then shared with other Archivematica components like MCPServer.  
-Database credentials can be set in the clientConfig.conf file instead, or 
+Traditionally, the dbsettings file was used to hold mysql login credentials,
+which are then shared with other Archivematica components like MCPServer.
+Database credentials can be set in the clientConfig.conf file instead, or
 non-database parameters could be set in the dbsettings file.
 
 ## Parameter list
@@ -253,6 +253,90 @@ This is the full list of variables supported by MCPClient:
     - **Config file example:** `MCPClient.capture_client_script_output`
     - **Type:** `boolean`
     - **Default:** `true`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_BACKEND`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.backend`
+    - **Type:** `string`
+    - **Default:** `django.core.mail.backends.console.EmailBackend`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_HOST`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.host`
+    - **Type:** `string`
+    - **Default:** `smtp.gmail.com`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_HOST_USER`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.host_user`
+    - **Type:** `string`
+    - **Default:** `your_email@example.com`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_HOST_PASSWORD`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.host_password`
+    - **Type:** `string`
+    - **Default:** `None`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_PORT`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.port`
+    - **Type:** `integer`
+    - **Default:** `587`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_SSL_CERTFILE`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.ssl_certfile`
+    - **Type:** `string`
+    - **Default:** `None`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_SSL_KEYFILE`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.ssl_keyfile`
+    - **Type:** `string`
+    - **Default:** `None`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_USE_SSL`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.use_ssl`
+    - **Type:** `boolean`
+    - **Default:** `False`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_USE_TLS`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.use_tls`
+    - **Type:** `boolean`
+    - **Default:** `True`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_FILE_PATH`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.file_path`
+    - **Type:** `string`
+    - **Default:** `None`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_DEFAULT_FROM_EMAIL`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.default_from_email`
+    - **Type:** `string`
+    - **Default:** `webmaster@example.com`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_SUBJECT_PREFIX`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.subject_prefix`
+    - **Type:** `string`
+    - **Default:** `[Archivematica]`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_TIMEOUT`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.timeout`
+    - **Type:** `integer`
+    - **Default:** `300`
+
+- ** `ARCHIVEMATICA_MCPCLIENT_EMAIL_SERVER_EMAIL`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details. When the value is `None`, Archivematica uses the value in `EMAIL_HOST_USER`.
+    - **Config file example:** `email.server_email`
+    - **Type:** `string`
+    - **Default:** `None`
 
 ## Logging configuration
 

--- a/src/MCPClient/lib/clientScripts/emailFailReport.py
+++ b/src/MCPClient/lib/clientScripts/emailFailReport.py
@@ -24,6 +24,7 @@ from lxml import etree
 import sys
 
 import django
+from django.conf import settings as mcpclient_settings
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
 from django.db import connection
@@ -49,15 +50,15 @@ def get_emails_from_dashboard_users():
     return User.objects.filter(is_active=True).values_list('email', flat=True).exclude(email__in=['demo@example.com', ''])
 
 
-def send_email(subject, to, efrom, content):
+def send_email(subject, to, content):
     try:
         logger.info('Sending email...')
         return send_mail(
             subject=subject,
             message='Please see the attached HTML document',
-            html_message=content,
-            from_email=efrom,
+            from_email=mcpclient_settings.DEFAULT_FROM_EMAIL,
             recipient_list=to,
+            html_message=content,
         )
     except:
         logger.exception('Report email was not delivered')
@@ -196,11 +197,10 @@ if __name__ == '__main__':
         logger.error('Nobody to send it to. Please add users with valid email addresses in the dashboard.')
         sys.exit(1)
     subject = 'Archivematica Fail Report for %s: %s-%s' % (args.unit_type, args.unit_name, args.unit_uuid)
-    efrom = 'ArchivematicaSystem@archivematica.org'
 
     # Generate report in HTML and send it by email
     content = get_content_for(args.unit_type, args.unit_name, args.unit_uuid, html=True)
-    send_email(subject, to, efrom, content)
+    send_email(subject, to, content)
 
     if args.stdout:
         print(content)

--- a/src/MCPClient/lib/clientScripts/normalizeReport.py
+++ b/src/MCPClient/lib/clientScripts/normalizeReport.py
@@ -8,6 +8,7 @@ import os.path
 import sys
 
 import django
+from django.conf import settings as mcpclient_settings
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
 from django.template import Context, Template
@@ -154,9 +155,9 @@ def report(uuid):
         send_mail(
             subject='Normalization failure report for {} ({})'.format(ctxdict['name'], ctxdict['uuid']),
             message='Please see the attached HTML document',
-            html_message=html_message,
-            from_email='Archivematica <ArchivematicaSystem@archivematica.org>',
+            from_email=mcpclient_settings.DEFAULT_FROM_EMAIL,
             recipient_list=recipient_list,
+            html_message=html_message,
         )
     except:
         logger.exception('Report email was not delivered')

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -22,6 +22,7 @@ import logging.config
 import os
 
 from appconfig import Config
+import email_settings
 
 
 CONFIG_MAPPING = {
@@ -68,6 +69,8 @@ CONFIG_MAPPING = {
     'db_port': {'section': 'client', 'option': 'port', 'type': 'string'},
 }
 
+CONFIG_MAPPING.update(email_settings.CONFIG_MAPPING)
+
 CONFIG_DEFAULTS = """[MCPClient]
 MCPArchivematicaServer = localhost:4730
 sharedDirectoryMounted = /var/archivematica/sharedDirectory/
@@ -102,6 +105,22 @@ host = localhost
 database = MCP
 port = 3306
 engine = django.db.backends.mysql
+
+[email]
+backend = django.core.mail.backends.console.EmailBackend
+host = smtp.gmail.com
+host_password =
+host_user = your_email@example.com
+port = 587
+ssl_certfile =
+ssl_keyfile =
+use_ssl = False
+use_tls = True
+file_path =
+default_from_email = webmaster@example.com
+subject_prefix = [Archivematica]
+timeout = 300
+#server_email =
 """
 
 config = Config(env_prefix='ARCHIVEMATICA_MCPCLIENT', attrs=CONFIG_MAPPING)
@@ -214,3 +233,7 @@ AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
 SEARCH_ENABLED = config.get('search_enabled')
 CAPTURE_CLIENT_SCRIPT_OUTPUT = config.get('capture_client_script_output')
 DEFAULT_CHECKSUM_ALGORITHM = 'sha256'
+
+
+# Apply email settings
+globals().update(email_settings.get_settings(config))

--- a/src/MCPClient/tests/test_email_fail_report.py
+++ b/src/MCPClient/tests/test_email_fail_report.py
@@ -23,12 +23,14 @@ def fake_send_email_with_exception(subject, message, from_email, recipient_list,
     raise SMTPException('Something really bad happened!')
 
 
-def test_send_email_ok():
-    total = send_email("Foobar", ["to@domain.tld"], "from@domain.tld",
-                       "<html>...</html>")
+def test_send_email_ok(settings):
+    settings.DEFAULT_FROM_EMAIL = "foo@bar.tld"
+    total = send_email("Foobar", ["to@domain.tld"], "<html>...</html>")
+
     assert total == 1
     assert len(mail.outbox) == 1
     assert mail.outbox[0].subject == "Foobar"
+    assert mail.outbox[0].from_email == "foo@bar.tld"
     assert mail.outbox[0].to == ["to@domain.tld"]
     assert mail.outbox[0].body == "Please see the attached HTML document"
     assert len(mail.outbox[0].alternatives) == 1
@@ -39,5 +41,4 @@ def test_send_email_err(monkeypatch):
     monkeypatch.setattr('django.core.mail.send_mail.func_code',
                         fake_send_email_with_exception.func_code)
     with pytest.raises(SMTPException):
-        send_email("Foobar", ["to@domain.tld"], "from@domain.tld",
-                   "<html>...</html>")
+        send_email("Foobar", ["to@domain.tld"], "<html>...</html>")

--- a/src/MCPServer/install/README.md
+++ b/src/MCPServer/install/README.md
@@ -10,21 +10,21 @@
 
 ## Introduction
 
-Archivematica components can be configured using multipe methods.  All 
+Archivematica components can be configured using multipe methods.  All
 components follow the same pattern:
 
-1. **Environment variables** - setting a configuration parameter with an 
+1. **Environment variables** - setting a configuration parameter with an
    environment variable will override all other methods.
-1. **Configuration file** - if the parameter is not set by an environment 
+1. **Configuration file** - if the parameter is not set by an environment
    variable, the component will look for a setting in its default configuration file.
-1. **Application defaults**  - if the parameter is not set in an environment 
+1. **Application defaults**  - if the parameter is not set in an environment
    variable or the config file, the application default is used.
 
 Logging behaviour is configured differently, and provides two methods:
 
 1. **`logging.json` file** - if a JSON file is present in the default location,
     the contents of the JSON file will control the components logging behaviour.
-1. **Application default** - if no JSON file is present, the default logging 
+1. **Application default** - if no JSON file is present, the default logging
    behaviour is to write to standard streams (standard out and standard error).
 
 MCPServer specific details are provided below.
@@ -51,17 +51,17 @@ of these settings or provide values to mandatory fields.
 
 ## Configuration file
 
-There is an example configuration file for MCPServer included in the source 
+There is an example configuration file for MCPServer included in the source
 code: (see [`the example`](./serverConfig.conf))
 
 MCPClient will look for a configuration file in one of two locations:
 
-- `/etc/archivematica/archivematicaCommon/dbsettings` 
-- `/etc/archivematica/MCPServer/serverConfig.conf` 
+- `/etc/archivematica/archivematicaCommon/dbsettings`
+- `/etc/archivematica/MCPServer/serverConfig.conf`
 
-Traditionally, the dbsettings file was used to hold mysql login credentials, 
-which are then shared with other Archivematica components like MCPClient.  
-Database credentials can be set in the serverConfig.conf file instead, or 
+Traditionally, the dbsettings file was used to hold mysql login credentials,
+which are then shared with other Archivematica components like MCPClient.
+Database credentials can be set in the serverConfig.conf file instead, or
 non-database parameters could be set in the dbsettings file.
 
 ## Parameter list
@@ -187,6 +187,90 @@ This is the full list of variables supported by MCPServer:
     - **Config file example:** `client.port`
     - **Type:** `string`
     - **Default:** `3306`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_BACKEND`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.backend`
+    - **Type:** `string`
+    - **Default:** `django.core.mail.backends.console.EmailBackend`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_HOST`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.host`
+    - **Type:** `string`
+    - **Default:** `smtp.gmail.com`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_HOST_USER`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.host_user`
+    - **Type:** `string`
+    - **Default:** `your_email@example.com`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_HOST_PASSWORD`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.host_password`
+    - **Type:** `string`
+    - **Default:** `None`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_PORT`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.port`
+    - **Type:** `integer`
+    - **Default:** `587`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_SSL_CERTFILE`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.ssl_certfile`
+    - **Type:** `string`
+    - **Default:** `None`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_SSL_KEYFILE`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.ssl_keyfile`
+    - **Type:** `string`
+    - **Default:** `None`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_USE_SSL`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.use_ssl`
+    - **Type:** `boolean`
+    - **Default:** `False`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_USE_TLS`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.use_tls`
+    - **Type:** `boolean`
+    - **Default:** `True`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_FILE_PATH`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.file_path`
+    - **Type:** `string`
+    - **Default:** `None`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_DEFAULT_FROM_EMAIL`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.default_from_email`
+    - **Type:** `string`
+    - **Default:** `webmaster@example.com`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_SUBJECT_PREFIX`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.subject_prefix`
+    - **Type:** `string`
+    - **Default:** `[Archivematica]`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_TIMEOUT`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.timeout`
+    - **Type:** `integer`
+    - **Default:** `300`
+
+- ** `ARCHIVEMATICA_MCPSERVER_EMAIL_SERVER_EMAIL`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details. When the value is `None`, Archivematica uses the value in `EMAIL_HOST_USER`.
+    - **Config file example:** `email.server_email`
+    - **Type:** `string`
+    - **Default:** `None`
 
 ## Logging configuration
 

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -22,6 +22,7 @@ import logging.config
 import os
 
 from appconfig import Config
+import email_settings
 
 
 CONFIG_MAPPING = {
@@ -55,6 +56,9 @@ CONFIG_MAPPING = {
     'db_port': {'section': 'client', 'option': 'port', 'type': 'string'},
 }
 
+
+CONFIG_MAPPING.update(email_settings.CONFIG_MAPPING)
+
 CONFIG_DEFAULTS = """[MCPServer]
 MCPArchivematicaServer = localhost:4730
 watchDirectoryPath = /var/archivematica/sharedDirectory/watchedDirectories/
@@ -80,6 +84,22 @@ host = localhost
 database = MCP
 port = 3306
 engine = django.db.backends.mysql
+
+[email]
+backend = django.core.mail.backends.console.EmailBackend
+host = smtp.gmail.com
+host_password =
+host_user = your_email@example.com
+port = 587
+ssl_certfile =
+ssl_keyfile =
+use_ssl = False
+use_tls = True
+file_path =
+default_from_email = webmaster@example.com
+subject_prefix = [Archivematica]
+timeout = 300
+#server_email =
 """
 
 
@@ -109,7 +129,8 @@ DATABASES = {
 }
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = config.get('secret_key', default='e7b-$#-3fgu)j1k01)3tp@^e0=yv1hlcc4k-b6*ap^zezv2$48')
+SECRET_KEY = config.get(
+    'secret_key', default='e7b-$#-3fgu)j1k01)3tp@^e0=yv1hlcc4k-b6*ap^zezv2$48')
 
 USE_TZ = True
 TIME_ZONE = 'UTC'
@@ -166,5 +187,9 @@ WATCH_DIRECTORY_INTERVAL = config.get('watch_directory_interval')
 LIMIT_TASK_THREADS = config.get('limit_task_threads')
 LIMIT_TASK_THREADS_SLEEP = config.get('limit_task_threads_sleep')
 LIMIT_GEARMAN_CONNS = config.get('limit_gearman_conns')
-RESERVED_AS_TASK_PROCESSING_THREADS = config.get('reserved_as_task_processing_threads')
 SEARCH_ENABLED = config.get('search_enabled')
+RESERVED_AS_TASK_PROCESSING_THREADS = config.get(
+    'reserved_as_task_processing_threads')
+
+# Apply email settings
+globals().update(email_settings.get_settings(config))

--- a/src/archivematicaCommon/lib/email_settings.py
+++ b/src/archivematicaCommon/lib/email_settings.py
@@ -1,0 +1,72 @@
+"""
+
+Email settings and globals.
+
+The main setting is `EMAIL_BACKEND`, which defines which backend to use. Valid
+backends are:
+
+* Console: `django.core.mail.backends.console.EmailBackend`
+* Dummy: `django.core.mail.backends.dummy.EmailBackend`
+* File: `django.core.mail.backends.filebased.EmailBackend`
+* In-Memory: `django.core.mail.backends.locmem.EmailBackend`
+* SMTP: `django.core.mail.backends.smtp.EmailBackend`
+
+By default, the Console backend will be used.
+
+"""
+
+from __future__ import absolute_import
+
+CONFIG_MAPPING = {
+    # [email]
+    'email_backend': {'section': 'email', 'option': 'backend', 'type': 'string'},
+    'email_host': {'section': 'email', 'option': 'host', 'type': 'string'},
+    'email_host_user': {'section': 'email', 'option': 'host_user', 'type': 'string'},
+    'email_host_password': {'section': 'email', 'option': 'host_password', 'type': 'string'},
+    'email_port': {'section': 'email', 'option': 'port', 'type': 'int'},
+    'email_ssl_certfile': {'section': 'email', 'option': 'ssl_certfile', 'type': 'string'},
+    'email_ssl_keyfile': {'section': 'email', 'option': 'ssl_keyfile', 'type': 'string'},
+    'email_use_ssl': {'section': 'email', 'option': 'use_ssl', 'type': 'boolean'},
+    'email_use_tls': {'section': 'email', 'option': 'use_tls', 'type': 'boolean'},
+    'email_file_path': {'section': 'email', 'option': 'file_path', 'type': 'string'},
+    'default_from_email': {'section': 'email', 'option': 'default_from_email', 'type': 'string'},
+    'email_subject_prefix': {'section': 'email', 'option': 'subject_prefix', 'type': 'string'},
+    'email_timeout': {'section': 'email', 'option': 'timeout', 'type': 'int'},
+    'server_email': {'section': 'email', 'option': 'server_email', 'type': 'int'},
+}
+
+
+def get_settings(config):
+    """
+    Extract a dict of Django email settings from the passed config object
+
+    This should be invoked from a Django settings module and the result merged
+    into the globals() dict.
+    """
+    settings = dict(
+        # Which backend to use?
+        EMAIL_BACKEND=config.get('email_backend'),
+
+        # File Backend
+        # See https://docs.djangoproject.com/en/dev/topics/email/#file-backend
+        EMAIL_FILE_PATH=config.get('email_file_path'),
+
+        # SMTP Backend
+        # See https://docs.djangoproject.com/en/dev/topics/email/#smtp-backend
+        EMAIL_HOST=config.get('email_host'),
+        EMAIL_HOST_PASSWORD=config.get('email_host_password'),
+        EMAIL_HOST_USER=config.get('email_host_user'),
+        EMAIL_PORT=config.get('email_port'),
+        EMAIL_SSL_CERTFILE=config.get('email_ssl_certfile'),
+        EMAIL_SSL_KEYFILE=config.get('email_ssl_keyfile'),
+        EMAIL_USE_SSL=config.get('email_use_ssl'),
+        EMAIL_USE_TLS=config.get('email_use_tls'),
+
+        # General settings, not backend-specific
+        DEFAULT_FROM_EMAIL=config.get('default_from_email'),
+        EMAIL_SUBJECT_PREFIX=config.get('email_subject_prefix'),
+        EMAIL_TIMEOUT=config.get('email_timeout', None),
+    )
+
+    settings['SERVER_EMAIL'] = config.get('server_email', settings['EMAIL_HOST_USER'])
+    return settings

--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -12,21 +12,21 @@
 
 ## Introduction
 
-Archivematica components can be configured using multipe methods.  All 
+Archivematica components can be configured using multipe methods.  All
 components follow the same pattern:
 
-1. **Environment variables** - setting a configuration parameter with an 
+1. **Environment variables** - setting a configuration parameter with an
    environment variable will override all other methods.
-1. **Configuration file** - if the parameter is not set by an environment 
+1. **Configuration file** - if the parameter is not set by an environment
    variable, the component will look for a setting in its default configuration file.
-1. **Application defaults**  - if the parameter is not set in an environment 
+1. **Application defaults**  - if the parameter is not set in an environment
    variable or the config file, the application default is used.
 
 Logging behaviour is configured differently, and provides two methods:
 
 1. **`logging.json` file** - if a JSON file is present in the default location,
     the contents of the JSON file will control the components logging behaviour.
-1. **Application default** - if no JSON file is present, the default logging 
+1. **Application default** - if no JSON file is present, the default logging
    behaviour is to write to standard streams (standard out and standard error).
 
 Dashboard specific details are provided below.
@@ -57,7 +57,7 @@ The Dashboard will look for a configuration file in one location:
 
 - `/etc/archivematica/archivematicaCommon/dbsettings`
 
-Traditionally, the dbsettings file was used to hold mysql login credentials, 
+Traditionally, the dbsettings file was used to hold mysql login credentials,
 which are then shared with other Archivematica components like MCPClient.
 Non-database parameters can be set in the dbsets,tings file, to override the
 application defaults.
@@ -65,7 +65,7 @@ application defaults.
 The dashboard is a [WSGI](https://wsgi.readthedocs.io/) application. The
 default configuration uses gunicorn as an application server together with
 nginx as an http server.  The dashboard is then typically run by a service
-manager such as systemd, although it can be run by other systems such as 
+manager such as systemd, although it can be run by other systems such as
 upstart or docker instead.
 
 This directory contains example configuration files for these services:
@@ -78,21 +78,21 @@ This directory contains example configuration files for these services:
 location for this file is `/etc/nginx/sites-available/dashboard.conf`.
 
 - [`archivematica-dashboard.service`](./archivematica-dashboard.service) -
-  systemd config sample.  The default location for this file is 
+  systemd config sample.  The default location for this file is
   `/etc/systemd/system/archivematica-dashboard.service`.
 
 - [`archivematica-dashboard.conf`](./archivematica-dashboard.conf) - upstart
    config sample, for use on Ubuntu 14.04 where systemd is not available. The
    default location for this file is /etc/init/archivematica-dashboard.conf.
 
-These are fairly basic example files, that can be extended or customised to 
+These are fairly basic example files, that can be extended or customised to
 meet local needs.  Depending on the method used to install your Archivematica
 instance, the contents of your files may differ from these examples.
 
 ## Parameter list
 
-This is the full list of variables supported by the Dashboard.  
-The first section lists application variables that can be set as environment 
+This is the full list of variables supported by the Dashboard.
+The first section lists application variables that can be set as environment
 variables or in the dbsettings file.
 The second section lists gunicorn variable that can be set as environment
 variables or in the gunicorn configuration file.
@@ -213,6 +213,91 @@ variables or in the gunicorn configuration file.
     - **Type:** `float`
     - **Default:** `0`
 
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_BACKEND`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.backend`
+    - **Type:** `string`
+    - **Default:** `django.core.mail.backends.console.EmailBackend`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_HOST`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.host`
+    - **Type:** `string`
+    - **Default:** `smtp.gmail.com`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_HOST_USER`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.host_user`
+    - **Type:** `string`
+    - **Default:** `your_email@example.com`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_HOST_PASSWORD`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.host_password`
+    - **Type:** `string`
+    - **Default:** `None`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_PORT`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.port`
+    - **Type:** `integer`
+    - **Default:** `587`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_SSL_CERTFILE`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.ssl_certfile`
+    - **Type:** `string`
+    - **Default:** `None`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_SSL_KEYFILE`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.ssl_keyfile`
+    - **Type:** `string`
+    - **Default:** `None`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_USE_SSL`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.use_ssl`
+    - **Type:** `boolean`
+    - **Default:** `False`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_USE_TLS`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.use_tls`
+    - **Type:** `boolean`
+    - **Default:** `True`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_FILE_PATH`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.file_path`
+    - **Type:** `string`
+    - **Default:** `None`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_DEFAULT_FROM_EMAIL`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.default_from_email`
+    - **Type:** `string`
+    - **Default:** `webmaster@example.com`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_SUBJECT_PREFIX`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.subject_prefix`
+    - **Type:** `string`
+    - **Default:** `[Archivematica]`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_TIMEOUT`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
+    - **Config file example:** `email.timeout`
+    - **Type:** `integer`
+    - **Default:** `300`
+
+- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_SERVER_EMAIL`**:
+    - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details. When the value is `None`, Archivematica uses the value in `EMAIL_HOST_USER`.
+    - **Config file example:** `email.server_email`
+    - **Type:** `string`
+    - **Default:** `None`
+
+
 ### Gunicorn variables
 
 - **`AM_GUNICORN_USER`**:
@@ -232,7 +317,7 @@ variables or in the gunicorn configuration file.
 
 - **`AM_GUNICORN_WORKERS`**:
     - **Description:** Number of gunicorn worker processes to run.  See [WORKERS](http://docs.gunicorn.org/en/stable/settings.html#workers)
-    - **Type:** `integer` 
+    - **Type:** `integer`
     - **Default:** `1`
 
 - **`AM_GUNICORN_WORKER_CLASS`**:

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -26,6 +26,7 @@ import os
 from django.utils.translation import ugettext_lazy as _
 
 from appconfig import Config
+import email_settings
 
 CONFIG_MAPPING = {
     # [Dashboard]
@@ -57,6 +58,8 @@ CONFIG_MAPPING = {
     'db_conn_max_age': {'section': 'client', 'option': 'conn_max_age', 'type': 'float'},
 }
 
+CONFIG_MAPPING.update(email_settings.CONFIG_MAPPING)
+
 CONFIG_DEFAULTS = """[Dashboard]
 shared_directory = /var/archivematica/sharedDirectory/
 watch_directory = /var/archivematica/sharedDirectory/watchedDirectories/
@@ -77,6 +80,22 @@ database = MCP
 port = 3306
 engine = django.db.backends.mysql
 conn_max_age = 0
+
+[email]
+backend = django.core.mail.backends.console.EmailBackend
+host = smtp.gmail.com
+host_password =
+host_user = your_email@example.com
+port = 587
+ssl_certfile =
+ssl_keyfile =
+use_ssl = False
+use_tls = True
+file_path =
+default_from_email = webmaster@example.com
+subject_prefix = [Archivematica]
+timeout = 300
+#server_email =
 """
 
 config = Config(env_prefix='ARCHIVEMATICA_DASHBOARD', attrs=CONFIG_MAPPING)
@@ -291,12 +310,6 @@ INSTALLED_APPS = [
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
-# For configuration option details see:
-# https://docs.djangoproject.com/en/1.8/ref/settings/#email-backend
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = '127.0.0.1'
-EMAIL_TIMEOUT = 15
-
 # Configure logging manually
 LOGGING_CONFIG = None
 
@@ -468,3 +481,6 @@ if LDAP_AUTHENTICATION:
         'components.accounts.backends.CustomLDAPBackend',
     ]
     from .components.ldap_auth import *  # noqa
+
+# Apply email settings
+globals().update(email_settings.get_settings(config))


### PR DESCRIPTION
With this PR we make the email settings highly configurable and set up the default backend to `django.core.mail.backends.console.EmailBackend` instead of a local MTA listening on `127.0.0.1:25`.

This is connected to #1128.

### Backward-compatibility

The new default is to use the backend `django.core.mail.backends.console.EmailBackend` (send to the standard streams) because we don't want to make an assumption on the email delivery solution used by the user. Before we used to assume that there was a MTA available at `127.0.0.1:25`.

To maintain backward-compatibility we will have to introduce the old change to our packages and the Ansible role via configuration. CC @scollazo @hakamine. The old behaviour can be reproduced passing the following environment variables to `archivematica-mcp-client`:

```
ARCHIVEMATICA_MCPCLIENT_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
ARCHIVEMATICA_MCPCLIENT_EMAIL_HOST=127.0.0.1
ARCHIVEMATICA_MCPCLIENT_EMAIL_PORT=25
ARCHIVEMATICA_MCPCLIENT_EMAIL_USE_TLS=False
```

### Configuration

| Environment variable | Default |
| - | - |
| `ARCHIVEMATICA_MCPCLIENT_EMAIL_BACKEND` | `"django.core.mail.backends.console.EmailBackend"` |

##### File backend

(https://docs.djangoproject.com/en/dev/topics/email/#file-backend)

| Environment variable | Default |
| - | - |
| `ARCHIVEMATICA_MCPCLIENT_FILE_PATH` | `""` |

##### SMTP backend

(https://docs.djangoproject.com/en/dev/topics/email/#smtp-backend)

| Environment variable | Default |
| - | - |
| `ARCHIVEMATICA_MCPCLIENT_HOST` | `"smtp.gmail.com"` |
| `ARCHIVEMATICA_MCPCLIENT_HOST_PASSWORD` | `""` |
| `ARCHIVEMATICA_MCPCLIENT_HOST_USER` | `"your_email@example.com"` |
| `ARCHIVEMATICA_MCPCLIENT_PORT` | `"587"` |
| `ARCHIVEMATICA_MCPCLIENT_SSL_CERTFILE` | `""` |
| `ARCHIVEMATICA_MCPCLIENT_SSL_KEYFILE` | `""` |
| `ARCHIVEMATICA_MCPCLIENT_USE_SSL` | `"False"` |
| `ARCHIVEMATICA_MCPCLIENT_USE_TLS` | `"True"` |


##### General settings, not backend-specific

| Environment variable | Default |
| - | - |
| `ARCHIVEMATICA_MCPCLIENT_DEFAULT_FROM_EMAIL` | `"webmaster@example.com"` |
| `ARCHIVEMATICA_MCPCLIENT_SUBJECT_PREFIX` | `"[Archivematica]"` |
| `ARCHIVEMATICA_MCPCLIENT_TIMEOUT` | `"300"` |

---

Same envs are made available in Dashboard and MCPServer although effectively neither of them send emails at all at this moment.