### PR TITLE
Capture any exception in index_aip to job's stderr

### DIFF
--- a/src/MCPClient/lib/clientScripts/index_aip.py
+++ b/src/MCPClient/lib/clientScripts/index_aip.py
@@ -3,6 +3,7 @@
 from glob import glob
 import os
 import sys
+import traceback
 
 # dashboard
 from main.models import UnitVariable
@@ -133,8 +134,11 @@ def call(jobs):
         with job.JobContext(logger=logger):
             try:
                 status_code = index_aip(job)
-            except Exception:
+            except Exception as err:
                 # We want to capture any exception so ``filter_status_code``
                 # makes the last call on what is the status returned.
                 status_code = 1
+                job.print_error(repr(err))
+                job.print_error(traceback.format_exc())
+
             job.set_status(filter_status_code(status_code))


### PR DESCRIPTION
Fixes #1194 whereby exceptions were being caught but not logged.  Patch ensures any exceptions are logged to the job's stderr.

This is connected to #1194.