### PR TITLE
Dashboard: fix migration 0033, make field nullable

### DIFF
--- a/src/dashboard/src/main/migrations/0033_store_transfer_file_modification_dates.py
+++ b/src/dashboard/src/main/migrations/0033_store_transfer_file_modification_dates.py
@@ -108,7 +108,8 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='file',
             name='modificationtime',
-            field=models.DateTimeField()
+            field=models.DateTimeField(auto_now_add=True, null=True,
+                                       db_column=b'modificationTime'),
         ),
         migrations.RunPython(data_migration),
     ]

--- a/src/dashboard/src/main/migrations/0035_fix_workflow_dip_generation.py
+++ b/src/dashboard/src/main/migrations/0035_fix_workflow_dip_generation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models
+from django.db import migrations
 
 
 def data_migration(apps, schema_editor):
@@ -28,11 +28,4 @@ class Migration(migrations.Migration):
     dependencies = [('main', '0034_add_readme_to_aips')]
     operations = [
         migrations.RunPython(data_migration),
-        # Also modify File.modificationtime so that it corresponds to the
-        # camelCased database column name.
-        migrations.AlterField(
-            model_name='file',
-            name='modificationtime',
-            field=models.DateTimeField(auto_now_add=True,
-                                       db_column=b'modificationTime'))
     ]

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -427,7 +427,7 @@ class File(models.Model):
     checksumtype = models.CharField(max_length=36, db_column='checksumType', blank=True)
     size = models.BigIntegerField(db_column='fileSize', null=True, blank=True)
     label = models.TextField(blank=True)
-    modificationtime = models.DateTimeField(db_column='modificationTime', auto_now_add=True)
+    modificationtime = models.DateTimeField(db_column='modificationTime', null=True, auto_now_add=True)
     enteredsystem = models.DateTimeField(db_column='enteredSystem', auto_now_add=True)
     removedtime = models.DateTimeField(db_column='removedTime', null=True, default=None)
 


### PR DESCRIPTION
If the field is not nullable and because of the lack of a default, Django
attempts to use the `0000-00-00 00:00:00` value which is considered invalid in
MySQL when using the strict mode.

This solves #959.