### PR TITLE
storageService.create_file: raise HTTP errors, refactor

### DIFF
--- a/src/MCPClient/lib/clientScripts/storeAIP.py
+++ b/src/MCPClient/lib/clientScripts/storeAIP.py
@@ -151,31 +151,31 @@ def store_aip(aip_destination_uri, aip_path, sip_uuid, sip_name, sip_type):
         aip_subtype = dc.type
 
     # Store the AIP
-    (new_file, error_msg) = storage_service.create_file(
-        uuid=uuid,
-        origin_location=current_location['resource_uri'],
-        origin_path=relative_aip_path,
-        current_location=aip_destination_uri,
-        current_path=current_path,
-        package_type=package_type,
-        aip_subtype=aip_subtype,
-        size=size,
-        update='REIN' in sip_type,
-        related_package_uuid=related_package_uuid,
-        events=get_events_from_db(uuid),
-        agents=get_agents_from_db(uuid)
-    )
-
-    if new_file is not None and new_file.get('status', '') != "FAIL":
-        message = "Storage service created {}: {}".format(sip_type, new_file)
-        LOGGER.info(message)
-        print(message)
-        sys.exit(0)
-    else:
+    try:
+        new_file = storage_service.create_file(
+            uuid=uuid,
+            origin_location=current_location['resource_uri'],
+            origin_path=relative_aip_path,
+            current_location=aip_destination_uri,
+            current_path=current_path,
+            package_type=package_type,
+            aip_subtype=aip_subtype,
+            size=size,
+            update='REIN' in sip_type,
+            related_package_uuid=related_package_uuid,
+            events=get_events_from_db(uuid),
+            agents=get_agents_from_db(uuid)
+        )
+    except Exception as e:
         print("{} creation failed.  See Storage Service logs for more details".format(sip_type), file=sys.stderr)
-        print(error_msg or "Package status: Failed", file=sys.stderr)
-        LOGGER.warning("{} unabled to be created: {}.  See logs for more details.".format(sip_type, error_msg))
-        sys.exit(1)
+        print(e, file=sys.stderr)
+        LOGGER.warning("Unable to create {}: {}.  See Storage Service logs for more details.".format(sip_type, e))
+        return 1
+
+    message = "Storage service created {}: {}".format(sip_type, new_file)
+    LOGGER.info(message)
+    print(message)
+    return 0
 
     # FIXME this should be moved to the storage service and areas that rely
     # on the thumbnails should be updated

--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -246,16 +246,21 @@ def create_file(uuid, origin_location, origin_path, current_location,
                 current_path, package_type, size, update=False,
                 related_package_uuid=None, events=None, agents=None,
                 aip_subtype=None):
-    """Creates a new file. Returns a tuple of (resulting dict, None) on
-    success, (None, error) on failure. Note: for backwards compatibility
+    """Creates a new file. Note: for backwards compatibility
     reasons, the SS API calls "packages" "files" and this function should be
     read as ``create_package``.
 
     origin_location and current_location should be URIs for the storage service.
+
+    Returns:
+        Dict with the JSON response from the SS API
+
+    Raises:
+        RequestException: if the SS API call fails
     """
     pipeline = _get_pipeline(get_setting('dashboard_uuid'))
     if pipeline is None:
-        return (None, 'Pipeline not available, see logs.')
+        raise ResourceNotFound('Pipeline not available')
     if events is None:
         events = []
     if agents is None:
@@ -285,15 +290,14 @@ def create_file(uuid, origin_location, origin_path, current_location,
         else:
             url = _storage_service_url() + 'file/'
             response = session.post(url, json=new_file)
+        # raise an HTTPError exception if getting HTTP 4xx or 5xx error
+        response.raise_for_status()
     except requests.exceptions.RequestException as e:
         LOGGER.warning("Unable to create file from %s because %s", new_file, e)
-        return (None, e)
-    # TODO: if the SS returns a 500 error, then the dashboard will not signal
-    # to the user that AIP storage has failed! This is not good.
+        raise
     LOGGER.info('Status code of create file/package request: %s',
                 response.status_code)
-    file_ = response.json()
-    return (file_, None)
+    return response.json()
 
 
 def get_file_info(uuid=None, origin_location=None, origin_path=None,


### PR DESCRIPTION
Fixes #815 
Note that this only fixes the issue of the "store AIP" job/micro-service not failing if getting an error from the SS (probably also need to roll back changes in the SS database in another PR)