### PR TITLE
MCPClient: add indexAIP error handling

### DIFF
--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -146,6 +146,12 @@ This is the full list of variables supported by MCPClient:
     - **Type:** `boolean`
     - **Default:** `true`
 
+- **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_INDEX_AIP_CONTINUE_ON_ERROR`**:
+    - **Description:** controls whether Archivematica continues processing the package when an error occurs in `indexAIP_v0.0`.
+    - **Config file example:** `MCPClient.index_aip_continue_on_error`
+    - **Type:** `boolean`
+    - **Default:** `false`
+
 - **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_REMOVABLEFILES`**:
     - **Description:** comma-separated listed of file names that will be deleted.
     - **Config file example:** `MCPClient.removableFiles`

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -41,6 +41,7 @@ CONFIG_MAPPING = {
         {'section': 'MCPClient', 'option': 'disableElasticsearchIndexing', 'type': 'iboolean'},
         {'section': 'MCPClient', 'option': 'search_enabled', 'type': 'boolean'},
     ],
+    'index_aip_continue_on_error': {'section': 'MCPClient', 'option': 'index_aip_continue_on_error', 'type': 'boolean'},
     'capture_client_script_output': {'section': 'MCPClient', 'option': 'capture_client_script_output', 'type': 'boolean'},
     'removable_files': {'section': 'MCPClient', 'option': 'removableFiles', 'type': 'string'},
     'temp_directory': {'section': 'MCPClient', 'option': 'temp_dir', 'type': 'string'},
@@ -82,6 +83,7 @@ clientAssetsDirectory = /usr/lib/archivematica/MCPClient/assets/
 elasticsearchServer = localhost:9200
 elasticsearchTimeout = 10
 search_enabled = true
+index_aip_continue_on_error = false
 capture_client_script_output = true
 temp_dir = /var/archivematica/sharedDirectory/tmp
 removableFiles = Thumbs.db, Icon, Icon\r, .DS_Store
@@ -228,6 +230,7 @@ STORAGE_SERVICE_CLIENT_TIMEOUT = config.get('storage_service_client_timeout')
 STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT = config.get('storage_service_client_quick_timeout')
 AGENTARCHIVES_CLIENT_TIMEOUT = config.get('agentarchives_client_timeout')
 SEARCH_ENABLED = config.get('search_enabled')
+INDEX_AIP_CONTINUE_ON_ERROR = config.get('index_aip_continue_on_error')
 CAPTURE_CLIENT_SCRIPT_OUTPUT = config.get('capture_client_script_output')
 DEFAULT_CHECKSUM_ALGORITHM = 'sha256'
 

--- a/src/dashboard/src/main/migrations/0054_index_aip_silent_error_branch.py
+++ b/src/dashboard/src/main/migrations/0054_index_aip_silent_error_branch.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+# Can't use apps.get_model for this model as we need to access class attributes.
+from main.models import Job
+
+
+NEW_EXIT_CODE_PK = 'c2638a7b-3308-4a0b-895a-001e09fd407a'
+
+
+def data_migration_up(apps, schema_editor):
+    """Add new branch to Index AIP chain link to continue on errors.
+
+    It is up to the client script to use this exit code when desired. It is
+    useful when you want to mark the job status as failing but you still want
+    to continue processing the package - which is something that we allow users
+    to do via configuration.
+    """
+    clean_up_after_storing_aip_pk = 'b7cf0d9a-504f-4f4e-9930-befa817d67ff'
+    index_aip_pk = '48703fad-dc44-4c8e-8f47-933df3ef6179'
+
+    apps.get_model('main', 'MicroServiceChainLinkExitCode').objects.create(
+        id=NEW_EXIT_CODE_PK,
+        microservicechainlink_id=index_aip_pk,
+        exitcode=179,
+        nextmicroservicechainlink_id=clean_up_after_storing_aip_pk,
+        exitmessage=Job.STATUS_FAILED,
+    )
+
+
+def data_migration_down(apps, schema_editor):
+    """Unapply migration."""
+    apps.get_model('main', 'MicroServiceChainLinkExitCode').objects.get(
+        pk=NEW_EXIT_CODE_PK).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0053_remove_mcp_unused_field'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            data_migration_up,
+            data_migration_down),
+    ]


### PR DESCRIPTION
This commit adds a new exit code branch (`179`) to the indexAIP chain link.
The client script reports this code when the desire is to set the job status as
failing but the processing should continue.

This is connected to #1136.