### PR TITLE
archivematicaCommon: stop accessing content attribute of exception

### DIFF
--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -220,7 +220,7 @@ def copy_files(source_location, destination_location, files):
         response = _storage_api_session().post(url, json=move_files)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
-        LOGGER.warning("Unable to move files with %s because %s", move_files, e.content)
+        LOGGER.warning("Unable to move files with %s because %s", move_files, e)
         return (None, e)
     ret = response.json()
     return (ret, None)


### PR DESCRIPTION
Stop accessing a non-existent `.content` attribute of an exception instance in the Storage Service client.

Fixes #962 
