### PR TITLE
MCPClient: Add subprocess Pyflame profiling

### DIFF
--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -254,6 +254,12 @@ This is the full list of variables supported by MCPClient:
     - **Type:** `boolean`
     - **Default:** `true`
 
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_PROFILE_CLIENT_SCRIPTS`**:
+    - **Description:** controls whether or not to use PyFlame to profile the client scripts; this should only be set to `true` in development for analyzing performance.
+    - **Config file example:** `MCPClient.profile_client_scripts`
+    - **Type:** `boolean`
+    - **Default:** `false`
+
 ## Logging configuration
 
 Archivematica 1.6.1 and earlier releases are configured by default to log to

--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -187,7 +187,8 @@ def execute_command(gearman_worker, gearman_job):
         exit_code, std_out, std_error = executeOrRun(
             'command', script, stdIn='',
             printing=django_settings.CAPTURE_CLIENT_SCRIPT_OUTPUT,
-            capture_output=django_settings.CAPTURE_CLIENT_SCRIPT_OUTPUT)
+            capture_output=django_settings.CAPTURE_CLIENT_SCRIPT_OUTPUT,
+            profile=django_settings.PROFILE_CLIENT_SCRIPTS)
     except OSError:
         logger.exception('Execution failed')
         return cPickle.dumps({'exitCode': 1,

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -43,6 +43,7 @@ CONFIG_MAPPING = {
         {'section': 'MCPClient', 'option': 'search_enabled', 'type': 'boolean'},
     ],
     'capture_client_script_output': {'section': 'MCPClient', 'option': 'capture_client_script_output', 'type': 'boolean'},
+    'profile_client_scripts': {'section': 'MCPClient', 'option': 'profile_client_scripts', 'type': 'boolean'},
     'removable_files': {'section': 'MCPClient', 'option': 'removableFiles', 'type': 'string'},
     'temp_directory': {'section': 'MCPClient', 'option': 'temp_dir', 'type': 'string'},
     'secret_key': {'section': 'MCPClient', 'option': 'django_secret_key', 'type': 'string'},
@@ -83,6 +84,7 @@ elasticsearchServer = localhost:9200
 elasticsearchTimeout = 10
 search_enabled = true
 capture_client_script_output = true
+profile_client_scripts = false
 temp_dir = /var/archivematica/sharedDirectory/tmp
 removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
 clamav_server = /var/run/clamav/clamd.ctl
@@ -213,3 +215,4 @@ STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
 AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
 SEARCH_ENABLED = config.get('search_enabled')
 CAPTURE_CLIENT_SCRIPT_OUTPUT = config.get('capture_client_script_output')
+PROFILE_CLIENT_SCRIPTS = config.get('profile_client_scripts')


### PR DESCRIPTION
To get Pyflame profiling of MCPClient client scripts, you must [enable ptrace](https://pyflame.readthedocs.io/en/latest/faq.html?#what-are-these-ptrace-permissions-errors) and [install Pyflame](https://github.com/uber/pyflame#quickstart).

1. To enable ptrace, modify am.git's `docker-compose.yml` file so that the `archivematica-mcp-client` container is privileged:

       archivematica-mcp-client:
         privileged: true

   Then set the env var `AM_PROFILE_CLIENT_SCRIPTS` to `"true"` when building the containers: 

       $ AM_PROFILE_CLIENT_SCRIPTS="true" docker-compose up -d --build

   Finally, [set kernel.yama.ptrace_scope to a value that is not too restrictive](https://bitworks.software/blog/en/2017-07-24-docker-ptrace-attach.html):

       $ docker-compose exec --user=root archivematica-mcp-client bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"

2. To install Pyflame on the docker-compose MCPClient container:

       docker-compose exec --user=root archivematica-mcp-client bash -c "apt-get update && apt-get install --yes autoconf automake autotools-dev pkg-config python3-dev libtool"
       docker-compose exec --user=root archivematica-mcp-client bash -c "git clone https://github.com/uber/pyflame.git /var/pyflame"
       docker-compose exec --user=root archivematica-mcp-client bash -c "cd /var/pyflame && ./autogen.sh && ./configure && make"

Now when a transfer is run through AM, you should see .txt files in /tmp/ of the MCPClient container. These are Pyflame output files that can be converted to FlameGraphs using FlameGraph. TODO: more details.