### PR TITLE
Exclude empty dublin core elements

### DIFF
--- a/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
+++ b/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
@@ -219,7 +219,8 @@ def parse_dc(sip_uuid, root):
         for elem in dc_xml:
             tag = elem.tag.replace(ns.dctermsBNS, '', 1).replace(ns.dcBNS, '', 1)
             print(tag, elem.text)
-            setattr(dc_model, DC_TERMS_MATCHING[tag], elem.text)
+            if elem.text is not None:
+                setattr(dc_model, DC_TERMS_MATCHING[tag], elem.text)
         dc_model.save()
     return dc_model
 


### PR DESCRIPTION
During aip-reingest, when reading dublin core metadata, do not write empty dublin core tags to the database.

This is connected to #1132.