### PR TITLE
Add some minor fixes to the `capture_output` kwarg

### DIFF
--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -51,7 +51,7 @@ def launchSubProcess(command, stdIn="", printing=True, arguments=[],
                 if ``command`` is a string.
     env_updates: Dict of changes to apply to the started process' environment.
     capture_output: Whether or not to capture output from the subprocess.
-                    Defaults to `True`.
+                    Defaults to `False`.
     """
     stdError = ""
     stdOut = ""

--- a/src/archivematicaCommon/tests/test_execute_functions.py
+++ b/src/archivematicaCommon/tests/test_execute_functions.py
@@ -9,10 +9,17 @@ def test_capture_output():
     # Test that stdout and stderr are not captured by default
     ret, std_out, std_err = execsub.launchSubProcess(['ls', '/tmp'])
     assert std_out is ''
-    assert std_err is''
+    assert std_err is ''
 
     # Test that stdout and stderr are captured when `capture_output` is
     # enabled.
     ret, std_out, std_err = execsub.launchSubProcess(
         ['ls', '/tmp'], capture_output=True)
     assert std_out is not '' or std_err is not ''
+
+    # Test that stdout and stderr are not captured when `capture_output` is
+    # not enabled.
+    ret, std_out, std_err = execsub.launchSubProcess(
+        ['ls', '/tmp'], capture_output=False)
+    assert std_out is ''
+    assert std_err is ''


### PR DESCRIPTION
This brings in the minor changes to https://github.com/JiscRDSS/archivematica/pull/42 that helenst recommended: correcting a docstring and adding test coverage.

Fixes https://github.com/artefactual/archivematica/issues/816