### PR TITLE
MCPClient: fix matching originals to manual derivatives

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -890,7 +890,12 @@ def createFileSec(directoryPath, parentDiv, baseDirectoryPath,
 
             elif use in ("preservation", "text/ocr"):
                 # Derived files should be in the original file's group
-                d = Derivation.objects.get(derived_file_id=f.uuid)
+                try:
+                    d = Derivation.objects.get(derived_file_id=f.uuid)
+                except Derivation.DoesNotExist:
+                    print('Fatal error: unable to locate a Derivation object'
+                          ' where the derived file is {}'.format(f.uuid))
+                    raise
                 GROUPID = "Group-" + d.source_file_id
 
             elif use == "service":

--- a/src/MCPClient/lib/clientScripts/manualNormalizationCreateMetadataAndRestructure.py
+++ b/src/MCPClient/lib/clientScripts/manualNormalizationCreateMetadataAndRestructure.py
@@ -117,6 +117,9 @@ try:
     e = Event.objects.get(event_type="normalization", file_uuid=original_file)
     e.event_outcome_detail = dstR
     e.save()
+    print('Updated the eventOutcomeDetailNote of an existing normalization'
+          ' Event for file {}. Not creating a Derivation object'.format(
+              fileUUID))
 except Event.DoesNotExist:
     # No normalization event was created in normalize.py - probably manually
     # normalized during Ingest
@@ -129,6 +132,8 @@ except Event.DoesNotExist:
         eventDetail="manual normalization",
         eventOutcome="",
         eventOutcomeDetailNote=dstR)
+    print('Created a manual normalization Event for file {}.'.format(
+        original_file.uuid))
 
     # Add linking information between files
     # Assuming that if an event already exists, then the derivation does as well
@@ -136,5 +141,7 @@ except Event.DoesNotExist:
         sourceFileUUID=original_file.uuid,
         derivedFileUUID=fileUUID,
         relatedEventUUID=derivationEventUUID)
+    print('Created a Derivation for original file {}, derived file {}, and'
+          ' event {}'.format(original_file.uuid, fileUUID, derivationEventUUID))
 
 exit(0)


### PR DESCRIPTION
Fixes the matching of original files to their manually created preservation derivatives in a manualNormalization/preservation/ directory. Previous behaviour would find a match and all other Files that matched by having a path that was a superfix of the original path. This would trigger an exception. This fixes the issue by returning the shortest match. It also adds print statements to better understand what has happened through the Tasks GUI.

Fixes #972 

Should resolve internal https://projects.artefactual.com/issues/11996.