### PR TITLE
Package API: add processing_config parameter

### DIFF
--- a/src/MCPServer/lib/RPCServer.py
+++ b/src/MCPServer/lib/RPCServer.py
@@ -107,17 +107,22 @@ def job_awaiting_approval_handler(*args):
 def package_create_handler(*args, **kwargs):
     """Handle create package request."""
     payload = kwargs['payload']
-    create_package_args = (
+    args = (
         payload.get('name'),
         payload.get('type'),
         payload.get('accession'),
         payload.get('access_system_id'),
         payload.get('path'),
         payload.get('metadata_set_id'),
-        payload.get('auto_approve'),
-        payload.get('wait_until_complete'),
     )
-    return create_package(*create_package_args).pk
+    kwargs = {
+        'auto_approve': payload.get('auto_approve'),
+        'wait_until_complete': payload.get('wait_until_complete'),
+    }
+    processing_config = payload.get('processing_config')
+    if processing_config is not None:
+        kwargs['processing_config'] = processing_config
+    return create_package(*args, **kwargs).pk
 
 
 def startRPCServer():

--- a/src/dashboard/frontend/transfer-browser/app/services/transfer.service.js
+++ b/src/dashboard/frontend/transfer-browser/app/services/transfer.service.js
@@ -53,22 +53,29 @@ class Transfer {
     // give it a dummy name instead.
     let name = this.type === 'zipped bag' ? 'ZippedBag' : this.name;
     let _self = this;
+
+    let payload = {
+      name: name,
+      type: _self.type,
+      accession: _self.accession,
+      access_system_id: _self.access_system_id,
+      auto_approve: _self.auto_approve,
+    }
+    if (window.hasOwnProperty('processing_config')) {
+      payload.processing_config = window.processing_config;
+    }
+
     let requests = this.components.map(function(component) {
+      payload.path = Base64.encode(`${component.location}:${component.path}`);
+      payload.metadata_set_id = component.id || '';
+
       return jQuery.ajax('/api/v2beta/package/', {
         method: 'POST',
         headers: {'X-CSRFToken': _self.getCookie('csrftoken')},
         cache: false,
         contentType: "application/json; charset=utf-8",
         dataType: "json",
-        data: JSON.stringify({
-          name: name,
-          type: _self.type,
-          accession: _self.accession,
-          access_system_id: _self.access_system_id,
-          path: Base64.encode(`${component.location}:${component.path}`),
-          metadata_set_id: component.id || '',
-          auto_approve: _self.auto_approve,
-        })
+        data: JSON.stringify(payload)
       });
     });
 

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -784,11 +784,17 @@ def _package_create(request):
         payload.get('access_system_id'),
         path,
         payload.get('metadata_set_id'),
-        payload.get('auto_approve', True)
     )
+    kwargs = {
+        'auto_approve': payload.get('auto_approve', True),
+        'wait_until_complete': False,
+    }
+    processing_config = payload.get('processing_config')
+    if processing_config is not None:
+        kwargs['processing_config'] = processing_config
     try:
         client = MCPClient()
-        id_ = client.create_package(*args)
+        id_ = client.create_package(*args, **kwargs)
     except Exception as err:
         LOGGER.error(err)
         msg = 'Package cannot be created'

--- a/src/dashboard/src/contrib/mcp/client.py
+++ b/src/dashboard/src/contrib/mcp/client.py
@@ -66,9 +66,9 @@ class MCPClient:
 
     def create_package(self, name, type_, accession, access_system_id, path,
                        metadata_set_id, auto_approve=True,
-                       wait_until_complete=False):
+                       wait_until_complete=False, processing_config=None):
         gm_client = gearman.GearmanClient([self.server])
-        data = cPickle.dumps({
+        data = {
             'name': name,
             'type': type_,
             'accession': accession,
@@ -77,8 +77,11 @@ class MCPClient:
             'metadata_set_id': metadata_set_id,
             'auto_approve': auto_approve,
             'wait_until_complete': wait_until_complete,
-        })
-        response = gm_client.submit_job('packageCreate', data,
+        }
+        if processing_config is not None:
+            data['processing_config'] = processing_config
+        response = gm_client.submit_job('packageCreate',
+                                        cPickle.dumps(data),
                                         background=False,
                                         wait_until_complete=True,
                                         poll_timeout=INFLIGHT_POLL_TIMEOUT)


### PR DESCRIPTION
This pull request includes two commits:

#### Package API: add processing_config parameter

In this commit, the new `/api/v2beta/package/` API endpoint learns a new `processing_config` parameter where the user can define the name of the processing configuration that wants to be used, e.g. `automated` or any other configuration added to the system.

#### Transfer Browser: add basic support for processing config

The transfer browser widget is updated so the user can set the processing configuration by opening the web console and creating a new property in the `window` object named `processing_config`. Usage:

1. Open JavaScript console.
2. Type:

        window.processing_config = 'automated';

This meant to be a temporary solution until we have time to explore ways to integrate this in the user interface.

Connects to https://github.com/artefactual/archivematica/issues/800.