### PR TITLE
Restore SS's file status check

### DIFF
--- a/src/MCPClient/lib/clientScripts/moveToBacklog.py
+++ b/src/MCPClient/lib/clientScripts/moveToBacklog.py
@@ -14,6 +14,30 @@ from custom_handlers import get_script_logger
 import storageService as storage_service
 
 
+class StorageServiceCreateFileError(Exception):
+    pass
+
+
+def _create_file(transfer_uuid, current_location, relative_transfer_path,
+                 backlog, backlog_path, size):
+    new_file = storage_service.create_file(
+        uuid=transfer_uuid,
+        origin_location=current_location['resource_uri'],
+        origin_path=relative_transfer_path,
+        current_location=backlog['resource_uri'],
+        current_path=backlog_path,
+        package_type='transfer',  # TODO use constant from storage service
+        size=size,
+    )
+    if new_file is None:
+        raise StorageServiceCreateFileError(
+            'Value returned by Storage Service is unexpected')
+    if new_file.get('status') == 'FAIL':
+        raise StorageServiceCreateFileError(
+            'Object returned by Storage Service has status "FAIL"')
+    return new_file
+
+
 def main(transfer_uuid, transfer_path):
     current_location = storage_service.get_location(purpose="CP")[0]
     backlog = storage_service.get_location(purpose="BL")[0]
@@ -35,19 +59,15 @@ def main(transfer_uuid, transfer_path):
     backlog_path = os.path.join('originals', transfer_name)
 
     try:
-        new_file = storage_service.create_file(
-            uuid=transfer_uuid,
-            origin_location=current_location['resource_uri'],
-            origin_path=relative_transfer_path,
-            current_location=backlog['resource_uri'],
-            current_path=backlog_path,
-            package_type='transfer',  # TODO use constant from storage service
-            size=size,
-        )
+        new_file = _create_file(
+            transfer_uuid, current_location, relative_transfer_path, backlog,
+            backlog_path, size)
     except Exception as e:
-        print("Moving to backlog failed.  See Storage Service logs for more details", file=sys.stderr)
+        print('Moving to backlog failed.'
+              ' See Storage Service logs for more details', file=sys.stderr)
         print(e, file=sys.stderr)
-        logging.warning("Moving to backlog failed: {}.  See Storage Service logs for more details.".format(e))
+        logging.warning('Moving to backlog failed: {}. See Storage Service'
+                        ' logs for more details.'.format(e))
         return 1
 
     message = "Transfer moved to backlog: {}".format(new_file)


### PR DESCRIPTION
This commit restores a check we used to make on the returned value of `storage_service.create_file` (before 833bbc97b2b65f77335cc514b1f7c321533a21ed) because it's possible that the `status` equals to `FAIL` and if that's the case we should also have the client script fail.

This is in addition to #1049.
It relates to #815.