### PR TITLE
MCPClient: add hashdeep to osdeps for Xenial

### DIFF
--- a/src/MCPClient/osdeps/Ubuntu-16.json
+++ b/src/MCPClient/osdeps/Ubuntu-16.json
@@ -23,6 +23,7 @@
   { "name": "fits", "state": "latest"},
   { "name": "gearman", "state": "latest"},
   { "name": "ghostscript", "state": "latest"},
+  { "name": "hashdeep", "state": "latest"},
   { "name": "imagemagick", "state": "latest"},
   { "name": "inkscape", "state": "latest"},
   { "name": "jhove", "state": "latest"},


### PR DESCRIPTION
This fixes the issue:

https://github.com/artefactual-labs/ansible-archivematica-src/issues/207

It is needed to use the `hashdeep` package from the Archivematica
repository on Ubuntu 16 and this change will force its updated if the
system has an old version installed from the Ubuntu repository.

No changes are needed for Ubuntu 14, because it uses the `md5deep`
package instead of `hashdeep`.