### PR TITLE
Makes the Tree Control configuration consistent

### DIFF
--- a/src/dashboard/frontend/appraisal-tab/app/front_page/content.html
+++ b/src/dashboard/frontend/appraisal-tab/app/front_page/content.html
@@ -241,7 +241,7 @@
     </div>
     <div class="transfer-tree panel-body">
       <treecontrol id="archivesspace-tree"
-             class="tree-light"
+             class="tree-classic"
              tree-model="data"
              options="options"
              selected-node="selected"


### PR DESCRIPTION
Following analysis of the issue it seems that one of our configuration options for the tree control that we use inside the appraisal tab was modified and so didn't show the default icons that were anticipated. This regression has been fixed with this pull-request. Documented in #760. 

Before merging @kellyannewithane and myself will check that the behaviour is consistent in an AM VM that @mamedin will configure in the morning. 

**N.B.** Because of the regression we should take a look at the functionality of the tree component in a bit more detail too to ensure we're interacting with it as expected.