### PR TITLE
Add MediaConch install to MCPClient.Dockerfile

### DIFF
--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -40,6 +40,8 @@ RUN set -ex \
 		inkscape \
 		jhove \
 		libimage-exiftool-perl \
+		libevent-dev \
+		libjansson4 \
 		libxml2-utils \
 		md5deep \
 		mediainfo \
@@ -76,6 +78,18 @@ RUN set -ex \
 		libxslt-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
+# OS dependencies from .deb files
+RUN set -ex \
+	&& curl https://mediaarea.net/download/binary/libzen0/0.4.34/libzen0_0.4.34-1_amd64.xUbuntu_14.04.deb --output libzen0_0.4.34-1_amd64.xUbuntu_14.04.deb \
+	&& curl https://mediaarea.net/download/binary/libmediainfo0/0.7.91/libmediainfo0_0.7.91-1_amd64.xUbuntu_14.04.deb --output libmediainfo0_0.7.91-1_amd64.xUbuntu_14.04.deb \
+	&& curl https://mediaarea.net/download/binary/mediaconch/16.12/mediaconch_16.12-1_amd64.xUbuntu_14.04.deb --output mediaconch_16.12-1_amd64.xUbuntu_14.04.deb \
+	&& dpkg -i libzen0_0.4.34-1_amd64.xUbuntu_14.04.deb \
+	&& dpkg -i libmediainfo0_0.7.91-1_amd64.xUbuntu_14.04.deb \
+	&& dpkg -i mediaconch_16.12-1_amd64.xUbuntu_14.04.deb \
+	&& rm libzen0_0.4.34-1_amd64.xUbuntu_14.04.deb \
+	&& rm libmediainfo0_0.7.91-1_amd64.xUbuntu_14.04.deb \
+	&& rm mediaconch_16.12-1_amd64.xUbuntu_14.04.deb
+
 COPY archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/
 COPY dashboard/src/requirements/ /src/dashboard/src/requirements/
 COPY MCPClient/requirements/ /src/MCPClient/requirements/
@@ -92,7 +106,7 @@ COPY archivematicaCommon/lib/externals/fido/archivematica_format_extensions.xml 
 
 RUN set -ex \
 	&& groupadd --gid 333 --system archivematica \
-	&& useradd --uid 333 --gid 333 --system archivematica
+	&& useradd -m --uid 333 --gid 333 --system archivematica
 
 USER archivematica
 


### PR DESCRIPTION
This commit adds a Docker `Run` command to download the .deb files to install MediaConch v. 16.12 and then install it using dpkg.

Fixes #882