### PR TITLE
Fix Handle config form bug

### DIFF
--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -366,7 +366,8 @@ def handle_config(request):
     else:
         settings_dict = models.DashboardSetting.objects.get_dict('handle')
         settings_dict['pid_request_verify_certs'] = {
-            'False': False}.get(settings_dict['pid_request_verify_certs'], True)
+            'False': False}.get(
+                settings_dict.get('pid_request_verify_certs', True), True)
         form = HandleForm(initial=settings_dict)
     return render(request, 'administration/handle_config.html', {'form': form})
 


### PR DESCRIPTION
Before rendering the Handle config form in the dashboard, the view used to expect a ``'pid_request_verify_certs'`` key in ``settings_dict``. However, this key will not be present if the form has never been saved and a ``KeyError`` will be raised. This change sets the default for this key to ``True``.

Should be cherry-picked to stable/1.7.x after merge.

Fixes https://github.com/artefactual/archivematica/issues/854