### PR TITLE
Dashboard: disable CSRF in /api (shib only)

### DIFF
--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -60,6 +60,14 @@ def _api_endpoint(expected_methods):
             if request.method not in expected_methods:
                 return django.http.HttpResponseNotAllowed(expected_methods)  # 405
 
+            # Disable CSRF protection when Shibboleth is enabled.
+            # This is necessary when we're authenticating the user with
+            # `SessionAuthentication` because in a Shibboleth-enabled
+            # environment the `csrftoken` cookie is never set. This is likely
+            # not a problem since Shibboleth provides equivalent protections.
+            if django_settings.SHIBBOLETH_AUTHENTICATION:
+                request._dont_enforce_csrf_checks = True
+
             # Auth
             auth_error = authenticate_request(request)
             if auth_error is not None:


### PR DESCRIPTION
Dashboard's `/api` expects a `csrftoken` when you're authenticating using your session cookie, i.e. not your API keys. This is the method used by the transfer browser widget now that we've updated it so it uses `/api/v2beta/package`. The `csrftoken` is emitted by Django in the login page. Shibboleth-enabled deployments have a different authentication flow where the login page is never visited so the `csrftoken` wasn't made available to the client.

The solution here is to disable the CSRF check in `/api` when Shibboleth is enabled.

This is connected to https://github.com/archivematica/Issues/issues/18.