### PR TITLE
osdeps: update dashboard dependencies

### DIFF
--- a/src/dashboard/osdeps/RedHat-7.json
+++ b/src/dashboard/osdeps/RedHat-7.json
@@ -17,6 +17,7 @@
   { "name": "libxml2-devel", "state": "latest"},
   { "name": "libxslt-devel", "state": "latest"},
   { "name": "openssl-devel", "state": "latest"},
-  { "name": "python-devel", "state": "latest"}
+  { "name": "python-devel", "state": "latest"},
+  { "name": "openldap-devel", "state": "latest"}
   ]
 }


### PR DESCRIPTION
Added openssl-devel as RHEL dependency. This dependency was already present on CentOS osdeps file.

It closes #838