### PR TITLE
Explicitly handle Archivematica Archivesspace cfg

### DIFF
--- a/src/dashboard/src/components/access/views.py
+++ b/src/dashboard/src/components/access/views.py
@@ -53,7 +53,7 @@ def _authenticate_to_archivesspace(func):
             }
             return django.http.HttpResponseServerError(json.dumps(response),
                                                        content_type="application/json")
-        except ArchivesSpaceError:
+        except (ArchivesSpaceError):
             response = {
                 "success": False,
                 "message": "Unable to connect to ArchivesSpace server at the default location! Check administrative settings."

--- a/src/dashboard/src/components/ingest/views_as.py
+++ b/src/dashboard/src/components/ingest/views_as.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedire
 from components import advanced_search
 from main import models
 
-from agentarchives.archivesspace import ArchivesSpaceClient, AuthenticationError, ConnectionError
+from agentarchives.archivesspace import ArchivesSpaceError, ArchivesSpaceClient, AuthenticationError, ConnectionError
 
 from components.ingest import pair_matcher
 
@@ -18,6 +18,9 @@ logger = logging.getLogger('archivematica.dashboard')
 
 def get_as_system_client():
     config = models.DashboardSetting.objects.get_dict('upload-archivesspace_v0.0')
+
+    if not config['host']:
+        raise ArchivesSpaceError("ArchivesSpace host string has not been set")
 
     return ArchivesSpaceClient(
         host=config['host'],


### PR DESCRIPTION
Because we are able to identify in our own configuration that the host
string to conect to Archivesspace is still blank we know that it hasn't
been configured. In those instances, we can raise a custom exception
stating as much, instead of attempting to create an Archivesspace client
and handling an InvalidURL exception.

Resolves #967