### PR TITLE
Add 7zip copy mode

### DIFF
--- a/src/dashboard/src/main/migrations/0057_7zip_no_compression.py
+++ b/src/dashboard/src/main/migrations/0057_7zip_no_compression.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Migration to add a 7-zip method to the list of Archivematica AIP 7-zip
+methods that does not use compression. 7-zip copy mode.
+"""
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+choice_no_compression_uuid = "e3906da0-41fb-4cb8-a598-6c73981b63e9"
+
+
+def get_chain_choice_dict(apps):
+    """Retrieve Chain Choice Replacement Dict model."""
+    return apps.get_model('main', 'MicroServiceChoiceReplacementDic')
+
+
+def get_ms_chain_link_instance(apps, ms_uuid):
+    """Get chainlink instance from the database."""
+    return apps\
+        .get_model("main", "MicroServiceChainLink")\
+        .objects.get(id=ms_uuid)
+
+
+def data_migration_down(apps, schema_editor):
+    get_chain_choice_dict(apps).objects.filter(id=choice_no_compression_uuid)\
+        .delete()
+
+
+def data_migration_up(apps, schema_editor):
+    ms_prepare_aip = get_ms_chain_link_instance(
+        apps, "01d64f58-8295-4b7b-9cab-8f1b153a504f")
+    get_chain_choice_dict(apps).objects.create(
+        id=choice_no_compression_uuid,
+        description="7z without compression (Copy)",
+        replacementdic="{\"%AIPCompressionAlgorithm%\":\"7z-copy\"}",
+        choiceavailableatlink=ms_prepare_aip,
+    )
+
+
+class Migration(migrations.Migration):
+    """Entry point for the migration."""
+    dependencies = [('main', '0056_transfer_access_system_id')]
+    operations = [
+        migrations.RunPython(data_migration_up, data_migration_down),
+    ]


### PR DESCRIPTION
Adds the necessary migration to the database which creates a 7-zip
compression option using file-level storage, that is, a 'copy' mode
which creates a 7-zip wrapper around objects without applying a
compression algorithm, e.g. without lzma, or bzip.

This is connected to https://github.com/archivematica/Issues/issues/46.