### PR TITLE
MCPClient: prevent archivematicaUpdateSizeAndChecksum.py from detecting OCR transcription files as derivatives

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaUpdateSizeAndChecksum.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaUpdateSizeAndChecksum.py
@@ -53,64 +53,58 @@ def find_mets_file(unit_path):
 
 
 def get_file_info_from_mets(shared_path, file_):
-    """
-    Get file size, checksum & type, and derivation for this file from METS.
+    """Get file size, checksum & type, and derivation for this file from METS.
 
     Given an instance of a File, return a dict with keys: file_size,
     checksum and checksum_type, as they are described in the original METS
     document of the transfer. The dict will be empty or missing keys on error.
     """
     transfer = file_.transfer
-    transfer_location = transfer.currentlocation.replace('%sharedPath%', shared_path, 1)
-
+    transfer_location = transfer.currentlocation.replace(
+        '%sharedPath%', shared_path, 1)
     mets_file = find_mets_file(transfer_location)
     if not mets_file:
-        logger.info('Archivematica AIP: METS file not found in %s.', transfer_location)
+        logger.info('Archivematica AIP: METS file not found in %s.',
+                    transfer_location)
         return {}
-
     logger.info('Archivematica AIP: reading METS file %s.', mets_file)
     mets = metsrw.METSDocument.fromfile(mets_file)
-
     fsentry = mets.get_file(file_uuid=file_.uuid)
     if not fsentry:
         logger.error('Archivematica AIP: FSEntry with UUID %s not found', file_.uuid)
         return {}
-    if not len(fsentry.amdsecs):
-        logger.error('Archivematica AIP: FSEntry.amdsecs is empty')
-        return {}
-    amdsec = fsentry.amdsecs[0]
-    for item in amdsec.subsections:
-        if item.subsection == 'techMD':
-            techmd = item
-    if not techmd:
-        logger.error('Archivematica AIP: techMD section could not be found')
-        return {}
-    if techmd.contents.mdtype != 'PREMIS:OBJECT':
+
+    # Get the UUID of a preservation derivative, if one exists
+    try:
+        premis_object = fsentry.get_premis_objects()[0]
+    except IndexError:
         logger.error('Archivematica AIP: PREMIS:OBJECT could not be found')
         return {}
-    pobject = techmd.contents.document  # Element
+    premis_object = fsentry.get_premis_objects()[0]
+    related_object_uuid = None
+    for relationship in premis_object.relationship:
+        if relationship.sub_type != 'is source of':
+            continue
+        event = fsentry.get_premis_event(
+            relationship.related_event_identifier_value)
+        if (not event) or (event.type != 'normalization'):
+            continue
+        related_object_uuid = relationship.related_object_identifier_value
+        break
 
-    size = pobject.findtext('premis:objectCharacteristics/premis:objectCharacteristicsExtension/Mediainfo/File/track[@type="General"]/File_size', namespaces=metsrw.utils.NAMESPACES)
-    checksum = pobject.findtext('premis:objectCharacteristics/premis:fixity/premis:messageDigest', namespaces=metsrw.utils.NAMESPACES)
-    checksum_type = pobject.findtext('premis:objectCharacteristics/premis:fixity/premis:messageDigestAlgorithm', namespaces=metsrw.utils.NAMESPACES)
-
-    derivation_uuid = None
-    related_uuid = pobject.findtext('premis:relationship/premis:relatedObjectIdentification/premis:relatedObjectIdentifierValue', namespaces=metsrw.utils.NAMESPACES)
-    rel = pobject.findtext('premis:relationship/premis:relationshipSubType', namespaces=metsrw.utils.NAMESPACES)
-    if rel == 'is source of':
-        derivation_uuid = related_uuid
-
-    format_version = parse_mets_to_db.parse_format_version(pobject)
+    premis_object_doc = [
+        ss.contents.document for ss in fsentry.amdsecs[0].subsections
+        if ss.contents.mdtype == metsrw.FSEntry.PREMIS_OBJECT][0]
 
     ret = {
-        'file_size': size,
-        'checksum': checksum,
-        'checksum_type': checksum_type,
-        'derivation': derivation_uuid,
-        'format_version': format_version,
+        'file_size': premis_object.size,
+        'checksum': premis_object.message_digest,
+        'checksum_type': premis_object.message_digest_algorithm,
+        'derivation': related_object_uuid,
+        'format_version': parse_mets_to_db.parse_format_version(
+            premis_object_doc),
     }
     logger.info('Archivematica AIP: %s', ret)
-
     return ret
 
 
@@ -125,20 +119,24 @@ def main(shared_path, file_uuid, file_path, date, event_uuid):
     # If so, try to extract the size, checksum and checksum function from the
     # original METS document.
     kw = {}
-    if file_.transfer and not file_.sip:
-        if file_.transfer.type == 'Archivematica AIP':
-            info = get_file_info_from_mets(shared_path, file_)
-            kw.update(fileSize=info['file_size'], checksum=info['checksum'], checksumType=info['checksum_type'], add_event=False)
-            if info.get('derivation'):
-                insertIntoDerivations(
-                    sourceFileUUID=file_uuid,
-                    derivedFileUUID=info['derivation'],
-                )
-            if info.get('format_version'):
-                FileFormatVersion.objects.create(
-                    file_uuid_id=file_uuid,
-                    format_version=info['format_version']
-                )
+    if (file_.transfer and
+            (not file_.sip) and
+            file_.transfer.type == 'Archivematica AIP'):
+        info = get_file_info_from_mets(shared_path, file_)
+        kw.update(fileSize=info['file_size'],
+                  checksum=info['checksum'],
+                  checksumType=info['checksum_type'],
+                  add_event=False)
+        if info.get('derivation'):
+            insertIntoDerivations(
+                sourceFileUUID=file_uuid,
+                derivedFileUUID=info['derivation'],
+            )
+        if info.get('format_version'):
+            FileFormatVersion.objects.create(
+                file_uuid_id=file_uuid,
+                format_version=info['format_version']
+            )
 
     updateSizeAndChecksum(file_uuid, file_path, date, event_uuid, **kw)
 

--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -7,7 +7,7 @@ django-extensions==1.1.1
 mysqlclient==1.3.9
 gearman==2.0.2
 lxml==3.5.0
-metsrw==0.2.0
+metsrw==0.2.1
 requests==2.18.4
 unidecode==0.04.19
 opf-fido==1.3.7

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -179,8 +179,9 @@ def insertIntoEvents(fileUUID, eventIdentifierUUID="", eventType="", eventDateTi
 
 
 def insertIntoDerivations(sourceFileUUID, derivedFileUUID, relatedEventUUID=None):
-    """
-    Creates a new entry in the Derivations table using the supplied arguments. The two files in this relationship should already exist in the Files table.
+    """Creates a new entry in the Derivations table using the supplied
+    arguments. The two files in this relationship should already exist in the
+    Files table.
 
     :param str sourceFileUUID: The UUID of the original file.
     :param str derivedFileUUID: The UUID of the derived file.

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -17,7 +17,7 @@ gunicorn==19.7.1
 futures==3.0.5  # used by gunicorn's async workers
 lazy-paged-sequence
 lxml==3.5.0
-metsrw==0.2.0
+metsrw==0.2.1
 mysqlclient==1.3.7
 pytz
 pyopenssl


### PR DESCRIPTION
Fixes #1043 

Requires https://github.com/artefactual-labs/mets-reader-writer/pull/46