### PR TITLE
storageService: add new query timeout

### DIFF
--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -164,6 +164,12 @@ This is the full list of variables supported by MCPClient:
     - **Type:** `float`
     - **Default:** `86400`
 
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT`**:
+    - **Description:** configures the Storage Service client to stop waiting for a response after a given number of seconds when the client uses asynchronous API endpoints.
+    - **Config file example:** `MCPClient.storage_service_client_quick_timeout`
+    - **Type:** `float`
+    - **Default:** `5`
+
 - **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_AGENTARCHIVES_CLIENT_TIMEOUT`**:
     - **Description:** configures the agentarchives client to stop waiting for a response after a given number of seconds.
     - **Config file example:** `MCPClient.agentarchives_client_timeout`

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -45,6 +45,7 @@ CONFIG_MAPPING = {
     'temp_directory': {'section': 'MCPClient', 'option': 'temp_dir', 'type': 'string'},
     'secret_key': {'section': 'MCPClient', 'option': 'django_secret_key', 'type': 'string'},
     'storage_service_client_timeout': {'section': 'MCPClient', 'option': 'storage_service_client_timeout', 'type': 'float'},
+    'storage_service_client_quick_timeout': {'section': 'MCPClient', 'option': 'storage_service_client_quick_timeout', 'type': 'float'},
     'agentarchives_client_timeout': {'section': 'MCPClient', 'option': 'agentarchives_client_timeout', 'type': 'float'},
 
     # [antivirus]
@@ -85,6 +86,7 @@ removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
 clamav_server = /var/run/clamav/clamd.ctl
 clamav_pass_by_stream = True
 storage_service_client_timeout = 86400
+storage_service_client_quick_timeout = 5
 agentarchives_client_timeout = 300
 clamav_client_timeout = 86400
 clamav_client_backend = clamdscanner    ; Options: clamdscanner or clamscanner
@@ -221,6 +223,7 @@ CLAMAV_CLIENT_BACKEND = config.get('clamav_client_backend')
 CLAMAV_CLIENT_MAX_FILE_SIZE = config.get('clamav_client_max_file_size')
 CLAMAV_CLIENT_MAX_SCAN_SIZE = config.get('clamav_client_max_scan_size')
 STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
+STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT = config.get('storage_service_client_quick_timeout')
 AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
 SEARCH_ENABLED = config.get('search_enabled')
 DEFAULT_CHECKSUM_ALGORITHM = 'sha256'

--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -165,6 +165,12 @@ variables or in the gunicorn configuration file.
     - **Type:** `float`
     - **Default:** `86400`
 
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT`**:
+    - **Description:** configures the Storage Service client to stop waiting for a response after a given number of seconds when the client uses asynchronous API endpoints.
+    - **Config file example:** `Dashboard.storage_service_client_quick_timeout`
+    - **Type:** `float`
+    - **Default:** `5`
+
 - **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_AGENTARCHIVES_CLIENT_TIMEOUT`**:
     - **Description:** configures the agentarchives client to stop waiting for a response after a given number of seconds.
     - **Config file example:** `Dashboard.agentarchives_client_timeout`

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -42,6 +42,7 @@ CONFIG_MAPPING = {
     'shibboleth_authentication': {'section': 'Dashboard', 'option': 'shibboleth_authentication', 'type': 'boolean'},
     'ldap_authentication': {'section': 'Dashboard', 'option': 'ldap_authentication', 'type': 'boolean'},
     'storage_service_client_timeout': {'section': 'Dashboard', 'option': 'storage_service_client_timeout', 'type': 'float'},
+    'storage_service_client_quick_timeout': {'section': 'Dashboard', 'option': 'storage_service_client_quick_timeout', 'type': 'float'},
     'agentarchives_client_timeout': {'section': 'Dashboard', 'option': 'agentarchives_client_timeout', 'type': 'float'},
     'site_url': {'section': 'Dashboard', 'option': 'site_url', 'type': 'string'},
 
@@ -71,6 +72,7 @@ gearman_server = 127.0.0.1:4730
 shibboleth_authentication = False
 ldap_authentication = False
 storage_service_client_timeout = 86400
+storage_service_client_quick_timeout = 5
 agentarchives_client_timeout = 300
 site_url =
 
@@ -443,6 +445,7 @@ ELASTICSEARCH_SERVER = config.get('elasticsearch_server')
 ELASTICSEARCH_TIMEOUT = config.get('elasticsearch_timeout')
 SEARCH_ENABLED = config.get('search_enabled')
 STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
+STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT = config.get('storage_service_client_quick_timeout')
 AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
 
 SITE_URL = config.get('site_url')


### PR DESCRIPTION
This is in addition to the existing client timeout that already exists in the
storageService module. This new timeout is used in requests that we know they
should be processed immediately.

This is connected to #1133.