### PR TITLE
Dashboard: set_agent_code command

### DIFF
--- a/src/dashboard/src/components/administration/management/commands/set_agent_code.py
+++ b/src/dashboard/src/components/administration/management/commands/set_agent_code.py
@@ -1,0 +1,22 @@
+from django.core.management.base import BaseCommand
+
+from installer.steps import set_agent_code
+from main.models import Agent
+
+
+class Command(BaseCommand):
+    help = """Set the code of an agent.
+
+    By default it updates the agent code of the Archivematica preservation
+    system (pk=1). Use the argument `--pk=` to select a different agent.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('agent-code')
+        parser.add_argument('--pk', default=1, type=int)
+
+    def handle(self, *args, **options):
+        try:
+            set_agent_code(options['agent-code'], options['pk'])
+        except Agent.DoesNotExist:
+            self.stderr.write("Agent not found")

--- a/src/dashboard/src/installer/steps.py
+++ b/src/dashboard/src/installer/steps.py
@@ -43,6 +43,12 @@ def create_super_user(username, email, password, key):
     api_key, created = ApiKey.objects.update_or_create(user=user, defaults={'key': key})
 
 
+def set_agent_code(agent_code, pk):
+    archivematica_agent = Agent.objects.get(pk=pk)
+    archivematica_agent.identifiervalue = agent_code
+    archivematica_agent.save()
+
+
 def setup_pipeline(org_name, org_identifier, site_url):
     dashboard_uuid = helpers.get_setting('dashboard_uuid')
     # Setup pipeline only if dashboard_uuid doesn't already exists
@@ -54,9 +60,7 @@ def setup_pipeline(org_name, org_identifier, site_url):
     helpers.set_setting('dashboard_uuid', dashboard_uuid)
 
     # Update Archivematica version in DB
-    archivematica_agent = Agent.objects.get(pk=1)
-    archivematica_agent.identifiervalue = "Archivematica-" + get_version()
-    archivematica_agent.save()
+    set_agent_code("Archivematica-" + get_version(), pk=1)
 
     if org_name != '' or org_identifier != '':
         agent = get_agent()


### PR DESCRIPTION
This command enables users to override the Archivematica identifier
(`Agent.pk=1`), also known as the Archivematica PREMIS agent.

Usage example seen in the RDSS project:
```
# Set agent code in Dashboard
docker-compose run \
	--rm \
	--entrypoint /src/dashboard/src/manage.py \
		archivematica-dashboard \
			set_agent_code v0.6.0-14-g89693bb
```

Optionally you can use the `--pk=` argument to pass a different primary key. You can only update existing agents.

Connects to https://github.com/artefactual/archivematica/issues/1192.
Based on https://github.com/JiscRDSS/archivematica/pull/48.