### PR TITLE
change root handlers log level to warning

### DIFF
--- a/src/archivematicaCommon/lib/custom_handlers.py
+++ b/src/archivematicaCommon/lib/custom_handlers.py
@@ -56,7 +56,7 @@ def get_script_logger(name, formatter=SCRIPT_FILE_FORMAT, root="archivematica", 
         },
         'root': {  # Everything else
             'handlers': ['console'],
-            'level': 'DEBUG',
+            'level': 'WARNING',
         },
     }
 


### PR DESCRIPTION
connects to #1141 

This log level was set to WARNING in https://github.com/artefactual/archivematica/commit/e40f2099813f6374b5717836c289e2dc34bf0479
in order to log only WARNING and higher from other libraries, notably elasticsearch.

This got changed to DEBUG in https://github.com/artefactual/archivematica/commit/716f95c77da859df99632b239179b4076774df86

This PR changes it back to WARNING.

Connects to https://github.com/artefactual/archivematica/issues/1141.