### PR TITLE
getfilesize return now gets compared with None (antivirus)

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
@@ -259,8 +259,8 @@ def scan_file(file_uuid, path, date, task_uuid):
 
     try:
         size = get_size(file_uuid, path)
-        if not size:
-            logger.error('Unexpected file size')
+        if size is None:
+            logger.error('Getting file size returned: %s', size)
             return 1
 
         scanner = get_scanner(size)

--- a/src/MCPClient/tests/test_clamscan.py
+++ b/src/MCPClient/tests/test_clamscan.py
@@ -300,11 +300,17 @@ RecordEventParams = namedtuple('RecordEventParams', [
 
 
 @pytest.mark.parametrize("setup_kwargs, exit_code, record_event_params", [
-    # Invalid size
+    # Invalid return from getsize
     (
-        {'file_size': 0},
+        {'file_size': None},
         1,
         RecordEventParams(scanner_is_None=True, passed=False),
+    ),
+    # Zero byte file passes
+    (
+        {'file_size': 0, 'scanner_passed': True},
+        0,
+        RecordEventParams(scanner_is_None=False, passed=True),
     ),
     # Faulty scanner
     (


### PR DESCRIPTION
This fix ensures that the comparison for a valid file size of zero is not a negation, but will still return 1 as a failure if trying to find file size returns None. 

A fix that helps unblock @sromkey QA testing. 

Fixes #808 