### PR TITLE
Models: use longblob in SIPArrange

### DIFF
--- a/src/dashboard/src/main/migrations/0059_siparrange_longblob.py
+++ b/src/dashboard/src/main/migrations/0059_siparrange_longblob.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, OperationalError
+import main.models
+import django_extensions.db.fields
+
+
+def drop_original_path_unique_key(apps, schema_editor):
+    """Drop the unique key index from `original_path`.
+
+    As the column is becoming a longblog, we need to remove its index to avoid
+    issues with the length of the key. The function is implemented so it works
+    regardless the name of the index.
+
+    See https://github.com/artefactual/archivematica/pull/1232.
+    """
+    db_name = schema_editor.connection.settings_dict['NAME']
+    with schema_editor.connection.cursor() as cursor:
+        try:
+            cursor.execute(
+                'SELECT INDEX_NAME FROM information_schema.STATISTICS'
+                ' WHERE TABLE_SCHEMA = %s'
+                ' AND TABLE_NAME = "main_siparrange"'
+                ' AND COLUMN_NAME = "original_path"',
+                (db_name,),
+            )
+        except OperationalError:
+            return  # We tried our best.
+        row = cursor.fetchone()
+        if not row:
+            return
+        index_name = row[0]
+    schema_editor.execute(
+        'ALTER TABLE main_siparrange DROP INDEX %s' % (index_name,))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0058_fix_unit_variable_pull_link'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            drop_original_path_unique_key,
+            migrations.RunPython.noop
+        ),
+        migrations.AlterField(
+            model_name='siparrange',
+            name='arrange_path',
+            field=main.models.BlobTextField(),
+        ),
+        migrations.AlterField(
+            model_name='siparrange',
+            name='file_uuid',
+            field=django_extensions.db.fields.UUIDField(null=True, default=None, editable=False, max_length=36, blank=True, unique=True),
+        ),
+        migrations.AlterField(
+            model_name='siparrange',
+            name='original_path',
+            field=main.models.BlobTextField(default=None, null=True, blank=True),
+        ),
+    ]

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -65,6 +65,8 @@ class BlobTextField(models.TextField):
     Text field backed by `longblob` instead of `longtext`.
 
     Used for storing strings that need to match unsanitized paths on disk.
+
+    BLOBs are byte strings (bynary character set and collation).
     """
 
     def db_type(self, connection):
@@ -354,9 +356,9 @@ class Transfer(models.Model):
 
 class SIPArrange(models.Model):
     """ Information about arranged files: original and arranged location, current status. """
-    original_path = models.CharField(max_length=255, null=True, blank=True, default=None, unique=True)
-    arrange_path = models.CharField(max_length=255)
-    file_uuid = UUIDField(auto=False, null=True, blank=True, default=None)
+    original_path = BlobTextField(null=True, blank=True, default=None)
+    arrange_path = BlobTextField()
+    file_uuid = UUIDField(auto=False, null=True, blank=True, default=None, unique=True)
     transfer_uuid = UUIDField(auto=False, null=True, blank=True, default=None)
     sip = models.ForeignKey(SIP, to_field='uuid', null=True, blank=True, default=None)
     level_of_description = models.CharField(max_length=2014)


### PR DESCRIPTION
Convert `varchar` columns into `longblob` (`SIPArrange`).

This is connected to https://github.com/archivematica/Issues/issues/53.
Relates to https://github.com/artefactual/archivematica/pull/509.