### PR TITLE
Allow package create without transfer source details

### DIFF
--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -178,6 +178,13 @@ def get_location(path=None, purpose=None, space=None):
     return return_locations
 
 
+def get_default_location(purpose):
+    url = _storage_service_url() + 'location/default/{}'.format(purpose)
+    response = _storage_api_session().get(url)
+    response.raise_for_status()
+    return response.json()
+
+
 def browse_location(uuid, path):
     """
     Browse files in a location. Encodes path in base64 for transimission, returns decoded entries.


### PR DESCRIPTION
This commit makes possible to take `path` values in the Package create API
where the UUID of the transfer source location is not included, e.g. `<path>`
instead of `<uuid>:<path>`.

When this is the case, we attempt to determine the default transfer source
location asking the Storage Service.

Connects to https://github.com/archivematica/Issues/issues/21.