### PR TITLE
Correct PREMIS:originalName for packaged objects

### DIFF
--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -253,9 +253,9 @@ def create_structured_directory(basepath,
 
 
 def get_dir_uuids(dir_paths, logger=None, printfn=print):
-    """Return a generator of 2-tuples, each containing one of the directory
-    paths in ``dir_paths`` and its newly minted UUID. Used by multiple client
-    scripts.
+    """Return a generator of dict instances, each containing one of the
+    directory paths in ``dir_paths`` and its newly minted UUID. Used by
+    multiple client scripts.
     """
     for dir_path in dir_paths:
         dir_uuid = str(uuid4())
@@ -264,7 +264,8 @@ def get_dir_uuids(dir_paths, logger=None, printfn=print):
         printfn(msg)
         if logger:
             logger.info(msg)
-        yield dir_path, dir_uuid
+        yield {"currentLocation": dir_path,
+               "uuid": dir_uuid}
 
 
 def format_subdir_path(dir_path, path_prefix_to_repl):

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -64,7 +64,8 @@ def getDeciDate(date):
     return str("{:10.10f}".format(float(ret)))
 
 
-def insertIntoFiles(fileUUID, filePath, enteredSystem=None, transferUUID="", sipUUID="", use="original"):
+def insertIntoFiles(fileUUID, filePath, enteredSystem=None, transferUUID="",
+                    sipUUID="", use="original", originalLocation=None):
     """
     Creates a new entry in the Files table using the supplied arguments.
 
@@ -74,15 +75,19 @@ def insertIntoFiles(fileUUID, filePath, enteredSystem=None, transferUUID="", sip
     :param str transferUUID: UUID for the transfer containing this file. Can be empty. At least one of transferUUID or sipUUID must be defined. Mutually exclusive with sipUUID.
     :param str sipUUID: UUID for the SIP containing this file. Can be empty. At least one of transferUUID or sipUUID must be defined. Mutually exclusive with transferUUID.
     :param str use: A category used to group the file with others of the same kind. Will be included in the AIP's METS document in the USE attribute. Defaults to "original".
+    :param str originalLocation: where the original location of the file needs to be recorded, such as premis:OriginalName fields, it can be set using this parameter here.
 
     :returns: None
     """
     if enteredSystem is None:
         enteredSystem = getUTCDate()
 
+    if not originalLocation:
+        originalLocation = filePath
+
     kwargs = {
         "uuid": fileUUID,
-        "originallocation": filePath,
+        "originallocation": originalLocation,
         "currentlocation": filePath,
         "enteredsystem": enteredSystem,
         "filegrpuse": use

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -60,9 +60,14 @@ def updateSizeAndChecksum(fileUUID, filePath, date, eventIdentifierUUID, fileSiz
                          eventOutcomeDetailNote=checksum)
 
 
-def addFileToTransfer(filePathRelativeToSIP, fileUUID, transferUUID, taskUUID, date, sourceType="ingestion", eventDetail="", use="original"):
-    # print filePathRelativeToSIP, fileUUID, transferUUID, taskUUID, date, sourceType, eventDetail, use
-    insertIntoFiles(fileUUID, filePathRelativeToSIP, date, transferUUID=transferUUID, use=use)
+def addFileToTransfer(filePathRelativeToSIP, fileUUID, transferUUID, taskUUID,
+                      date, sourceType="ingestion", eventDetail="",
+                      use="original", originalLocation=None):
+    if not originalLocation:
+        originalLocation = filePathRelativeToSIP
+    insertIntoFiles(
+        fileUUID, filePathRelativeToSIP, date,
+        transferUUID=transferUUID, use=use, originalLocation=originalLocation)
     insertIntoEvents(fileUUID=fileUUID,
                      eventType=sourceType,
                      eventDateTime=date,


### PR DESCRIPTION
This commit does a number of things. First, the logic for extracting
zipped packages is reversed so the package is temporarily renamed so
they can be extracted into a folder that reflects their original name.

Second the commit adds behavior that allows the originalLocation to be
set verbosely inside the code, where previously, we were not exploiting
the full capabilities of the Directory model type in the ORM.

--

**For discussion** should I replace the use of a tuple in all instances where we use the Directory create_many member function? https://github.com/artefactual/archivematica/search?q=create_many&unscoped_q=create_many There doesn't seem that many, and I think I prefer the verbosity.

**To test** the zip attached contains another zip. There are accents in the directory names, spaces, and an accent in the file names. All should be preserved in all the `premis:originalName` entries when reviewed, e.g. 

`<premis:originalName>%transferDirectory%objects/space space.zip/space space/ÉtoileBrûler.zip/ÉtoileBrûler/filè.txt</premis:originalName>`

**NB.** From an analyst's perspective, do we think this is accurate? Do we want to have the `.zip` extension?

[space space.zip](https://github.com/artefactual/archivematica/files/2161189/space.space.zip)

Connects to #1094
