### PR TITLE
Fix MCP{Server,Client} config path

### DIFF
--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -3,8 +3,8 @@
 This directory contains the following files:
 
 - [`clientConfig.conf`](./clientConfig.conf) - a sample configuration file that
-the user can place in `/etc/archivematica/clientConfig.conf` to tweak the
-configuration of MCPClient.
+the user can place in `/etc/archivematica/MCPClient/clientConfig.conf` to tweak
+the configuration of MCPClient.
 
 - [`clientConfig.logging.json`](./clientConfig.logging.json) - read the
 [logging configuration section](#logging-configuration) for more details.

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -103,7 +103,7 @@ config = Config(env_prefix='ARCHIVEMATICA_MCPCLIENT', attrs=CONFIG_MAPPING)
 config.read_defaults(StringIO.StringIO(CONFIG_DEFAULTS))
 config.read_files([
     '/etc/archivematica/archivematicaCommon/dbsettings',
-    '/etc/archivematica/clientConfig.conf',
+    '/etc/archivematica/MCPClient/clientConfig.conf',
 ])
 
 

--- a/src/MCPServer/install/README.md
+++ b/src/MCPServer/install/README.md
@@ -3,8 +3,8 @@
 This directory contains the following files:
 
 - [`serverConfig.conf`](./serverConfig.conf) - a sample configuration file that
-the user can place in `/etc/archivematica/serverConfig.conf` to tweak the
-configuration of MCPServer.
+the user can place in `/etc/archivematica/MCPServer/serverConfig.conf` to tweak
+the configuration of MCPServer.
 
 - [`serverConfig.logging.json`](./serverConfig.logging.json) - read the
 [logging configuration section](#logging-configuration) for more details.

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -83,7 +83,7 @@ config = Config(env_prefix='ARCHIVEMATICA_MCPSERVER', attrs=CONFIG_MAPPING)
 config.read_defaults(StringIO.StringIO(CONFIG_DEFAULTS))
 config.read_files([
     '/etc/archivematica/archivematicaCommon/dbsettings',
-    '/etc/archivematica/serverConfig.conf',
+    '/etc/archivematica/MCPServer/serverConfig.conf',
 ])
 
 


### PR DESCRIPTION
We have a backward-compatibility strategy to support the old configuration
files but the paths were not correct. This commit fixes that.

It should also be included in `qa/1.x`.