### PR TITLE
Fix fetch LoD from AtoM

### DIFF
--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -39,7 +39,7 @@ urlpatterns = [
     url(r'^ingest/copy_metadata_files/$', views.copy_metadata_files_api),
 
     url(r'administration/dips/atom/levels/$', views.get_levels_of_description),
-    url(r'administration/dips/atom/fetch_levels/$', views.fetch_levels_of_description_from_atom),
+    url(r'administration/dips/atom/fetch_levels/$', views.fetch_levels_of_description_from_atom, name='fetch_atom_lods'),
     url(r'filesystem/metadata/$', views.path_metadata),
     url(r'processing-configuration/(?P<name>\w{1,16})', views.processing_configuration),
 ]

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -602,7 +602,6 @@ def copy_metadata_files_api(request):
 # TODO should this have auth?
 
 
-@_api_endpoint(expected_methods=['GET'])
 def get_levels_of_description(request):
     """
     Returns a JSON-encoded set of the configured levels of description.
@@ -617,7 +616,6 @@ def get_levels_of_description(request):
 # TODO should this have auth?
 
 
-@_api_endpoint(expected_methods=['GET'])
 def fetch_levels_of_description_from_atom(request):
     """
     Fetch all levels of description from an AtoM database, removing

--- a/src/dashboard/src/components/helpers.py
+++ b/src/dashboard/src/components/helpers.py
@@ -202,12 +202,12 @@ def get_atom_levels_of_description(clear=True):
     """
     settings = models.DashboardSetting.objects.get_dict('upload-qubit_v0.0')
 
-    url = settings('url', None)
+    url = settings.get('url')
     if not url:
         raise AtomError(_("AtoM URL not defined!"))
 
-    email = settings('email', None)
-    password = settings('password', None)
+    email = settings.get('email')
+    password = settings.get('password')
     if not email or not password:
         raise AtomError(_("AtoM authentication settings not defined!"))
     auth = (email, password)

--- a/src/dashboard/src/templates/administration/atom_levels_of_description.html
+++ b/src/dashboard/src/templates/administration/atom_levels_of_description.html
@@ -21,10 +21,8 @@
 
     <div class="col-md-10">
 
-      {% url 'components.api.views.fetch_levels_of_description_from_atom' as url_fetch_atom_levels_of_description %}
-
       <div style="float: right">
-        <a onClick="fetchAtomLevelsOfDescription('{{ url_fetch_atom_levels_of_description }}')" class="btn btn-default">{% trans "Fetch from AtoM" %}</a>
+        <a onClick="fetchAtomLevelsOfDescription('{% url 'fetch_atom_lods' %}')" class="btn btn-default">{% trans "Fetch from AtoM" %}</a>
       </div>
 
       <h3>{% trans "AtoM Levels of Description" %}</h3>
@@ -45,7 +43,7 @@
                 <td>
                   <a onClick="deleteLevel('{{ level.id }}')" href="#"><img src="{% static 'images/delete.png' %}" alt="{% trans 'Delete' %}" title="{% trans 'Delete' %}" /></a>
                   <a onClick="promoteLevel('{{ level.id }}')" href="#"><img src="{% static 'images/bullet_arrow_up.png' %}" alt="{% trans 'Promote' %}" title="{% trans 'Promote' %}" {% if level.sortorder == sortorder_min %}style="visibility: hidden"{% endif %}/></a>
-                  {% if level.sortorder != sortorder_max %}<a onClick="demoteLevel('{{ level.id }}')" href="#"><img src="{% static 'images/bullet_arrow_down.png' %} alt="{% trans 'Demote' %}" title="{% trans 'Demote' %}" /></a>{% endif %}
+                  {% if level.sortorder != sortorder_max %}<a onClick="demoteLevel('{{ level.id }}')" href="#"><img src="{% static 'images/bullet_arrow_down.png' %}" alt="{% trans 'Demote' %}" title="{% trans 'Demote' %}" /></a>{% endif %}
                 </td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
- Fix button URL, the reverse method was not obtaining the URL used
in the onClick function, naming the url fixes the issue.
- Fix dict access, use the get method to obtain the values from the dict,
which defaults to 'None'.
- Add missing double quotes in up arrow link.
- Remove auth from LoDs get and fetch endpoints, called from the
dashboard GUI to fetch and get the AtoM LoDs, but the auth. method
used in the API doesn't take in consideration the current user session,
only the API key.

Refs #866.