### PR TITLE
Delay submission of Upload DIP to ArchivesSpace after pair reviewing

### DIFF
--- a/src/dashboard/src/components/ingest/urls.py
+++ b/src/dashboard/src/components/ingest/urls.py
@@ -65,5 +65,6 @@ urlpatterns += [
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/as/match/$', views_as.ingest_upload_as_match),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/as/reset/$', views_as.ingest_upload_as_reset),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/as/review/$', views_as.ingest_upload_as_review_matches),
+    url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/as/complete/$', views_as.complete_matching),
     url(r'^(?P<uuid>' + settings.UUID_REGEX + ')/upload/as/$', views_as.ingest_upload_as)
 ]

--- a/src/dashboard/src/media/js/ingest.js
+++ b/src/dashboard/src/media/js/ingest.js
@@ -294,22 +294,28 @@ $(function()
 
           var chainId = $select.find('option:selected').val();
           var unitId = this.model.sip.get('uuid');
-          var loadingMessage = gettext('Loading...');
 
-          // "Upload DIP to Archivists Toolkit" chain matched by its UUID.
-          // Redirect to object/resource mapping pages.
-          if (chainId == 'f11409ad-cf3c-4e7f-b0d5-4be32d98229b')
-          {
-            $('body').html('<h1>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + loadingMessage + '</h1>');
-            window.location.href = '/ingest/' + unitId + '/upload/atk/';
+          // If the Upload DIP targets a system where manual mapping is
+          // required, we forward the user to the corresponding page where
+          // we're going to collect the data required and continue the work.
+          //
+          // In other words, we're not going to execute the next job from
+          // JavaScript as we expect the pairing page to do it once the user
+          // has paired the items.
+          var dipUploadWithMappingPage = {
+            // "Upload DIP to ArchivesSpace" chain matched by its UUID.
+            '3572f844-5e69-4000-a24b-4e32d3487f82': '/ingest/' + unitId + '/upload/as/',
+            // "Upload DIP to Archivists Toolkit" chain matched by its UUID.
+            'f11409ad-cf3c-4e7f-b0d5-4be32d98229b': '/ingest/' + unitId + '/upload/atk/',
           }
+          if (chainId in dipUploadWithMappingPage) {
+            $('body').html('<h1 style="text-align: center;">' + gettext('Loading...') + '</h1>');
+            window.location.href = dipUploadWithMappingPage[chainId];
 
-          // "Upload DIP to ArchivesSpace" chain matched by its UUID.
-          // Redirect to object/resource mapping pages.
-          if (chainId == '3572f844-5e69-4000-a24b-4e32d3487f82')
-          {
-            $('body').html('<h1>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + loadingMessage + '</h1>');
-            window.location.href = '/ingest/' + unitId + '/upload/as/';
+            // TODO: needs to be tested with Archivists' Toolkit.
+            if (chainId == 'f11409ad-cf3c-4e7f-b0d5-4be32d98229b') {
+              return;
+            }
           }
 
           // "Upload DIP to AtoM/Binder" chain matched by its UUID.

--- a/src/dashboard/src/templates/ingest/as/review_matches.html
+++ b/src/dashboard/src/templates/ingest/as/review_matches.html
@@ -16,8 +16,10 @@
     {% breadcrumb_url 'DIP upload' 'components.ingest.views_as.ingest_upload_as' uuid %}
   </ul>
 
-  <div id='reset_matching'><a class="btn btn-default" href="{% url 'components.ingest.views_as.ingest_upload_as_reset' uuid %}">{% trans "Restart matching" %}</a>
-  <a class='btn btn-default' href="{% url 'components.ingest.views.ingest_grid' %}">{% trans "Finish matching" %}</a>
+  <form method="POST" action="{% url 'components.ingest.views_as.complete_matching' uuid %}">
+    <a class="btn btn-submit" href="{% url 'components.ingest.views_as.ingest_upload_as_reset' uuid %}">{% trans "Restart matching" %}</a>
+    <button class="btn btn-primary">{% trans "Finish matching" %}</button>
+  </form>
 
   <table class="table">
     <thead>


### PR DESCRIPTION
This pull request is an alternative to #1177 that does not require workflow modifications by making changes in the user interface so the job "Upload DIP" is not executed until the user is presented with the pair reviewing page and submits the form.

Once submitted, the user is forwarded to the ingest grid page and it's prompted with the "Choose Config for ArchivesSpace DIP Upload". Further work could be done to remove this step but that would require a database migration which is not ideal in this work because it's targeting a point release too.

More details have been included in the description of the commits.

This is connected to #1112.