### PR TITLE
Change 'None' to '' in default AtoM config

### DIFF
--- a/src/dashboard/src/main/migrations/0048_fix_upload_qubit_setting.py
+++ b/src/dashboard/src/main/migrations/0048_fix_upload_qubit_setting.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def data_migration(apps, schema_editor):
+    """Migration 0032 inadvertently set previously non-existent "Upload DIP to
+    AtoM" values to 'None'. This fixes that.
+    """
+    apps.get_model('main', 'DashboardSetting').objects.filter(
+        scope='upload-qubit_v0.0', value='None').update(value='')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0047_version_number'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration)
+    ]


### PR DESCRIPTION
Fixes migration 0032 so that when an AtoM setting has no value in the previous state of the database it will be set to the empty string instead of `str(None)`, i.e., 'None'.

Fixes #879.