### PR TITLE
Document configuration sources

### DIFF
--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -1,13 +1,221 @@
-## Configuration files
+## Table of contents
 
-This directory contains the following files:
+- [Introduction](#introduction)
+- [Environment variables](#environment-variables)
+- [Logging configuration](#logging-configuration)
 
-- [`clientConfig.conf`](./clientConfig.conf) - a sample configuration file that
-the user can place in `/etc/archivematica/MCPClient/clientConfig.conf` to tweak
-the configuration of MCPClient.
+## Introduction
 
-- [`clientConfig.logging.json`](./clientConfig.logging.json) - read the
-[logging configuration section](#logging-configuration) for more details.
+MCPClient has multiple sources of configuration. This is the full list ordered
+by precedence (with the last listed item winning prioritization):
+
+- Application defaults
+- Configuration files: (see [`the example`](./clientConfig.conf))
+    - `/etc/archivematica/archivematicaCommon/dbsettings` (optional)
+    - `/etc/archivematica/MCPClient/clientConfig.conf` (optional)
+- Environment variables (always win precedence)
+
+## Environment variables
+
+The value of an environment variable is a string of characters. The
+configuration system coerces the value to the types supported:
+
+- `string` (e.g. `"foobar"`)
+- `int` (e.g. `"60"`)
+- `float` (e.g. `"1.20"`)
+- `boolean` where truth values can be represented as follows (checked in a
+case-insensitive manner):
+    - True (enabled):  `"1"`, `"yes"`, `"true"` or `"on"`
+    - False (disabled): `"0"`, `"no"`, `"false"` or `"off"`
+
+Certain environment strings are mandatory, i.e. they don't have defaults and
+the application will refuse to start if the user does not provide one.
+
+Please be aware that Archivematica supports different types of distributions
+(Ubuntu/CentOS packages, Ansible or Docker images) and they may override some
+of these settings or provide values to mandatory fields.
+
+This is the full list of environment strings supported:
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_DJANGO_SECRET_KEY`**:
+    - **Description:** a secret key used for cryptographic signing. See [SECRET_KEY](https://docs.djangoproject.com/en/1.8/ref/settings/#secret-key) for more details.
+    - **Config file example:** `MCPClient.django_secret_key`
+    - **Type:** `string`
+    - :red_circle: **Mandatory!**
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_SHAREDDIRECTORYMOUNTED`**:
+    - **Description:** location of the Archivematica Shared Directory.
+    - **Config file example:** `MCPClient.sharedDirectoryMounted`
+    - **Type:** `string`
+    - **Default:** `/var/archivematica/sharedDirectory/`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_PROCESSINGDIRECTORY`**:
+    - **Description:** location of the Archivematica Currently Procesing Directory.
+    - **Config file example:** `MCPClient.processingDirectory`
+    - **Type:** `string`
+    - **Default:** `/var/archivematica/sharedDirectory/currentlyProcessing/`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_REJECTEDDIRECTORY`**:
+    - **Description:** location of the Archivematica Rejected Directory.
+    - **Config file example:** `MCPClient.rejectedDirectory`
+    - **Type:** `string`
+    - **Default:** `%%sharedPath%%rejected/`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_WATCHDIRECTORYPATH`**:
+    - **Description:** location of the Archivematica Watched Directories.
+    - **Config file example:** `MCPClient.watchDirectoryPath`
+    - **Type:** `string`
+    - **Default:** `/var/archivematica/sharedDirectory/watchedDirectories/`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLIENTSCRIPTSDIRECTORY`**:
+    - **Description:** location of the client scripts directory.
+    - **Config file example:** `MCPClient.clientScriptsDirectory`
+    - **Type:** `string`
+    - **Default:** `/usr/lib/archivematica/MCPClient/clientScripts/`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLIENTASSETSDIRECTORY`**:
+    - **Description:** location of the client assets directory.
+    - **Config file example:** `MCPClient.clientAssetsDirectory`
+    - **Type:** `string`
+    - **Default:** `/usr/lib/archivematica/MCPClient/assets/`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_LOADSUPPORTEDCOMMANDSSPECIAL`**:
+    - **Description:** enables loading special modules.
+    - **Config file example:** `MCPClient.LoadSupportedCommandsSpecial`
+    - **Type:** `boolean`
+    - **Default:** `true`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_MCPARCHIVEMATICASERVER`**:
+    - **Description:** address of the Gearman server.
+    - **Config file example:** `MCPClient.MCPArchivematicaServer`
+    - **Type:** `string`
+    - **Default:** `localhost:4730`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_NUMBEROFTASKS`**:
+    - **Description:** number of Gearman workers that the process will run in parallel. When `0`, MCPClient will start as many workers as CPU cores are found in the system.
+    - **Config file example:** `MCPClient.numberOfTasks`
+    - **Type:** `int`
+    - **Default:** `0`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_ARCHIVEMATICACLIENTMODULES`**:
+    - **Description:** location of the client modules configuration file. This can be useful when the user wants to set up workers that can only work in a limited number of tasks, e.g. a worker exclusively dedicated to antivirus scanning or file identification.
+    - **Config file example:** `MCPClient.archivematicaClientModules`
+    - **Type:** `string`
+    - **Default:** `/usr/lib/archivematica/MCPClient/archivematicaClientModules`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_ELASTICSEARCHSERVER`**:
+    - **Description:** address of the Elasticsearch server.
+    - **Config file example:** `MCPClient.elasticsearchServer`
+    - **Type:** `string`
+    - **Default:** `localhost:9200`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_ELASTICSEARCHTIMEOUT`**:
+    - **Description:** configures the Elasticsearch client to stop waiting for a response after a given number of seconds.
+    - **Config file example:** `MCPClient.elasticsearchTimeout`
+    - **Type:** `float`
+    - **Default:** `10`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_DISABLEELASTICSEARCHINDEXING`**:
+    - **Description:** disables search indexing.
+    - **Config file example:** `MCPClient.disableElasticsearchIndexing`
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_REMOVABLEFILES`**:
+    - **Description:** comma-separated listed of file names that will be deleted.
+    - **Config file example:** `MCPClient.removableFiles`
+    - **Type:** `string`
+    - **Default:** `Thumbs.db, Icon, Icon\r, .DS_Store`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_TEMP_DIR`**:
+    - **Description:** location of the temporary directory.
+    - **Config file example:** `MCPClient.temp_dir`
+    - **Type:** `string`
+    - **Default:** `/var/archivematica/sharedDirectory/tmp`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_STORAGE_SERVICE_CLIENT_TIMEOUT`**:
+    - **Description:** configures the Storage Service client to stop waiting for a response after a given number of seconds.
+    - **Config file example:** `MCPClient.storage_service_client_timeout`
+    - **Type:** `float`
+    - **Default:** `86400`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_AGENTARCHIVES_CLIENT_TIMEOUT`**:
+    - **Description:** configures the agentarchives client to stop waiting for a response after a given number of seconds.
+    - **Config file example:** `MCPClient.agentarchives_client_timeout`
+    - **Type:** `float`
+    - **Default:** `300`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_SERVER`**:
+    - **Description:** configures the `clamdscanner` backend so it knows how to reach the clamd server via UNIX socket (if the value starts with /) or TCP socket (form `host:port`, e.g.: `myclamad:3310`).
+    - **Config file example:** `MCPClient.clamav_server`
+    - **Type:** `string`
+    - **Default:** `/var/run/clamav/clamd.ctl`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_PASS_BY_REFERENCE`**:
+    - **Description:** configures the `clamdscanner` backend to pass files to clamd by reference. When disabled, the files are streamed which is useful when clamd does not have access to the filesystem where the file is stored.
+    - **Config file example:** `MCPClient.clamav_pass_by_reference`
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_TIMEOUT`**:
+    - **Description:** configures the `clamdscanner` backend to stop waiting for a response after a given number of seconds.
+    - **Config file example:** `MCPClient.clamav_client_timeout`
+    - **Type:** `float`
+    - **Default:** `86400`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_BACKEND`**:
+    - **Description:** the ClamAV backend used for anti-virus scanning. The two options that are available are: `clamscanner` (via CLI) and `clamdscanner` (over TCP or UNIX socket).
+    - **Config file example:** `MCPClient.clamav_client_backend`
+    - **Type:** `string`
+    - **Default:** `clamdscanner`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_MAX_FILE_SIZE`**:
+    - **Description:** files larger than this limit won't be scanned. The unit used is megabyte (MB).
+    - **Config file example:** `MCPClient.clamav_client_max_file_size`
+    - **Type:** `float`
+    - **Default:** `42`
+
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_MAX_SCAN_SIZE`**:
+    - **Description**: sets the maximum amount of data to be scanned for each input file. Files larger than this value will be scanned but only up to this limit. Archives and other containers are recursively extracted and scanned up to this value. The unit used is megabyte (MB).
+    - **Config file example:** `MCPClient.clamav_client_max_scan_size`
+    - **Type:** `float`
+    - **Default:** `42`
+
+- **`ARCHIVEMATICA_MCPCLIENT_CLIENT_ENGINE`**
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.engine`
+    - **Type:** `string`
+    - **Default:** `django.db.backends.mysql`
+
+- **`ARCHIVEMATICA_MCPCLIENT_CLIENT_DATABASE`**
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.database`
+    - **Type:** `string`
+    - **Default:** `MCP`
+
+- **`ARCHIVEMATICA_MCPCLIENT_CLIENT_USER`**
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.user`
+    - **Type:** `string`
+    - **Default:** `archivematica`
+
+- **`ARCHIVEMATICA_MCPCLIENT_CLIENT_PASSWORD`**
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.password`
+    - **Type:** `string`
+    - **Default:** `demo`
+
+- **`ARCHIVEMATICA_MCPCLIENT_CLIENT_HOST`**
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.host`
+    - **Type:** `string`
+    - **Default:** `localhost`
+
+- **`ARCHIVEMATICA_MCPCLIENT_CLIENT_PORT`**
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.port`
+    - **Type:** `string`
+    - **Default:** `3306`
 
 ## Logging configuration
 
@@ -15,7 +223,7 @@ Archivematica 1.6.1 and earlier releases are configured by default to log to
 subdirectories in `/var/log/archivematica`, such as
 `/var/log/archivematica/MCPClient/MCPClient.debug.log`. Starting with
 Archivematica 1.7.0, logging configuration defaults to using stdout and stderr
-for all logs. If no changes are made to the new default configuration logs
+for all logs. If no changes are made to the new default configuration, logs
 will be handled by whichever process is managing Archivematica's services. For
 example on Ubuntu 16.04 or Centos 7, Archivematica's processes are managed by
 systemd. Logs for the MCPClient can be accessed using

--- a/src/MCPServer/install/README.md
+++ b/src/MCPServer/install/README.md
@@ -1,13 +1,155 @@
-## Configuration files
+## Table of contents
 
-This directory contains the following files:
+- [Introduction](#introduction)
+- [Environment variables](#environment-variables)
+- [Logging configuration](#logging-configuration)
 
-- [`serverConfig.conf`](./serverConfig.conf) - a sample configuration file that
-the user can place in `/etc/archivematica/MCPServer/serverConfig.conf` to tweak
-the configuration of MCPServer.
+## Introduction
 
-- [`serverConfig.logging.json`](./serverConfig.logging.json) - read the
-[logging configuration section](#logging-configuration) for more details.
+MCPServer has multiple sources of configuration. This is the full list ordered
+by precedence (with the last listed item winning prioritization):
+
+- Application defaults
+- Configuration files: (see [`the example`](./serverConfig.conf))
+    - `/etc/archivematica/archivematicaCommon/dbsettings` (optional)
+    - `/etc/archivematica/MCPServer/serverConfig.conf` (optional)
+- Environment variables (always win precedence)
+
+## Environment variables
+
+The value of an environment variable is a string of characters. The
+configuration system coerces the value to the types supported:
+
+- `string` (e.g. `"foobar"`)
+- `int` (e.g. `"60"`)
+- `float` (e.g. `"1.20"`)
+- `boolean` where truth values can be represented as follows (checked in a
+case-insensitive manner):
+    - True (enabled):  `"1"`, `"yes"`, `"true"` or `"on"`
+    - False (disabled): `"0"`, `"no"`, `"false"` or `"off"`
+
+Certain environment strings are mandatory, i.e. they don't have defaults and
+the application will refuse to start if the user does not provide one.
+
+Please be aware that Archivematica supports different types of distributions
+(Ubuntu/CentOS packages, Ansible or Docker images) and they may override some
+of these settings or provide values to mandatory fields.
+
+This is the full list of environment strings supported:
+
+- **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_DJANGO_SECRET_KEY`**:
+    - **Description:** a secret key used for cryptographic signing. See [SECRET_KEY](https://docs.djangoproject.com/en/1.8/ref/settings/#secret-key) for more details.
+    - **Config file example:** `MCPServer.django_secret_key`
+    - **Type:** `string`
+    - :red_circle: **Mandatory!**
+
+- **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_SHAREDDIRECTORY`**:
+    - **Description:** location of the Archivematica Shared Directory.
+    - **Config file example:** `MCPServer.sharedDirectory`
+    - **Type:** `string`
+    - **Default:** `"/var/archivematica/sharedDirectory/"`
+
+- **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_PROCESSINGXMLFILE`**:
+    - **Description:** name of the processing configuration file.
+    - **Config file example:** `MCPServer.processingXMLFile`
+    - **Type:** `string`
+    - **Default:** `"processingMCP.xml"`
+
+- **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_MCPARCHIVEMATICASERVER`**:
+    - **Description:** address of the Gearman server.
+    - **Config file example:** `MCPServer.MCPArchivematicaServer`
+    - **Type:** `string`
+    - **Default:** `"localhost:4730"`
+
+- **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_WATCHDIRECTORYPATH`**:
+    - **Description:** location of the Archivematica Watched Directories.
+    - **Config file example:** `MCPServer.watchDirectoryPath`
+    - **Type:** `string`
+    - **Default:** `"/var/archivematica/sharedDirectory/watchedDirectories/"`
+
+- **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_PROCESSINGDIRECTORY`**:
+    - **Description:** loation of the processing directory.
+    - **Config file example:** `MCPServer.processingDirectory`
+    - **Type:** `string`
+    - **Default:** `"/var/archivematica/sharedDirectory/currentlyProcessing/"`
+
+- **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_REJECTEDDIRECTORY`**:
+    - **Description:** location of the rejected directory.
+    - **Config file example:** `MCPServer.rejectedDirectory`
+    - **Type:** `string`
+    - **Default:** `"%%sharedPath%%rejected/"`
+
+- **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_WAITONAUTOAPPROVE`**:
+    - **Description:** number of seconds that a thread will wait before attempting to approve a chain when it is pre-configured.
+    - **Config file example:** `MCPServer.waitOnAutoApprove`
+    - **Type:** `int`
+    - **Default:** `"0"`
+
+- **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_WATCHDIRECTORIESPOLLINTERVAL`**:
+    - **Description:** time in seconds between filesystem poll intervals .
+    - **Config file example:** `MCPServer.watchDirectoriesPollInterval`
+    - **Type:** `int`
+    - **Default:** `"1"`
+
+- **`ARCHIVEMATICA_MCPSERVER_PROTOCOL_LIMITTASKTHREADS`**:
+    - **Description:** max. number of threads that MCPServer will run simultaneously.
+    - **Config file example:** `protocol.limitTaskThreads`
+    - **Type:** `int`
+    - **Default:** `"75"`
+
+- **`ARCHIVEMATICA_MCPSERVER_PROTOCOL_LIMITTASKTHREADSSLEEP`**:
+    - **Description:** number of seconds that the application will wait before trying to start a new thread when the limit is reached.
+    - **Config file example:** `protocol.limitTaskThreadsSleep`
+    - **Type:** `float`
+    - **Default:** `"0.2"`
+
+- **`ARCHIVEMATICA_MCPSERVER_PROTOCOL_LIMITGEARMANCONNECTIONS`**:
+    - **Description:** max. number of concurrent connections to Gearman server.
+    - **Config file example:** `protocol.limitGearmanConnections`
+    - **Type:** `int`
+    - **Default:** `"10000"`
+
+- **`ARCHIVEMATICA_MCPSERVER_PROTOCOL_RESERVEDASTASKPROCESSINGTHREADS`**:
+    - **Description:** max. number of concurrent processing threads running foreground Gearman jobs.
+    - **Config file example:** `protocol.reservedAsTaskProcessingThreads`
+    - **Type:** `int`
+    - **Default:** `"8"`
+
+- **`ARCHIVEMATICA_MCPSERVER_CLIENT_ENGINE`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.engine`
+    - **Type:** `string`
+    - **Default:** `django.db.backends.mysql`
+
+- **`ARCHIVEMATICA_MCPSERVER_CLIENT_DATABASE`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.database`
+    - **Type:** `string`
+    - **Default:** `MCP`
+
+- **`ARCHIVEMATICA_MCPSERVER_CLIENT_USER`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.user`
+    - **Type:** `string`
+    - **Default:** `archivematica`
+
+- **`ARCHIVEMATICA_MCPSERVER_CLIENT_PASSWORD`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.password`
+    - **Type:** `string`
+    - **Default:** `demo`
+
+- **`ARCHIVEMATICA_MCPSERVER_CLIENT_HOST`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.host`
+    - **Type:** `string`
+    - **Default:** `localhost`
+
+- **`ARCHIVEMATICA_MCPSERVER_CLIENT_PORT`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.port`
+    - **Type:** `string`
+    - **Default:** `3306`
 
 ## Logging configuration
 
@@ -15,7 +157,7 @@ Archivematica 1.6.1 and earlier releases are configured by default to log to
 subdirectories in `/var/log/archivematica`, such as
 `/var/log/archivematica/MCPServer/MCPServer.debug.log`. Starting with
 Archivematica 1.7.0, logging configuration defaults to using stdout and stderr
-for all logs. If no changes are made to the new default configuration logs
+for all logs. If no changes are made to the new default configuration, logs
 will be handled by whichever process is managing Archivematica's services. For
 example on Ubuntu 16.04 or Centos 7, Archivematica's processes are managed by
 systemd. Logs for the MCPServer can be accessed using

--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -1,4 +1,157 @@
-## Configuration files
+# Configuration
+
+- [Introduction](#introduction)
+- [Environment variables](#environment-variables)
+- [Other configuration files](#other-configuration-files)
+- [Logging configuration](#logging-configuration)
+
+## Introduction
+
+Dashboard has multiple sources of configuration. This is the full list ordered
+by precedence (with the last listed item winning prioritization):
+
+- Application defaults
+- Configuration file: `/etc/archivematica/archivematicaCommon/dbsettings`
+- Environment variables (always win precedence)
+
+## Environment variables
+
+The value of an environment variable is a string of characters. The
+configuration system coerces the value to the types supported:
+
+- `string` (e.g. `"foobar"`)
+- `int` (e.g. `"60"`)
+- `float` (e.g. `"1.20"`)
+- `boolean` where truth values can be represented as follows (checked in a
+case-insensitive manner):
+    - True (enabled):  `"1"`, `"yes"`, `"true"` or `"on"`
+    - False (disabled): `"0"`, `"no"`, `"false"` or `"off"`
+
+Certain environment strings are mandatory, i.e. they don't have defaults and
+the application will refuse to start if the user does not provide one.
+
+Please be aware that Archivematica supports different types of distributions
+(Ubuntu/CentOS packages, Ansible or Docker images) and they may override some
+of these settings or provide values to mandatory fields.
+
+This is the full list of environment strings supported:
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_ALLOWED_HOSTS`**:
+    - **Description:** a list of strings representing the host/domain names that this Django site can serve. See [`ALLOWED_HOSTS`](https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts) for more details.
+    - **Config file example:** `Dashboard.django_allowed_hosts`
+    - **Type:** `string`
+    - :red_circle: **Mandatory!**
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_SECRET_KEY`**:
+    - **Description:** a secret key used for cryptographic signing. See [SECRET_KEY](https://docs.djangoproject.com/en/1.8/ref/settings/#secret-key) for more details.
+    - **Config file example:** `Dashboard.django_secret_key`
+    - **Type:** `string`
+    - :red_circle: **Mandatory!**
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_SHARED_DIRECTORY`**:
+    - **Description:** location of the Archivematica Shared Directory.
+    - **Config file example:** `Dashboard.shared_directory`
+    - **Type:** `string`
+    - **Default:** `"/var/archivematica/sharedDirectory/"`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_WATCH_DIRECTORY`**:
+    - **Description:** location of the Archivematica Watched Directories.
+    - **Config file example:** `Dashboard.watch_directory`
+    - **Type:** `string`
+    - **Default:** `"/var/archivematica/sharedDirectory/watchedDirectories/"`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_ELASTICSEARCH_SERVER`**:
+    - **Description:** address of the Elasticsearch server.
+    - **Config file example:** `Dashboard.elasticsearch_server`
+    - **Type:** `string`
+    - **Default:** `"127.0.0.1:9200"`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_ELASTICSEARCH_TIMEOUT`**:
+    - **Description:** configures the Elasticsearch client to stop waiting for a response after a given number of seconds.
+    - **Config file example:** `Dashboard.elasticsearch_timeout`
+    - **Type:** `float`
+    - **Default:** `10`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_GEARMAN_SERVER`**:
+    - **Description:** address of the Gearman server.
+    - **Config file example:** `Dashboard.gearman_server`
+    - **Type:** `string`
+    - **Default:** `127.0.0.1:4730`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_SHIBBOLETH_AUTHENTICATION`**:
+    - **Description:** enables the Shibboleth authentication system.
+    - **Config file example:** `Dashboard.shibboleth_authentication`
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_LDAP_AUTHENTICATION`**:
+    - **Description:** enables the LDAP authentication system.
+    - **Config file example:** `Dashboard.ldap_authentication`
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_STORAGE_SERVICE_CLIENT_TIMEOUT`**:
+    - **Description:** configures the Storage Service client to stop waiting for a response after a given number of seconds.
+    - **Config file example:** `Dashboard.storage_service_client_timeout`
+    - **Type:** `float`
+    - **Default:** `86400`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_AGENTARCHIVES_CLIENT_TIMEOUT`**:
+    - **Description:** configures the agentarchives client to stop waiting for a response after a given number of seconds.
+    - **Config file example:** `Dashboard.agentarchives_client_timeout`
+    - **Type:** `float`
+    - **Default:** `300`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_FPR_CLIENT_TIMEOUT`**:
+    - **Description:** configures the fpr client to stop waiting for a response after a given number of seconds.
+    - **Config file example:** `Dashboard.fpr_client_timeout`
+    - **Type:** `float`
+    - **Default:** `60`
+
+- **`ARCHIVEMATICA_DASHBOARD_CLIENT_ENGINE`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.engine`
+    - **Type:** `string`
+    - **Default:** `django.db.backends.mysql`
+
+- **`ARCHIVEMATICA_DASHBOARD_CLIENT_DATABASE`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.database`
+    - **Type:** `string`
+    - **Default:** `MCP`
+
+- **`ARCHIVEMATICA_DASHBOARD_CLIENT_USER`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.user`
+    - **Type:** `string`
+    - **Default:** `archivematica`
+
+- **`ARCHIVEMATICA_DASHBOARD_CLIENT_PASSWORD`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.password`
+    - **Type:** `string`
+    - **Default:** `demo`
+
+- **`ARCHIVEMATICA_DASHBOARD_CLIENT_HOST`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.host`
+    - **Type:** `string`
+    - **Default:** `localhost`
+
+- **`ARCHIVEMATICA_DASHBOARD_CLIENT_PORT`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.port`
+    - **Type:** `string`
+    - **Default:** `3306`
+
+- **`ARCHIVEMATICA_DASHBOARD_CLIENT_CONN_MAX_AGE`**:
+    - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.
+    - **Config file example:** `client.conn_max_age`
+    - **Type:** `float`
+    - **Default:** `0`
+
+
+## Other configuration files
 
 This directory contains the following files:
 
@@ -19,7 +172,7 @@ Archivematica 1.6.1 and earlier releases are configured by default to log to
 subdirectories in `/var/log/archivematica`, such as
 `/var/log/archivematica/dashboard/dashboard.debug.log`. Starting with
 Archivematica 1.7.0, logging configuration defaults to using stdout and stderr
-for all logs. If no changes are made to the new default configuration logs
+for all logs. If no changes are made to the new default configuration, logs
 will be handled by whichever process is managing Archivematica's services. For
 example on Ubuntu 16.04 or Centos 7, Archivematica's processes are managed by
 systemd. Logs for the Dashboard can be accessed using


### PR DESCRIPTION
This PR adds notes about the configuration sources to the files listed below. Please click on the links to take a look at the suggested changes:

- [MCPClient/install/README.md](https://github.com/artefactual/archivematica/blob/dev/docs-envs/src/MCPClient/install/README.md)
- [MCPServer/install/README.md](https://github.com/artefactual/archivematica/blob/dev/docs-envs/src/MCPServer/install/README.md)
- [dashboard/install/README.md](https://github.com/artefactual/archivematica/blob/dev/docs-envs/src/dashboard/install/README.md)

See #846 for further improvement that we may address later (in AM18).