### PR TITLE
Backlog Tab: Ensure the dashboard backlog table reinitializes

### DIFF
--- a/src/dashboard/src/media/js/backlog/backlog-search.js
+++ b/src/dashboard/src/media/js/backlog/backlog-search.js
@@ -74,9 +74,20 @@ $(document).ready(function()
     var dtable = get_datatable();
 
     function refresh_search_results() {
-      $('#backlog-entries thead').empty();
+
+      // If we have a datatable destroy its layout.
       dtable.fnDestroy();
+
+      // JQuery makes sure that the HTML element itself is emptied. The
+      // datatable library will raise an error if the number of columns it
+      // expects to find differs. This can happen, if like we're doing, when
+      // changing the layout of the tables we want to display.
+      $('#backlog-entries').empty();
+
+      // Return the correct datatable based on whether the user has selected
+      // to see the transfer backlog only, or file list.
       dtable = get_datatable();
+
     }
 
     $('#id_show_files').change(function() {


### PR DESCRIPTION
This change makes sure that the datatable we're using to display both transfer backlog information, and information about the files in those transfers, depending on what the user has selected, will refresh completely and without raising a JavaScript error as noted in issue #855.