### PR TITLE
Correct default behaviour of extract packages and adds Unicode formatted strings

### DIFF
--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -233,7 +233,7 @@ def get_dir_uuids(dir_paths, logger=None):
     """
     for dir_path in dir_paths:
         dir_uuid = str(uuid4())
-        msg = 'Assigning UUID {} to directory path {}'.format(
+        msg = u'Assigning UUID {} to directory path {}'.format(
             dir_uuid, dir_path)
         print(msg)
         if logger:
@@ -288,7 +288,7 @@ def reconstruct_empty_directories(mets_file_path, objects_path, logger=None):
     if (not os.path.isfile(mets_file_path) or
             not os.path.isdir(objects_path)):
         if logger:
-            logger.info('Unable to construct empty directories, either because'
+            logger.info(u'Unable to construct empty directories, either because'
                         ' there is no METS file at {} or because there is no'
                         ' objects/ directory at {}'.format(mets_file_path,
                                                            objects_path))
@@ -299,7 +299,7 @@ def reconstruct_empty_directories(mets_file_path, objects_path, logger=None):
             NORMATIVE_STRUCTMAP_LABEL), NSMAP)
     if logical_struct_map_el is None:
         if logger:
-            logger.info('Unable to locate a logical structMap labelled {}.'
+            logger.info(u'Unable to locate a logical structMap labelled {}.'
                         ' Aborting attempt to reconstruct empty'
                         ' directories.'.format(NORMATIVE_STRUCTMAP_LABEL))
         return
@@ -307,7 +307,7 @@ def reconstruct_empty_directories(mets_file_path, objects_path, logger=None):
         'mets:div/mets:div[@LABEL="objects"]', NSMAP)
     if root_div_el is None:
         if logger:
-            logger.info('Unable to locate a logical structMap labelled {}.'
+            logger.info(u'Unable to locate a logical structMap labelled {}.'
                         ' Aborting attempt to reconstruct empty'
                         ' directories.'.format(NORMATIVE_STRUCTMAP_LABEL))
         return

--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -21,9 +21,8 @@
 # @subpackage archivematicaCommon
 # @author Joseph Perry <joseph@artefactual.com>
 
-"""archivematicaFunctions.py
-
-Provides various helper functions across the different Archivematica modules.
+"""archivematicaFunctions provides various helper functions across the
+different Archivematica modules.
 """
 
 from __future__ import print_function

--- a/src/dashboard/src/main/migrations/0052_correct_extract_packages_fallback_link.py
+++ b/src/dashboard/src/main/migrations/0052_correct_extract_packages_fallback_link.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""0052_correct_extact_packages_fallback_link.py
+
+Migration to ensure that if extract contents from compressed archives
+fails that the workflow doesn't continue to trudge along to completion where
+there is a likelihood of other errors.
+"""
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def data_migration(apps, schema_editor):
+    """Update two fields in the Dashboard data model for the two affected
+    transfer types.
+    """
+    std_transfer_extract_packages_link = "1cb7e228-6e94-4c93-bf70-430af99b9264"
+    dspace_extract_packages_link = "bd792750-a55b-42e9-903a-8c898bb77df1"
+    failed_transfer_link = "61c316a6-0a50-4f65-8767-1f44b1eeb6dd"
+    MicroServiceChainLink = apps.get_model('main', 'MicroServiceChainLink')
+    MicroServiceChainLink.objects\
+        .filter(id=dspace_extract_packages_link)\
+        .update(defaultnextchainlink=failed_transfer_link)
+    MicroServiceChainLink.objects\
+        .filter(id=std_transfer_extract_packages_link)\
+        .update(defaultnextchainlink=failed_transfer_link)
+
+
+class Migration(migrations.Migration):
+    """Entry point for the migration."""
+    dependencies = [('main', '0051_remove_verify_premis_checksums')]
+    operations = [
+        migrations.RunPython(data_migration),
+    ]

--- a/src/dashboard/src/main/migrations/0052_correct_extract_packages_fallback_link.py
+++ b/src/dashboard/src/main/migrations/0052_correct_extract_packages_fallback_link.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""0052_correct_extact_packages_fallback_link.py
-
-Migration to ensure that if extract contents from compressed archives
+"""Migration to ensure that if extract contents from compressed archives
 fails that the workflow doesn't continue to trudge along to completion where
 there is a likelihood of other errors.
 """
@@ -10,25 +8,41 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 
-def data_migration(apps, schema_editor):
+def data_migration_down(apps, schema_editor):
+    """Reset the two fields in the Dashboard data model for the two affected
+    transfer types.
+    """
+    std_transfer_extract_packages_link = "1cb7e228-6e94-4c93-bf70-430af99b9264"
+    dspace_extract_packages_link = "bd792750-a55b-42e9-903a-8c898bb77df1"
+    original_failed_transfer_link = "307edcde-ad10-401c-92c4-652917c993ed"
+    MicroServiceChainLink = apps.get_model('main', 'MicroServiceChainLink')
+    MicroServiceChainLink.objects\
+        .filter(id=dspace_extract_packages_link)\
+        .update(defaultnextchainlink=original_failed_transfer_link)
+    MicroServiceChainLink.objects\
+        .filter(id=std_transfer_extract_packages_link)\
+        .update(defaultnextchainlink=original_failed_transfer_link)
+
+
+def data_migration_up(apps, schema_editor):
     """Update two fields in the Dashboard data model for the two affected
     transfer types.
     """
     std_transfer_extract_packages_link = "1cb7e228-6e94-4c93-bf70-430af99b9264"
     dspace_extract_packages_link = "bd792750-a55b-42e9-903a-8c898bb77df1"
-    failed_transfer_link = "61c316a6-0a50-4f65-8767-1f44b1eeb6dd"
+    new_failed_transfer_link = "61c316a6-0a50-4f65-8767-1f44b1eeb6dd"
     MicroServiceChainLink = apps.get_model('main', 'MicroServiceChainLink')
     MicroServiceChainLink.objects\
         .filter(id=dspace_extract_packages_link)\
-        .update(defaultnextchainlink=failed_transfer_link)
+        .update(defaultnextchainlink=new_failed_transfer_link)
     MicroServiceChainLink.objects\
         .filter(id=std_transfer_extract_packages_link)\
-        .update(defaultnextchainlink=failed_transfer_link)
+        .update(defaultnextchainlink=new_failed_transfer_link)
 
 
 class Migration(migrations.Migration):
     """Entry point for the migration."""
     dependencies = [('main', '0051_remove_verify_premis_checksums')]
     operations = [
-        migrations.RunPython(data_migration),
+        migrations.RunPython(data_migration_up, data_migration_down),
     ]


### PR DESCRIPTION
This commit adds Unicode format strings to archivematicaCommonFunctions and corrects the fallback behaviour of the extract_packages microservice if the task should fail whatsoever.

@mcantelon as this fix impacts the dspace chainlinks as well, can you confirm whether the behaviour I have implemented here (fallback to fail transfer) is acceptable for that work as well or if there is additional nuance you'd like to see implemented. 

I made some pylint changes to the archivematicaCommonFunctions too. You will see this in a separate commit. 

Tested by re-deploying my docker implementation.

Additional test files can be found in #1104. 

Resolves #1104.