### PR TITLE
Fix flake8 builds in Py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,3 @@ matrix:
 
     - python: "3.6"
       env: TOXENV=py36
-
-    - python: "3.6"
-      env: TOXENV=py36-flake8

--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -69,6 +69,7 @@ from main.models import Task
 from databaseFunctions import getUTCDate, retryOnFailure
 
 from django.db import transaction
+from django.utils import six
 import shlex
 import importlib
 
@@ -109,7 +110,7 @@ def handle_batch_task(gearman_job):
     for task_uuid in gearman_data['tasks']:
         task_data = gearman_data['tasks'][task_uuid]
         arguments = task_data['arguments']
-        if isinstance(arguments, unicode):
+        if isinstance(arguments, six.text_type):
             arguments = arguments.encode('utf-8')
 
         replacements = (replacement_dict.items() +

--- a/src/MCPClient/lib/clientScripts/create_processed_structmap.py
+++ b/src/MCPClient/lib/clientScripts/create_processed_structmap.py
@@ -8,6 +8,7 @@ import create_mets_v2
 from create_mets_v2 import createDigiprovMD
 import namespaces as ns
 
+from django.utils import six
 from lxml import etree
 
 
@@ -15,7 +16,7 @@ def create_amdSecs(job, path, file_group_identifier, base_path, base_path_name, 
     amdSecs = []
 
     for child in each_child(job, path, file_group_identifier, base_path, base_path_name, sip_uuid):
-        if isinstance(child, basestring):  # directory
+        if isinstance(child, six.string_types):  # directory
             amdSecs.extend(create_amdSecs(job, child, file_group_identifier, base_path, base_path_name, sip_uuid))
         else:  # file
             admid = "digiprov-" + child.uuid

--- a/src/MCPClient/lib/clientScripts/extract_maildir_attachments.py
+++ b/src/MCPClient/lib/clientScripts/extract_maildir_attachments.py
@@ -31,6 +31,8 @@ import uuid
 import django
 django.setup()
 from django.db import transaction
+from django.utils import six
+
 # dashboard
 from main.models import File
 
@@ -120,7 +122,7 @@ def handle_job(job):
                         msg = etree.SubElement(directory, "msg")
                         etree.SubElement(msg, "Message-ID").text = out['msgobj']['Message-ID'][1:-1]
                         etree.SubElement(msg, "Extracted-from").text = item
-                        if isinstance(out["subject"], str):
+                        if isinstance(out["subject"], six.binary_type):
                             etree.SubElement(msg, "Subject").text = out["subject"].decode('utf-8')
                         else:
                             etree.SubElement(msg, "Subject").text = out["subject"]

--- a/src/MCPClient/lib/clientScripts/json_metadata_to_csv.py
+++ b/src/MCPClient/lib/clientScripts/json_metadata_to_csv.py
@@ -4,6 +4,8 @@ import csv
 import json
 import os
 
+from django.utils import six
+
 
 def fetch_keys(objects):
     """
@@ -66,7 +68,7 @@ def encode_item(item):
     """
     if not item:  # Handle case where json contains null.
         return
-    elif isinstance(item, basestring):
+    elif isinstance(item, six.string_types):
         return item.encode('utf-8')
     elif isinstance(item, (list, tuple)):
         return [i.encode('utf-8') if i else '' for i in item]

--- a/src/MCPClient/lib/clientScripts/transcoder.py
+++ b/src/MCPClient/lib/clientScripts/transcoder.py
@@ -24,11 +24,12 @@ from executeOrRunSubProcess import executeOrRun
 
 # dashboard
 from django.db.models import F
+from django.utils import six
 
 
 def toStrFromUnicode(inputString, encoding='utf-8'):
     """Converts to str, if it's unicode input type."""
-    if isinstance(inputString, unicode):
+    if isinstance(inputString, six.string_types):
         inputString = inputString.encode(encoding)
     return inputString
 

--- a/src/MCPClient/lib/clientScripts/upload_archivists_toolkit.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivists_toolkit.py
@@ -24,6 +24,7 @@ from main.models import AtkDIPObjectResourcePairing
 
 # external
 from agentarchives.atk import ArchivistsToolkitClient
+from django.utils.six.moves import input as raw_input
 
 # moved after django.setup()
 logger = get_script_logger("archivematica.mcp.client")

--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -197,7 +197,7 @@ def watchDirectories():
             # We should expect both bytes and unicode. See #932.
             if isinstance(item, six.binary_type):
                 item = item.decode("utf-8")
-            path = os.path.join(unicode(directory), item)
+            path = os.path.join(six.text_type(directory), item)
             createUnitAndJobChainThreaded(path, row, terminate=False)
         actOnFiles = True
         if watched_directory.only_act_on_directories:

--- a/src/MCPServer/lib/jobChainLink.py
+++ b/src/MCPServer/lib/jobChainLink.py
@@ -21,6 +21,8 @@
 import logging
 import uuid
 
+from django.utils import six
+
 from utils import log_exceptions
 from linkTaskManagerDirectories import linkTaskManagerDirectories
 from linkTaskManagerFiles import linkTaskManagerFiles
@@ -60,7 +62,7 @@ class jobChainLink:
 
         # Depending on the path that led to this, jobChainLinkPK may
         # either be a UUID or a MicroServiceChainLink instance
-        if isinstance(jobChainLinkPK, basestring):
+        if isinstance(jobChainLinkPK, six.string_types):
             try:
                 link = MicroServiceChainLink.objects.get(id=str(jobChainLinkPK))
             # This will sometimes return no values

--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -32,6 +32,7 @@ import pprint
 import re
 from uuid import uuid4
 
+from django.utils import six
 from lxml import etree
 
 from main.models import DashboardSetting
@@ -86,14 +87,14 @@ class OrderedListsDict(collections.OrderedDict):
 
 def unicodeToStr(string):
     """Convert Unicode to string format."""
-    if isinstance(string, unicode):
+    if isinstance(string, six.text_type):
         string = string.encode("utf-8")
     return string
 
 
 def strToUnicode(string, obstinate=False):
     """Convert string to Unicode format."""
-    if isinstance(string, str):
+    if isinstance(string, six.binary_type):
         try:
             string = string.decode('utf8')
         except UnicodeDecodeError:
@@ -138,7 +139,7 @@ def getTagged(root, tag):
 def escapeForCommand(string):
     """Escape special characters in a given string."""
     ret = string
-    if isinstance(ret, basestring):
+    if isinstance(ret, six.string_types):
         ret = ret.replace("\\", "\\\\")
         ret = ret.replace("\"", "\\\"")
         ret = ret.replace("`", "\`")
@@ -152,7 +153,7 @@ def escape(string):
     primarily for arbitrary strings (e.g. filenames, paths) that might not
     be valid unicode to begin with.
     """
-    if isinstance(string, str):
+    if isinstance(string, six.binary_type):
         string = string.decode('utf-8', errors='replace')
     return string
 

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -31,7 +31,7 @@ import uuid
 
 from django.db import close_old_connections
 from django.db.models import Q
-from django.utils import timezone
+from django.utils import six, timezone
 from main.models import Agent, Derivation, Event, File, FPCommandOutput, Job, SIP, Task, Transfer, UnitVariable
 
 LOGGER = logging.getLogger('archivematica.common')
@@ -350,16 +350,16 @@ def getAccessionNumberFromTransfer(UUID):
         raise ValueError("No Transfer found for UUID: {}".format(UUID))
 
 
-def deUnicode(str):
+def deUnicode(unicode_string):
     """
     Convert a unicode string into an str by encoding it using UTF-8.
 
     :param unicode: A string. If not already a unicode string, it will be converted to one before encoding.
     :returns str: A UTF-8 encoded string, or None if the provided string was None. May be identical to the original string, if the original string contained only ASCII values.
     """
-    if str is None:
+    if unicode_string is None:
         return None
-    return unicode(str).encode('utf-8')
+    return six.text_type(unicode_string).encode('utf-8')
 
 
 def retryOnFailure(description, callback, retries=10):

--- a/src/archivematicaCommon/lib/dicts.py
+++ b/src/archivematicaCommon/lib/dicts.py
@@ -25,6 +25,8 @@ import ast
 import os
 import re
 
+from django.utils import six
+
 from archivematicaFunctions import unicodeToStr
 
 from main import models
@@ -93,9 +95,9 @@ class ReplacementDict(dict):
         # In order to make this code accessible to MCPServer,
         # we need to support passing in UUID strings instead
         # of models.
-        if isinstance(file_, basestring):
+        if isinstance(file_, six.string_types):
             file_ = models.File.objects.get(uuid=file_)
-        if isinstance(sip, basestring):
+        if isinstance(sip, six.string_types):
             # sip can be a SIP or Transfer
             try:
                 sip = models.SIP.objects.get(uuid=sip)

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -34,6 +34,7 @@ import time
 from xml.etree import ElementTree
 
 from django.db.models import Q
+from django.utils.six.moves import xrange
 from main.models import File, Transfer
 
 # archivematicaCommon

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -21,11 +21,21 @@
 # @author Joseph Perry <joseph@artefactual.com>
 
 from __future__ import print_function
+
+import io
 import subprocess
 import shlex
 import uuid
 import os
 import sys
+
+from django.utils import six
+
+# https://stackoverflow.com/a/36321030
+try:
+    file_types = (file, io.IOBase)
+except NameError:
+    file_types = (io.IOBase,)
 
 
 def launchSubProcess(command, stdIn="", printing=True, arguments=[],
@@ -64,7 +74,7 @@ def launchSubProcess(command, stdIn="", printing=True, arguments=[],
 
     try:
         # Split command strings but pass through arrays untouched
-        if isinstance(command, basestring):
+        if isinstance(command, six.string_types):
             command = shlex.split(command)
         else:
             command.extend(arguments)
@@ -77,10 +87,10 @@ def launchSubProcess(command, stdIn="", printing=True, arguments=[],
             my_env['LANGUAGE'] = my_env['LANG']
         my_env.update(env_updates)
 
-        if isinstance(stdIn, basestring):
+        if isinstance(stdIn, six.string_types):
             stdin_pipe = subprocess.PIPE
             stdin_string = stdIn
-        elif isinstance(stdIn, file):
+        elif isinstance(stdIn, file_types):
             stdin_pipe = stdIn
             stdin_string = ""
         else:

--- a/src/archivematicaCommon/lib/externals/extractMaildirAttachments.py
+++ b/src/archivematicaCommon/lib/externals/extractMaildirAttachments.py
@@ -17,6 +17,9 @@ import sys
 from StringIO import StringIO
 import uuid
 
+from django.utils import six
+
+
 from sharedVariablesAcrossModules import sharedVariablesAcrossModules
 
 
@@ -66,7 +69,7 @@ def parse_attachment(message_part, attachments=None):
                         filename = name.decode(encoding)
                 else:  # filename not in Content-Disposition
                     print("""Warning, no filename found in: [{%s}%s] Content-Disposition: %s or Content-Type""" % (sharedVariablesAcrossModules.sourceFileUUID, sharedVariablesAcrossModules.sourceFilePath, params), file=sys.stderr)
-                    filename = unicode(uuid.uuid4())
+                    filename = six.text_type(uuid.uuid4())
                     print("Attempting extraction with random filename: %s" % (filename), file=sys.stderr)
                 # Remove newlines from filename because that breaks everything
                 filename = filename.replace("\r", "").replace("\n", "")

--- a/src/archivematicaCommon/lib/xml2obj.py
+++ b/src/archivematicaCommon/lib/xml2obj.py
@@ -3,6 +3,8 @@ import re
 import xml.sax.handler
 from collections import defaultdict
 
+from django.utils import six
+
 
 class Tree(defaultdict):
     def __init__(self, value=None):
@@ -64,7 +66,7 @@ def xml2obj(src):
             return 1
 
         def __getitem__(self, key):
-            if isinstance(key, basestring):
+            if isinstance(key, six.string_types):
                 return self._attrs.get(key, None)
             else:
                 return [self][key]
@@ -132,7 +134,7 @@ def xml2obj(src):
             self.text_parts.append(content)
 
     builder = TreeBuilder()
-    if isinstance(src, basestring):
+    if isinstance(src, six.string_types):
         xml.sax.parseString(src, builder)
     else:
         xml.sax.parse(src, builder)

--- a/src/archivematicaCommon/tests/test_dicts.py
+++ b/src/archivematicaCommon/tests/test_dicts.py
@@ -2,6 +2,8 @@
 import os
 import pytest
 
+from django.utils import six
+
 from dicts import ReplacementDict, ChoicesDict
 from dicts import setup as setup_dicts
 
@@ -120,8 +122,8 @@ def test_replacementdict_options():
 
 def test_replacementdict_replace_returns_bytestring():
     in_str = u"%originalLocation%/location/การแปล"
-    assert isinstance(in_str, unicode)
+    assert isinstance(in_str, six.text_type)
 
     d = ReplacementDict({'%originalLocation%': '\x82\xdb\x82\xc1\x82\xd5\x82\xe9\x83\x81\x83C\x83\x8b'})
     out_str = d.replace(in_str)[0]
-    assert isinstance(out_str, str)
+    assert isinstance(out_str, six.binary_type)

--- a/src/dashboard/src/components/administration/management/commands/graph_links.py
+++ b/src/dashboard/src/components/administration/management/commands/graph_links.py
@@ -37,6 +37,7 @@ import sys
 from django.conf import settings as django_settings
 from django.core.management.base import BaseCommand
 from django.db import connection
+from django.utils import six
 
 from lxml import etree
 import pygraphviz as pgv
@@ -410,7 +411,7 @@ config.read('/etc/archivematica/MCPClient/archivematicaClientModules')
 
 def get_script_name(name):
     """Extract client script name."""
-    if not isinstance(name, basestring):
+    if not isinstance(name, six.string_types):
         return
     if config.has_option('supportedBatchCommands', name.lower()):
         return config.get('supportedBatchCommands', name.lower())

--- a/src/dashboard/src/components/administration/management/commands/json_links.py
+++ b/src/dashboard/src/components/administration/management/commands/json_links.py
@@ -29,10 +29,10 @@ import os
 import sys
 import tempfile
 
-
 import django
 from django.conf import settings as django_settings
 from django.core.management.base import BaseCommand
+from django.utils import six
 
 # Workflow models
 from main.models import (
@@ -186,7 +186,7 @@ def process_chain_link_task_details(link_dict, link, task_config):
 def job_status_unicode(value):
     status = dict(Job.STATUS)
     try:
-        return unicode(status[int(value)])
+        return six.text_type(status[int(value)])
     except ValueError:
         # https://github.com/artefactual/archivematica/issues/784
         d = {
@@ -194,7 +194,7 @@ def job_status_unicode(value):
             'Completed successfully': 2,
         }
         if value in d:
-            return unicode(status[d[value]])
+            return six.text_type(status[d[value]])
         raise
     except KeyError:
         logging.error('Job status %s cannot be recognized', value)
@@ -221,7 +221,7 @@ def i18nize_field(field, description):
 
     Side effect: update global catalogue.
     """
-    value = unicode(field)
+    value = six.text_type(field)
     if not hasattr(sys.modules[__name__], 'i18n_catalogues'):
         return dict(en=value)
     catalogues = getattr(sys.modules[__name__], 'i18n_catalogues')

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -29,6 +29,7 @@ from django.db import IntegrityError
 import django.http
 import django.template.defaultfilters
 from django.utils.translation import ugettext as _, ungettext
+from django.utils import six
 
 from components import helpers
 import components.filesystem_ajax.helpers as filesystem_ajax_helpers
@@ -719,7 +720,7 @@ def copy_to_arrange(request, sources=None, destinations=None, fetch_children=Fal
     :param list destinations: List of paths within arrange folder. All paths should start with DEFAULT_ARRANGE_PATH
     :param bool fetch_children: If True, will fetch all children of the provided path(s) to copy to the destination.
     """
-    if isinstance(sources, basestring) or isinstance(destinations, basestring):
+    if isinstance(sources, six.string_types) or isinstance(destinations, six.string_types):
         fetch_children = True
         sources = [sources]
         destinations = [destinations]

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -30,6 +30,7 @@ from django.db import models, transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils.translation import ugettext as _, ugettext_lazy as _l
+from django.utils import six
 
 # Third party dependencies, alphabetical by import source
 from django_extensions.db.fields import UUIDField
@@ -127,7 +128,7 @@ class DashboardSettingManager(models.Manager):
         with transaction.atomic():
             self.unset_dict(scope)
             self.bulk_create([
-                DashboardSetting(scope=scope, name=unicode(name), value=unicode(value)) for name, value in items.items()
+                DashboardSetting(scope=scope, name=six.text_type(name), value=six.text_type(value)) for name, value in items.items()
             ])
 
     def unset_dict(self, scope):
@@ -241,7 +242,7 @@ class MetadataAppliesToType(models.Model):
         db_table = u'MetadataAppliesToTypes'
 
     def __unicode__(self):
-        return unicode(self.description)
+        return six.text_type(self.description)
 
 
 class Event(models.Model):

--- a/src/dashboard/tests/test_dashboardsetting_manager.py
+++ b/src/dashboard/tests/test_dashboardsetting_manager.py
@@ -1,5 +1,6 @@
 from main.models import DashboardSetting
 
+from django.utils import six
 import pytest
 
 
@@ -11,8 +12,8 @@ def test_dashboardsetting_set_simple_dict():
     DashboardSetting.objects.set_dict(scope, data)
 
     assert DashboardSetting.objects.filter(scope=scope).count() == len(data)
-    assert DashboardSetting.objects.get(scope=scope, name='url').value == unicode(data['url'])
-    assert DashboardSetting.objects.get(scope=scope, name='key').value == unicode(data['key'])
+    assert DashboardSetting.objects.get(scope=scope, name='url').value == six.text_type(data['url'])
+    assert DashboardSetting.objects.get(scope=scope, name='key').value == six.text_type(data['key'])
 
     with pytest.raises(DashboardSetting.DoesNotExist):
         DashboardSetting.objects.get(scope=scope, name='unknown')
@@ -34,9 +35,9 @@ def test_dashboardsetting_set_complex_dict():
 
     DashboardSetting.objects.set_dict(scope, data)
 
-    assert DashboardSetting.objects.get(scope=scope, name='hidden').value == unicode(data['hidden'])
-    assert DashboardSetting.objects.get(scope=scope, name='hours').value == unicode(data['hours'])
-    assert DashboardSetting.objects.get(scope=scope, name='path').value == unicode(data['path'])
+    assert DashboardSetting.objects.get(scope=scope, name='hidden').value == six.text_type(data['hidden'])
+    assert DashboardSetting.objects.get(scope=scope, name='hours').value == six.text_type(data['hours'])
+    assert DashboardSetting.objects.get(scope=scope, name='path').value == six.text_type(data['path'])
 
 
 @pytest.mark.django_db
@@ -51,8 +52,8 @@ def test_dashboardsetting_get_dict():
     assert len(ret) == len(data)
     assert u'url' in ret.keys()
     assert u'key' in ret.keys()
-    assert ret['url'] == unicode(data['url'])
-    assert ret['key'] == unicode(data['key'])
+    assert ret['url'] == six.text_type(data['url'])
+    assert ret['key'] == six.text_type(data['key'])
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
As you probably know already, in Py3 `str` is text and `bytes` is binary, `basestring` and `unicode` were removed and many other subtle differences that caused our flake8-py36 build to break. We used to ignore its build status. This PR uses the `six` library so the flake8 errors disappear and updates our Travis config so the outcome of flake8-py36 is not ignored anymore.

Connects to https://github.com/archivematica/Issues/issues/70.