### PR TITLE
MCPServer: use auto_close_db

### DIFF
--- a/src/MCPClient/lib/fork_runner.py
+++ b/src/MCPClient/lib/fork_runner.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 import traceback
 
+from databaseFunctions import auto_close_db
 from executeOrRunSubProcess import launchSubProcess
 
 logger = logging.getLogger('archivematica.mcp.client')
@@ -75,6 +76,7 @@ def _split_jobs(jobs, n):
     return result
 
 
+@auto_close_db
 def _run_jobs(module_name, jobs):
     (fd, output_file) = tempfile.mkstemp()
 

--- a/src/MCPServer/lib/RPCServer.py
+++ b/src/MCPServer/lib/RPCServer.py
@@ -26,6 +26,7 @@ import time
 from django.conf import settings as django_settings
 import gearman
 
+from databaseFunctions import auto_close_db
 from linkTaskManagerChoice import choicesAvailableForUnits
 from package import create_package
 
@@ -78,6 +79,7 @@ def pickle_result(fn):
     return wrap
 
 
+@auto_close_db
 @pickle_result
 @unpickle_payload
 @log_exceptions(LOGGER)
@@ -92,6 +94,7 @@ def job_approve_handler(*args, **kwargs):
     return "approving: ", job_id, chain
 
 
+@auto_close_db
 @pickle_result
 @log_exceptions(LOGGER)
 def job_awaiting_approval_handler(*args):
@@ -101,6 +104,7 @@ def job_awaiting_approval_handler(*args):
     return etree.tostring(ret, pretty_print=True)
 
 
+@auto_close_db
 @pickle_result
 @unpickle_payload
 @log_exceptions(LOGGER)

--- a/src/MCPServer/lib/package.py
+++ b/src/MCPServer/lib/package.py
@@ -28,6 +28,7 @@ from django.conf import settings as django_settings
 
 from archivematicaMCP import taskThreadPool
 from archivematicaFunctions import unicodeToStr
+from databaseFunctions import auto_close_db
 from jobChain import jobChain
 from main.models import Transfer, TransferMetadataSet
 import storageService as storage_service
@@ -270,6 +271,7 @@ def create_package(name, type_, accession, access_system_id, path,
     transfer = Transfer.objects.create(**kwargs)
     logger.debug('Transfer object created: %s', transfer.pk)
 
+    @auto_close_db
     def _start(transfer, name, type_, path):
         # TODO: use tempfile.TemporaryDirectory as a context manager in Py3.
         tmpdir = mkdtemp(


### PR DESCRIPTION
Ensure that threads close the database connections, otherwise they remain open
which can cause "MySQL server has gone away" errors when MySQL recycles its
thread associated after a long inactivity period.

CC @marktriggs @payten @jambun.

This is connected to #938.