### PR TITLE
Update version to 1.7

### DIFF
--- a/src/dashboard/src/main/migrations/0047_version_number.py
+++ b/src/dashboard/src/main/migrations/0047_version_number.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def data_migration(apps, schema_editor):
+    Agent = apps.get_model('main', 'Agent')
+    Agent.objects \
+        .filter(identifiertype='preservation system', name='Archivematica') \
+        .update(identifiervalue='Archivematica-1.7')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0046_optional_normative_structmap'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration)
+    ]


### PR DESCRIPTION
This is in addition to 1f9adf8fae46211459fe910b81e6c18e18ad853b.

Not including the `PATCH` component because we don't include database migrations in patch releases. Once we move it out of the database (#657) we can fix that.

This migration is important for users already running AM16. The agent is published during the installation process but users upgrading to AM17 shouldn't be running that step so we need to bump the version manually from the migration.