### PR TITLE
MCPClient: add capture output config option

### DIFF
--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -248,6 +248,11 @@ This is the full list of variables supported by MCPClient:
     - **Type:** `string`
     - **Default:** `3306`
 
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CAPTURE_CLIENT_SCRIPT_OUTPUT`**:
+    - **Description:** controls whether or not to capture stdout from client script subprocesses.  If set to `true`, then stdout is captured; if set to `false`, then stdout is not captured. If set to `true`, then stderr is captured; if set to `false`, then stderr is captured only if the subprocess has failed, i.e., returned a non-zero exit code.
+    - **Config file example:** `MCPClient.capture_client_script_output`
+    - **Type:** `boolean`
+    - **Default:** `true`
 
 ## Logging configuration
 

--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -2,7 +2,7 @@
 
 # This file is part of Archivematica.
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -129,7 +129,10 @@ Unable to determine if it completed successfully."""
         # Execute command
         command += " " + arguments
         logger.info('<processingCommand>{%s}%s</processingCommand>', gearman_job.unique, command)
-        exitCode, stdOut, stdError = executeOrRun("command", command, sInput, printing=True)
+        exitCode, stdOut, stdError = executeOrRun(
+            'command', command, stdIn=sInput,
+            printing=django_settings.CAPTURE_CLIENT_SCRIPT_OUTPUT,
+            capture_output=django_settings.CAPTURE_CLIENT_SCRIPT_OUTPUT)
         return cPickle.dumps({"exitCode": exitCode, "stdOut": stdOut, "stdError": stdError})
     except OSError:
         logger.exception('Execution failed')

--- a/src/MCPClient/lib/clientScripts/compressAIP.py
+++ b/src/MCPClient/lib/clientScripts/compressAIP.py
@@ -87,7 +87,8 @@ def compress_aip(compression, compression_level, sip_directory, sip_name, sip_uu
         return -1
 
     print('Executing command:', command)
-    exit_code, std_out, std_err = executeOrRun("bashScript", command, printing=True)
+    exit_code, std_out, std_err = executeOrRun("bashScript", command, printing=True,
+                                               capture_output=False)
 
     # Add new AIP File
     file_uuid = sip_uuid

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -42,6 +42,7 @@ CONFIG_MAPPING = {
         {'section': 'MCPClient', 'option': 'disableElasticsearchIndexing', 'type': 'iboolean'},
         {'section': 'MCPClient', 'option': 'search_enabled', 'type': 'boolean'},
     ],
+    'capture_client_script_output': {'section': 'MCPClient', 'option': 'capture_client_script_output', 'type': 'boolean'},
     'removable_files': {'section': 'MCPClient', 'option': 'removableFiles', 'type': 'string'},
     'temp_directory': {'section': 'MCPClient', 'option': 'temp_dir', 'type': 'string'},
     'secret_key': {'section': 'MCPClient', 'option': 'django_secret_key', 'type': 'string'},
@@ -81,6 +82,7 @@ numberOfTasks = 0
 elasticsearchServer = localhost:9200
 elasticsearchTimeout = 10
 search_enabled = true
+capture_client_script_output = true
 temp_dir = /var/archivematica/sharedDirectory/tmp
 removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
 clamav_server = /var/run/clamav/clamd.ctl
@@ -210,3 +212,4 @@ CLAMAV_CLIENT_MAX_SCAN_SIZE = config.get('clamav_client_max_scan_size')
 STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
 AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
 SEARCH_ENABLED = config.get('search_enabled')
+CAPTURE_CLIENT_SCRIPT_OUTPUT = config.get('capture_client_script_output')

--- a/src/archivematicaCommon/lib/custom_handlers.py
+++ b/src/archivematicaCommon/lib/custom_handlers.py
@@ -46,7 +46,7 @@ def get_script_logger(name, formatter=SCRIPT_FILE_FORMAT, root="archivematica", 
         },
         'root': {  # Everything else
             'handlers': ['console'],
-            'level': 'WARNING',
+            'level': 'DEBUG',
         },
     }
 

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -28,7 +28,8 @@ import os
 import sys
 
 
-def launchSubProcess(command, stdIn="", printing=True, arguments=[], env_updates={}):
+def launchSubProcess(command, stdIn="", printing=True, arguments=[],
+                     env_updates={}, capture_output=False):
     """
     Launches a subprocess using ``command``, where ``command`` is either:
     a) a single string containing a commandline statement, or
@@ -49,6 +50,14 @@ def launchSubProcess(command, stdIn="", printing=True, arguments=[], env_updates
                 only honoured if ``command`` is an array, and will be ignored
                 if ``command`` is a string.
     env_updates: Dict of changes to apply to the started process' environment.
+    capture_output: Whether or not to capture stdout from the subprocess.
+                    Defaults to `False`. If `False`, then stdout is never
+                    captured and is returned as an empty string; if `True`,
+                    then stdout is always captured. The stderr is always
+                    captured from the subprocess, regardless of this setting.
+                    If `capture_output` is `False`, then that stderr is only
+                    returned IF the subprocess has failed, i.e., returned a
+                    non-zero exit code.
     """
     stdError = ""
     stdOut = ""
@@ -76,14 +85,27 @@ def launchSubProcess(command, stdIn="", printing=True, arguments=[], env_updates
             stdin_string = ""
         else:
             raise Exception("stdIn must be a string or a file object")
-
-        p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=stdin_pipe, env=my_env)
-        stdOut, stdError = p.communicate(input=stdin_string)
+        if capture_output:
+            # Capture the stdout and stderr of the subprocess
+            p = subprocess.Popen(command, stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE, stdin=stdin_pipe,
+                                 env=my_env)
+            stdOut, stdError = p.communicate(input=stdin_string)
+        else:
+            # Ignore the stdout of the subprocess, capturing only stderr
+            with open(os.devnull, 'w') as devnull:
+                p = subprocess.Popen(command, stdin=stdin_pipe, env=my_env,
+                                     stdout=devnull, stderr=subprocess.PIPE)
+                __, stdError = p.communicate(input=stdin_string)
+        retcode = p.returncode
+        # If we are not capturing output and the subprocess has succeeded, set
+        # its stderr to the empty string.
+        if (not capture_output) and (retcode == 0):
+            stdError = ''
         # append the output to stderror and stdout
         if printing:
             print(stdOut)
             print(stdError, file=sys.stderr)
-        retcode = p.returncode
     except OSError as ose:
         print("Execution failed:", ose, file=sys.stderr)
         return -1, "Config Error!", ose.__str__()
@@ -95,7 +117,8 @@ def launchSubProcess(command, stdIn="", printing=True, arguments=[], env_updates
     return retcode, stdOut, stdError
 
 
-def createAndRunScript(text, stdIn="", printing=True, arguments=[], env_updates={}):
+def createAndRunScript(text, stdIn="", printing=True, arguments=[],
+                       env_updates={}, capture_output=True):
     # Output the text to a /tmp/ file
     scriptPath = "/tmp/" + uuid.uuid4().__str__()
     FILE = os.open(scriptPath, os.O_WRONLY | os.O_CREAT, 0o770)
@@ -106,7 +129,8 @@ def createAndRunScript(text, stdIn="", printing=True, arguments=[], env_updates=
 
     # Run it
     ret = launchSubProcess(cmd, stdIn="", printing=printing,
-                           env_updates=env_updates)
+                           env_updates=env_updates,
+                           capture_output=capture_output)
 
     # Remove the temp file
     os.remove(scriptPath)
@@ -114,7 +138,8 @@ def createAndRunScript(text, stdIn="", printing=True, arguments=[], env_updates=
     return ret
 
 
-def executeOrRun(type, text, stdIn="", printing=True, arguments=[], env_updates={}):
+def executeOrRun(type, text, stdIn="", printing=True, arguments=[],
+                 env_updates={}, capture_output=True):
     """
     Attempts to run the provided command on the shell, with the text of
     "stdIn" passed as standard input if provided. The type parameter
@@ -142,14 +167,24 @@ def executeOrRun(type, text, stdIn="", printing=True, arguments=[], env_updates=
                 honoured if ``command`` is an array, and will be ignored if ``command``
                 is a string.
     env_updates: Dict of changes to apply to the started process' environment.
+    capture_output: Whether or not to capture output for the executed process.
+                Default is `True`.
     """
     if type == "command":
-        return launchSubProcess(text, stdIn=stdIn, printing=printing, arguments=arguments, env_updates=env_updates)
+        return launchSubProcess(text, stdIn=stdIn, printing=printing,
+                                arguments=arguments, env_updates=env_updates,
+                                capture_output=capture_output)
     if type == "bashScript":
         text = "#!/bin/bash\n" + text
-        return createAndRunScript(text, stdIn=stdIn, printing=printing, arguments=arguments, env_updates=env_updates)
+        return createAndRunScript(text, stdIn=stdIn, printing=printing,
+                                  arguments=arguments, env_updates=env_updates,
+                                  capture_output=capture_output)
     if type == "pythonScript":
         text = "#!/usr/bin/env python2\n" + text
-        return createAndRunScript(text, stdIn=stdIn, printing=printing, arguments=arguments, env_updates=env_updates)
+        return createAndRunScript(text, stdIn=stdIn, printing=printing,
+                                  arguments=arguments, env_updates=env_updates,
+                                  capture_output=capture_output)
     if type == "as_is":
-        return createAndRunScript(text, stdIn=stdIn, printing=printing, arguments=arguments, env_updates=env_updates)
+        return createAndRunScript(text, stdIn=stdIn, printing=printing,
+                                  arguments=arguments, env_updates=env_updates,
+                                  capture_output=capture_output)

--- a/src/archivematicaCommon/tests/test_execute_functions.py
+++ b/src/archivematicaCommon/tests/test_execute_functions.py
@@ -1,0 +1,52 @@
+# -*- coding: UTF-8 -*-
+
+import shlex
+
+import executeOrRunSubProcess as execsub
+
+
+def test_capture_output():
+    """Tests behaviour of capture_output when executing sub processes."""
+
+    # Test that stdout and stderr are not captured by default
+    ret, std_out, std_err = execsub.launchSubProcess(['ls', '/tmp'])
+    assert std_out is ''
+    assert std_err is ''
+
+    # Test that stdout and stderr are captured when `capture_output` is
+    # enabled.
+    ret, std_out, std_err = execsub.launchSubProcess(
+        ['ls', '/tmp'], capture_output=True)
+    assert std_out is not '' or std_err is not ''
+
+    # Test that stdout and stderr are not captured when `capture_output` is
+    # not enabled.
+    ret, std_out, std_err = execsub.launchSubProcess(
+        ['ls', '/tmp'], capture_output=False)
+    assert std_out is ''
+    assert std_err is ''
+
+    # Test that when `capture_output` is `False`, then stdout is never returned
+    # and stderr is only returned when the exit code is non-zero.
+    cmd1 = 'sh -c \'>&2 echo "error"; echo "out"; exit 1\''
+    cmd0 = 'sh -c \'>&2 echo "error"; echo "out"; exit 0\''
+
+    ret, std_out, std_err = execsub.launchSubProcess(
+        shlex.split(cmd1), capture_output=False)
+    assert std_out.strip() is ''
+    assert std_err.strip() == 'error'
+
+    ret, std_out, std_err = execsub.launchSubProcess(
+        shlex.split(cmd0), capture_output=False)
+    assert std_out.strip() is ''
+    assert std_err.strip() == ''
+
+    ret, std_out, std_err = execsub.launchSubProcess(
+        shlex.split(cmd1), capture_output=True)
+    assert std_out.strip() == 'out'
+    assert std_err.strip() == 'error'
+
+    ret, std_out, std_err = execsub.launchSubProcess(
+        shlex.split(cmd0), capture_output=True)
+    assert std_out.strip() == 'out'
+    assert std_err.strip() == 'error'


### PR DESCRIPTION
Adds a CAPTURE_CLIENT_SCRIPT_OUTPUT setting to the MCPClient's Django settings. This controls what is passed to `executeOrRun`'s newly introduced `capture_output` kwarg. Similar kwargs added to subprocess-calling functions in executeOrRunSubProcess.py. Includes tests for correct behaviour of archivematicaCommon/lib/executeOrRunSubProcess.py::launchSubProcess.

Note: output capturing of the compression call in the compressAIP.py client script is turned off here uniformly because a lot of useless output is generated here for very large AIPs, which hampers performance.

Fixes #763 
Connected to #909 
Connected to #816 

Acceptance tests that confirm correct behaviour and performance enhancement of this feature are in [acceptance tests PR 75](https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/75).

Note: the same commits were merged into qa/1.x via https://github.com/artefactual/archivematica/pull/937.