### PR TITLE
Transfer Browser: add auto_approve checkbox

### DIFF
--- a/src/MCPServer/lib/RPCServer.py
+++ b/src/MCPServer/lib/RPCServer.py
@@ -114,6 +114,8 @@ def package_create_handler(*args, **kwargs):
         payload.get('access_system_id'),
         payload.get('path'),
         payload.get('metadata_set_id'),
+        payload.get('auto_approve'),
+        payload.get('wait_until_complete'),
     )
     return create_package(*create_package_args).pk
 

--- a/src/dashboard/frontend/transfer-browser/app/front_page/content.html
+++ b/src/dashboard/frontend/transfer-browser/app/front_page/content.html
@@ -12,7 +12,7 @@
   <div class="help-block">{{ "Transfer type" | translate }}</div>
   </div>
 
-  <div class="col-xs-3" ng-if="vm.transfer.type !== 'zipped bag'">
+  <div class="col-xs-2" ng-if="vm.transfer.type !== 'zipped bag'">
   <input class="form-control" ng-model="vm.transfer.name"/>
   <div class="help-block">{{ "Transfer name" | translate }}</div>
   </div>
@@ -27,22 +27,20 @@
   <div class="help-block">{{ "Access system ID" | translate }}</div>
   </div>
 
-  <div class="col-xs-1">
+  <div class="col-xs-3">
   <button type="submit"
           class="btn btn-default"
           data-toggle="collapse"
           data-target="#transfer_browse_tree"
           aria-expanded="false"
-          aria-controls="transfer_browse_tree">
-    {{ "Browse" | translate }}
-  </button>
-  </div>
-
-  <div class="col-xs-2">
+          aria-controls="transfer_browse_tree">{{ "Browse" | translate }}</button>
   <button type="submit"
           class="btn btn-success"
           ng-disabled="!vm.enable_submit_button()"
           ng-click="vm.transfer.start()">{{ "Start transfer" | translate }}</button>
+  <div class="checkbox">
+    <label><input type="checkbox" ng-model="vm.transfer.auto_approve">{{ "Approve automatically" | translate }}</label>
+  </div>
   </div>
 
   <div class="col-xs-1">

--- a/src/dashboard/frontend/transfer-browser/app/services/transfer.service.js
+++ b/src/dashboard/frontend/transfer-browser/app/services/transfer.service.js
@@ -18,6 +18,7 @@ class Transfer {
     this.accession = '';
     this.access_system_id = '';
     this.components = [];
+    this.auto_approve = true;
   }
 
   add_component(entry) {
@@ -65,7 +66,8 @@ class Transfer {
           accession: _self.accession,
           access_system_id: _self.access_system_id,
           path: Base64.encode(`${component.location}:${component.path}`),
-          metadata_set_id: component.id || ''
+          metadata_set_id: component.id || '',
+          auto_approve: _self.auto_approve,
         })
       });
     });

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -784,6 +784,7 @@ def _package_create(request):
         payload.get('access_system_id'),
         path,
         payload.get('metadata_set_id'),
+        payload.get('auto_approve', True)
     )
     try:
         client = MCPClient()

--- a/src/dashboard/tests/test_api_v2beta.py
+++ b/src/dashboard/tests/test_api_v2beta.py
@@ -16,7 +16,9 @@ class MCPClientMock(object):
     def __init__(self, fails=False):
         self.fails = fails
 
-    def create_package(self, name, type_, accession, access_system_id, path, metadata_set_id):
+    def create_package(self, name, type_,
+                       accession, access_system_id, path, metadata_set_id,
+                       auto_approve=True, wait_until_complete=False):
         if self.fails:
             raise Exception('Something bad happened!')
         return b'59402c61-3aba-4af7-966a-996073c0601d'


### PR DESCRIPTION
The new Package API endpoint starts transfers automatically. In this commit,
the endpoint learns a new optional parameter `auto_approve` which defaults to
`True`. In the transfer browser, a new checkbox `Approve automatically` has
been added and it is disabled by default.

![image](https://user-images.githubusercontent.com/606459/43110282-eb453108-8e9f-11e8-9ad7-138b34e690c2.png)

This is connected to #1139.