### PR TITLE
Frontend: update vulnerable deps

### DIFF
--- a/src/dashboard/frontend/appraisal-tab/package-lock.json
+++ b/src/dashboard/frontend/appraisal-tab/package-lock.json
@@ -936,16 +936,6 @@
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
     },
-    "camel-case": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
-      "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
-      "dev": true,
-      "requires": {
-        "sentence-case": "1.1.3",
-        "upper-case": "1.1.3"
-      }
-    },
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -993,30 +983,6 @@
         "supports-color": "2.0.0"
       }
     },
-    "change-case": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
-      "integrity": "sha1-LE/ePwY7tB0AzWjg1aCdthy+iU8=",
-      "dev": true,
-      "requires": {
-        "camel-case": "1.2.2",
-        "constant-case": "1.1.2",
-        "dot-case": "1.1.2",
-        "is-lower-case": "1.1.3",
-        "is-upper-case": "1.1.2",
-        "lower-case": "1.1.4",
-        "lower-case-first": "1.0.2",
-        "param-case": "1.1.2",
-        "pascal-case": "1.1.2",
-        "path-case": "1.1.2",
-        "sentence-case": "1.1.3",
-        "snake-case": "1.1.2",
-        "swap-case": "1.1.2",
-        "title-case": "1.1.2",
-        "upper-case": "1.1.3",
-        "upper-case-first": "1.1.2"
-      }
-    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -1040,59 +1006,6 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3"
-      }
-    },
-    "clean-css": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.1.9.tgz",
-      "integrity": "sha1-29BaFIvklDuzfOBnnmdsvJ9YAmY=",
-      "dev": true,
-      "requires": {
-        "commander": "2.6.0",
-        "source-map": "0.1.43"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
-      }
-    },
-    "cli": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
-      "integrity": "sha1-Aq1Eo4Cr8nraxebwzdewQ9dMU+M=",
-      "dev": true,
-      "requires": {
-        "exit": "0.1.2",
-        "glob": "3.2.11"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
-          }
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.2.4",
-            "sigmund": "1.0.1"
-          }
-        }
       }
     },
     "cliui": {
@@ -1181,12 +1094,6 @@
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
-    "commander": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-      "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
-      "dev": true
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1217,43 +1124,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "concat-stream": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
-      "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14",
-        "typedarray": "0.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "connect": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.3.tgz",
@@ -1273,16 +1143,6 @@
       "dev": true,
       "requires": {
         "date-now": "0.1.4"
-      }
-    },
-    "constant-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
-      "integrity": "sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=",
-      "dev": true,
-      "requires": {
-        "snake-case": "1.1.2",
-        "upper-case": "1.1.3"
       }
     },
     "constants-browserify": {
@@ -1319,6 +1179,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
       "dev": true
     },
     "crypto-browserify": {
@@ -1515,37 +1381,6 @@
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
       "dev": true
     },
-    "dot-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz",
-      "integrity": "sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=",
-      "dev": true,
-      "requires": {
-        "sentence-case": "1.1.3"
-      }
-    },
-    "ecstatic": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-0.4.13.tgz",
-      "integrity": "sha1-nLbq/+IRuchO+z9VPN4sMAJxeyk=",
-      "dev": true,
-      "requires": {
-        "ent": "0.0.7",
-        "mime": "1.2.11",
-        "optimist": "0.3.7"
-      },
-      "dependencies": {
-        "optimist": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-          "dev": true,
-          "requires": {
-            "wordwrap": "0.0.3"
-          }
-        }
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1687,12 +1522,6 @@
         }
       }
     },
-    "ent": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-0.0.7.tgz",
-      "integrity": "sha1-g11Of556jUkhxpLpAQ7JdtpemUk=",
-      "dev": true
-    },
     "errno": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
@@ -1736,12 +1565,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "dev": true
-    },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expand-braces": {
@@ -2043,6 +1866,12 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -2058,20 +1887,6 @@
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
       "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
       "dev": true
-    },
-    "html-minifier": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.7.2.tgz",
-      "integrity": "sha1-K3lZsQUaSB5xzXxuWaZCcq+JXP0=",
-      "dev": true,
-      "requires": {
-        "change-case": "2.3.1",
-        "clean-css": "3.1.9",
-        "cli": "0.6.6",
-        "concat-stream": "1.4.10",
-        "relateurl": "0.2.7",
-        "uglify-js": "2.4.24"
-      }
     },
     "http-errors": {
       "version": "1.6.2",
@@ -2096,24 +1911,100 @@
       }
     },
     "http-server": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.6.1.tgz",
-      "integrity": "sha1-BvzmXPK9QTKleL2sYv+suX1hOYE=",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.10.0.tgz",
+      "integrity": "sha1-sqRGsWqduH7TxiK6m+sbCFsSNKc=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "ecstatic": "0.4.13",
-        "opener": "1.3.0",
-        "optimist": "0.5.2",
-        "portfinder": "0.2.1",
-        "union": "0.3.8"
+        "colors": "1.0.3",
+        "corser": "2.0.1",
+        "ecstatic": "2.2.1",
+        "http-proxy": "1.16.2",
+        "opener": "1.4.3",
+        "optimist": "0.6.1",
+        "portfinder": "1.0.13",
+        "union": "0.4.6"
       },
       "dependencies": {
-        "colors": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
+        "ecstatic": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-2.2.1.tgz",
+          "integrity": "sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ==",
+          "dev": true,
+          "requires": {
+            "he": "1.1.1",
+            "mime": "1.2.11",
+            "minimist": "1.2.0",
+            "url-join": "2.0.2"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "opener": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+          "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+          "dev": true
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+              "dev": true
+            }
+          }
+        },
+        "portfinder": {
+          "version": "1.0.13",
+          "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+          "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "debug": "2.6.8",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "qs": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
+          "dev": true
+        },
+        "union": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
+          "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
+          "dev": true,
+          "requires": {
+            "qs": "2.3.3"
+          }
         }
       }
     },
@@ -2250,15 +2141,6 @@
         "is-extglob": "1.0.0"
       }
     },
-    "is-lower-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
-      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
-      "dev": true,
-      "requires": {
-        "lower-case": "1.1.4"
-      }
-    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -2293,15 +2175,6 @@
       "dev": true,
       "requires": {
         "html-comment-regex": "1.1.1"
-      }
-    },
-    "is-upper-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
-      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
-      "dev": true,
-      "requires": {
-        "upper-case": "1.1.3"
       }
     },
     "isarray": {
@@ -2637,15 +2510,6 @@
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
-    "lower-case-first": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
-      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
-      "dev": true,
-      "requires": {
-        "lower-case": "1.1.4"
-      }
-    },
     "lru-cache": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
@@ -2766,6 +2630,15 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "ncname": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+      "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
+      "dev": true,
+      "requires": {
+        "xml-char-classes": "1.0.0"
+      }
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -2773,15 +2646,105 @@
       "dev": true
     },
     "ng-cache-loader": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/ng-cache-loader/-/ng-cache-loader-0.0.15.tgz",
-      "integrity": "sha1-XyFNn8YbPa9lET/UoccOfD0hE7Q=",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/ng-cache-loader/-/ng-cache-loader-0.0.26.tgz",
+      "integrity": "sha512-CQCTCjn6b5jFTEOa+AjJpmYOweWEdYvSg28kMIMd5SfuHMPQu/NwsD7Ua7ZPriVsdHpdoWiAFpoQlJYLzjXejQ==",
       "dev": true,
       "requires": {
         "extend": "3.0.1",
         "fastparse": "1.1.1",
-        "html-minifier": "0.7.2",
-        "loader-utils": "0.2.17"
+        "html-minifier": "3.5.7",
+        "loader-utils": "1.1.0"
+      },
+      "dependencies": {
+        "camel-case": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+          "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+          "dev": true,
+          "requires": {
+            "no-case": "2.3.2",
+            "upper-case": "1.1.3"
+          }
+        },
+        "clean-css": {
+          "version": "4.1.9",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
+          "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.6"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
+        "html-minifier": {
+          "version": "3.5.7",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.7.tgz",
+          "integrity": "sha512-GISXn6oKDo7+gVpKOgZJTbHMCUI2TSGfpg/8jgencWhWJsvEmsvp3M8emX7QocsXsYznWloLib3OeSfeyb/ewg==",
+          "dev": true,
+          "requires": {
+            "camel-case": "3.0.0",
+            "clean-css": "4.1.9",
+            "commander": "2.12.2",
+            "he": "1.1.1",
+            "ncname": "1.0.0",
+            "param-case": "2.1.1",
+            "relateurl": "0.2.7",
+            "uglify-js": "3.2.2"
+          }
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
+        "param-case": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+          "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+          "dev": true,
+          "requires": {
+            "no-case": "2.3.2"
+          }
+        },
+        "uglify-js": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.2.tgz",
+          "integrity": "sha512-++1NO/zZIEdWf6cDIGceSJQPX31SqIpbVAHwFG5+240MtZqPG/NIPoinj8zlXQtAfMBqEt1Jyv2FiLP3n9gVhQ==",
+          "dev": true,
+          "requires": {
+            "commander": "2.12.2",
+            "source-map": "0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "requires": {
+        "lower-case": "1.1.4"
       }
     },
     "node-libs-browser": {
@@ -2908,21 +2871,6 @@
         "wrappy": "1.0.2"
       }
     },
-    "opener": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.3.0.tgz",
-      "integrity": "sha1-EwumYiE/qELttM0DYdMaFTAaQ+I=",
-      "dev": true
-    },
-    "optimist": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.5.2.tgz",
-      "integrity": "sha1-hcjBRUszFeSniUfoV7HfAzRQv7w=",
-      "dev": true,
-      "requires": {
-        "wordwrap": "0.0.3"
-      }
-    },
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
@@ -2952,15 +2900,6 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
-    },
-    "param-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
-      "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
-      "dev": true,
-      "requires": {
-        "sentence-case": "1.1.3"
-      }
     },
     "parse-glob": {
       "version": "3.0.4",
@@ -3007,30 +2946,11 @@
       "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
       "dev": true
     },
-    "pascal-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz",
-      "integrity": "sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=",
-      "dev": true,
-      "requires": {
-        "camel-case": "1.2.2",
-        "upper-case-first": "1.1.2"
-      }
-    },
     "path-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
-    },
-    "path-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz",
-      "integrity": "sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=",
-      "dev": true,
-      "requires": {
-        "sentence-case": "1.1.3"
-      }
     },
     "path-exists": {
       "version": "2.1.0",
@@ -3075,29 +2995,6 @@
       "dev": true,
       "requires": {
         "find-up": "1.1.2"
-      }
-    },
-    "pkginfo": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
-      "integrity": "sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg=",
-      "dev": true
-    },
-    "portfinder": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-0.2.1.tgz",
-      "integrity": "sha1-srmwFk+eF/o6nH2yME0KdRQMca0=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.0.7"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.0.7.tgz",
-          "integrity": "sha1-2JtPDkw+XlylQjWTFnXglP4aUHI=",
-          "dev": true
-        }
       }
     },
     "postcss": {
@@ -3730,12 +3627,6 @@
       "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
       "dev": true
     },
-    "qs": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
-      "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q=",
-      "dev": true
-    },
     "query-string": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
@@ -4035,15 +3926,6 @@
       "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
       "dev": true
     },
-    "sentence-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz",
-      "integrity": "sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=",
-      "dev": true,
-      "requires": {
-        "lower-case": "1.1.4"
-      }
-    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -4074,26 +3956,11 @@
       "integrity": "sha1-kEktcv/MgVmXa6umL7D2iE8MM3g=",
       "dev": true
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
-    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
-    },
-    "snake-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz",
-      "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
-      "dev": true,
-      "requires": {
-        "sentence-case": "1.1.3"
-      }
     },
     "socket.io": {
       "version": "1.7.4",
@@ -4369,16 +4236,6 @@
         "whet.extend": "0.9.9"
       }
     },
-    "swap-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
-      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
-      "dev": true,
-      "requires": {
-        "lower-case": "1.1.4",
-        "upper-case": "1.1.3"
-      }
-    },
     "tapable": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
@@ -4399,16 +4256,6 @@
       "requires": {
         "global": "4.3.2",
         "setimmediate": "1.0.5"
-      }
-    },
-    "title-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz",
-      "integrity": "sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=",
-      "dev": true,
-      "requires": {
-        "sentence-case": "1.1.3",
-        "upper-case": "1.1.3"
       }
     },
     "tmp": {
@@ -4460,41 +4307,6 @@
         "mime-types": "2.1.16"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "uglify-js": {
-      "version": "2.4.24",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-      "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
-      "dev": true,
-      "requires": {
-        "async": "0.2.10",
-        "source-map": "0.1.34",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.5.4"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.1.34",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-          "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
-      }
-    },
     "uglify-to-browserify": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
@@ -4506,16 +4318,6 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
       "dev": true
-    },
-    "union": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/union/-/union-0.3.8.tgz",
-      "integrity": "sha1-JqcCpNNSi0NYyXEcir/2zJHSQlc=",
-      "dev": true,
-      "requires": {
-        "pkginfo": "0.2.3",
-        "qs": "0.5.6"
-      }
     },
     "uniq": {
       "version": "1.0.1",
@@ -4550,15 +4352,6 @@
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
-    "upper-case-first": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
-      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-      "dev": true,
-      "requires": {
-        "upper-case": "1.1.3"
-      }
-    },
     "url": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -4576,6 +4369,12 @@
           "dev": true
         }
       }
+    },
+    "url-join": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.2.tgz",
+      "integrity": "sha1-wHJ1aWetJLi1nldBVRyqx49QuLc=",
+      "dev": true
     },
     "url-loader": {
       "version": "0.5.9",
@@ -4860,6 +4659,12 @@
       "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
       "dev": true
     },
+    "xml-char-classes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
+      "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0=",
+      "dev": true
+    },
     "xmlbuilder": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
@@ -4877,26 +4682,6 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
-    },
-    "yargs": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-      "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
-      "dev": true,
-      "requires": {
-        "camelcase": "1.2.1",
-        "decamelize": "1.2.0",
-        "window-size": "0.1.0",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        }
-      }
     },
     "yeast": {
       "version": "0.1.2",

--- a/src/dashboard/frontend/appraisal-tab/package.json
+++ b/src/dashboard/frontend/appraisal-tab/package.json
@@ -11,7 +11,7 @@
     "babel-preset-es2015": "^6.3.13",
     "css-loader": "^0.23.1",
     "file-loader": "^0.8.5",
-    "http-server": "^0.6.1",
+    "http-server": "^0.10.0",
     "jasmine-core": "^2.4.1",
     "json-loader": "^0.5.4",
     "karma": "~0.13",
@@ -19,11 +19,11 @@
     "karma-jasmine": "^0.3.6",
     "karma-junit-reporter": "^0.2.2",
     "karma-webpack": "^1.7.0",
-    "ng-cache-loader": "0.0.15",
+    "ng-cache-loader": "^0.0.26",
     "shelljs": "^0.2.6",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
-    "webpack": "^1.12.9"
+    "webpack": "^1.15.0"
   },
   "scripts": {
     "prepublish": "webpack --progress --colors --entry ./app.js",

--- a/src/dashboard/frontend/transfer-browser/package-lock.json
+++ b/src/dashboard/frontend/transfer-browser/package-lock.json
@@ -987,16 +987,6 @@
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
     },
-    "camel-case": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
-      "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
-      "dev": true,
-      "requires": {
-        "sentence-case": "1.1.3",
-        "upper-case": "1.1.3"
-      }
-    },
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -1044,30 +1034,6 @@
         "supports-color": "2.0.0"
       }
     },
-    "change-case": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
-      "integrity": "sha1-LE/ePwY7tB0AzWjg1aCdthy+iU8=",
-      "dev": true,
-      "requires": {
-        "camel-case": "1.2.2",
-        "constant-case": "1.1.2",
-        "dot-case": "1.1.2",
-        "is-lower-case": "1.1.3",
-        "is-upper-case": "1.1.2",
-        "lower-case": "1.1.4",
-        "lower-case-first": "1.0.2",
-        "param-case": "1.1.2",
-        "pascal-case": "1.1.2",
-        "path-case": "1.1.2",
-        "sentence-case": "1.1.3",
-        "snake-case": "1.1.2",
-        "swap-case": "1.1.2",
-        "title-case": "1.1.2",
-        "upper-case": "1.1.3",
-        "upper-case-first": "1.1.2"
-      }
-    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -1091,59 +1057,6 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3"
-      }
-    },
-    "clean-css": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.1.9.tgz",
-      "integrity": "sha1-29BaFIvklDuzfOBnnmdsvJ9YAmY=",
-      "dev": true,
-      "requires": {
-        "commander": "2.6.0",
-        "source-map": "0.1.43"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
-      }
-    },
-    "cli": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
-      "integrity": "sha1-Aq1Eo4Cr8nraxebwzdewQ9dMU+M=",
-      "dev": true,
-      "requires": {
-        "exit": "0.1.2",
-        "glob": "3.2.11"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
-          }
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.2.4",
-            "sigmund": "1.0.1"
-          }
-        }
       }
     },
     "cliui": {
@@ -1232,12 +1145,6 @@
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
-    "commander": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-      "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
-      "dev": true
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1268,43 +1175,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "concat-stream": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
-      "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14",
-        "typedarray": "0.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "connect": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.3.tgz",
@@ -1324,16 +1194,6 @@
       "dev": true,
       "requires": {
         "date-now": "0.1.4"
-      }
-    },
-    "constant-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
-      "integrity": "sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=",
-      "dev": true,
-      "requires": {
-        "snake-case": "1.1.2",
-        "upper-case": "1.1.3"
       }
     },
     "constants-browserify": {
@@ -1370,6 +1230,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
       "dev": true
     },
     "crypto-browserify": {
@@ -1561,37 +1427,6 @@
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
       "dev": true
     },
-    "dot-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz",
-      "integrity": "sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=",
-      "dev": true,
-      "requires": {
-        "sentence-case": "1.1.3"
-      }
-    },
-    "ecstatic": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-0.4.13.tgz",
-      "integrity": "sha1-nLbq/+IRuchO+z9VPN4sMAJxeyk=",
-      "dev": true,
-      "requires": {
-        "ent": "0.0.7",
-        "mime": "1.2.11",
-        "optimist": "0.3.7"
-      },
-      "dependencies": {
-        "optimist": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-          "dev": true,
-          "requires": {
-            "wordwrap": "0.0.3"
-          }
-        }
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1733,12 +1568,6 @@
         }
       }
     },
-    "ent": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-0.0.7.tgz",
-      "integrity": "sha1-g11Of556jUkhxpLpAQ7JdtpemUk=",
-      "dev": true
-    },
     "errno": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
@@ -1782,12 +1611,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "dev": true
-    },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expand-braces": {
@@ -2089,6 +1912,12 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -2104,20 +1933,6 @@
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
       "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
       "dev": true
-    },
-    "html-minifier": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.7.2.tgz",
-      "integrity": "sha1-K3lZsQUaSB5xzXxuWaZCcq+JXP0=",
-      "dev": true,
-      "requires": {
-        "change-case": "2.3.1",
-        "clean-css": "3.1.9",
-        "cli": "0.6.6",
-        "concat-stream": "1.4.10",
-        "relateurl": "0.2.7",
-        "uglify-js": "2.4.24"
-      }
     },
     "http-errors": {
       "version": "1.6.2",
@@ -2142,24 +1957,100 @@
       }
     },
     "http-server": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.6.1.tgz",
-      "integrity": "sha1-BvzmXPK9QTKleL2sYv+suX1hOYE=",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.10.0.tgz",
+      "integrity": "sha1-sqRGsWqduH7TxiK6m+sbCFsSNKc=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "ecstatic": "0.4.13",
-        "opener": "1.3.0",
-        "optimist": "0.5.2",
-        "portfinder": "0.2.1",
-        "union": "0.3.8"
+        "colors": "1.0.3",
+        "corser": "2.0.1",
+        "ecstatic": "2.2.1",
+        "http-proxy": "1.16.2",
+        "opener": "1.4.3",
+        "optimist": "0.6.1",
+        "portfinder": "1.0.13",
+        "union": "0.4.6"
       },
       "dependencies": {
-        "colors": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
+        "ecstatic": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-2.2.1.tgz",
+          "integrity": "sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ==",
+          "dev": true,
+          "requires": {
+            "he": "1.1.1",
+            "mime": "1.2.11",
+            "minimist": "1.2.0",
+            "url-join": "2.0.2"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "opener": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+          "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+          "dev": true
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+              "dev": true
+            }
+          }
+        },
+        "portfinder": {
+          "version": "1.0.13",
+          "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+          "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "debug": "2.6.8",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "qs": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
+          "dev": true
+        },
+        "union": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
+          "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
+          "dev": true,
+          "requires": {
+            "qs": "2.3.3"
+          }
         }
       }
     },
@@ -2317,15 +2208,6 @@
         "is-extglob": "1.0.0"
       }
     },
-    "is-lower-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
-      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
-      "dev": true,
-      "requires": {
-        "lower-case": "1.1.4"
-      }
-    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -2360,15 +2242,6 @@
       "dev": true,
       "requires": {
         "html-comment-regex": "1.1.1"
-      }
-    },
-    "is-upper-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
-      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
-      "dev": true,
-      "requires": {
-        "upper-case": "1.1.3"
       }
     },
     "isarray": {
@@ -2692,15 +2565,6 @@
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
-    "lower-case-first": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
-      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
-      "dev": true,
-      "requires": {
-        "lower-case": "1.1.4"
-      }
-    },
     "lru-cache": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
@@ -2816,6 +2680,15 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "ncname": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+      "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
+      "dev": true,
+      "requires": {
+        "xml-char-classes": "1.0.0"
+      }
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -2823,15 +2696,105 @@
       "dev": true
     },
     "ng-cache-loader": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/ng-cache-loader/-/ng-cache-loader-0.0.15.tgz",
-      "integrity": "sha1-XyFNn8YbPa9lET/UoccOfD0hE7Q=",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/ng-cache-loader/-/ng-cache-loader-0.0.26.tgz",
+      "integrity": "sha512-CQCTCjn6b5jFTEOa+AjJpmYOweWEdYvSg28kMIMd5SfuHMPQu/NwsD7Ua7ZPriVsdHpdoWiAFpoQlJYLzjXejQ==",
       "dev": true,
       "requires": {
         "extend": "3.0.1",
         "fastparse": "1.1.1",
-        "html-minifier": "0.7.2",
-        "loader-utils": "0.2.17"
+        "html-minifier": "3.5.7",
+        "loader-utils": "1.1.0"
+      },
+      "dependencies": {
+        "camel-case": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+          "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+          "dev": true,
+          "requires": {
+            "no-case": "2.3.2",
+            "upper-case": "1.1.3"
+          }
+        },
+        "clean-css": {
+          "version": "4.1.9",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
+          "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.6"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
+        "html-minifier": {
+          "version": "3.5.7",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.7.tgz",
+          "integrity": "sha512-GISXn6oKDo7+gVpKOgZJTbHMCUI2TSGfpg/8jgencWhWJsvEmsvp3M8emX7QocsXsYznWloLib3OeSfeyb/ewg==",
+          "dev": true,
+          "requires": {
+            "camel-case": "3.0.0",
+            "clean-css": "4.1.9",
+            "commander": "2.12.2",
+            "he": "1.1.1",
+            "ncname": "1.0.0",
+            "param-case": "2.1.1",
+            "relateurl": "0.2.7",
+            "uglify-js": "3.2.2"
+          }
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
+        "param-case": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+          "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+          "dev": true,
+          "requires": {
+            "no-case": "2.3.2"
+          }
+        },
+        "uglify-js": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.2.tgz",
+          "integrity": "sha512-++1NO/zZIEdWf6cDIGceSJQPX31SqIpbVAHwFG5+240MtZqPG/NIPoinj8zlXQtAfMBqEt1Jyv2FiLP3n9gVhQ==",
+          "dev": true,
+          "requires": {
+            "commander": "2.12.2",
+            "source-map": "0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "requires": {
+        "lower-case": "1.1.4"
       }
     },
     "node-libs-browser": {
@@ -2958,21 +2921,6 @@
         "wrappy": "1.0.2"
       }
     },
-    "opener": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.3.0.tgz",
-      "integrity": "sha1-EwumYiE/qELttM0DYdMaFTAaQ+I=",
-      "dev": true
-    },
-    "optimist": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.5.2.tgz",
-      "integrity": "sha1-hcjBRUszFeSniUfoV7HfAzRQv7w=",
-      "dev": true,
-      "requires": {
-        "wordwrap": "0.0.3"
-      }
-    },
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
@@ -3002,15 +2950,6 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
-    },
-    "param-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
-      "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
-      "dev": true,
-      "requires": {
-        "sentence-case": "1.1.3"
-      }
     },
     "parse-glob": {
       "version": "3.0.4",
@@ -3057,30 +2996,11 @@
       "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
       "dev": true
     },
-    "pascal-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz",
-      "integrity": "sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=",
-      "dev": true,
-      "requires": {
-        "camel-case": "1.2.2",
-        "upper-case-first": "1.1.2"
-      }
-    },
     "path-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
-    },
-    "path-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz",
-      "integrity": "sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=",
-      "dev": true,
-      "requires": {
-        "sentence-case": "1.1.3"
-      }
     },
     "path-exists": {
       "version": "2.1.0",
@@ -3125,29 +3045,6 @@
       "dev": true,
       "requires": {
         "find-up": "1.1.2"
-      }
-    },
-    "pkginfo": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
-      "integrity": "sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg=",
-      "dev": true
-    },
-    "portfinder": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-0.2.1.tgz",
-      "integrity": "sha1-srmwFk+eF/o6nH2yME0KdRQMca0=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.0.7"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.0.7.tgz",
-          "integrity": "sha1-2JtPDkw+XlylQjWTFnXglP4aUHI=",
-          "dev": true
-        }
       }
     },
     "postcss": {
@@ -3780,12 +3677,6 @@
       "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
       "dev": true
     },
-    "qs": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
-      "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q=",
-      "dev": true
-    },
     "query-string": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
@@ -4092,15 +3983,6 @@
       "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
       "dev": true
     },
-    "sentence-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz",
-      "integrity": "sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=",
-      "dev": true,
-      "requires": {
-        "lower-case": "1.1.4"
-      }
-    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -4131,26 +4013,11 @@
       "integrity": "sha1-kEktcv/MgVmXa6umL7D2iE8MM3g=",
       "dev": true
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
-    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
-    },
-    "snake-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz",
-      "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
-      "dev": true,
-      "requires": {
-        "sentence-case": "1.1.3"
-      }
     },
     "socket.io": {
       "version": "1.7.4",
@@ -4426,16 +4293,6 @@
         "whet.extend": "0.9.9"
       }
     },
-    "swap-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
-      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
-      "dev": true,
-      "requires": {
-        "lower-case": "1.1.4",
-        "upper-case": "1.1.3"
-      }
-    },
     "tapable": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
@@ -4456,16 +4313,6 @@
       "requires": {
         "global": "4.3.2",
         "setimmediate": "1.0.5"
-      }
-    },
-    "title-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz",
-      "integrity": "sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=",
-      "dev": true,
-      "requires": {
-        "sentence-case": "1.1.3",
-        "upper-case": "1.1.3"
       }
     },
     "tmp": {
@@ -4517,41 +4364,6 @@
         "mime-types": "2.1.16"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "uglify-js": {
-      "version": "2.4.24",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-      "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
-      "dev": true,
-      "requires": {
-        "async": "0.2.10",
-        "source-map": "0.1.34",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.5.4"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.1.34",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-          "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
-      }
-    },
     "uglify-to-browserify": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
@@ -4563,16 +4375,6 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
       "dev": true
-    },
-    "union": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/union/-/union-0.3.8.tgz",
-      "integrity": "sha1-JqcCpNNSi0NYyXEcir/2zJHSQlc=",
-      "dev": true,
-      "requires": {
-        "pkginfo": "0.2.3",
-        "qs": "0.5.6"
-      }
     },
     "uniq": {
       "version": "1.0.1",
@@ -4607,15 +4409,6 @@
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
-    "upper-case-first": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
-      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-      "dev": true,
-      "requires": {
-        "upper-case": "1.1.3"
-      }
-    },
     "url": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -4633,6 +4426,12 @@
           "dev": true
         }
       }
+    },
+    "url-join": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.2.tgz",
+      "integrity": "sha1-wHJ1aWetJLi1nldBVRyqx49QuLc=",
+      "dev": true
     },
     "url-loader": {
       "version": "0.5.9",
@@ -4917,6 +4716,12 @@
       "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
       "dev": true
     },
+    "xml-char-classes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
+      "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0=",
+      "dev": true
+    },
     "xmlbuilder": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
@@ -4934,26 +4739,6 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
-    },
-    "yargs": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-      "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
-      "dev": true,
-      "requires": {
-        "camelcase": "1.2.1",
-        "decamelize": "1.2.0",
-        "window-size": "0.1.0",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        }
-      }
     },
     "yeast": {
       "version": "0.1.2",

--- a/src/dashboard/frontend/transfer-browser/package.json
+++ b/src/dashboard/frontend/transfer-browser/package.json
@@ -10,7 +10,7 @@
     "babel-preset-es2015": "^6.3.13",
     "css-loader": "^0.23.1",
     "file-loader": "^0.8.5",
-    "http-server": "^0.6.1",
+    "http-server": "^0.10.0",
     "imports-loader": "^0.6.5",
     "jasmine-core": "^2.4.1",
     "json-loader": "^0.5.4",
@@ -19,11 +19,11 @@
     "karma-jasmine": "^0.3.6",
     "karma-junit-reporter": "^0.2.2",
     "karma-webpack": "^1.7.0",
-    "ng-cache-loader": "0.0.15",
+    "ng-cache-loader": "^0.0.26",
     "shelljs": "^0.2.6",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
-    "webpack": "^1.12.9"
+    "webpack": "^1.15.0"
   },
   "scripts": {
     "prepublish": "webpack --progress --colors --entry ./app.js",


### PR DESCRIPTION
We haven't been able to keep up with the frequent updates seen in the dependencies of our transfer-browser and appraisal-tab projects. This pull request attempts to upgrade just those that addressed vulnerability issues. FWIW they're not even regular dependencies, they're just development dependencies.

In the future we should consider a massive upgrade of dependencies (most of them still backward-compatible) and also we should consider the idea of merging transfer-browser and appraisal-tabs into a single project - they're separate today because they were developed separately in two different git repos.