### PR TITLE
MCPClient/Server: from-stdout task overrides output capturing

### DIFF
--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -91,6 +91,7 @@ def executeCommand(gearman_worker, gearman_job):
         data = cPickle.loads(gearman_job.data)
         utcDate = getUTCDate()
         arguments = data["arguments"]  # .encode("utf-8")
+        always_capture = data["alwaysCapture"]
         if isinstance(arguments, unicode):
             arguments = arguments.encode("utf-8")
 
@@ -129,10 +130,11 @@ Unable to determine if it completed successfully."""
         # Execute command
         command += " " + arguments
         logger.info('<processingCommand>{%s}%s</processingCommand>', gearman_job.unique, command)
+        capture_output = (
+            django_settings.CAPTURE_CLIENT_SCRIPT_OUTPUT or always_capture)
         exitCode, stdOut, stdError = executeOrRun(
-            'command', command, stdIn=sInput,
-            printing=django_settings.CAPTURE_CLIENT_SCRIPT_OUTPUT,
-            capture_output=django_settings.CAPTURE_CLIENT_SCRIPT_OUTPUT)
+            'command', command, stdIn=sInput, printing=capture_output,
+            capture_output=capture_output)
         return cPickle.dumps({"exitCode": exitCode, "stdOut": stdOut, "stdError": stdError})
     except OSError:
         logger.exception('Execution failed')

--- a/src/MCPServer/lib/linkTaskManagerGetMicroserviceGeneratedListInStdOut.py
+++ b/src/MCPServer/lib/linkTaskManagerGetMicroserviceGeneratedListInStdOut.py
@@ -71,7 +71,12 @@ class linkTaskManagerGetMicroserviceGeneratedListInStdOut(LinkTaskManager):
             commandReplacementDic[key] = archivematicaFunctions.escapeForCommand(value)
         arguments, standardOutputFile, standardErrorFile = commandReplacementDic.replace(arguments, standardOutputFile, standardErrorFile)
 
-        self.task = taskStandard(self, execute, arguments, standardOutputFile, standardErrorFile, UUID=self.UUID)
+        # This type of task must always capture stdout because communicating
+        # via stdout is the very nature of this task type.
+        self.task = taskStandard(
+            self, execute, arguments, standardOutputFile, standardErrorFile,
+            UUID=self.UUID, alwaysCapture=True)
+
         databaseFunctions.logTaskCreatedSQL(self, commandReplacementDic, self.UUID, arguments)
         t = threading.Thread(target=self.task.performTask)
         t.daemon = True


### PR DESCRIPTION
Cause linkTaskManagerGetMicroserviceGeneratedListInStdOut-type tasks to always override the global output-capturing setting. Without doing this, we defeate the purpose of these types of tasks, which is to print processing options (lists) to stdout for later parsing.

Fixes #1095