### PR TITLE
Standardise global state in create_mets_v2

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py
@@ -300,13 +300,14 @@ def add_new_files(job, mets, sip_uuid, sip_dir):
         return mets
 
     # Set global counters so getAMDSec will work
-    createmets2.globalAmdSecCounter = int(
-        mets.tree.xpath('count(mets:amdSec)', namespaces=ns.NSMAP))
-    createmets2.globalTechMDCounter = int(
-        mets.tree.xpath('count(mets:amdSec/mets:techMD)', namespaces=ns.NSMAP))
-    createmets2.globalDigiprovMDCounter = int(
-        mets.tree.xpath('count(mets:amdSec/mets:digiprovMD)',
-                        namespaces=ns.NSMAP))
+    createmets2.initGlobalState(
+        globalAmdSecCounter=int(mets.tree.xpath('count(mets:amdSec)',
+                                                namespaces=ns.NSMAP)),
+        globalTechMDCounter=int(mets.tree.xpath('count(mets:amdSec/mets:techMD)',
+                                                namespaces=ns.NSMAP)),
+        globalDigiprovMDCounter=int(mets.tree.xpath('count(mets:amdSec/mets:digiprovMD)',
+                                    namespaces=ns.NSMAP))
+    )
 
     objects_fsentry = mets.get_file(label='objects', type='Directory')
 

--- a/src/MCPClient/lib/clientScripts/create_aic_mets.py
+++ b/src/MCPClient/lib/clientScripts/create_aic_mets.py
@@ -160,5 +160,6 @@ def call(jobs):
     with transaction.atomic():
         for job in jobs:
             with job.JobContext():
+                create_mets_v2.initGlobalState()
                 args = parser.parse_args(job.qrgs[1:])
                 create_aic_mets(args.aic_uuid, args.aic_dir, job)

--- a/src/MCPClient/lib/clientScripts/create_processed_structmap.py
+++ b/src/MCPClient/lib/clientScripts/create_processed_structmap.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 from create_mets_v0 import createFileSec, each_child
+import create_mets_v2
 from create_mets_v2 import createDigiprovMD
 import namespaces as ns
 
@@ -37,6 +38,8 @@ def call(jobs):
 
     for job in jobs:
         with job.JobContext():
+            create_mets_v2.initGlobalState()
+
             opts = parser.parse_args(job.args[1:])
 
             if not os.path.exists(opts.xmlFile):

--- a/src/MCPClient/tests/test_create_aip_mets.py
+++ b/src/MCPClient/tests/test_create_aip_mets.py
@@ -19,6 +19,8 @@ import archivematicaCreateMETSRights
 
 from main.models import RightsStatement
 
+create_mets_v2.initGlobalState()
+
 NSMAP = {
     'dc': 'http://purl.org/dc/elements/1.1/',
     'dcterms': 'http://purl.org/dc/terms/',

--- a/src/MCPClient/tests/test_reingest_mets.py
+++ b/src/MCPClient/tests/test_reingest_mets.py
@@ -11,6 +11,7 @@ from main import models
 
 from job import Job
 
+import create_mets_v2
 import metsrw
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -36,6 +37,7 @@ class TestUpdateObject(TestCase):
 
     def setUp(self):
         self.sip_uuid = '4060ee97-9c3f-4822-afaf-ebdf838284c3'
+        create_mets_v2.initGlobalState()
 
     def load_fixture(self, fixture_paths):
         try:
@@ -233,6 +235,9 @@ class TestUpdateDublinCore(TestCase):
     sip_uuid_original = '8b891d7c-5bd2-4249-84a1-2f00f725b981'
     sip_uuid_reingest = '87d30df4-63f5-434b-9da6-25aa995de6fe'
     sip_uuid_updated = '5d78a2a5-57a6-430f-87b2-b89fb3ccb050'
+
+    def setUp(self):
+        create_mets_v2.initGlobalState()
 
     def test_no_dc(self):
         """ It should do nothing if there is no DC entry. """
@@ -433,6 +438,9 @@ class TestUpdateRights(TestCase):
     sip_uuid_reingest = '10d57d98-29e5-4b2c-9f9f-d163e632eb31'
     sip_uuid_updated = '2941f14c-bd57-4f4a-a514-a3bf6ac5adf0'
 
+    def setUp(self):
+        create_mets_v2.initGlobalState()
+
     def test_no_rights(self):
         """ It should do nothing if there are no rights entries. """
         mets = metsrw.METSDocument.fromfile(os.path.join(FIXTURES_DIR, 'mets_no_metadata.xml'))
@@ -563,6 +571,9 @@ class TestAddEvents(TestCase):
 
     sip_uuid = '4060ee97-9c3f-4822-afaf-ebdf838284c3'
 
+    def setUp(self):
+        create_mets_v2.initGlobalState()
+
     def test_all_files_get_events(self):
         """
         It should add reingestion events to all files.
@@ -627,6 +638,9 @@ class TestAddingNewFiles(TestCase):
     fixtures = [os.path.join(FIXTURES_DIR, p) for p in fixture_files]
 
     sip_uuid = '4060ee97-9c3f-4822-afaf-ebdf838284c3'
+
+    def setUp(self):
+        create_mets_v2.initGlobalState()
 
     def test_no_new_files(self):
         """ It should not modify the fileSec or structMap if there are no new files. """
@@ -827,6 +841,9 @@ class TestDeleteFiles(TestCase):
 
     sip_uuid = '4060ee97-9c3f-4822-afaf-ebdf838284c3'
 
+    def setUp(self):
+        create_mets_v2.initGlobalState()
+
     def test_delete_file(self):
         """
         It should change the fileGrp USE to deleted.
@@ -868,6 +885,7 @@ class TestUpdateMetadataCSV(TestCase):
 
     def setUp(self):
         self.csv_file = models.File.objects.get(uuid='66370f14-2f64-4750-9d50-547614be40e8')
+        create_mets_v2.initGlobalState()
 
     def test_new_dmdsecs(self):
         """ It should add file-level dmdSecs. """

--- a/src/archivematicaCommon/lib/externals/extractMaildirAttachments.py
+++ b/src/archivematicaCommon/lib/externals/extractMaildirAttachments.py
@@ -18,7 +18,6 @@ from StringIO import StringIO
 import uuid
 
 from sharedVariablesAcrossModules import sharedVariablesAcrossModules
-sharedVariablesAcrossModules.errorCounter = 0
 
 
 def parse_attachment(message_part, attachments=None):
@@ -89,6 +88,8 @@ def parse(content):
     """
     Eメールのコンテンツを受け取りparse,encodeして返す
     """
+    sharedVariablesAcrossModules.errorCounter = 0
+
     p = email.Parser.Parser()
     msgobj = p.parse(content)
     attachments = []


### PR DESCRIPTION
The `create_mets_v2` client script uses a bunch of global state for things like counters and file IDs.  The original implementation could rely on these globals being reset between runs (by virtue of running the script in a new subprocess each time) but, after the batching changes, this is no longer the case.

To make things more manageable, we pull all of this global stuff into a single top-level object which gets replaced at the beginning of each job run.  Where other modules call the functions of create_mets_v2, they reset the global state as appropriate as well.

A secondary piece of shared state is the `sharedVariablesAcrossModules` module, used by `create_mets_v2` and a handful of other scripts.  Handling for this needed to be updated for the batching changes in a small number of places.

This is connected to https://github.com/archivematica/Issues/issues/42.
This is connected to https://github.com/archivematica/Issues/issues/43.
This is connected to https://github.com/artefactual/archivematica/issues/938.