### PR TITLE
Reenables the preview capability of appraisal tab

### DIFF
--- a/src/dashboard/frontend/appraisal-tab/app/preview/preview.controller.js
+++ b/src/dashboard/frontend/appraisal-tab/app/preview/preview.controller.js
@@ -15,7 +15,8 @@ controller('PreviewController', ['$scope', 'gettextCatalog', '$routeSegment', 'A
 
   vm.set_file_data = file => {
     $scope.file = file;
-    $scope.url = '/filesystem/' + file.id + '/download';
+    $scope.download = '/filesystem/' + file.id + '/download';
+    $scope.preview = '/filesystem/' + file.id + '/preview';
   };
 
   $scope.$routeSegment = $routeSegment;

--- a/src/dashboard/frontend/appraisal-tab/app/preview/preview.html
+++ b/src/dashboard/frontend/appraisal-tab/app/preview/preview.html
@@ -1,6 +1,6 @@
-<div class="preview-frame"><iframe ng-src="{{ url }}" name="preview-frame"></iframe></div>
+<div class="preview-frame"><iframe ng-src="{{ preview }}" name="preview-frame"></iframe></div>
 <p ng-if='file'>
   <span translate>Previewing {{ file.title }}</span>
-  <a ng-href="{{ url }}" download="filename">({{ "Download" | translate }})</a>
+  <a ng-href="{{ download }}" download="filename">({{ "Download" | translate }})</a>
 </p>
 <p ng-if='!file'>{{ "No file selected" | translate }}</p>

--- a/src/dashboard/src/components/filesystem_ajax/urls.py
+++ b/src/dashboard/src/components/filesystem_ajax/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     url(r'^download_ss/$', views.download_ss),
     url(r'^download_fs/$', views.download_fs),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/download/$', views.download_by_uuid),
+    url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/preview/$', views.preview_by_uuid),
     url(r'^contents/arrange/$', views.arrange_contents),
     url(r'^contents/$', views.contents),
     url(r'^children/location/(?P<location_uuid>' + settings.UUID_REGEX + ')/$', views.directory_children_proxy_to_storage_server),

--- a/src/dashboard/src/components/helpers.py
+++ b/src/dashboard/src/components/helpers.py
@@ -304,14 +304,27 @@ def processing_config_path():
     )
 
 
-def stream_file_from_storage_service(url, error_message='Remote URL returned {}'):
-    stream = requests.get(url, stream=True, timeout=django_settings.STORAGE_SERVICE_CLIENT_TIMEOUT)
+def stream_file_from_storage_service(url,
+                                     error_message='Remote URL returned {}',
+                                     preview_file=False):
+    # Repetetive or constant values to use below when seeting the headers.
+    header_content_disposition = 'Content-Disposition'
+    content_disposition_inline = 'inline'
+    storage_timeout = django_settings.STORAGE_SERVICE_CLIENT_TIMEOUT
+    stream = requests.get(url,
+                          stream=True,
+                          timeout=storage_timeout)
     if stream.status_code == 200:
         content_type = stream.headers.get('content-type', 'text/plain')
-        content_disposition = stream.headers.get('content-disposition')
         response = StreamingHttpResponse(stream, content_type=content_type)
-        if content_disposition:
-            response['Content-Disposition'] = content_disposition
+
+        # Provide a content-disposition so the browser knows how to handles
+        # the response.
+        content_disposition = stream.headers.get('content-disposition')
+        if preview_file:
+            response[header_content_disposition] = content_disposition_inline
+        elif content_disposition:
+            response[header_content_disposition] = content_disposition
         return response
     else:
         response = {


### PR DESCRIPTION
* Creates a new url to resolve links of type:preview
* Content disposition to inline for preview only if explicitly requested
* Resolves preview for standard transfers or those with examine contents set
* Resolves #884