### PR TITLE
Fix PDF normalization command output

### DIFF
--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -9,7 +9,7 @@ logutils==0.3.3
 django-tastypie==0.13.2
 django-extensions==1.1.1
 elasticsearch>=1.0.0,<2.0.0
-git+https://github.com/artefactual/archivematica-fpr-admin.git@v1.7.6#egg=archivematica-fpr-admin
+git+https://github.com/artefactual/archivematica-fpr-admin.git@v1.7.7#egg=archivematica-fpr-admin
 gearman==2.0.2
 gevent==1.2.1  # used by gunicorn's async workers
 gunicorn==19.7.1


### PR DESCRIPTION
This changes the archivematica-fpr-admin requirement to point to a dev branch which contains a migration that fixes the Ghostscript PDF normalization FPCommand so that it states the correct output FormatVersion as PDF/A 1b (not PDF/A 1a). This will need to be updated to a new AM-fpr-admin v.1.7.7 tag/release once such is available.

This is connected to https://github.com/artefactual/archivematica/issues/1158.