### PR TITLE
MCPClient: job.py allow Unicode printing

### DIFF
--- a/src/MCPClient/lib/job.py
+++ b/src/MCPClient/lib/job.py
@@ -58,18 +58,23 @@ class Job():
         self.error += s
 
     def print_output(self, *args):
-        self.write_output(' '.join([str(x) for x in args]) + "\n")
+        self.write_output(' '.join([self._to_str(x) for x in args]) + "\n")
 
     def print_error(self, *args):
-        self.write_error(' '.join([str(x) for x in args]) + "\n")
+        self.write_error(' '.join([self._to_str(x) for x in args]) + "\n")
+
+    @staticmethod
+    def _to_str(thing):
+        try:
+            return str(thing)
+        except UnicodeEncodeError:
+            return thing.encode('utf8')
 
     def pyprint(self, *objects, **kwargs):
         file = kwargs.get('file', sys.stdout)
         sep = kwargs.get('sep', ' ')
         end = kwargs.get('end', "\n")
-
-        msg = sep.join([str(x) for x in objects]) + end
-
+        msg = sep.join([self._to_str(x) for x in objects]) + end
         if file == sys.stdout:
             self.write_output(msg)
         elif file == sys.stderr:
@@ -88,7 +93,7 @@ class Job():
 
     @contextmanager
     def JobContext(self, logger=None):
-        handler = CallbackHandler(self.write_error, self.name)
+        handler = CallbackHandler(self.print_error, self.name)
 
         if logger:
             logger.addHandler(handler)

--- a/src/MCPClient/tests/test_job.py
+++ b/src/MCPClient/tests/test_job.py
@@ -1,0 +1,23 @@
+import os
+import sys
+from uuid import uuid4
+
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(
+    os.path.abspath(os.path.join(THIS_DIR, '../lib/clientScripts')))
+from job import Job
+
+
+def test_job(tmpdir):
+    job_name = 'somejob'
+    job_uuid = str(uuid4())
+    job_args = ['a', 'b']
+    j = Job(
+        name=job_name,
+        uuid=job_uuid,
+        args=job_args)
+    unicode_printable = u'change\u0301'
+    j.pyprint(unicode_printable)
+    stdout = j.get_stdout()
+    expected = '{}\n'.format(unicode_printable.encode('utf8'))
+    assert expected == stdout

--- a/src/archivematicaCommon/lib/custom_handlers.py
+++ b/src/archivematicaCommon/lib/custom_handlers.py
@@ -22,7 +22,7 @@ class CallbackHandler(logging.Handler):
         self.callback = callback
 
     def emit(self, record):
-        self.callback(self.format(record) + "\n")
+        self.callback(self.format(record))
 
 
 STANDARD_FORMAT = "%(levelname)-8s  %(asctime)s  %(name)s.%(funcName)s:%(lineno)d  %(message)s"


### PR DESCRIPTION
Adds exception handling to the IO-related methods in MCPClient's job.py module so that Unicode objects can be "written" and "printed".

Connected to archivematica/Issues#16