### PR TITLE
Add package API (async transfers)

### DIFF
--- a/src/MCPServer/install/README.md
+++ b/src/MCPServer/install/README.md
@@ -122,6 +122,12 @@ This is the full list of variables supported by MCPServer:
     - **Type:** `boolean`
     - **Default:** `true`
 
+- **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_WORKERS`**:
+    - **Description:** numbers of internal threaded workers. Workers process background operations (jobs) queued by Gearman. This is an internal mechanism in MCPServer to execute jobs asynchronously with the support of Gearman.
+    - **Config file example:** `MCPServer.workers`
+    - **Type:** `int`
+    - **Default:** `"2"`
+
 - **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_WATCHDIRECTORIESPOLLINTERVAL`**:
     - **Description:** time in seconds between filesystem poll intervals .
     - **Config file example:** `MCPServer.watchDirectoriesPollInterval`

--- a/src/MCPServer/lib/RPCServer.py
+++ b/src/MCPServer/lib/RPCServer.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python2
+"""Archivematica MCPServer RPC."""
 
 # This file is part of Archivematica.
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2018 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -17,74 +17,70 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-# @package Archivematica
-# @subpackage MCPServer
-# @author Joseph Perry <joseph@artefactual.com>
-
-import cPickle
-import gearman
 import logging
 import lxml.etree as etree
 from socket import gethostname
 import time
 
-from linkTaskManagerChoice import choicesAvailableForUnits
-
 from django.conf import settings as django_settings
+import gearman
+
+from linkTaskManagerChoice import choicesAvailableForUnits
+from package import create_package
+from worker_util import log_exceptions, unpickle_payload, pickle_result
 
 
 LOGGER = logging.getLogger("archivematica.mcp.server.rpcserver")
 
 
-def rpcError(code="", details=""):
-    ret = etree.Element("Error")
-    etree.SubElement(ret, "code").text = code.__str__()
-    etree.SubElement(ret, "details").text = details.__str__()
-    return ret
+@pickle_result
+@unpickle_payload
+@log_exceptions(LOGGER)
+def job_approve_handler(payload, gearman_worker, gearman_job):
+    job_id = payload["jobUUID"]
+    chain = payload["chain"]
+    user_id = str(payload["uid"])
+    LOGGER.debug("Approving: %s %s %s", job_id, chain, user_id)
+    if job_id in choicesAvailableForUnits:
+        choicesAvailableForUnits[job_id].proceedWithChoice(chain, user_id)
+    return "approving: ", job_id, chain
 
 
-def getJobsAwaitingApproval():
-    ret = etree.Element("choicesAvailableForUnits")
-    for UUID, choice in choicesAvailableForUnits.items():
+@pickle_result
+@log_exceptions(LOGGER)
+def job_awaiting_approval_handler(gearman_worker, gearman_job):
+    ret = etree.Element('choicesAvailableForUnits')
+    for uuid, choice in choicesAvailableForUnits.items():
         ret.append(choice.xmlify())
     return etree.tostring(ret, pretty_print=True)
 
 
-def approveJob(jobUUID, chain, user_id):
-    LOGGER.debug("Approving: %s %s %s", jobUUID, chain, user_id)
-    if jobUUID in choicesAvailableForUnits:
-        choicesAvailableForUnits[jobUUID].proceedWithChoice(chain, user_id)
-    return "approving: ", jobUUID, chain
-
-
-def gearmanApproveJob(gearman_worker, gearman_job):
-    try:
-        data = cPickle.loads(gearman_job.data)
-        jobUUID = data["jobUUID"]
-        chain = data["chain"]
-        user_id = str(data["uid"])
-        return cPickle.dumps(approveJob(jobUUID, chain, user_id))
-    # catch OS errors
-    except Exception:
-        LOGGER.exception('Error approving job')
-        raise
-
-
-def gearmanGetJobsAwaitingApproval(gearman_worker, gearman_job):
-    try:
-        return cPickle.dumps(getJobsAwaitingApproval())
-    # catch OS errors
-    except Exception:
-        LOGGER.exception('Error getting jobs awaiting approval')
-        raise
+@pickle_result
+@unpickle_payload
+@log_exceptions(LOGGER)
+def package_create_handler(payload, gearman_worker, gearman_job):
+    """Handle create package request."""
+    create_package_args = (
+        payload.get('name'),
+        payload.get('type'),
+        payload.get('accession'),
+        payload.get('path'),
+        payload.get('metadata_set_id'),
+        payload.get('auto_approve', True),
+    )
+    return create_package(*create_package_args).pk
 
 
 def startRPCServer():
     gm_worker = gearman.GearmanWorker([django_settings.GEARMAN_SERVER])
     hostID = gethostname() + "_MCPServer"
     gm_worker.set_client_id(hostID)
-    gm_worker.register_task("approveJob", gearmanApproveJob)
-    gm_worker.register_task("getJobsAwaitingApproval", gearmanGetJobsAwaitingApproval)
+
+    # The tasks registered in this worker should not block.
+    gm_worker.register_task("approveJob", job_approve_handler)
+    gm_worker.register_task("getJobsAwaitingApproval", job_awaiting_approval_handler)
+    gm_worker.register_task("packageCreate", package_create_handler)
+
     failMaxSleep = 30
     failSleep = 1
     failSleepIncrementor = 2

--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -60,6 +60,7 @@ from unitFile import unitFile
 from unitTransfer import unitTransfer
 from utils import isUUID
 import RPCServer
+import worker
 
 from archivematicaFunctions import unicodeToStr
 from databaseFunctions import auto_close_db, createSIP, getUTCDate
@@ -659,6 +660,16 @@ if __name__ == '__main__':
     t = threading.Thread(target=flushOutputs)
     t.daemon = True
     t.start()
+
+    # Start internal workers to process background operations. Workers were
+    # introduced when the non-blocking `packageCreate` method was added to the
+    # RPC service and we needed to schedule background jobs. If the workers are
+    # busy the jobs are queued by Gearman.
+    for i in range(django_settings.WORKERS):
+        t = threading.Thread(target=worker.start_worker, args=(i + 1,))
+        t.daemon = True
+        t.start()
+
     cleanupOldDbEntriesOnNewRun()
     watchDirectories()
 

--- a/src/MCPServer/lib/jobChain.py
+++ b/src/MCPServer/lib/jobChain.py
@@ -57,7 +57,7 @@ def fetchUnitVariableForUnit(unit_uuid):
 
 
 class jobChain:
-    def __init__(self, unit, chain_id):
+    def __init__(self, unit, chain_id, starting_link_id=None):
         """Create an instance of a chain from the MicroServiceChains table"""
         LOGGER.debug('Creating jobChain %s for chain %s', unit, chain_id)
         if chain_id is None:
@@ -66,16 +66,17 @@ class jobChain:
 
         chain = MicroServiceChain.objects.get(id=str(chain_id))
         LOGGER.debug('Chain: %s', chain)
-        self.startingChainLink = chain.startinglink_id
+
+        if starting_link_id is None:
+            starting_link_id = chain.startinglink_id
 
         # Migrate over unit variables containing replacement dicts from
         # previous chains but prioritize any values contained in passVars
         # passed in as kwargs.
         rd = fetchUnitVariableForUnit(unit.UUID)
 
-        self.currentLink = jobChainLink(self, self.startingChainLink, unit, passVar=rd)
-        if self.currentLink is None:
-            return None
+        # Run!
+        jobChainLink(self, starting_link_id, unit, passVar=rd)
 
     def nextChainLink(self, link_id, passVar=None):
         """Proceed to next link."""

--- a/src/MCPServer/lib/jobChainLink.py
+++ b/src/MCPServer/lib/jobChainLink.py
@@ -55,7 +55,7 @@ constlinkTaskManagerUnitVariableLinkPull = TaskType.objects.get(description="lin
 
 
 class jobChainLink:
-    def __init__(self, jobChain, jobChainLinkPK, unit, passVar=None, subJobOf=""):
+    def __init__(self, jobChain, jobChainLinkPK, unit, passVar=None):
         if jobChainLinkPK is None:
             return None
         self.UUID = uuid.uuid4().__str__()
@@ -63,7 +63,6 @@ class jobChainLink:
         self.unit = unit
         self.passVar = passVar
         self.createdDate = getUTCDate()
-        self.subJobOf = subJobOf
 
         # Depending on the path that led to this, jobChainLinkPK may
         # either be a UUID or a MicroServiceChainLink instance

--- a/src/MCPServer/lib/package.py
+++ b/src/MCPServer/lib/package.py
@@ -1,0 +1,401 @@
+"""Package management."""
+
+# This file is part of Archivematica.
+#
+# Copyright 2010-2018 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+import cPickle
+import collections
+import logging
+import os
+import shutil
+from tempfile import mkdtemp
+from uuid import uuid4
+
+from django.conf import settings as django_settings
+import gearman
+
+from archivematicaFunctions import unicodeToStr
+from jobChain import jobChain
+from main.models import Transfer, TransferMetadataSet
+import storageService as storage_service
+from unitTransfer import unitTransfer
+
+
+logger = logging.getLogger('archivematica.mcp.server')
+
+
+StartingPoint = collections.namedtuple('StartingPoint',
+                                       'watched_dir chain link')
+
+# Each package type has its corresponding watched directory and its
+# associated chain, e.g. a "standard" transfer triggers the chain with UUID
+# "fffd5342-2337-463f-857a-b2c8c3778c6d". This is stored in the
+# WatchedDirectory model. These starting chains all have in common that they
+# prompt the user to Accept/Reject the transfer.
+#
+# In this module we don't want to prompt the user. Instead we want to jump
+# directly into action, this is whatever happens when the transfer is
+# accepted. The following dictionary points to the chains and links where
+# this is happening. Presumably this could be written in a generic way querying
+# the workflow data but in the first iteraiton we've decided to do it this way.
+# There is also the hope that the watched directories can be deprecated in the
+# near future.
+PACKAGE_TYPE_STARTING_POINTS = {
+    'standard': StartingPoint(
+        watched_dir=os.path.join(
+            django_settings.WATCH_DIRECTORY,
+            'activeTransfers/standardTransfer'),
+        chain='6953950b-c101-4f4c-a0c3-0cd0684afe5e',
+        link='045c43ae-d6cf-44f7-97d6-c8a602748565',
+    ),
+    'unzipped bag': StartingPoint(
+        watched_dir=os.path.join(
+            django_settings.WATCH_DIRECTORY,
+            'activeTransfers/baggitDirectory'),
+        chain='c75ef451-2040-4511-95ac-3baa0f019b48',
+        link='154dd501-a344-45a9-97e3-b30093da35f5',
+    ),
+    'zipped bag': StartingPoint(
+        watched_dir=os.path.join(
+            django_settings.WATCH_DIRECTORY,
+            'activeTransfers/baggitZippedDirectory'),
+        chain='167dc382-4ab1-4051-8e22-e7f1c1bf3e6f',
+        link='3229e01f-adf3-4294-85f7-4acb01b3fbcf',
+    ),
+    'dspace': StartingPoint(
+        watched_dir=os.path.join(
+            django_settings.WATCH_DIRECTORY,
+            'activeTransfers/Dspace'),
+        chain='1cb2ef0e-afe8-45b5-8d8f-a1e120f06605',
+        link='bda96b35-48c7-44fc-9c9e-d7c5a05016c1',
+    ),
+    'maildir': StartingPoint(
+        watched_dir=os.path.join(
+            django_settings.WATCH_DIRECTORY,
+            'activeTransfers/maildir'),
+        chain='d381cf76-9313-415f-98a1-55c91e4d78e0',
+        link='da2d650e-8ce3-4b9a-ac97-8ca4744b019f',
+    ),
+    'TRIM': StartingPoint(
+        watched_dir=os.path.join(
+            django_settings.WATCH_DIRECTORY,
+            'activeTransfers/TRIM'),
+        chain='e4a59e3e-3dba-4eb5-9cf1-c1fb3ae61fa9',
+        link='2483c25a-ade8-4566-a259-c6c37350d0d6',
+    ),
+}
+
+
+def _file_is_an_archive(filepath):
+    filepath = filepath.lower()
+    return filepath.endswith('.zip') \
+        or filepath.endswith('.tgz') \
+        or filepath.endswith('.tar.gz')
+
+
+def _pad_destination_filepath_if_it_already_exists(filepath, original=None,
+                                                   attempt=0):
+    if original is None:
+        original = filepath
+    attempt = attempt + 1
+    if not os.path.exists(filepath):
+        return filepath
+    if os.path.isdir(filepath):
+        return _pad_destination_filepath_if_it_already_exists(
+            original + '_' + str(attempt), original, attempt)
+    # need to work out basename
+    basedirectory = os.path.dirname(original)
+    basename = os.path.basename(original)
+    # do more complex padding to preserve file extension
+    period_position = basename.index('.')
+    non_extension = basename[0:period_position]
+    extension = basename[period_position:]
+    new_basename = '{}_{}{}'.format(non_extension, attempt, extension)
+    new_filepath = os.path.join(basedirectory, new_basename)
+    return _pad_destination_filepath_if_it_already_exists(
+        new_filepath, original, attempt)
+
+
+def _check_filepath_exists(filepath):
+    if filepath == '':
+        return 'No filepath provided.'
+    if not os.path.exists(filepath):
+        return 'Filepath {} does not exist.'.format(filepath)
+    if '..' in filepath:  # check for trickery
+        return 'Illegal path.'
+    return None
+
+
+def _copy_from_transfer_sources(paths, relative_destination):
+    """Copy files from source locations to the currently processing location.
+
+    Any files in locations not associated with this pipeline will be ignored.
+
+    :param list paths: List of paths. Each path should be formatted
+                       <uuid of location>:<full path in location>
+    :param str relative_destination: Path relative to the currently processing
+                                     space to move the files to.
+    """
+    processing_location = storage_service.get_location(purpose='CP')[0]
+    transfer_sources = storage_service.get_location(purpose='TS')
+    files = {l['uuid']: {'location': l, 'files': []} for l in transfer_sources}
+
+    for item in paths:
+        try:
+            location, path = item.split(':', 1)
+        except ValueError:
+            raise Exception(
+                'Path {} cannot be split into location:path'.format(item))
+        if location not in files:
+            raise Exception('Location %(location)s is not associated'
+                            ' with this pipeline' % {'location': location})
+
+        # ``path`` will be a UTF-8 bytestring but the replacement pattern path
+        # from ``files`` will be a Unicode object. Therefore, the latter must
+        # be UTF-8 encoded prior. Same reasoning applies to ``destination``
+        # below. This allows transfers to be started on UTF-8-encoded directory
+        # names.
+        source = path.replace(
+            files[location]['location']['path'].encode('utf8'),
+            '', 1).lstrip('/')
+        # Use the last segment of the path for the destination - basename for a
+        # file, or the last folder if not. Keep the trailing / for folders.
+        last_segment = os.path.basename(source.rstrip('/')) + '/' \
+            if source.endswith('/') else os.path.basename(source)
+        destination = os.path.join(processing_location['path'].encode('utf8'),
+                                   relative_destination,
+                                   last_segment).replace('%sharedPath%', '')
+        files[location]['files'].append({
+            'source': source,
+            'destination': destination
+        })
+        logger.debug('source: %s, destination: %s', source, destination)
+
+    message = []
+    for item in files.values():
+        reply, error = storage_service.copy_files(
+            item['location'], processing_location, item['files'])
+        if reply is None:
+            message.append(str(error))
+    if message:
+        raise Exception('The following errors occured: %(message)s'
+                        % {'message': ', '.join(message)})
+
+
+def _move_to_internal_shared_dir(filepath, dest, transfer):
+    """Move package to an internal Archivematica directory.
+
+    The side effect of this function is to update the transfer object with the
+    final location. This is important so other components can continue the
+    processing. When relying on watched directories to start a transfer (see
+    _start_package_transfer), this also matters because unitTransfer is going
+    to look up the object in the database based on the location.
+    """
+    error = _check_filepath_exists(filepath)
+    if error:
+        raise Exception(error)
+    # Confine destination to subdir of originals.
+    basename = os.path.basename(filepath)
+    dest = _pad_destination_filepath_if_it_already_exists(
+        os.path.join(dest, basename))
+    # Ensure directories end with a trailing slash.
+    if os.path.isdir(filepath):
+        dest = os.path.join(dest, '')
+    try:
+        shutil.move(filepath, dest)
+    except (OSError, shutil.Error) as e:
+        raise Exception('Error moving from %s to %s (%s)', filepath, dest, e)
+    else:
+        transfer.currentlocation = dest.replace(
+            django_settings.SHARED_DIRECTORY, '%sharedPath%', 1)
+        transfer.save()
+
+
+def create_package(name, type_, accession, path, metadata_set_id,
+                   auto_approve=True):
+    """Create new package.
+
+    It creates the Transfer object and submits the job to the intenral queue.
+    """
+    if not name:
+        raise ValueError('No transfer name provided.')
+    if not path:
+        raise ValueError('No path provided.')
+    name = unicodeToStr(name)
+    if type_ is None or type_ == 'disk image':
+        type_ = 'standard'
+    if type_ not in PACKAGE_TYPE_STARTING_POINTS:
+        raise ValueError('Unexpected type of package provided')
+    # Create Transfer object.
+    kwargs = {'uuid': str(uuid4())}
+    if accession is not None:
+        kwargs['accessionid'] = unicodeToStr(accession)
+    if metadata_set_id is not None:
+        try:
+            kwargs['transfermetadatasetrow'] = \
+                TransferMetadataSet.objects.get(id=metadata_set_id)
+        except TransferMetadataSet.DoesNotExist:
+            pass
+    transfer = Transfer.objects.create(**kwargs)
+    logger.debug('Transfer object created: %s', transfer.pk)
+    _submit_create_package_internal_job(transfer.pk, name, type_, path,
+                                        auto_approve)
+    return transfer
+
+
+def _submit_create_package_internal_job(id_, name, type_, path, auto_approve):
+    """Submit package creation background job to queue.
+
+    We will block and wait until the job completes when the user did not
+    request auto approval. We do this to support the old
+    `/api/transfer/start_transfer` endpoint that used to block until the files
+    are copied into the activeTransfer directory that triggers the start of
+    the transfer.
+    """
+    payload = {
+        'id': id_, 'name': name, 'type': type_, 'path': path,
+        'auto_approve': auto_approve,
+    }
+    gm_client = gearman.GearmanClient([django_settings.GEARMAN_SERVER])
+    logger.debug('Submitting job MCPServerInternalPackageStartTransfer (%s)',
+                 payload)
+    response = gm_client.submit_job('MCPServerInternalPackageStartTransfer',
+                                    cPickle.dumps(payload),
+                                    background=auto_approve,
+                                    wait_until_complete=not auto_approve)
+    gm_client.shutdown()
+    return response
+
+
+def _capture_transfer_failure(fn):
+    """Detect errors during transfer/ingest."""
+    def wrap(*args, **kwargs):
+        try:
+            # Our decorated function isn't expected to return anything.
+            fn(*args, **kwargs)
+        except Exception as err:
+            # The main purpose of this decorator is to update the Transfer with
+            # the new state (fail). If the Transfer does not exist we give up.
+            if isinstance(err, Transfer.DoesNotExist):
+                raise
+        else:
+            # No exceptions!
+            return
+        # At this point we know that the transfer has failed and we want to do
+        # our best effort to update the state without further interruptions.
+        try:
+            Transfer.objects.get(pk=args[0])
+            #
+            # TODO: update state once we have a FSM.
+            #
+        except Exception:
+            pass
+        # Finally raised the exception and log it.
+        try:
+            logger.exception('Exception: %s', err, exc_info=True)
+        except NameError:
+            pass
+    return wrap
+
+
+def _determine_transfer_paths(name, path, tmpdir):
+    if _file_is_an_archive(path):
+        transfer_dir = tmpdir
+        p = path.split(':', 1)[1]
+        filepath = os.path.join(tmpdir, os.path.basename(p))
+    else:
+        path = os.path.join(path, '.')  # Copy contents of dir but not dir
+        transfer_dir = filepath = os.path.join(tmpdir, name)
+    return (
+        transfer_dir.replace(django_settings.SHARED_DIRECTORY, '', 1),
+        unicodeToStr(filepath),
+        path
+    )
+
+
+@_capture_transfer_failure
+def _start_package_transfer_with_auto_approval(id_, name, path,
+                                               tmpdir, starting_point,
+                                               transfer):
+    """Start transfer manually.
+
+    This method does not rely on the activeTransfer watched directory. It
+    blocks until the process completes.
+    """
+    transfer_rel, filepath, path = _determine_transfer_paths(name, path, tmpdir)
+    logger.debug('Package %s: determined vars '
+                 'transfer_rel=%s, filepath=%s, path=%s',
+                 id_, transfer_rel, filepath, path)
+
+    logger.debug('Package %s: copying chosen contents from transfer sources'
+                 ' (from=%s, to=%s)', id_, path, transfer_rel)
+    _copy_from_transfer_sources([path], transfer_rel)
+
+    logger.debug('Package %s: moving package to processing directory', id_)
+    _move_to_internal_shared_dir(
+        filepath, django_settings.PROCESSING_DIRECTORY, transfer)
+
+    logger.debug('Package %s: starting workflow processing', id_)
+    unit = unitTransfer(path, id_)
+    jobChain(unit, starting_point.chain, starting_point.link)
+
+
+@_capture_transfer_failure
+def _start_package_transfer(id_, name, path, tmpdir, starting_point, transfer):
+    """Start a new transfer by moving it to the corresponding watched dir."""
+    transfer_rel, filepath, path = _determine_transfer_paths(name, path, tmpdir)
+    logger.debug('Package %s: determined vars '
+                 'transfer_rel=%s, filepath=%s, path=%s',
+                 id_, transfer_rel, filepath, path)
+
+    logger.debug('Package %s: copying chosen contents from transfer sources '
+                 '(from=%s, to=%s)', id_, path, transfer_rel)
+    _copy_from_transfer_sources([path], transfer_rel)
+
+    logger.debug('Package %s: moving package to activeTransfers dir '
+                 'from=%s, to=%s)', id_, filepath, starting_point.watched_dir)
+    # MCPServer will pick up the transfer when once moved into the watched dir.
+    _move_to_internal_shared_dir(filepath, starting_point.watched_dir, transfer)
+
+
+def start_package_transfer(id_, name, type_, path, auto_approve):
+    """Start package transfer.
+
+    The auto approval keyword determines the underlyng function that we're
+    going to use. Their implementations are significantly different.
+
+    TODO: use tempfile.TemporaryDirectory as a context manager once we move to
+    Python 3.
+    """
+    tmpdir = mkdtemp(dir=os.path.join(django_settings.SHARED_DIRECTORY, 'tmp'))
+    transfer = Transfer.objects.get(pk=id_)
+    logger.debug('Package %s: starting transfer (%s)',
+                 id_, (name, type_, path, tmpdir))
+    try:
+        sp = PACKAGE_TYPE_STARTING_POINTS.get(type_)
+        if auto_approve is True:
+            _start_package_transfer_with_auto_approval(id_, name, path,
+                                                       tmpdir, sp,
+                                                       transfer)
+            return
+        elif auto_approve is False:
+            _start_package_transfer(id_, name, path, tmpdir, sp, transfer)
+        else:
+            raise ValueError('Unexpected value in auto_approve parameter')
+    finally:
+        os.chmod(tmpdir, 0o770)  # Needs to be writeable by the SS.
+        return tmpdir

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -40,6 +40,7 @@ CONFIG_MAPPING = {
         {'section': 'MCPServer', 'option': 'search_enabled', 'type': 'boolean'},
     ],
     'storage_service_client_timeout': {'section': 'MCPServer', 'option': 'storage_service_client_timeout', 'type': 'float'},
+    'workers': {'section': 'MCPServer', 'option': 'workers', 'type': 'int'},
 
     # [Protocol]
     'limit_task_threads': {'section': 'Protocol', 'option': 'limitTaskThreads', 'type': 'int'},
@@ -67,6 +68,7 @@ processingXMLFile = processingMCP.xml
 waitOnAutoApprove = 0
 search_enabled = true
 storage_service_client_timeout = 2
+workers = 2
 
 [Protocol]
 delimiter = <!&\delimiter/&!>
@@ -171,3 +173,4 @@ LIMIT_GEARMAN_CONNS = config.get('limit_gearman_conns')
 RESERVED_AS_TASK_PROCESSING_THREADS = config.get('reserved_as_task_processing_threads')
 SEARCH_ENABLED = config.get('search_enabled')
 STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
+WORKERS = config.get('workers')

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -39,6 +39,7 @@ CONFIG_MAPPING = {
         {'section': 'MCPServer', 'option': 'disable_search_indexing', 'type': 'iboolean'},
         {'section': 'MCPServer', 'option': 'search_enabled', 'type': 'boolean'},
     ],
+    'storage_service_client_timeout': {'section': 'MCPServer', 'option': 'storage_service_client_timeout', 'type': 'float'},
 
     # [Protocol]
     'limit_task_threads': {'section': 'Protocol', 'option': 'limitTaskThreads', 'type': 'int'},
@@ -65,6 +66,7 @@ watchDirectoriesPollInterval = 1
 processingXMLFile = processingMCP.xml
 waitOnAutoApprove = 0
 search_enabled = true
+storage_service_client_timeout = 2
 
 [Protocol]
 delimiter = <!&\delimiter/&!>
@@ -168,3 +170,4 @@ LIMIT_TASK_THREADS_SLEEP = config.get('limit_task_threads_sleep')
 LIMIT_GEARMAN_CONNS = config.get('limit_gearman_conns')
 RESERVED_AS_TASK_PROCESSING_THREADS = config.get('reserved_as_task_processing_threads')
 SEARCH_ENABLED = config.get('search_enabled')
+STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')

--- a/src/MCPServer/lib/unitDIP.py
+++ b/src/MCPServer/lib/unitDIP.py
@@ -43,7 +43,6 @@ class unitDIP(unit):
         self.currentPath = currentPath.__str__()
         self.UUID = UUID
         self.fileList = {}
-        self.owningUnit = None
         self.pathString = "%SIPDirectory%"
         self.unitType = "DIP"
 

--- a/src/MCPServer/lib/unitSIP.py
+++ b/src/MCPServer/lib/unitSIP.py
@@ -41,7 +41,6 @@ class unitSIP(unit):
         self.UUID = UUID
         self.fileList = {}
         self.pathString = "%SIPDirectory%"
-        self.owningUnit = None
         self.unitType = "SIP"
         self.aipFilename = ""
 

--- a/src/MCPServer/lib/unitTransfer.py
+++ b/src/MCPServer/lib/unitTransfer.py
@@ -38,7 +38,6 @@ LOGGER = logging.getLogger('archivematica.mcp.server')
 
 class unitTransfer(unit):
     def __init__(self, currentPath, UUID=""):
-        self.owningUnit = None
         self.unitType = "Transfer"
         # Just use the end of the directory name
         self.pathString = "%transferDirectory%"
@@ -67,12 +66,6 @@ class unitTransfer(unit):
 
     def __str__(self):
         return 'unitTransfer: <UUID: {u.UUID}, path: {u.currentPath}>'.format(u=self)
-
-    def updateLocation(self, newLocation):
-        self.currentPath = newLocation
-        transfer = Transfer.objects.get(uuid=self.UUID)
-        transfer.currentlocation = newLocation
-        transfer.save()
 
     def setMagicLink(self, link, exitStatus=""):
         """Assign a link to the unit to process when loaded.

--- a/src/MCPServer/lib/worker.py
+++ b/src/MCPServer/lib/worker.py
@@ -1,0 +1,48 @@
+""" ... """
+
+from socket import gethostname
+import logging
+import time
+
+from django.conf import settings as django_settings
+import gearman
+
+from worker_util import log_exceptions, unpickle_payload, pickle_result
+from package import start_package_transfer
+
+
+LOGGER = logging.getLogger("archivematica.mcp.server.worker")
+
+
+@pickle_result
+@unpickle_payload
+@log_exceptions(LOGGER)
+def package_start_transfer_handler(payload, gearman_worker, gearman_job):
+    start_package_transfer(
+        payload.get('id'),
+        payload.get('name'),
+        payload.get('type'),
+        payload.get('path'),
+        payload.get('auto_approve', True),
+    )
+
+
+def start_worker(name):
+    client_id = '{}_{}_MCPServer_worker'.format(gethostname(), name)
+    gm_worker = gearman.GearmanWorker([django_settings.GEARMAN_SERVER])
+    gm_worker.set_client_id(client_id)
+    gm_worker.register_task(
+        'MCPServerInternalPackageStartTransfer',
+        package_start_transfer_handler)
+    LOGGER.debug('Created new MCPserver worker (id=%s)', client_id)
+
+    fail_max_sleep = 30
+    fail_sleep = 1
+    fail_sleep_inc = 2
+    while True:
+        try:
+            gm_worker.work()
+        except gearman.errors.ServerUnavailable:
+            time.sleep(fail_sleep)
+            if fail_sleep < fail_max_sleep:
+                fail_sleep += fail_sleep_inc

--- a/src/MCPServer/lib/worker_error.py
+++ b/src/MCPServer/lib/worker_error.py
@@ -1,0 +1,24 @@
+# This file is part of Archivematica.
+#
+# Copyright 2010-2018 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class RPCServerError(Exception):
+    """Base exception of RPCServer."""
+
+
+class UnexpectedPayloadError(RPCServerError):
+    """Missing parameters in payload."""

--- a/src/MCPServer/lib/worker_util.py
+++ b/src/MCPServer/lib/worker_util.py
@@ -1,0 +1,58 @@
+"""Decorators used by the MCPServer worker found in the worker module."""
+
+# This file is part of Archivematica.
+#
+# Copyright 2010-2018 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+import cPickle
+
+from worker_error import RPCServerError, UnexpectedPayloadError
+
+
+def log_exceptions(logger):
+    """Worker handler decorator to log exceptions."""
+    def decorator(fn):
+        def wrap(*args, **kwargs):
+            try:
+                return fn(*args, **kwargs)
+            except Exception as err:
+                internal_err = isinstance(err, RPCServerError)
+                logger.error('Exception raised by handler %s: %s',
+                             fn.__name__, err, exc_info=not internal_err)
+                raise  # So GearmanWorker knows that it failed.
+        return wrap
+    return decorator
+
+
+def unpickle_payload(fn):
+    """Worker handler decorator to unpickle the incoming payload.
+
+    It prepends an argument before calling the decorated function.
+    """
+    def wrap(*args, **kwargs):
+        gearman_job = args[1]
+        payload = cPickle.loads(gearman_job.data)
+        if not isinstance(payload, dict):
+            raise UnexpectedPayloadError('Payload is not a dictionary')
+        return fn(payload, *args, **kwargs)
+    return wrap
+
+
+def pickle_result(fn):
+    """Worker handler decorator to pickle the returned value."""
+    def wrap(*args, **kwargs):
+        return cPickle.dumps(fn(*args, **kwargs))
+    return wrap

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -274,8 +274,11 @@ def logJobCreatedSQL(job):
     # microseconds are always 6 digits
     # The number returned may have a leading 0 which needs to be preserved
     decDate = getDeciDate("." + str(job.createdDate.microsecond).zfill(6))
-    if job.unit.owningUnit is not None:
-        unitUUID = job.unit.owningUnit.UUID
+    try:
+        if job.unit.owningUnit is not None:
+            unitUUID = job.unit.owningUnit.UUID
+    except AttributeError:
+        pass
     Job.objects.create(jobuuid=job.UUID,
                        jobtype=job.description,
                        directory=job.unit.currentPath,
@@ -285,8 +288,7 @@ def logJobCreatedSQL(job):
                        microservicegroup=str(job.microserviceGroup),
                        createdtime=job.createdDate,
                        createdtimedec=decDate,
-                       microservicechainlink_id=str(job.pk),
-                       subjobof=str(job.subJobOf))
+                       microservicechainlink_id=str(job.pk))
 
     # TODO -un hardcode executing exeCommand
 

--- a/src/dashboard/frontend/transfer-browser/app/services/transfer.service.js
+++ b/src/dashboard/frontend/transfer-browser/app/services/transfer.service.js
@@ -39,24 +39,38 @@ class Transfer {
     });
   }
 
+  getCookie(name) {
+    let value = "; " + document.cookie;
+    let parts = value.split("; " + name + "=");
+    if (parts.length == 2) return parts.pop().split(";").shift();
+  }
+
   // Starts a transfer using this service's current attributes.
   start() {
     // If this is a zipped bag, then there will be no transfer name;
     // give it a dummy name instead.
     let name = this.type === 'zipped bag' ? 'ZippedBag' : this.name;
+    let _self = this;
+    let requests = this.components.map(function(component) {
+      return jQuery.ajax('/api/v2beta/package/', {
+        method: 'POST',
+        headers: {'X-CSRFToken': _self.getCookie('csrftoken')},
+        cache: false,
+        contentType: "application/json; charset=utf-8",
+        dataType: "json",
+        data: JSON.stringify({
+          name: name,
+          type: _self.type,
+          accession: _self.accession,
+          path: Base64.encode(`${component.location}:${component.path}`),
+          metadata_set_id: component.id || ''
+        })
+      });
+    });
 
-    let params = {
-      name: name,
-      type: this.type,
-      accession: this.accession,
-      'paths[]': this.components.map(component => Base64.encode(`${component.location}:${component.path}`)),
-      'row_ids[]': this.components.map(component => component.id || ''),
-    };
-
-    // Cleanup object state on success or failure
-    let promise = jQuery.post('/filesystem/transfer/', params);
     this.empty_properties();
-    return promise;
+
+    return $.when(...requests);
   }
 }
 

--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -42,4 +42,6 @@ urlpatterns = [
     url(r'administration/dips/atom/fetch_levels/$', views.fetch_levels_of_description_from_atom, name='fetch_atom_lods'),
     url(r'filesystem/metadata/$', views.path_metadata),
     url(r'processing-configuration/(?P<name>\w{1,16})', views.processing_configuration),
+
+    url(r'v2beta/package', views.package),
 ]

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -77,6 +77,10 @@ def _api_endpoint(expected_methods):
     return decorator
 
 
+class HttpResponseNotImplemented(django.http.HttpResponse):
+    status_code = 501
+
+
 def allowed_by_whitelist(ip_address):
     whitelist = [
         ip.strip()
@@ -263,8 +267,6 @@ def start_transfer_api(request):
     transfer_name = request.POST.get('name', '')
     transfer_type = request.POST.get('type', '')
     accession = request.POST.get('accession', '')
-    # Note that the path may contain arbitrary, non-unicode characters,
-    # and hence is POSTed to the server base64-encoded
     paths = request.POST.getlist('paths[]', [])
     paths = [base64.b64decode(path) for path in paths]
     row_ids = request.POST.getlist('row_ids[]', [''])
@@ -703,3 +705,38 @@ def processing_configuration(request, name):
         return django.http.HttpResponse(content, content_type='text/xml')
     except IOError:
         raise django.http.Http404
+
+
+@_api_endpoint(expected_methods=['GET', 'POST'])
+def package(request):
+    """Package resource handler."""
+    if request.method == 'POST':
+        return _package_create(request)
+    else:
+        return HttpResponseNotImplemented()
+
+
+def _package_create(request):
+    """Create a package."""
+    try:
+        payload = json.loads(request.body)
+        path = base64.b64decode(payload.get('path'))
+    except (TypeError, ValueError):
+        return helpers.json_response({
+            'error': True,
+            'message': 'Parameter "path" cannot be decoded.'}, 400)
+    args = (
+        payload.get('name'),
+        payload.get('type'),
+        payload.get('accession'),
+        path,
+        payload.get('metadata_set_id'),
+    )
+    try:
+        client = MCPClient()
+        id_ = client.create_package(*args)
+    except Exception as err:
+        LOGGER.error(err)
+        msg = 'Package cannot be created'
+        return helpers.json_response({'error': True, 'message': msg}, 500)
+    return helpers.json_response({'id': id_}, 202)

--- a/src/dashboard/src/components/filesystem_ajax/helpers.py
+++ b/src/dashboard/src/components/filesystem_ajax/helpers.py
@@ -63,24 +63,3 @@ def directory_to_dict(path, directory={}, entry=False):
 
     # return fully traversed data
     return directory
-
-
-def check_filepath_exists(filepath):
-    error = None
-    if filepath == '':
-        error = 'No filepath provided.'
-
-    # check if exists
-    if error is None and not os.path.exists(filepath):
-        error = 'Filepath ' + filepath + ' does not exist.'
-
-    # check if is file or directory
-
-    # check for trickery
-    try:
-        filepath.index('..')
-        error = 'Illegal path.'
-    except:
-        pass
-
-    return error

--- a/src/dashboard/src/components/filesystem_ajax/urls.py
+++ b/src/dashboard/src/components/filesystem_ajax/urls.py
@@ -29,7 +29,6 @@ urlpatterns = [
     url(r'^delete/arrange/$', views.delete_arrange),
     url(r'^create_directory_within_arrange/$', views.create_directory_within_arrange),
     url(r'^copy_to_arrange/$', views.copy_to_arrange),
-    url(r'^transfer/$', views.start_transfer_logged_in),
     url(r'^copy_from_arrange/$', views.copy_from_arrange_to_completed),
     url(r'^copy_metadata_files/$', views.copy_metadata_files_logged_in),
 ]

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -201,31 +201,6 @@ def delete_arrange(request, filepath=None):
     return helpers.json_response({'message': _('Delete successful.')})
 
 
-def start_transfer_logged_in(request):
-    """
-    Endpoint for starting a transfer if logged in and calling from the dashboard.
-    """
-    if request.method not in ('POST',):
-        return django.http.HttpResponseNotAllowed(['POST'])
-
-    transfer_name = archivematicaFunctions.unicodeToStr(request.POST.get('name', ''))
-    transfer_type = archivematicaFunctions.unicodeToStr(request.POST.get('type', ''))
-    accession = archivematicaFunctions.unicodeToStr(request.POST.get('accession', ''))
-    # Note that the path may contain arbitrary, non-unicode characters,
-    # and hence is POSTed to the server base64-encoded
-    paths = request.POST.getlist('paths[]', [])
-    paths = [base64.b64decode(path) for path in paths]
-    row_ids = request.POST.getlist('row_ids[]', [])
-    try:
-        response = start_transfer(transfer_name, transfer_type, accession, paths, row_ids)
-    except ValueError as e:
-        return helpers.json_response({'error': True, 'message': str(e)}, status_code=400)
-    except storage_service.StorageServiceError as e:
-        return helpers.json_response({'error': True, 'message': str(e)}, status_code=500)
-    else:
-        return helpers.json_response(response)
-
-
 def start_transfer(transfer_name, transfer_type, accession, paths, row_ids):
     """
     Start a new transfer.

--- a/src/dashboard/src/contrib/mcp/client.py
+++ b/src/dashboard/src/contrib/mcp/client.py
@@ -15,14 +15,21 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-import gearman
 import cPickle
+import logging
 
 from django.conf import settings
+import gearman
+
+
+LOGGER = logging.getLogger('archivematica.dashboard.mcp.client')
 
 
 class RPCError(Exception):
     pass
+
+
+INFLIGHT_POLL_TIMEOUT = 5.0
 
 
 class MCPClient:
@@ -56,3 +63,35 @@ class MCPClient:
             return cPickle.loads(completed_job_request.result)
         elif completed_job_request.state == gearman.JOB_FAILED:
             raise RPCError("getNotifications failed (check MCPServer logs)")
+
+    def create_package(self, name, type_, accession, path, metadata_set_id):
+        gm_client = gearman.GearmanClient([self.server])
+        data = cPickle.dumps({
+            'name': name,
+            'type': type_,
+            'accession': accession,
+            'path': path,
+            'metadata_set_id': metadata_set_id,
+        })
+        response = gm_client.submit_job('packageCreate', data,
+                                        background=False,
+                                        wait_until_complete=True,
+                                        poll_timeout=INFLIGHT_POLL_TIMEOUT)
+        gm_client.shutdown()
+        if response.state == gearman.JOB_COMPLETE:
+            return cPickle.loads(response.result)  # Transfer ID (pickled)
+        elif response.state == gearman.JOB_FAILED:
+            raise RPCError('MCPServer returned an error (check the logs)')
+
+    def read_package(self, id_):
+        gm_client = gearman.GearmanClient([self.server])
+        data = cPickle.dumps({'id': id_})
+        response = gm_client.submit_job('packageRead', data,
+                                        background=False,
+                                        wait_until_complete=True,
+                                        poll_timeout=INFLIGHT_POLL_TIMEOUT)
+        gm_client.shutdown()
+        if response.state == gearman.JOB_COMPLETE:
+            return cPickle.loads(response.result)
+        elif response.state == gearman.JOB_FAILED:
+            raise RPCError('MCPServer returned an error (check the logs)')

--- a/src/dashboard/tests/test_access.py
+++ b/src/dashboard/tests/test_access.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2
-
 import base64
 import json
 import os

--- a/src/dashboard/tests/test_api.py
+++ b/src/dashboard/tests/test_api.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2
-
 import os
 
 from django.core.management import call_command

--- a/src/dashboard/tests/test_api_v2beta.py
+++ b/src/dashboard/tests/test_api_v2beta.py
@@ -1,0 +1,87 @@
+import base64
+import json
+import os
+
+from django.test import TestCase, Client
+import mock
+
+from components import helpers
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class MCPClientMock(object):
+
+    def __init__(self, fails=False):
+        self.fails = fails
+
+    def create_package(self, name, type_, accession, path, metadata_set_id):
+        if self.fails:
+            raise Exception('Something bad happened!')
+        return b'59402c61-3aba-4af7-966a-996073c0601d'
+
+
+class TestAPIv2(TestCase):
+    fixture_files = ['test_user.json']
+    fixtures = [os.path.join(THIS_DIR, 'fixtures', p) for p in fixture_files]
+
+    # This is valid path value that we're going to pass to the API server.
+    path = base64.b64encode('{location_uuid}:{relative_path}'.format(**{
+        'location_uuid': '671643e1-5bec-4a5f-b244-abb76fedb0c4',
+        'relative_path': 'foo/bar.jpg',
+    }))
+
+    def setUp(self):
+        self.client = Client()
+        self.client.login(username='test', password='test')
+        helpers.set_setting('dashboard_uuid', 'test-uuid')
+
+    def test_package_list(self):
+        resp = self.client.get('/api/v2beta/package/')
+        assert resp.status_code == 501  # Not implemented yet.
+
+    def test_package_create_with_errors(self):
+        # Missing payload
+        resp = self.client.post(
+            '/api/v2beta/package/',
+            content_type='application/json')
+        assert resp.status_code == 400
+
+        # Invalid document
+        resp = self.client.post(
+            '/api/v2beta/package/',
+            'INVALID-JSON',
+            content_type='application/json')
+        assert resp.status_code == 400
+
+        # Invalid path
+        resp = self.client.post(
+            '/api/v2beta/package/',
+            json.dumps({'path': 'invalid'}),
+            content_type='application/json')
+        assert resp.status_code == 400
+
+    @mock.patch('components.api.views.MCPClient',
+                return_value=MCPClientMock())
+    def test_package_create_mcpclient_ok(self, patcher):
+        resp = self.client.post(
+            '/api/v2beta/package/',
+            json.dumps({'path': self.path}),
+            content_type='application/json')
+        assert resp.status_code == 202
+        assert resp.content == json.dumps({
+            'id': '59402c61-3aba-4af7-966a-996073c0601d'
+        })
+
+    @mock.patch('components.api.views.MCPClient',
+                return_value=MCPClientMock(fails=True))
+    def test_package_create_mcpclient_fails(self, patcher):
+        resp = self.client.post(
+            '/api/v2beta/package/',
+            json.dumps({'path': self.path}),
+            content_type='application/json')
+        assert resp.status_code == 500
+        payload = json.loads(resp.content)
+        assert payload['error'] is True
+        assert payload['message'] == 'Package cannot be created'

--- a/src/dashboard/tests/test_filesystem_ajax.py
+++ b/src/dashboard/tests/test_filesystem_ajax.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2
-
 import base64
 import json
 import os

--- a/src/dashboard/tests/test_signals.py
+++ b/src/dashboard/tests/test_signals.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2
-
 import os
 
 from django.test import TestCase


### PR DESCRIPTION
[RDSSARK-474](https://jiscdev.atlassian.net/browse/RDSSARK-474)

New package API - it allows to create new packages.

It's an alternative to the [existing methods](https://gist.github.com/sevein/5615e0df0ff9645f17ed06672a271633) to start a transfer. JiscRDSS's channel adapter (deposit packages directly into `activeTransfers/*`) and automation tools (uses existing `/api/{start_transfer,approve,unapproved}` APIs) could adopt this new API but the existing functionality isn't going to stop working. This PR updates the transfer browser widget to adopt the new API - before it used internal endpoints (`/filesystem/transfer/`, `/mcp/list`, `/mcp/execute`).

Request example:

```
$ curl \
	-v \
	-d "@send-transfer.json" \
	-H "Content-type: application/json" \
	-H "Authorization: ApiKey test:test" \
	-X POST \
		http://127.0.0.1:62080/api/v2beta/package/
```

This is the document we sent in the payload:

```json5
{
  "name": "Test12345",
  // The value of `path` is the result of `base64(location-uuid:relative-path)`
  "path": "MWQ0ZmU3NTctNGM2ZS00MmQxLWE5Y2ItZmQ4YTBkMjNlZWRkOi9ob21lL2FyY2hpdmVtYXRpY2EvYXJjaGl2ZW1hdGljYS1zYW1wbGVkYXRhL1NhbXBsZVRyYW5zZmVycy9JbWFnZXMvcGljdHVyZXM="
}
```

It starts the transfer without approval - as MCPServer knows when the files have been copied and the package is ready for processing. `POST /package` returns the UUID of the package/transfer immediately.