### PR TITLE
MCPClient: stop pickling custom exception

### DIFF
--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -174,8 +174,11 @@ def execute_command(gearman_worker, gearman_job):
     try:
         script, task_uuid = _process_gearman_job(
             gearman_job, gearman_worker)
-    except ProcessGearmanJobError as error:
-        return cPickle.dumps(error)
+    except ProcessGearmanJobError:
+        return cPickle.dumps({
+            'exitCode': 1,
+            'stdOut': 'Archivematica Client Process Gearman Job Error!',
+            'stdError': traceback.format_exc()})
     except Exception:
         return _unexpected_error()
     logger.info('<processingCommand>{%s}%s</processingCommand>',


### PR DESCRIPTION
Return a pickled dict instead of having the MCPClient return a pickle serialization of a custom exeption, which will break MCPServer when unpickling is attempted.

Fixes #961