### PR TITLE
Corrects negation of the PASS_BY_REFERENCE envvar

### DIFF
--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -151,11 +151,11 @@ This is the full list of environment strings supported:
     - **Type:** `string`
     - **Default:** `/var/run/clamav/clamd.ctl`
 
-- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_PASS_BY_REFERENCE`**:
-    - **Description:** configures the `clamdscanner` backend to pass files to clamd by reference. When disabled, the files are streamed which is useful when clamd does not have access to the filesystem where the file is stored.
-    - **Config file example:** `MCPClient.clamav_pass_by_reference`
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_PASS_BY_STREAM`**:
+    - **Description:** configures the `clamdscanner` backend to stream the file's contents to clamd. This is useful when clamd does not have access to the filesystem where the file is stored. When disabled, the files are read from the filesystem by reference.
+    - **Config file example:** `MCPClient.clamav_pass_by_stream`
     - **Type:** `boolean`
-    - **Default:** `false`
+    - **Default:** `true`
 
 - **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_TIMEOUT`**:
     - **Description:** configures the `clamdscanner` backend to stop waiting for a response after a given number of seconds.
@@ -170,16 +170,16 @@ This is the full list of environment strings supported:
     - **Default:** `clamdscanner`
 
 - **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_MAX_FILE_SIZE`**:
-    - **Description:** files larger than this limit won't be scanned. The unit used is megabyte (MB).
+    - **Description:** files larger than this limit will not be scanned. The unit used is megabyte (MB).
     - **Config file example:** `MCPClient.clamav_client_max_file_size`
     - **Type:** `float`
-    - **Default:** `42`
+    - **Default:** `2000`
 
 - **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_MAX_SCAN_SIZE`**:
     - **Description**: sets the maximum amount of data to be scanned for each input file. Files larger than this value will be scanned but only up to this limit. Archives and other containers are recursively extracted and scanned up to this value. The unit used is megabyte (MB).
     - **Config file example:** `MCPClient.clamav_client_max_scan_size`
     - **Type:** `float`
-    - **Default:** `42`
+    - **Default:** `2000`
 
 - **`ARCHIVEMATICA_MCPCLIENT_CLIENT_ENGINE`**
     - **Description:** a database setting. See [DATABASES](https://docs.djangoproject.com/en/1.8/ref/settings/#databases) for more details.

--- a/src/MCPClient/install/clientConfig.conf
+++ b/src/MCPClient/install/clientConfig.conf
@@ -15,11 +15,15 @@ disableElasticsearchIndexing = False
 temp_dir = /var/archivematica/sharedDirectory/tmp
 removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
 clamav_server = /var/run/clamav/clamd.ctl
-clamav_pass_by_reference = False
+clamav_pass_by_stream = True
+clamav_client_timeout = 86400
+clamav_client_backend =  clamdscanner ; available are clamscanner (via CLI) and clamdscanner
+clamav_max_file_size = 2000 ; Unit: MB
+clamav_max_scan_size = 2000 ; Unit: MB
+clamav_max_stream_length = 2000 ; Unit: MB
 storage_service_client_timeout = 86400
 agentarchives_client_timeout = 300
-clamav_client_timeout = 86400
-clamav_client_threshold = 20  ; Unit: MB
+
 
 [client]
 user = archivematica

--- a/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaClamscan.py
@@ -100,12 +100,12 @@ class ClamdScanner(ScannerBase):
     def __init__(self):
         self.addr = mcpclient_settings.CLAMAV_SERVER
         self.timeout = mcpclient_settings.CLAMAV_CLIENT_TIMEOUT
-        self.stream = not mcpclient_settings.CLAMAV_PASS_BY_REFERENCE
+        self.stream = mcpclient_settings.CLAMAV_PASS_BY_STREAM
         self.client = self.get_client()
 
     def scan(self, path):
         if self.stream:
-            method_name = 'pass_by_value'
+            method_name = 'pass_by_stream'
             result_key = 'stream'
         else:
             method_name = 'pass_by_reference'
@@ -166,9 +166,12 @@ class ClamdScanner(ScannerBase):
             timeout=self.timeout)
 
     def pass_by_reference(self, path):
+        logger.info("File being being read by Clamdscan from filesystem \
+            reference.")
         return self.client.scan(path)
 
-    def pass_by_value(self, path):
+    def pass_by_stream(self, path):
+        logger.info("File contents being streamed to Clamdscan.")
         return self.client.instream(open(path))
 
 
@@ -273,6 +276,7 @@ def get_scanner():
     """
     choice = str(mcpclient_settings.CLAMAV_CLIENT_BACKEND).lower()
     if choice not in SCANNERS_NAMES:
+
         logger.warning('Unexpected antivirus scanner (CLAMAV_CLIENT_BACKEND):'
                        ' "%s"; using %s.',
                        choice, DEFAULT_SCANNER.__name__)

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -47,7 +47,7 @@ CONFIG_MAPPING = {
 
     # [antivirus]
     'clamav_server': {'section': 'MCPClient', 'option': 'clamav_server', 'type': 'string'},
-    'clamav_pass_by_reference': {'section': 'MCPClient', 'option': 'clamav_pass_by_reference', 'type': 'boolean'},
+    'clamav_pass_by_stream': {'section': 'MCPClient', 'option': 'clamav_pass_by_stream', 'type': 'boolean'},
     'clamav_client_timeout': {'section': 'MCPClient', 'option': 'clamav_client_timeout', 'type': 'float'},
     'clamav_client_backend': {'section': 'MCPClient', 'option': 'clamav_client_backend', 'type': 'string'},
 
@@ -81,7 +81,7 @@ disableElasticsearchIndexing = False
 temp_dir = /var/archivematica/sharedDirectory/tmp
 removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
 clamav_server = /var/run/clamav/clamd.ctl
-clamav_pass_by_reference = False
+clamav_pass_by_stream = True
 storage_service_client_timeout = 86400
 agentarchives_client_timeout = 300
 clamav_client_timeout = 86400
@@ -200,7 +200,7 @@ TEMP_DIRECTORY = config.get('temp_directory')
 ELASTICSEARCH_SERVER = config.get('elasticsearch_server')
 ELASTICSEARCH_TIMEOUT = config.get('elasticsearch_timeout')
 CLAMAV_SERVER = config.get('clamav_server')
-CLAMAV_PASS_BY_REFERENCE = config.get('clamav_pass_by_reference')
+CLAMAV_PASS_BY_STREAM = config.get('clamav_pass_by_stream')
 CLAMAV_CLIENT_TIMEOUT = config.get('clamav_client_timeout')
 CLAMAV_CLIENT_BACKEND = config.get('clamav_client_backend')
 CLAMAV_CLIENT_MAX_FILE_SIZE = config.get('clamav_client_max_file_size')


### PR DESCRIPTION
* Corrects the negation of the PASS_BY_REFERENCE envvar.
* PASS_BY_REFERENCE is not a published variable so PASS_BY_STREAM introduced.
* Partly resolves the localsed envvars issue:  https://github.com/artefactual-labs/am/issues/38.
* Also addresses the issue of maximum default values: https://github.com/artefactual-labs/am/issues/39.

**NB:** This is a sprawling PR and is being submitted in support of the two am-labs issues described above. Those will be ready later this afternoon.