### PR TITLE
Make the locale to be consistent across containers

### DIFF
--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -1,5 +1,11 @@
 FROM ubuntu:14.04
 
+# Set the locale
+RUN locale-gen en_US.UTF-8  
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8
+
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE settings.common

--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -12,7 +12,14 @@ RUN set -ex \
 		libmysqlclient-dev \
 		libldap2-dev \
 		libsasl2-dev \
+		locales \
+		locales-all \
 	&& rm -rf /var/lib/apt/lists/*
+
+# Set the locale
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8
 
 COPY archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/
 COPY dashboard/src/requirements/ /src/dashboard/src/requirements/

--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -16,7 +16,14 @@ RUN set -ex \
 		libldap2-dev \
 		libsasl2-dev \
 		nodejs \
+		locales \
+		locales-all \
 	&& rm -rf /var/lib/apt/lists/*
+
+# Set the locale  
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8
 
 COPY archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/
 COPY dashboard/src/requirements/ /src/dashboard/src/requirements/


### PR DESCRIPTION
The various docker container components of Archivematica utilise locale
inconistently. This fix updates the mcp client container to be consistent
with en_US.UTF-8 along with the other containers we are using. resolves #898 

**NB:** The differences in install script per container account for the difference between Debian images and Ubuntu ones, e.g. `locale-gen` is not available on Debian images.

This has been tested with a fresh docker deployment in concert with the other pull requests supporting this issue:

* https://github.com/artefactual-labs/docker-fits-ngserver/pull/1
* https://github.com/artefactual/archivematica-storage-service/pull/313
* https://github.com/artefactual/archivematica/pull/903
* https://github.com/artefactual-labs/am/pull/40
