### PR TITLE
Fix ASpace DIP upload

### DIFF
--- a/src/MCPClient/lib/clientScripts/upload-archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload-archivesspace.py
@@ -225,6 +225,6 @@ if __name__ == '__main__':
 
     args.inherit_notes = args.inherit_notes.lower() in INHERIT_NOTES_CHOICES
 
-    client = ArchivesSpaceClient(host=args.host, user=args.user, passwd=args.passwd)
+    client = ArchivesSpaceClient(host=args.host, port=args.port, user=args.user, passwd=args.passwd)
     files = get_files_from_dip(args.dip_location, args.dip_name, args.dip_uuid)
     upload_to_archivesspace(files, client, args.xlink_show, args.xlink_actuate, args.object_type, args.use_statement, args.uri_prefix, args.dip_uuid, args.access_conditions, args.use_conditions, args.restrictions, args.dip_location, args.inherit_notes)

--- a/src/dashboard/src/components/administration/forms_dip_upload.py
+++ b/src/dashboard/src/components/administration/forms_dip_upload.py
@@ -29,7 +29,7 @@ class ArchivesSpaceConfigForm(forms.Form):
     port = forms.IntegerField(label=_('ArchivesSpace backend port'), help_text=_('Example: 8089'), initial=8089)
     user = forms.CharField(label=_('ArchivesSpace administrative user'), help_text=_('Example: admin'))
     passwd = forms.CharField(required=False, label=_('ArchivesSpace administrative user password'), help_text=_('Password for user set above. Re-enter this password every time changes are made.'))
-    premis = forms.ChoiceField(choices=PREMIS_CHOICES, label=_('Restrictions apply'), initial='yes')
+    restrictions = forms.ChoiceField(choices=PREMIS_CHOICES, label=_('Restrictions apply'), initial='yes')
     xlink_show = forms.ChoiceField(choices=EAD_SHOW_CHOICES, label=_('XLink Show'), initial='embed')
     xlink_actuate = forms.ChoiceField(choices=EAD_ACTUATE_CHOICES, label=_('XLink Actuate'), initial='none')
     object_type = forms.CharField(required=False, label=_('Object type'), help_text=_('Optional, must come from ArchivesSpace controlled list. Example: sound_recording'))

--- a/src/dashboard/src/main/migrations/0045_archivesspace_config_dict.py
+++ b/src/dashboard/src/main/migrations/0045_archivesspace_config_dict.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+_AS_DICTNAME = 'upload-archivesspace_v0.0'
+
+
+def data_migration_up(apps, schema_editor):
+    """
+    Update ASpace config dict:
+
+    The ASpace config dict is used in linkTaskManagerReplacementDicFromChoice
+    to set the parameters sent to the upload-archivesspace script, which is
+    expecting "restrictions" instead of "premis". This field doesn't seem to
+    be used anywhere else, so it only needs to be updated in the related form
+    fields that are used to update the config dict.
+    """
+    DashboardSetting = apps.get_model('main', 'DashboardSetting')
+    as_dict = DashboardSetting.objects.get_dict(_AS_DICTNAME)
+    # Get 'premis' value removing it from the dict
+    value = as_dict.pop('premis', None)
+    # Add default value if not present
+    if value is None:
+        value = 'yes'
+    # Set it in the new field
+    as_dict.update({'restrictions': value})
+    DashboardSetting.objects.set_dict(_AS_DICTNAME, as_dict)
+
+
+def data_migration_down(apps, schema_editor):
+    """
+    Restore ASpace config dict:
+
+    Restore previous dict state with "premis" field instead of "restrictions"
+    """
+    DashboardSetting = apps.get_model('main', 'DashboardSetting')
+    as_dict = DashboardSetting.objects.get_dict(_AS_DICTNAME)
+    # Get 'restrictions' value removing it from the dict
+    value = as_dict.pop('restrictions', None)
+    # Add default value if not present
+    if value is None:
+        value = 'yes'
+    # Set it in the new field
+    as_dict.update({'premis': value})
+    DashboardSetting.objects.set_dict(_AS_DICTNAME, as_dict)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0044_update_idtools'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration_up, data_migration_down)
+    ]


### PR DESCRIPTION
The ASpace config dict is used in linkTaskManagerReplacementDicFromChoice
to set the parameters sent to the upload-archivesspace script, which is
expecting restrictions instead of premis. This field doesn't seem to
be used anywhere else, so it only needs to be updated in the related form
fields that are used to update the config dict.

This also fixes an issue where the config port was not being used in the upload.

Fixes https://github.com/artefactual/archivematica/issues/746