### PR TITLE
MediaConch: update to 17.12 and reduce verbosity

### DIFF
--- a/src/MCPClient-base.Dockerfile
+++ b/src/MCPClient-base.Dockerfile
@@ -82,15 +82,15 @@ RUN set -ex \
 
 # OS dependencies from .deb files
 RUN set -ex \
-  && curl -s https://mediaarea.net/download/binary/libzen0/0.4.34/libzen0_0.4.34-1_amd64.xUbuntu_14.04.deb --output libzen0_0.4.34-1_amd64.xUbuntu_14.04.deb \
-  && curl -s https://mediaarea.net/download/binary/libmediainfo0/0.7.91/libmediainfo0_0.7.91-1_amd64.xUbuntu_14.04.deb --output libmediainfo0_0.7.91-1_amd64.xUbuntu_14.04.deb \
-  && curl -s https://mediaarea.net/download/binary/mediaconch/16.12/mediaconch_16.12-1_amd64.xUbuntu_14.04.deb --output mediaconch_16.12-1_amd64.xUbuntu_14.04.deb \
-  && dpkg -i libzen0_0.4.34-1_amd64.xUbuntu_14.04.deb \
-  && dpkg -i libmediainfo0_0.7.91-1_amd64.xUbuntu_14.04.deb \
-  && dpkg -i mediaconch_16.12-1_amd64.xUbuntu_14.04.deb \
-  && rm libzen0_0.4.34-1_amd64.xUbuntu_14.04.deb \
-  && rm libmediainfo0_0.7.91-1_amd64.xUbuntu_14.04.deb \
-  && rm mediaconch_16.12-1_amd64.xUbuntu_14.04.deb
+  && curl -s https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb --output libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb \
+  && curl -s https://mediaarea.net/download/binary/libmediainfo0/17.12/libmediainfo0_17.12-1_amd64.xUbuntu_14.04.deb --output libmediainfo0_17.12-1_amd64.xUbuntu_14.04.deb \
+  && curl -s https://mediaarea.net/download/binary/mediaconch/17.12/mediaconch_17.12-1_amd64.xUbuntu_14.04.deb --output mediaconch_17.12-1_amd64.xUbuntu_14.04.deb \
+  && dpkg -i libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb \
+  && dpkg -i libmediainfo0_17.12-1_amd64.xUbuntu_14.04.deb \
+  && dpkg -i mediaconch_17.12-1_amd64.xUbuntu_14.04.deb \
+  && rm libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb \
+  && rm libmediainfo0_17.12-1_amd64.xUbuntu_14.04.deb \
+  && rm mediaconch_17.12-1_amd64.xUbuntu_14.04.deb
 
 RUN set -ex \
   && groupadd --gid 333 --system archivematica \

--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -1,4 +1,4 @@
-FROM artefactual/archivematica-mcp-client-base:20180228.01.e44c2e3c
+FROM artefactual/archivematica-mcp-client-base:20180315.01.34ad14f
 
 ENV DJANGO_SETTINGS_MODULE settings.common
 ENV PYTHONPATH /src/MCPClient/lib/:/src/archivematicaCommon/lib/:/src/dashboard/src/

--- a/src/MCPClient/lib/clientScripts/validateFile.py
+++ b/src/MCPClient/lib/clientScripts/validateFile.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python2
-"""
-Runs zero or more FPR validation commands against the provided file and returns
-an exit code. May also print to stdout, generate an Event models in the db,
-and/or write command-specific stdout to disk.
+"""Runs zero or more FPR validation commands against the provided file and
+returns an exit code. May also print to stdout, generate an Event model in the
+db, and/or write command-specific stdout to disk.
 
 If a format has no defined validation commands, no command is run.
 
@@ -93,8 +92,7 @@ class Validator(object):
             rule_outputs.append(self._execute_rule_command(rule))
         if 'failed' in rule_outputs:
             return FAIL_CODE
-        else:
-            return SUCCESS_CODE
+        return SUCCESS_CODE
 
     def _get_rules(self):
         """Return all FPR rules that apply to files of this type."""
@@ -136,8 +134,11 @@ class Validator(object):
             printing=False,
             arguments=args)
         if exitstatus != 0:
-            print('Command {} failed with exit status {}; stderr:'.format(
-                rule.command.description, exitstatus), stderr, file=sys.stderr)
+            print('Command {description} failed with exit status {status};'
+                  ' stderr:'.format(
+                      description=rule.command.description,
+                      status=exitstatus),
+                  stderr, file=sys.stderr)
             return 'failed'
         # Parse output and generate an Event
         # TODO: Evaluating a python string from a user-definable script seems
@@ -156,15 +157,18 @@ class Validator(object):
         if output.get('eventOutcomeInformation') == 'pass':
             print('Command "{}" was successful'.format(rule.command.description))
         else:
-            print('Command "{}" indicated failure with this'
-                  ' output:\n\n{}'.format(
-                      rule.command.description, pformat(stdout)),
+            print('Command {cmd_description} indicated failure with this'
+                  ' output:\n\n{output}'.format(
+                      cmd_description=rule.command.description,
+                      output=pformat(stdout)),
                   file=sys.stderr)
             result = 'failed'
         if self.file_type == 'preservation':
             self._save_stdout_to_logs_dir(output)
-        print('Creating {} event for {} ({})'.format(
-            self.purpose, self.file_path, self.file_uuid))
+        print('Creating {purpose} event for {file_path} ({file_uuid})'.format(
+            purpose=self.purpose,
+            file_path=self.file_path,
+            file_uuid=self.file_uuid))
         databaseFunctions.insertIntoEvents(
             fileUUID=self.file_uuid,
             eventType='validation',  # From PREMIS controlled vocab.

--- a/src/MCPClient/osdeps/Ubuntu-14.json
+++ b/src/MCPClient/osdeps/Ubuntu-14.json
@@ -47,8 +47,8 @@
   { "name": "uuid", "state": "latest"}
   ],
   "osdeps_debfiles": [
-  "https://mediaarea.net/download/binary/libzen0/0.4.34/libzen0_0.4.34-1_amd64.xUbuntu_14.04.deb",
-  "https://mediaarea.net/download/binary/libmediainfo0/0.7.91/libmediainfo0_0.7.91-1_amd64.xUbuntu_14.04.deb",
-  "https://mediaarea.net/download/binary/mediaconch/16.12/mediaconch_16.12-1_amd64.xUbuntu_14.04.deb"
+  "https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb",
+  "https://mediaarea.net/download/binary/libmediainfo0/17.12/libmediainfo0_17.12-1_amd64.xUbuntu_14.04.deb",
+  "https://mediaarea.net/download/binary/mediaconch/17.12/mediaconch_17.12-1_amd64.xUbuntu_14.04.deb"
   ]
 }

--- a/src/MCPClient/osdeps/Ubuntu-16.json
+++ b/src/MCPClient/osdeps/Ubuntu-16.json
@@ -49,8 +49,8 @@
   { "name": "uuid", "state": "latest"}
   ],
   "osdeps_debfiles": [
-  "https://mediaarea.net/download/binary/libzen0/0.4.35/libzen0v5_0.4.35-1_amd64.xUbuntu_16.04.deb",
-  "https://mediaarea.net/download/binary/libmediainfo0/0.7.97/libmediainfo0v5_0.7.97-1_amd64.xUbuntu_16.04.deb",
-  "https://mediaarea.net/download/binary/mediaconch/16.12/mediaconch_16.12-1_amd64.xUbuntu_16.04.deb"
+  "https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb",
+  "https://mediaarea.net/download/binary/libmediainfo0/17.12/libmediainfo0v5_17.12-1_amd64.xUbuntu_16.04.deb",
+  "https://mediaarea.net/download/binary/mediaconch/17.12/mediaconch_17.12-1_amd64.xUbuntu_16.04.deb"
   ]
 }

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -128,7 +128,7 @@ def createAndRunScript(text, stdIn="", printing=True, arguments=[],
     cmd.extend(arguments)
 
     # Run it
-    ret = launchSubProcess(cmd, stdIn="", printing=True,
+    ret = launchSubProcess(cmd, stdIn="", printing=printing,
                            env_updates=env_updates,
                            capture_output=capture_output)
 

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -9,7 +9,7 @@ logutils==0.3.3
 django-tastypie==0.13.2
 django-extensions==1.1.1
 elasticsearch>=1.0.0,<2.0.0
-git+https://github.com/artefactual/archivematica-fpr-admin.git@v1.7.4#egg=archivematica-fpr-admin
+git+https://github.com/artefactual/archivematica-fpr-admin.git@v1.7.5#egg=archivematica-fpr-admin
 gearman==2.0.2
 gevent==1.2.1  # used by gunicorn's async workers
 gunicorn==19.7.1


### PR DESCRIPTION
Fixes #966 

- Makes validateFile print less to stdout/stderr so the Tasks GUI is less cluttered.
- Updates MCPClient to use MediaConch v. 17.12 so that .mkv implementation checks to do not hang indefinitely on certain files.
- Modifies the MCPClient Dockerfile base image (required by above step).

- Related PRs:
  - [AM-fpr-admin PR 75](https://github.com/artefactual/archivematica-fpr-admin/pull/75) which adds migrations to reduce update the MediaConch version and reduced the verbosity of MediaConch-based validation and policy check micro-services.
  - [AM-acceptance-tests PR 77](https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/77) which adds a feature that confirms that the changes in this PR fix #966.