### PR TITLE
Fix saveLevelOfDescription request authentication

### DIFF
--- a/src/dashboard/src/media/js/ingest/directory-metadata-form-dialog.js
+++ b/src/dashboard/src/media/js/ingest/directory-metadata-form-dialog.js
@@ -86,6 +86,12 @@ var DirectoryMetadataFormView = Backbone.View.extend({
     this.currentLevel = metadata.level_of_description;
   },
 
+  getCookie: function(name) {
+    var value = "; " + document.cookie;
+    var parts = value.split("; " + name + "=");
+    if (parts.length == 2) return parts.pop().split(";").shift();
+  },
+
   saveLevelOfDescription: function(callback) {
     var self = this;
 
@@ -93,6 +99,7 @@ var DirectoryMetadataFormView = Backbone.View.extend({
     $.ajax({
       url: '/api/filesystem/metadata/',
       type: 'POST',
+      headers: {'X-CSRFToken': self.getCookie('csrftoken')},
       async: false,
       cache: false,
       data: {


### PR DESCRIPTION
Tastypie SessionAuthentication requires to send the CSRFToken in the
X-CSRFToken header for some request methods. This is the only request
not using GET made from the dashboard frontend (using session auth.).

Refs #866