### PR TITLE
MCPClient: stop passing capture_output to executeOrRun

### DIFF
--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -126,7 +126,6 @@ def _process_gearman_job(gearman_job, gearman_worker):
     data = cPickle.loads(gearman_job.data)
     utc_date = getUTCDate()
     arguments = data['arguments']
-    capture_output = data.get('capture_output', False)
     if isinstance(arguments, unicode):
         arguments = arguments.encode('utf-8')
     client_id = gearman_worker.worker_client_id
@@ -157,7 +156,7 @@ def _process_gearman_job(gearman_job, gearman_worker):
         arguments = arguments.replace(var, val)
     arguments = arguments.replace('%taskUUID%', task_uuid)
     script = client_script_full_path + ' ' + arguments
-    return script, task_uuid, capture_output
+    return script, task_uuid
 
 
 def _unexpected_error():
@@ -173,7 +172,7 @@ def execute_command(gearman_worker, gearman_job):
     standard output and standard error as a pickled dict.
     """
     try:
-        script, task_uuid, capture_output = _process_gearman_job(
+        script, task_uuid = _process_gearman_job(
             gearman_job, gearman_worker)
     except ProcessGearmanJobError as error:
         return cPickle.dumps(error)
@@ -183,8 +182,7 @@ def execute_command(gearman_worker, gearman_job):
                 task_uuid, script)
     try:
         exit_code, std_out, std_error = executeOrRun(
-            'command', script, stdIn='', printing=True,
-            capture_output=capture_output)
+            'command', script, stdIn='', printing=True)
     except OSError:
         logger.exception('Execution failed')
         return cPickle.dumps({'exitCode': 1,


### PR DESCRIPTION
Commit f527d53a3b61164a327038084b007beb2f9240a7 added call `executeOrRun('command', script, stdIn='', printing=True, capture_output=capture_output)`, which is problematic because `executeOrRun` does not recognize the `capture_output` kwarg, which is currently only available in dev/1.8.x.