### PR TITLE
MCPClient: fix post_store_aip_hook (indexless)

### DIFF
--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -88,12 +88,11 @@ def post_store_hook(job, sip_uuid):
     """
     Hook for doing any work after an AIP is stored successfully.
     """
-    if not mcpclient_settings.SEARCH_ENABLED:
+    if mcpclient_settings.SEARCH_ENABLED:
+        elasticSearchFunctions.setup_reading_from_conf(mcpclient_settings)
+        client = elasticSearchFunctions.get_client()
+    else:
         logger.info('Skipping indexing: indexing is currently disabled.')
-        return 0
-
-    elasticSearchFunctions.setup_reading_from_conf(mcpclient_settings)
-    client = elasticSearchFunctions.get_client()
 
     # SIP ARRANGEMENT
 
@@ -118,7 +117,8 @@ def post_store_hook(job, sip_uuid):
                 user_email='archivematica system',
                 reason_for_deletion='All files in Transfer are now in AIPs.'
             )
-            elasticSearchFunctions.remove_transfer_files(client, transfer_uuid)
+            if mcpclient_settings.SEARCH_ENABLED:
+                elasticSearchFunctions.remove_transfer_files(client, transfer_uuid)
 
     # DSPACE HANDLE TO ARCHIVESSPACE
     dspace_handle_to_archivesspace(job, sip_uuid)


### PR DESCRIPTION
When the search functionality is disabled, the post_store_aip_hook will
only avoid making the changes related to the transfers ES index. The
following workflows will be restored in that case:

- SS file deletion request (when all files have been arranged).
- DuraSpace handle to ArchivesSpace.
- SS post store AIP callback.

Connects to #1174.