### PR TITLE
Dashboard: add rebuild-transfer-backlog

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -197,12 +197,20 @@ def wait_for_cluster_yellow_status(client, wait_between_tries=10, max_tries=10):
 
 
 def create_indexes_if_needed(client):
+    create_aips_index(client)
+    create_transfers_index(client)
+
+
+def create_aips_index(client):
     create_index(client, 'aips')
+    if not aip_mapping_is_correct(client):
+        raise ElasticsearchError('The AIP index mapping is incorrect. The "aips" index should be re-created.')
+
+
+def create_transfers_index(client):
     create_index(client, 'transfers')
     if not transfer_mapping_is_correct(client):
         raise ElasticsearchError('The transfer index mapping is incorrect. The "transfers" index should be re-created.')
-    if not aip_mapping_is_correct(client):
-        raise ElasticsearchError('The AIP index mapping is incorrect. The "aips" index should be re-created.')
 
 
 def search_all_results(client, body, index=None, doc_type=None, **query_params):

--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -446,3 +446,10 @@ def index_backlogged_transfer_contents(transfer_uuid, file_set):
     response = _storage_api_session().put(url, json=file_set)
     if 400 <= response.status_code < 500:
         raise BadRequest("Unable to add files to transfer: {}".format(response.text))
+
+
+def reindex_file(transfer_uuid):
+    url = _storage_service_url() + 'file/' + transfer_uuid + '/reindex/'
+    response = _storage_api_session().post(url)
+    response.raise_for_status()
+    return response.json()

--- a/src/dashboard/src/main/management/commands/__init__.py
+++ b/src/dashboard/src/main/management/commands/__init__.py
@@ -1,0 +1,23 @@
+from django.core.management.base import BaseCommand
+from django.utils.six.moves import input
+
+
+class DashboardCommand(BaseCommand):
+    def success(self, message):
+        self.stdout.write(self.style.MIGRATE_SUCCESS(message))
+
+    def error(self, message):
+        self.stdout.write(self.style.ERROR(message))
+
+    def warning(self, message):
+        self.stdout.write(self.style.WARNING(message))
+
+
+def boolean_input(question, default=None):
+    question += '\n\nType "yes" to continue, or "no" to cancel: '
+    result = input('%s ' % question)
+    if not result and default is not None:
+        return default
+    while len(result) < 1 or result.lower() not in ('yes', 'no'):
+        result = input('Please answer "yes" or "no": ')
+    return result.lower() == 'yes'

--- a/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
+++ b/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
@@ -1,0 +1,137 @@
+"""Recreate the ``transfers`` Elasticsearch index from the Transfer Backlog.
+
+This is useful if the Elasticsearch index has been deleted or damaged
+or during software upgrades where the document schema has changed.
+
+It also requests the Storage Service to reindex the transfers.
+
+This must be run on the same system that Archivematica is installed on, since
+it uses code from the Archivematica codebase.
+
+The one required parameter is the path to the directory where Transfer Backlog
+location is stored.
+
+Copied from https://git.io/vN6v6.
+"""
+
+import logging
+import os
+import sys
+import time
+
+from django.conf import settings as django_settings
+from django.core.management.base import CommandError
+
+import elasticSearchFunctions
+import storageService
+from main.management.commands import boolean_input, DashboardCommand
+from main.models import Transfer
+
+
+logger = logging.getLogger('archivematica.dashboard')
+
+
+class Command(DashboardCommand):
+    """Recreate the ``transfers`` Elasticsearch index from the Transfer Backlog."""
+
+    help = __doc__
+
+    DEFAULT_TRANSFER_BACKLOG_DIR = \
+        '/var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog'
+
+    CHECKSUM_TYPE = 'sha256'
+    CHECKSUM_UTIL = 'sha256sum'
+
+    def add_arguments(self, parser):
+        """Entry point to add custom arguments."""
+        parser.add_argument('--transfer-backlog-dir',
+                            default=self.DEFAULT_TRANSFER_BACKLOG_DIR)
+        parser.add_argument('--no-prompt', action='store_true')
+
+    def handle(self, *args, **options):
+        """Entry point of the rebuild_transfer_backlog command."""
+        if not self.confirm(options['no_prompt']):
+            sys.exit(0)
+
+        transfer_backlog_dir = self.prepdir(options['transfer_backlog_dir'])
+        if not os.path.exists(transfer_backlog_dir):
+            raise CommandError('Directory does not exist: %s',
+                               transfer_backlog_dir)
+        self.success('Rebuilding "transfers" index from {}.'.format(
+            transfer_backlog_dir))
+
+        # Connect to Elasticsearch.
+        elasticSearchFunctions.setup_reading_from_conf(django_settings)
+        es_client = elasticSearchFunctions.get_client()
+        try:
+            es_info = es_client.info()
+        except Exception as err:
+            raise CommandError("Unable to connect to Elasticsearch: %s" % err)
+        else:
+            self.success('Connected to Elasticsearch node {} (v{}).'.format(
+                es_info['name'], es_info['version']['number']))
+
+        self.delete_index(es_client)
+        self.create_index(es_client)
+        self.populate_index(es_client, transfer_backlog_dir)
+        self.success('Indexing complete!')
+
+    def confirm(self, no_prompt):
+        """Ask user to confirm the operation."""
+        if no_prompt:
+            return True
+        self.warning('WARNING: This script will delete your current'
+                     ' Elasticsearch transfer data, rebuilding it using'
+                     ' files.')
+        return boolean_input('Are you sure you want to continue?')
+
+    def prepdir(self, path):
+        """Append ''originals'' to the path if it's missing."""
+        tail = os.path.basename(os.path.normpath(path))
+        suffix = 'originals'
+        if tail != suffix:
+            return os.path.join(path, suffix)
+
+    def delete_index(self, es_client):
+        """Delete search index."""
+        self.stdout.write('Deleting all transfers in the "transfers" index...')
+        time.sleep(3)  # Time for the user to panic and kill the process.
+        es_client.indices.delete('transfers', ignore=404)
+
+    def create_index(self, es_client):
+        """Create search index."""
+        self.stdout.write('Creating index...')
+        elasticSearchFunctions.create_transfers_index(es_client)
+
+    def populate_index(self, es_client, transfer_backlog_dir):
+        """Populate search index."""
+        for directory in os.listdir(transfer_backlog_dir):
+            if directory == '.gitignore':
+                continue
+
+            transfer_uuid = directory[-36:]
+            transfer_dir = os.path.basename(directory)
+
+            try:
+                Transfer.objects.get(uuid=transfer_uuid)
+            except Transfer.DoesNotExist:
+                self.warning(
+                    'Skipping transfer {}: not found!'.format(transfer_uuid))
+                continue
+
+            self.stdout.write('Indexing {} ({})'.format(
+                transfer_uuid, transfer_dir))
+
+            self.index_files(es_client,
+                             os.path.join(transfer_backlog_dir, directory),
+                             transfer_uuid)
+            storageService.reindex_file(transfer_uuid)
+
+    def index_files(self, es_client, transfer_path, transfer_uuid):
+        transfer_path = elasticSearchFunctions.index_files(
+            es_client,
+            'transfers',
+            'transferfile',
+            transfer_uuid,
+            os.path.join(transfer_path, ''),  # Expected by index_files().
+            status='backlog')


### PR DESCRIPTION
[`rebuild-transfer-backlog`](https://github.com/artefactual/archivematica-devtools/blob/master/tools/rebuild-transfer-backlog) used to belong to archivematica-devtools. This
pull request implements it as a Dashboard management command for the
following reasons:

- Its implementation does not make use of formal APIs.
- It was designed to run in the environment where Archivematica was installed.
- The command MUST be used during AM upgrades, i.e.: devtools is for devs?

The installation docs will need to be upgraded accordingly.

In [Compose](https://github.com/artefactual-labs/am/tree/master/compose), you can run the command as follows:

    $ docker-compose run \
          --no-deps --rm \
          --entrypoint /src/dashboard/src/manage.py \
              archivematica-dashboard \
                  rebuild_transfer_backlog --no-prompt

Or in a running container:

    $ docker-compose exec archivematica-dashboard /src/dashboard/src/manage.py rebuild_transfer_backlog

You can pass an argument `--transfer-backlog-dir`. If missing, `/var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog` will be used.

You should see something like the following:

```
Rebuilding "transfers" index from /var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog/originals.
Connected to Elasticsearch node TestNode (v1.7.6).
Deleting all transfers in the "transfers" index...
Creating index...
Indexing 0bbdb151-167c-4c81-ab5b-12014cbafe7b (Prueba001-0bbdb151-167c-4c81-ab5b-12014cbafe7b)
Skipping indexing Prueba001-0bbdb151-167c-4c81-ab5b-12014cbafe7b/processingMCP.xml
Indexing Prueba001-0bbdb151-167c-4c81-ab5b-12014cbafe7b/metadata/directory_tree.txt (UUID: )
Indexing Prueba001-0bbdb151-167c-4c81-ab5b-12014cbafe7b/metadata/submissionDocumentation/METS.xml (UUID: )
Indexing Prueba001-0bbdb151-167c-4c81-ab5b-12014cbafe7b/objects/go-outline (UUID: f9b6b334-7843-4ea2-b48d-9a9f17c1d1f7)
Indexing Prueba001-0bbdb151-167c-4c81-ab5b-12014cbafe7b/logs/fileFormatIdentification.log (UUID: )
Indexing Prueba001-0bbdb151-167c-4c81-ab5b-12014cbafe7b/logs/clamAVScan.txt (UUID: )
Indexing Prueba001-0bbdb151-167c-4c81-ab5b-12014cbafe7b/logs/filenameCleanup.log (UUID: )
Indexing Prueba001-0bbdb151-167c-4c81-ab5b-12014cbafe7b/logs/FileUUIDsError.log (UUID: )
transferfile UUID: 0bbdb151-167c-4c81-ab5b-12014cbafe7b
Files indexed: 7
Request tranfer reindex in Storage Service.
```


It fixes https://github.com/artefactual/archivematica-devtools/issues/52.
Related: https://github.com/artefactual/archivematica-devtools/issues/43.