### PR TITLE
Docker: use Debian jessie base images

### DIFF
--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7-jessie
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DJANGO_SETTINGS_MODULE settings.common

--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7-jessie
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DJANGO_SETTINGS_MODULE settings.production


### PR DESCRIPTION
Our images were based on `python:2.7`. This image moved to Debian stretch
causing an issue in our build. For further details see https://git.io/fCV6c.

This commit moves the base images to `python:2.7-jessie` to ensure that we
continue using Debian jessie until we have time to evaluate the upgrade.

This is connected to #1124.