### PR TITLE
Fix handle form

### DIFF
--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -112,7 +112,7 @@ class HandleForm(SettingsForm):
     )
 
     resolve_url_template_archive = forms.CharField(
-        required=False,
+        required=True,
         label=_('Archive resolve URL template'),
         help_text=_('Template (Django or Jinja2) for the URL that a unit\'s'
                     ' PURL should resolve to. Has access to "pid" and'
@@ -126,7 +126,7 @@ class HandleForm(SettingsForm):
                     ' access to "pid" and "naming_authority" variables.'))
 
     resolve_url_template_file = forms.CharField(
-        required=False,
+        required=True,
         label=_('File resolve URL template'),
         help_text=_('Template (Django or Jinja2) for the URL that a file\'s'
                     ' PURL should resolve to. Has access to "pid" and'

--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -364,8 +364,10 @@ def handle_config(request):
                 'handle', form.cleaned_data)
             messages.info(request, _('Saved.'))
     else:
-        form = HandleForm(
-            initial=models.DashboardSetting.objects.get_dict('handle'))
+        settings_dict = models.DashboardSetting.objects.get_dict('handle')
+        settings_dict['pid_request_verify_certs'] = {
+            'False': False}.get(settings_dict['pid_request_verify_certs'], True)
+        form = HandleForm(initial=settings_dict)
     return render(request, 'administration/handle_config.html', {'form': form})
 
 


### PR DESCRIPTION
1. Ensures that the `verify_ssl_certs` HTML widget matches the state of the configuration setting in the database. The `pid_request_verify_certs` field/attribute of the Handle config settings is stored as a `DashboardSetting` instance/row. However, it is a boolean and the dashboard settings key/value pairs are untyped. Therefore it is passed to the template as a string `'False'`. This commit is a hack that converts it to boolean `False`. A more thorough fix would add type information to the dashboard settings table (or assume the value column is JSON, which would be parsed to Python). Fixes #834.

2. Marks required Handle fields as required. Fixes #835.