### PR TITLE
archivematicaCommon: disable ES date detection

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -310,7 +310,7 @@ def set_up_mapping_aip_index(client):
     logger.info('Creating AIP mapping...')
     client.indices.put_mapping(
         doc_type='aip',
-        body={'aip': {'date_detection': True, 'properties': mapping}},
+        body={'aip': {'date_detection': False, 'properties': mapping}},
         index='aips'
     )
     logger.info('AIP mapping created.')
@@ -332,7 +332,7 @@ def set_up_mapping_aip_index(client):
     logger.info('Creating AIP file mapping...')
     client.indices.put_mapping(
         doc_type='aipfile',
-        body={'aipfile': {'date_detection': True, 'properties': mapping}},
+        body={'aipfile': {'date_detection': False, 'properties': mapping}},
         index='aips'
     )
     logger.info('AIP file mapping created.')

--- a/src/archivematicaCommon/lib/elasticsearch/aip_mets_mapping.json
+++ b/src/archivematicaCommon/lib/elasticsearch/aip_mets_mapping.json
@@ -111,6 +111,10 @@
                       "properties": {
                         "transfer_metadata_dict_list": {
                           "properties": {
+                            "Bagging-Date": {
+                              "type": "date",
+                              "format": "dateOptionalTime"
+                            },
                             "imaging_process_notes": {
                               "type": "string"
                             },


### PR DESCRIPTION
- Disables Elasticsearch date_detection
- Explicitly specifies the `Bagging-Date` field of BagIt transfer metadata as a date-typed field.

Fixes #1033