### PR TITLE
Appraisal Tab: Reverts a 1.6.x Tree Regression

### DIFF
--- a/src/dashboard/frontend/appraisal-tab/app/app.js
+++ b/src/dashboard/frontend/appraisal-tab/app/app.js
@@ -1,5 +1,6 @@
 // Styles
 import './app.css';
+import 'font-awesome/css/font-awesome.min.css';
 import './vendor/angular-tree-control/css/tree-control.css';
 import './vendor/angular-tree-control/css/tree-control-attribute.css';
 

--- a/src/dashboard/frontend/appraisal-tab/app/front_page/content.html
+++ b/src/dashboard/frontend/appraisal-tab/app/front_page/content.html
@@ -241,7 +241,7 @@
     </div>
     <div class="transfer-tree panel-body">
       <treecontrol id="archivesspace-tree"
-             class="tree-classic"
+             class="tree-light"
              tree-model="data"
              options="options"
              selected-node="selected"

--- a/src/dashboard/frontend/appraisal-tab/package-lock.json
+++ b/src/dashboard/frontend/appraisal-tab/package-lock.json
@@ -1720,6 +1720,11 @@
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/src/dashboard/frontend/appraisal-tab/package.json
+++ b/src/dashboard/frontend/appraisal-tab/package.json
@@ -44,6 +44,7 @@
     "archivematica-browse-helpers": "git+https://github.com/artefactual-labs/archivematica-browse-helpers.git",
     "base64-helpers": "git+https://github.com/artefactual-labs/base64-helpers.git",
     "d3": "^3.5.12",
+    "font-awesome": "^4.3.0",
     "lodash": "^4.5.1",
     "moment": "^2.15.1",
     "restangular": "^1.3.1"


### PR DESCRIPTION
* Fixes a regression in the ArchivesSpace appraisal tab tree navigation.
* Adds Fontawesome back to the code dependencies.
* Sets Tree Control back to 'tree-light' futurist mode as was previously used.
* Resolves #760