### PR TITLE
Unzipped Bag: Restructure doesn't move processingMCP

### DIFF
--- a/src/MCPClient/lib/clientScripts/verifyAndRestructureTransferBag.py
+++ b/src/MCPClient/lib/clientScripts/verifyAndRestructureTransferBag.py
@@ -99,9 +99,12 @@ def restructureBagForComplianceFileUUIDsAssigned(unitPath, unitIdentifier, unitI
         if os.path.isfile(src):
             if item.startswith("manifest"):
                 dst = os.path.join(unitPath, "metadata", item)
+                fileOperations.updateFileLocation2(src, dst, unitPath, unitIdentifier, unitIdentifierType, unitPathReplaceWith)
+            elif item in OPTIONAL_FILES:
+                print "not moving:", item
             else:
                 dst = os.path.join(bagFileDefaultDest, item)
-            fileOperations.updateFileLocation2(src, dst, unitPath, unitIdentifier, unitIdentifierType, unitPathReplaceWith)
+                fileOperations.updateFileLocation2(src, dst, unitPath, unitIdentifier, unitIdentifierType, unitPathReplaceWith)
     for item in os.listdir(unitDataPath):
         itemPath =  os.path.join(unitDataPath, item)
         if os.path.isdir(itemPath) and item not in REQUIRED_DIRECTORIES:


### PR DESCRIPTION
When verifying and restructuring a bag, do not move OPTIONAL_FILES
(currently just processingMCP).

This is a cherry pick of commit [24f5f6](https://github.com/artefactual/archivematica/commit/24f5f6263d6fea28211cdc87c66dff2fc2b659b5#diff-297009910c86453cc7053bc52c6f97ca) from branch stable/1.7.x to qa/1.5.x-moma branch. This fixes a problem of the processingMCP.xml file added by automation tools to unzipped bags being not used for ingesting.