### PR TITLE
Reingest: fix AttributeError MDRef

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py
@@ -158,6 +158,9 @@ def update_rights(mets, sip_uuid):
     for fsentry in original_files:
         rightsmds = [s for s in fsentry.amdsecs[0].subsections if s.subsection == 'rightsMD']
         for r in rightsmds:
+            # Don't follow MDRef pointers (see #1083 for more details).
+            if isinstance(r.contents, metsrw.metadata.MDRef):
+                continue
             if r.status == 'superseded':
                 continue
             rightsbasis = r.contents.document.findtext('.//premis:rightsBasis', namespaces=ns.NSMAP)


### PR DESCRIPTION
metsrw assumes that the METS is self-contained, MDRef pointers are not
followed. It would be up to `archivematicaCreateMETSReingest.py` to do so but
instead this commit ignores them. We're doing this because any rights updates
performed during re-ingest would result in the AIP METS file being edited, not
the DSpace one.

Connects to https://github.com/artefactual/archivematica/issues/1083.