### PR TITLE
MCPClient: osdeps, delete python-unidecode

### DIFF
--- a/src/MCPClient/osdeps/CentOS-7.json
+++ b/src/MCPClient/osdeps/CentOS-7.json
@@ -52,7 +52,6 @@
   { "name": "pbzip2", "state": "latest"},
   { "name": "perl-Image-ExifTool", "state": "latest"},
   { "name": "postfix", "state": "latest"},
-  { "name": "python-unidecode", "state": "latest"},
   { "name": "rsync", "state": "latest"},
   { "name": "siegfried", "state": "latest"},
   { "name": "sleuthkit", "state": "latest"},

--- a/src/MCPClient/osdeps/RedHat-7.json
+++ b/src/MCPClient/osdeps/RedHat-7.json
@@ -52,7 +52,6 @@
   { "name": "pbzip2", "state": "latest"},
   { "name": "perl-Image-ExifTool", "state": "latest"},
   { "name": "postfix", "state": "latest"},
-  { "name": "python-unidecode", "state": "latest"},
   { "name": "rsync", "state": "latest"},
   { "name": "siegfried", "state": "latest"},
   { "name": "sleuthkit", "state": "latest"},


### PR DESCRIPTION
Installed via pip.

This closes #897.