### PR TITLE
Auto-select DIP upload configuration, refs #11213

### DIFF
--- a/src/MCPServer/lib/linkTaskManagerReplacementDicFromChoice.py
+++ b/src/MCPServer/lib/linkTaskManagerReplacementDicFromChoice.py
@@ -68,7 +68,11 @@ class linkTaskManagerReplacementDicFromChoice(LinkTaskManager):
             args = DashboardSetting.objects.get_dict(stc.execute)
             if args:
                 args = {'%{}%'.format(key): value for key, value in args.items()}
-                self.choices.append((len(self.choices), stc.execute, str(args)))
+                self.jobChainLink.setExitMessage(Job.STATUS_COMPLETED_SUCCESSFULLY)
+                rd = ReplacementDict(args)
+                self.update_passvar_replacement_dict(rd)
+                self.jobChainLink.linkProcessingComplete(0, passVar=self.jobChainLink.passVar)
+                return
 
         preConfiguredChain = self.checkForPreconfiguredXML()
         if preConfiguredChain is not None:

--- a/src/dashboard/src/main/migrations/0032_dashboardsetting_scope.py
+++ b/src/dashboard/src/main/migrations/0032_dashboardsetting_scope.py
@@ -92,6 +92,8 @@ def data_migration_atom_restore_std(apps, schema_editor):
     MicroServiceChainLinkExitCode.objects.create(
         id=uuids[2],
         microservicechainlink=new_mscl,
+        exitcode=0,
+        exitmessage=Job.STATUS_COMPLETED_SUCCESSFULLY,
         nextmicroservicechainlink_id='651236d2-d77f-4ca7-bfe9-6332e96608ff',
     )
 


### PR DESCRIPTION
If pulling replacement dict data from dashboard settings, automatically advance
to the next link rather than requiring the user to manually select the config.