### PR TITLE
MCPClient: Update MediaConch to v. 18.03

### DIFF
--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -88,14 +88,14 @@ RUN set -ex \
 # OS dependencies from .deb files
 RUN set -ex \
   && curl -s https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb --output libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb \
-  && curl -s https://mediaarea.net/download/binary/libmediainfo0/17.12/libmediainfo0_17.12-1_amd64.xUbuntu_14.04.deb --output libmediainfo0_17.12-1_amd64.xUbuntu_14.04.deb \
-  && curl -s https://mediaarea.net/download/binary/mediaconch/17.12/mediaconch_17.12-1_amd64.xUbuntu_14.04.deb --output mediaconch_17.12-1_amd64.xUbuntu_14.04.deb \
+  && curl -s https://mediaarea.net/download/binary/libmediainfo0/18.03/libmediainfo0_18.03-1_amd64.xUbuntu_14.04.deb --output libmediainfo0_18.03-1_amd64.xUbuntu_14.04.deb \
+  && curl -s https://mediaarea.net/download/binary/mediaconch/18.03/mediaconch_18.03-1_amd64.xUbuntu_14.04.deb --output mediaconch_18.03-1_amd64.xUbuntu_14.04.deb \
   && dpkg -i libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb \
-  && dpkg -i libmediainfo0_17.12-1_amd64.xUbuntu_14.04.deb \
-  && dpkg -i mediaconch_17.12-1_amd64.xUbuntu_14.04.deb \
+  && dpkg -i libmediainfo0_18.03-1_amd64.xUbuntu_14.04.deb \
+  && dpkg -i mediaconch_18.03-1_amd64.xUbuntu_14.04.deb \
   && rm libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb \
-  && rm libmediainfo0_17.12-1_amd64.xUbuntu_14.04.deb \
-  && rm mediaconch_17.12-1_amd64.xUbuntu_14.04.deb
+  && rm libmediainfo0_18.03-1_amd64.xUbuntu_14.04.deb \
+  && rm mediaconch_18.03-1_amd64.xUbuntu_14.04.deb
 
 COPY archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/
 COPY dashboard/src/requirements/ /src/dashboard/src/requirements/

--- a/src/MCPClient/osdeps/Ubuntu-14.json
+++ b/src/MCPClient/osdeps/Ubuntu-14.json
@@ -48,7 +48,7 @@
   ],
   "osdeps_debfiles": [
   "https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb",
-  "https://mediaarea.net/download/binary/libmediainfo0/17.12/libmediainfo0_17.12-1_amd64.xUbuntu_14.04.deb",
-  "https://mediaarea.net/download/binary/mediaconch/17.12/mediaconch_17.12-1_amd64.xUbuntu_14.04.deb"
+  "https://mediaarea.net/download/binary/libmediainfo0/18.03/libmediainfo0_18.03-1_amd64.xUbuntu_14.04.deb",
+  "https://mediaarea.net/download/binary/mediaconch/18.03/mediaconch_18.03-1_amd64.xUbuntu_14.04.deb"
   ]
 }

--- a/src/MCPClient/osdeps/Ubuntu-16.json
+++ b/src/MCPClient/osdeps/Ubuntu-16.json
@@ -50,7 +50,7 @@
   ],
   "osdeps_debfiles": [
   "https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0v5_0.4.37-1_amd64.xUbuntu_16.04.deb",
-  "https://mediaarea.net/download/binary/libmediainfo0/17.12/libmediainfo0v5_17.12-1_amd64.xUbuntu_16.04.deb",
-  "https://mediaarea.net/download/binary/mediaconch/17.12/mediaconch_17.12-1_amd64.xUbuntu_16.04.deb"
+  "https://mediaarea.net/download/binary/libmediainfo0/18.03/libmediainfo0v5_18.03-1_amd64.xUbuntu_16.04.deb",
+  "https://mediaarea.net/download/binary/mediaconch/18.03/mediaconch_18.03-1_amd64.xUbuntu_16.04.deb"
   ]
 }


### PR DESCRIPTION
Fixes #1006 for stable/1.7.x.