### PR TITLE
Fix typo "perservation"

### DIFF
--- a/src/MCPClient/lib/clientScripts/validateFile.py
+++ b/src/MCPClient/lib/clientScripts/validateFile.py
@@ -219,7 +219,7 @@ class Validator(object):
 
     def _not_derivative_msg(self):
         """Return the message to print if the file is not a derivative."""
-        if self.file_type == 'perservation':
+        if self.file_type == 'preservation':
             return 'is not a preservation derivative'
         return 'is not an access derivative'
 


### PR DESCRIPTION
Fixing the above typo fixes the erroneous stdout message printed by validateFile when an original is not validated during preservation derivation: "File is not an access derivative; not validating".

Fixes #888.