### PR TITLE
Enhance search enabled configuration

### DIFF
--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -141,9 +141,12 @@ This is the full list of variables supported by MCPClient:
     - **Default:** `10`
 
 - **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_SEARCH_ENABLED`**:
-    - **Description:** controls whether Elasticsearch is enabled. When set to `false`, certain client scripts will exit without doing anything, e.g., indexAIP_v0.0, elasticSearchIndex_v0.0, postStoreAIPHook_v1.0, and removeAIPFilesFromIndex_v0.0.
+    - **Description:** controls what Elasticsearch indexes are enabled:
+        - When set to `aips` or `false`, certain client scripts will exit without interacting with the Transfers related indexes, e.g., elasticSearchIndex_v0.0 and postStoreAIPHook_v1.0.
+        - When set to `transfers` or `false`, certain client scripts will exit without interacting with the AIPs related indexes, e.g., indexAIP_v0.0 and removeAIPFilesFromIndex_v0.0.
+        - When set to `aips,transfers` (the order does not matter) or `true`, all interactions with the Elasticsearch indexes will be made.
     - **Config file example:** `MCPClient.search_enabled`
-    - **Type:** `boolean`
+    - **Type:** `boolean` or `string`
     - **Default:** `true`
 
 - **`ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_INDEX_AIP_CONTINUE_ON_ERROR`**:

--- a/src/MCPClient/lib/clientScripts/elastic_search_index_process_transfer.py
+++ b/src/MCPClient/lib/clientScripts/elastic_search_index_process_transfer.py
@@ -38,8 +38,8 @@ def call(jobs):
     with transaction.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
-                if not mcpclient_settings.SEARCH_ENABLED:
-                    logger.info('Skipping indexing: indexing is currently disabled.')
+                if 'transfers' not in mcpclient_settings.SEARCH_ENABLED:
+                    logger.info('Skipping indexing: Transfers indexing is currently disabled.')
                     job.set_status(0)
                     continue
 

--- a/src/MCPClient/lib/clientScripts/index_aip.py
+++ b/src/MCPClient/lib/clientScripts/index_aip.py
@@ -48,8 +48,8 @@ def index_aip(job):
     sip_path = job.args[3]  # %SIPDirectory%
     sip_type = job.args[4]  # %SIPType%
 
-    if not mcpclient_settings.SEARCH_ENABLED:
-        logger.info('Skipping indexing: indexing is currently disabled.')
+    if 'aips' not in mcpclient_settings.SEARCH_ENABLED:
+        logger.info('Skipping indexing: AIPs indexing is currently disabled.')
         return 0
 
     elasticSearchFunctions.setup_reading_from_conf(mcpclient_settings)

--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -88,11 +88,12 @@ def post_store_hook(job, sip_uuid):
     """
     Hook for doing any work after an AIP is stored successfully.
     """
-    if mcpclient_settings.SEARCH_ENABLED:
+    update_es = 'transfers' in mcpclient_settings.SEARCH_ENABLED
+    if update_es:
         elasticSearchFunctions.setup_reading_from_conf(mcpclient_settings)
         client = elasticSearchFunctions.get_client()
     else:
-        logger.info('Skipping indexing: indexing is currently disabled.')
+        logger.info('Skipping indexing: Transfers indexing is currently disabled.')
 
     # SIP ARRANGEMENT
 
@@ -117,7 +118,7 @@ def post_store_hook(job, sip_uuid):
                 user_email='archivematica system',
                 reason_for_deletion='All files in Transfer are now in AIPs.'
             )
-            if mcpclient_settings.SEARCH_ENABLED:
+            if update_es:
                 elasticSearchFunctions.remove_transfer_files(client, transfer_uuid)
 
     # DSPACE HANDLE TO ARCHIVESSPACE

--- a/src/MCPClient/lib/clientScripts/remove_aip_files_from_index.py
+++ b/src/MCPClient/lib/clientScripts/remove_aip_files_from_index.py
@@ -38,8 +38,9 @@ def call(jobs):
         with job.JobContext(logger=logger):
             aip_uuid = job.args[1]
 
-            if not mcpclient_settings.SEARCH_ENABLED:
-                logger.info('Skipping. Indexing is currently disabled.')
+            if 'aips' not in mcpclient_settings.SEARCH_ENABLED:
+                logger.info('Skipping. AIPs indexing is currently disabled.')
+                return
 
             elasticSearchFunctions.setup_reading_from_conf(mcpclient_settings)
             client = elasticSearchFunctions.get_client()

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -21,9 +21,8 @@ import logging
 import logging.config
 import os
 
-from appconfig import Config
+from appconfig import Config, process_search_enabled
 import email_settings
-
 
 CONFIG_MAPPING = {
     # [MCPClient]
@@ -37,10 +36,7 @@ CONFIG_MAPPING = {
     'client_modules_file': {'section': 'MCPClient', 'option': 'archivematicaClientModules', 'type': 'string'},
     'elasticsearch_server': {'section': 'MCPClient', 'option': 'elasticsearchServer', 'type': 'string'},
     'elasticsearch_timeout': {'section': 'MCPClient', 'option': 'elasticsearchTimeout', 'type': 'float'},
-    'search_enabled': [
-        {'section': 'MCPClient', 'option': 'disableElasticsearchIndexing', 'type': 'iboolean'},
-        {'section': 'MCPClient', 'option': 'search_enabled', 'type': 'boolean'},
-    ],
+    'search_enabled': {'section': 'MCPClient', 'process_function': process_search_enabled},
     'index_aip_continue_on_error': {'section': 'MCPClient', 'option': 'index_aip_continue_on_error', 'type': 'boolean'},
     'capture_client_script_output': {'section': 'MCPClient', 'option': 'capture_client_script_output', 'type': 'boolean'},
     'removable_files': {'section': 'MCPClient', 'option': 'removableFiles', 'type': 'string'},

--- a/src/MCPServer/install/README.md
+++ b/src/MCPServer/install/README.md
@@ -117,9 +117,14 @@ This is the full list of variables supported by MCPServer:
     - **Default:** `"0"`
 
 - **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_SEARCH_ENABLED`**:
-    - **Description:** controls whether Elasticsearch is enabled. This can affect which options the MCP server makes available for user choices. E.g., If search is disabled, then the MCP server will not make the "Send to backlong" option available at the "Create SIP(s)" choice point.
+    - **Description:** controls what Elasticsearch indexes are enabled. This can affect which options the MCP server makes available for user choices. E.g., If set to `false` or `aips`, then the MCP server will not make the "Send to backlong" option available at the "Create SIP(s)" choice point, as it will require the `transfers` indexes. Available options:
+        - `true`: all indexes enabled.
+        - `false`: no indexing enabled.
+        - `aips`: only AIPs related indexes.
+        - `transfers`: only Transfers related indexes.
+        - `aips,transfers` (the order does not matter): same as `true`.
     - **Config file example:** `MCPServer.search_enabled`
-    - **Type:** `boolean`
+    - **Type:** `boolean` or `string`
     - **Default:** `true`
 
 - **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_STORAGE_SERVICE_CLIENT_TIMEOUT`**:

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -21,9 +21,8 @@ import logging
 import logging.config
 import os
 
-from appconfig import Config
+from appconfig import Config, process_search_enabled
 import email_settings
-
 
 CONFIG_MAPPING = {
     # [MCPServer]
@@ -36,10 +35,7 @@ CONFIG_MAPPING = {
     'wait_on_auto_approve': {'section': 'MCPServer', 'option': 'waitOnAutoApprove', 'type': 'int'},
     'watch_directory_interval': {'section': 'MCPServer', 'option': 'watchDirectoriesPollInterval', 'type': 'int'},
     'secret_key': {'section': 'MCPServer', 'option': 'django_secret_key', 'type': 'string'},
-    'search_enabled': [
-        {'section': 'MCPServer', 'option': 'disable_search_indexing', 'type': 'iboolean'},
-        {'section': 'MCPServer', 'option': 'search_enabled', 'type': 'boolean'},
-    ],
+    'search_enabled': {'section': 'MCPServer', 'process_function': process_search_enabled},
     'batch_size': {'section': 'MCPServer', 'option': 'batch_size', 'type': 'int'},
     'storage_service_client_timeout': {'section': 'MCPServer', 'option': 'storage_service_client_timeout', 'type': 'float'},
     'storage_service_client_quick_timeout': {'section': 'MCPServer', 'option': 'storage_service_client_quick_timeout', 'type': 'float'},

--- a/src/archivematicaCommon/lib/abilities.py
+++ b/src/archivematicaCommon/lib/abilities.py
@@ -5,13 +5,15 @@ MCPClient).
 
 
 ABILITIES = (
-    # The (elastic)search ability must be enabled in order for Archivematica's
-    # transfer backlog to work. Therefore, the "Send to backlog" choice at the
-    # "Create SIP(s)" decision point should not be available when the search
-    # ability is disabled.
+    # The (elastic)search Transfers indexes must be enabled for the transfers
+    # backlog. Therefore, the "Send to backlog" choice at the "Create SIP(s)"
+    # decision point should not be available when the 'transfers' indexes are
+    # not included in the SEARCH_ENABLED setting.
     {
         'name': 'search',
         'enabled_attr': 'SEARCH_ENABLED',
+        'enabled_condition': 'in',
+        'enabled_value': 'transfers',
         'dependencies': (
             ('Create SIP(s)', 'Send to backlog'),
         )
@@ -22,11 +24,17 @@ ABILITIES = (
 def choice_is_available(choice, settings):
     """Return ``True`` if the ``MicroServiceChainChoice`` instance ``choice``
     should be presented to the user, given ``ABILITIES`` and the configuration
-    object ``settings``.
+    object ``settings``. If the ability ``enabled_condition`` is set to ``in``,
+    check that the ``enabled_value`` is included in the ``enabled_attr`` value.
+    Otherwise, check ``enabled_attr`` boolean value.
     """
     for ability in ABILITIES:
         enabled_attr = ability['enabled_attr']
-        feature_enabled = getattr(settings, enabled_attr, False)
+        if ability['enabled_condition'] == 'in':
+            attr_value = getattr(settings, enabled_attr, [])
+            feature_enabled = ability['enabled_value'] in attr_value
+        else:
+            feature_enabled = getattr(settings, enabled_attr, False)
         if not feature_enabled:
             choice_tuple = (
                 choice.choiceavailableatlink.currenttask.description,

--- a/src/archivematicaCommon/lib/appconfig.py
+++ b/src/archivematicaCommon/lib/appconfig.py
@@ -1,3 +1,18 @@
+"""
+Configuration helper for MCPServer, MCPClient and Dashboard, used in:
+
+    - MCPClient/lib/settings/common.py
+    - MCPServer/lib/settings/common.py
+    - Dashboard/src/settings/base.py
+
+Config. attributes are declared on those settings files and they can be defined
+by a dictionary indicating the 'section', 'option' and 'type' to be parsed by
+the Config class. They can also be defined by a list of the same type of
+dictionary and, in that case, the first obtained value will be the one returned.
+Alternatively, they can include the 'section' and a 'process_function' callback
+where a specific parsing process can be defined. Those callbacks must accept the
+current appconfig Config object and the section.
+"""
 import ConfigParser
 
 from django.core.exceptions import ImproperlyConfigured
@@ -6,14 +21,7 @@ from env_configparser import EnvConfigParser
 
 
 class Config(object):
-    """Configuration helper for MCPServer, MCPClient and Dashboard.
-
-    It wraps EnvConfigParser. It is used in the following files:
-
-        - MCPClient/lib/settings/common.py
-        - MCPServer/lib/settings/common.py
-        - Dashboard/src/settings/base.py
-    """
+    """EnvConfigParser wrapper"""
     def __init__(self, env_prefix, attrs):
         self.config = EnvConfigParser(prefix=env_prefix)
         self.attrs = attrs
@@ -40,6 +48,8 @@ class Config(object):
         attr_opts = self.attrs[attr]
         if isinstance(attr_opts, list):
             return self.get_from_opts_list(attr, attr_opts, default=default)
+        if all(k in attr_opts for k in ('section', 'process_function')):
+            return attr_opts['process_function'](self, attr_opts['section'])
         if not all(k in attr_opts for k in ('section', 'option', 'type')):
             raise ImproperlyConfigured(self.INVALID_ATTR_MSG % attr)
 
@@ -60,7 +70,6 @@ class Config(object):
                 k in attr_opts for k in ('section', 'option', 'type'))
                 for attr_opts in attr_opts_list):
             raise ImproperlyConfigured(self.INVALID_ATTR_MSG % attr)
-        opts = []
         for attr_opts in attr_opts_list:
             opt_type = attr_opts['type']
             getter = 'get{}'.format({'string': ''}.get(opt_type, opt_type))
@@ -71,11 +80,48 @@ class Config(object):
             elif 'default' in attr_opts:
                 kwargs['fallback'] = attr_opts['default']
             try:
-                opt = getattr(self.config, getter)(**kwargs)
-            except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+                return getattr(self.config, getter)(**kwargs)
+            except (ConfigParser.NoSectionError, ConfigParser.NoOptionError, ValueError):
                 pass
-            else:
-                opts.append(opt)
-        if opts:
-            return opts[0]
         raise ImproperlyConfigured(self.UNDEFINED_ATTR_MSG % attr)
+
+
+def process_search_enabled(config, section):
+    """
+    The 'search_enabled' attribute accepts four options and its value
+    may be a boolean or a string containing a list of enabled parts
+    separated by comma after it's obtained from the ConfigParser.
+    This function normalizes and verifies the value to always return a list
+    with the enabled parts. It may raise ImproperlyConfigured if the
+    string value is empty or it contains an unrecognized search part.
+    """
+    ALLOWED_SEARCH_PARTS = set(['aips', 'transfers'])
+    options = [
+        {'section': section, 'option': 'disableElasticsearchIndexing', 'type': 'iboolean'},
+        {'section': section, 'option': 'disable_search_indexing', 'type': 'iboolean'},
+        {'section': section, 'option': 'search_enabled', 'type': 'boolean'},
+        {'section': section, 'option': 'search_enabled', 'type': 'string'},
+    ]
+    value = config.get_from_opts_list('search_enabled', options)
+    if isinstance(value, bool):
+        if value:
+            return ALLOWED_SEARCH_PARTS
+        else:
+            return set()
+    value = value.strip()
+    if len(value) == 0:
+        raise ImproperlyConfigured(config.UNDEFINED_ATTR_MSG % 'search_enabled')
+    enabled_parts = []
+    for item in value.split(','):
+        item = item.strip()
+        if len(item) == 0:
+            continue
+        if item in ALLOWED_SEARCH_PARTS:
+            enabled_parts.append(item)
+        else:
+            raise ImproperlyConfigured(
+                '"%s" is not a recognized value for the search_enabled '
+                'attribute. Only "aips" and/or "transfers" are allowed.'
+                % item
+            )
+    return set(enabled_parts)

--- a/src/archivematicaCommon/tests/test_appconfig.py
+++ b/src/archivematicaCommon/tests/test_appconfig.py
@@ -5,59 +5,85 @@ import StringIO
 from django.core.exceptions import ImproperlyConfigured
 import pytest
 
-from appconfig import Config
+from appconfig import Config, process_search_enabled
 
 
 CONFIG_MAPPING = {
-    'search_enabled': [
-        {'section': 'Dashboard', 'option': 'disable_search_indexing', 'type': 'iboolean'},
-        {'section': 'Dashboard', 'option': 'search_enabled', 'type': 'boolean'},
-    ],
+    'search_enabled': {
+        'section': 'Dashboard',
+        'process_function': process_search_enabled,
+    },
 }
 
 
 @pytest.mark.parametrize('option, value, expect', [
-    ('search_enabled', 'true', True),
-    ('search_enabled', 'false', False),
-    ('disable_search_indexing', 'true', False),
-    ('disable_search_indexing', 'false', True),
+    ('search_enabled', 'true', ['aips', 'transfers']),
+    ('search_enabled', 'false', []),
+    ('search_enabled', ' ', ImproperlyConfigured),
+    ('search_enabled', 'aips', ['aips']),
+    ('search_enabled', 'transfers', ['transfers']),
+    ('search_enabled', 'aips,transfers', ['aips', 'transfers']),
+    ('search_enabled', 'aips, transfers', ['aips', 'transfers']),
+    ('search_enabled', 'unknown', ImproperlyConfigured),
+    ('search_enabled', 'aips,unknown', ImproperlyConfigured),
+    ('disable_search_indexing', 'true', []),
+    ('disable_search_indexing', 'false', ['aips', 'transfers']),
 ])
 def test_mapping_list_config_file(option, value, expect):
     config = Config(env_prefix='ARCHIVEMATICA_DASHBOARD', attrs=CONFIG_MAPPING)
     config.read_defaults(StringIO.StringIO(
         '[Dashboard]\n'
         '{option} = {value}'.format(option=option, value=value)))
-    assert config.get('search_enabled') is expect
+    if isinstance(expect, list):
+        assert sorted(config.get('search_enabled')) == sorted(expect)
+    else:
+        with pytest.raises(expect):
+            config.get('search_enabled')
 
 
 @pytest.mark.parametrize('envvars, expect', [
-    ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED': 'true'}, True),
-    ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED': 'false'}, False),
-    ({'ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED': 'true'}, True),
-    ({'ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED': 'false'}, False),
+    ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED': 'true'},
+     ['aips', 'transfers']),
+    ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED': 'false'},
+     []),
+    ({'ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED': 'true'},
+     ['aips', 'transfers']),
+    ({'ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED': 'false'},
+     []),
     ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_DISABLE_SEARCH_INDEXING': 'true'},
-     False),
+     []),
     ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_DISABLE_SEARCH_INDEXING': 'false'},
-     True),
-    ({'ARCHIVEMATICA_DASHBOARD_DISABLE_SEARCH_INDEXING': 'true'}, False),
-    ({'ARCHIVEMATICA_DASHBOARD_DISABLE_SEARCH_INDEXING': 'false'}, True),
+     ['aips', 'transfers']),
+    ({'ARCHIVEMATICA_DASHBOARD_DISABLE_SEARCH_INDEXING': 'true'},
+     []),
+    ({'ARCHIVEMATICA_DASHBOARD_DISABLE_SEARCH_INDEXING': 'false'},
+     ['aips', 'transfers']),
+    ({'ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED': ''},
+     ImproperlyConfigured),
+    ({'ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED': 'aips'},
+     ['aips']),
+    ({'ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED': 'transfers'},
+     ['transfers']),
+    ({'ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED': 'aips,transfers'},
+     ['aips', 'transfers']),
+    ({'ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED': 'unknown,transfers'},
+     ImproperlyConfigured),
     ({}, ImproperlyConfigured),
     # Following two show that the DISABLE env var overrides the ENABLE one
     # because of the ordering in CONFIG_MAPPING.
-    ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED': 'true',
+    ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED': 'aips',
       'ARCHIVEMATICA_DASHBOARD_DASHBOARD_DISABLE_SEARCH_INDEXING': 'true'},
-     False),
+     []),
     ({'ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED': 'false',
       'ARCHIVEMATICA_DASHBOARD_DASHBOARD_DISABLE_SEARCH_INDEXING': 'false'},
-     True),
+     ['aips', 'transfers']),
 ])
 def test_mapping_list_env_var(envvars, expect):
     for var, val in envvars.items():
         os.environ[var] = val
     config = Config(env_prefix='ARCHIVEMATICA_DASHBOARD', attrs=CONFIG_MAPPING)
-    if bool(expect) is expect:
-        search_enabled = config.get('search_enabled')
-        assert search_enabled is expect
+    if isinstance(expect, list):
+        assert sorted(config.get('search_enabled')) == sorted(expect)
     else:
         with pytest.raises(expect):
             config.get('search_enabled')

--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -136,9 +136,14 @@ variables or in the gunicorn configuration file.
     - **Default:** `10`
 
 - **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED`**:
-    - **Description:** controls whether Elasticsearch is enabled. When set to `false`, the Backlog, Appraisal, and Archival storage tabs will not be displayed; in addition, the SIP Arrange pane in the Ingest tab will not be displayed. The status of Elasticsearch indexing is indicated in the Archivematica GUI under Administration > General.
-    - **Config file example:** `MCPClient.search_enabled`
-    - **Type:** `boolean`
+    - **Description:** controls what Elasticsearch indexes are enabled:
+        - When set to `aips`, the Backlog tab, Appraisal tab, and the SIP Arrange pane in the Ingest tab will not be displayed.
+        - When set to `transfers`, the Archival storage tab will not be displayed.
+        - When set to `false`, all the mentioned parts in the previous cases will not be displayed.
+        - When set to `aips,transfers` (the order does not matter) or `true`, all the mentioned parts will be displayed.
+    The status of Elasticsearch indexing is indicated in the Archivematica GUI under Administration > General.
+    - **Config file example:** `Dashboard.search_enabled`
+    - **Type:** `boolean` or `string`
     - **Default:** `true`
 
 - **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_GEARMAN_SERVER`**:

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -436,7 +436,7 @@ def total_size_of_aips(es_client):
 
 def list_display(request):
 
-    if not settings.SEARCH_ENABLED:
+    if 'aips' not in settings.SEARCH_ENABLED:
         return render(request, 'archival_storage/list.html')
     current_page_number = int(request.GET.get('page', 1))
     logger.debug('Current page: %s', current_page_number)

--- a/src/dashboard/src/components/backlog/views.py
+++ b/src/dashboard/src/components/backlog/views.py
@@ -86,7 +86,7 @@ def execute(request):
     :param request: The Django request object
     :return: The main backlog page rendered
     """
-    if django_settings.SEARCH_ENABLED:
+    if 'transfers' in django_settings.SEARCH_ENABLED:
         es_client = elasticSearchFunctions.get_client()
         check_and_remove_deleted_transfers(es_client)
     return render(request, 'backlog/backlog.html', locals())

--- a/src/dashboard/src/main/context_processors.py
+++ b/src/dashboard/src/main/context_processors.py
@@ -2,4 +2,7 @@ from django.conf import settings
 
 
 def search_enabled(request):
-    return {'search_enabled': settings.SEARCH_ENABLED}
+    return {
+        'search_transfers_enabled': 'transfers' in settings.SEARCH_ENABLED,
+        'search_aips_enabled': 'aips' in settings.SEARCH_ENABLED,
+    }

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -25,7 +25,7 @@ import os
 
 from django.utils.translation import ugettext_lazy as _
 
-from appconfig import Config
+from appconfig import Config, process_search_enabled
 import email_settings
 
 CONFIG_MAPPING = {
@@ -34,10 +34,7 @@ CONFIG_MAPPING = {
     'watch_directory': {'section': 'Dashboard', 'option': 'watch_directory', 'type': 'string'},
     'elasticsearch_server': {'section': 'Dashboard', 'option': 'elasticsearch_server', 'type': 'string'},
     'elasticsearch_timeout': {'section': 'Dashboard', 'option': 'elasticsearch_timeout', 'type': 'float'},
-    'search_enabled': [
-        {'section': 'Dashboard', 'option': 'disable_search_indexing', 'type': 'iboolean'},
-        {'section': 'Dashboard', 'option': 'search_enabled', 'type': 'boolean'},
-    ],
+    'search_enabled': {'section': 'Dashboard', 'process_function': process_search_enabled},
     'gearman_server': {'section': 'Dashboard', 'option': 'gearman_server', 'type': 'string'},
     'shibboleth_authentication': {'section': 'Dashboard', 'option': 'shibboleth_authentication', 'type': 'boolean'},
     'ldap_authentication': {'section': 'Dashboard', 'option': 'ldap_authentication', 'type': 'boolean'},

--- a/src/dashboard/src/templates/administration/general.html
+++ b/src/dashboard/src/templates/administration/general.html
@@ -46,11 +46,22 @@
 
         <h4>{% trans "Elasticsearch Indexing" %}</h4>
 
-        {% if search_enabled %}
-          <p class="es-indexing-configuration">{% trans "Elasticsearch indexing is enabled in this Archivematica installation" %}</p>
-        {% else %}
-          <p class="es-indexing-configuration">{% trans "Elasticsearch indexing has been disabled in this Archivematica installation" %}</p>
-        {% endif %}
+        <ul>
+          <li>
+            {% if search_transfers_enabled %}
+              {% trans "Transfers related indexes enabled." %}
+            {% else %}
+              {% trans "Transfers related indexes disabled." %}
+            {% endif %}
+          </li>
+          <li>
+            {% if search_aips_enabled %}
+              {% trans "AIPs related indexes enabled." %}
+            {% else %}
+              {% trans "AIPs related indexes disabled." %}
+            {% endif %}
+          </li>
+        </ul>
 
         <div>
           <input type="submit" value="{% trans 'Save' %}" class="btn btn-primary">

--- a/src/dashboard/src/templates/appraisal/appraisal.html
+++ b/src/dashboard/src/templates/appraisal/appraisal.html
@@ -20,7 +20,7 @@
 {% endblock %}
 
 {% block content %}
-{% if search_enabled %}
+{% if search_transfers_enabled %}
   {% verbatim %}
   <div ng-app="appraisalTab">
     <ng-include src="'front_page/content.html'"></ng-include>
@@ -28,6 +28,6 @@
   {% endverbatim %}
 {% else %}
   <h1>{% trans "Elasticsearch Indexing Disabled" %}</h1>
-  <p class="es-indexing-disabled">{% trans "Sorry, Elasticsearch indexing has been disabled in this Archivematica installation. The appraisal tab is non-functional when indexing is turned off." %}</p>
+  <p class="es-indexing-disabled">{% trans "Sorry, Elasticsearch indexing has been disabled for the Transfers related indexes in this Archivematica installation. The appraisal tab is non-functional when indexing is turned off." %}</p>
 {% endif %}
 {% endblock %}

--- a/src/dashboard/src/templates/archival_storage/list.html
+++ b/src/dashboard/src/templates/archival_storage/list.html
@@ -25,7 +25,7 @@
 
 {% block content %}
 
-  {% if search_enabled %}
+  {% if search_aips_enabled %}
 
     <ul class="breadcrumb">
       {% trans "Archival storage" as archival_storage_label %}
@@ -130,7 +130,7 @@
   {% else %}
 
     <h1>{% trans "Elasticsearch Indexing Disabled" %}</h1>
-    <p class="es-indexing-disabled">{% trans "Sorry, Elasticsearch indexing has been disabled in this Archivematica installation. The archival storage tab is non-functional when indexing is turned off." %}</p>
+    <p class="es-indexing-disabled">{% trans "Sorry, Elasticsearch indexing has been disabled for the AIPs related indexes in this Archivematica installation. The archival storage tab is non-functional when indexing is turned off." %}</p>
 
   {% endif %}
 

--- a/src/dashboard/src/templates/backlog/backlog.html
+++ b/src/dashboard/src/templates/backlog/backlog.html
@@ -22,12 +22,12 @@
 {% endblock %}
 
 {% block content %}
-  {% if search_enabled %}
+  {% if search_transfers_enabled %}
     {% include "ingest/backlog/_search_form.html" with show_files=True %}
     <table id="backlog-entries">
     </table>
   {% else %}
     <h1>{% trans "Elasticsearch Indexing Disabled" %}</h1>
-    <p class="es-indexing-disabled">{% trans "Sorry, Elasticsearch indexing has been disabled in this Archivematica installation. The backlog tab is non-functional when indexing is turned off." %}</p>
+    <p class="es-indexing-disabled">{% trans "Sorry, Elasticsearch indexing has been disabled for the Transfers related indexes in this Archivematica installation. The backlog tab is non-functional when indexing is turned off." %}</p>
   {% endif %}
 {% endblock %}

--- a/src/dashboard/src/templates/ingest/grid.html
+++ b/src/dashboard/src/templates/ingest/grid.html
@@ -65,7 +65,7 @@
 
 {% block content %}
 
-  {% if search_enabled %}
+  {% if search_transfers_enabled %}
     {% include "ingest/backlog/_search_form.html" with show_files=False %}
     <div class="activity-indicator">
       <img src='/media/images/ajax-loader.gif' />

--- a/src/dashboard/src/templates/layout.html
+++ b/src/dashboard/src/templates/layout.html
@@ -55,12 +55,12 @@
             <ul class="nav navbar-nav">
 
               <li class="{% active request url_transfer %}"><a href="{{ url_transfer }}">{% trans "Transfer" %}</a></li>
-              {% if search_enabled %}
+              {% if search_transfers_enabled %}
                 <li class="{% active request url_backlog %}"><a href="{{ url_backlog }}">{% trans "Backlog" %}</a></li>
                 <li class="{% active request url_appraisal %}"><a href="{{ url_appraisal }}">{% trans "Appraisal" %}</a></li>
               {% endif %}
               <li class="{% active request url_ingest %}"><a href="{{ url_ingest }}">{% trans "Ingest" %}</a></li>
-              {% if search_enabled %}
+              {% if search_aips_enabled %}
                 <li class="{% active request url_archival_storage %}"><a href="{{ url_archival_storage }}">{% trans "Archival storage" %}</a></li>
               {% endif %}
               <li class="{% active request url_fpr %}"><a href="{{ url_fpr }}">{% trans "Preservation planning" %}</a></li>


### PR DESCRIPTION
Allow to partially disable/enable Elasticsearch indexing. Extend the
current `search_enabled` config. var. behavior in all the components
to allow a string with a list of enabled search indexes separated by
comma but maintain the current boolean functionality. Available options
for the list are `transfers`, for the Transfer related indexes and
`aips` for the AIPs related indexes. Check the install README files
from each component for more info.

Enhance config. mapping definition to allow a 'process_function' field
where a callback can be passed to allow a more complex parsing process
for specific attributes. Those callbacks must accept the current 
'appconfig.Config' object and the attribute section string.

**Questions:**
This is currently only extending the existing functionality, but I wonder:

- Should we add a note somewhere indicating that the `search_enabled` configuration should be consistent in the three components?
- Should we try to change this multiple declaration at some point and use some global settings for the three components?
- Should this setting be checked somewhere else? For example, showing a warning in the [rebuild commands](https://github.com/artefactual/archivematica/tree/stable/1.7.x/src/dashboard/src/main/management/commands). I can double check this in #1171 and #1173.
- Is this config/env var documented somewhere else besides the install readme files?
- Since we are maintaining backwards compatibility, I guess we don't need to change the declaration of this config/env var in other repositories, but let me know if I'm wrong.

Connects to #1172.