### PR TITLE
Add retry logic for concurrency sensitive database transactions

### DIFF
--- a/src/MCPServer/lib/taskGroup.py
+++ b/src/MCPServer/lib/taskGroup.py
@@ -78,12 +78,15 @@ class TaskGroup():
         with self.groupTasksLock:
             self.finalised = True
 
-            with transaction.atomic():
-                for task in self.groupTasks:
-                    databaseFunctions.logTaskCreatedSQL(self.linkTaskManager,
-                                                        task.commandReplacementDic,
-                                                        task.UUID,
-                                                        task.arguments)
+            def insertTasks():
+                with transaction.atomic():
+                    for task in self.groupTasks:
+                        databaseFunctions.logTaskCreatedSQL(self.linkTaskManager,
+                                                            task.commandReplacementDic,
+                                                            task.UUID,
+                                                            task.arguments)
+
+            databaseFunctions.retryOnFailure("Insert tasks", insertTasks)
 
     def calculateExitCode(self):
         """

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -25,6 +25,8 @@ import logging
 import os
 import string
 import sys
+import random
+import time
 import uuid
 
 from django.db import close_old_connections
@@ -353,3 +355,19 @@ def deUnicode(str):
     if str is None:
         return None
     return unicode(str).encode('utf-8')
+
+
+def retryOnFailure(description, callback, retries=10):
+    for retry in range(0, retries + 1):
+        try:
+            callback()
+            break
+        except Exception as e:
+            if retry == retries:
+                LOGGER.error('Failed to complete transaction "%s" after %s retries',
+                             description, retries)
+                raise e
+            else:
+                LOGGER.debug('Retrying "%s" transaction after caught exception (retry %d): %s',
+                             description, retry + 1, e)
+                time.sleep(random.uniform(0, 2))


### PR DESCRIPTION
When the MCP Server inserts rows into the `Tasks` table, it holds a lock on the table primary key index.  When the MCP Client updates existing tasks to set their start time, it does the same.  If these transactions overlap, MySQL may detect this condition as a deadlock and abort one the transactions with a retriable/retryable(?!) exception.

To handle this, we can retry the failed transaction after a short wait.  It should always succeed eventually.

Connects to https://github.com/artefactual/archivematica/issues/1198.