### PR TITLE
MCPClient: add ghostscript to osdeps

### DIFF
--- a/src/MCPClient-base.Dockerfile
+++ b/src/MCPClient-base.Dockerfile
@@ -35,6 +35,7 @@ RUN set -ex \
     bulk-extractor \
     clamav \
     ffmpeg \
+    ghostscript \
     libavcodec-extra-56 \
     fits \
     imagemagick \

--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -1,4 +1,4 @@
-FROM artefactual/archivematica-mcp-client-base:20180219.01.52dc9959
+FROM artefactual/archivematica-mcp-client-base:20180228.01.e44c2e3c
 
 ENV DJANGO_SETTINGS_MODULE settings.common
 ENV PYTHONPATH /src/MCPClient/lib/:/src/archivematicaCommon/lib/:/src/dashboard/src/

--- a/src/MCPClient/osdeps/Ubuntu-14.json
+++ b/src/MCPClient/osdeps/Ubuntu-14.json
@@ -22,6 +22,7 @@
   { "name": "ffmpeg", "state": "latest"},
   { "name": "fits", "state": "latest"},
   { "name": "gearman", "state": "latest"},
+  { "name": "ghostscript", "state": "latest"},
   { "name": "imagemagick", "state": "latest"},
   { "name": "inkscape", "state": "latest"},
   { "name": "jhove", "state": "latest"},

--- a/src/MCPClient/osdeps/Ubuntu-16.json
+++ b/src/MCPClient/osdeps/Ubuntu-16.json
@@ -22,6 +22,7 @@
   { "name": "ffmpeg", "state": "latest"},
   { "name": "fits", "state": "latest"},
   { "name": "gearman", "state": "latest"},
+  { "name": "ghostscript", "state": "latest"},
   { "name": "imagemagick", "state": "latest"},
   { "name": "inkscape", "state": "latest"},
   { "name": "jhove", "state": "latest"},


### PR DESCRIPTION
It was listed in CentOS but not Ubuntu.

This closes #943.