### PR TITLE
API: move workflow model lookups to MCPServer

### DIFF
--- a/src/MCPServer/lib/package.py
+++ b/src/MCPServer/lib/package.py
@@ -100,6 +100,15 @@ PACKAGE_TYPE_STARTING_POINTS = {
 }
 
 
+def get_approve_transfer_chain_id(transfer_type):
+    """Return chain ID to approve a transfer given its type."""
+    try:
+        item = PACKAGE_TYPE_STARTING_POINTS[transfer_type]
+    except KeyError:
+        raise ValueError("Unknown transfer type")
+    return item.chain
+
+
 def _file_is_an_archive(filepath):
     filepath = filepath.lower()
     return filepath.endswith('.zip') \

--- a/src/dashboard/src/contrib/mcp/client.py
+++ b/src/dashboard/src/contrib/mcp/client.py
@@ -27,15 +27,58 @@ from main.models import Job
 LOGGER = logging.getLogger('archivematica.dashboard.mcp.client')
 
 
-class RPCError(Exception):
-    pass
+class RPCGearmanClientError(Exception):
+    """Base exception."""
 
 
-class NoJobFoundError(Exception):
-    def __init__(self, *args, **kwargs):
-        try:
-            message = args[0]
-        except IndexError:
+class RPCError(RPCGearmanClientError):
+    """Unexpected error."""
+
+
+class RPCServerError(RPCGearmanClientError):
+    """Server application errors.
+
+    When the worker processes the job successfully but the response includes
+    an error.
+    """
+    GENERIC_ERROR_MSG = "The server failed to process the request"
+
+    def __init__(self, payload=None):
+        super(RPCServerError, self).__init__(self._process_error(payload))
+
+    def _process_error(self, payload):
+        """Extracts the error message from the payload."""
+        if payload is None or not isinstance(payload, dict):
+            return self.GENERIC_ERROR_MSG
+        message = payload.get("message", "Unknown error message")
+        handler = payload.get("function")
+        if handler:
+            message += " [handler=%s]" % (handler,)
+        return message
+
+
+class TimeoutError(RPCGearmanClientError):
+    """Deadline exceeded.
+
+    >> response = client.submit_job(
+           "doSomething", cPickle.dumps(data),
+           background=False, wait_until_complete=True,
+           poll_timeout=INFLIGHT_POLL_TIMEOUT)
+       if response.state == gearman.JOB_CREATED:
+           raise TimeoutError()
+
+    At this point we give up and raise this exception.
+    """
+    def __init__(self, timeout=None):
+        message = "Deadline exceeded"
+        if timeout is not None:
+            message = "{}: {}".format(message, timeout)
+        super(TimeoutError, self).__init__(message)
+
+
+class NoJobFoundError(RPCGearmanClientError):
+    def __init__(self, message=None):
+        if message is None:
             message = "No job was found"
         super(NoJobFoundError, self).__init__(message)
 
@@ -43,9 +86,34 @@ class NoJobFoundError(Exception):
 INFLIGHT_POLL_TIMEOUT = 5.0
 
 
-class MCPClient:
+class MCPClient(object):
+    """MCPServer client (RPC via Gearman)."""
+
     def __init__(self):
         self.server = settings.GEARMAN_SERVER
+
+    def _rpc_sync_call(self, ability, data, timeout=INFLIGHT_POLL_TIMEOUT):
+        """Invoke remote method synchronously and with a deadline.
+
+        When successful, it returns the payload of the response. Otherwise, it
+        raises an exception. ``TimeoutError`` when the deadline was exceeded,
+        ``RPCError`` when the worker failed abruptly, ``RPCServerError`` when
+        the worker returned an error.
+        """
+        client = gearman.GearmanClient([self.server])
+        response = client.submit_job(
+            ability, cPickle.dumps(data),
+            background=False, wait_until_complete=True,
+            poll_timeout=timeout)
+        client.shutdown()
+        if response.state == gearman.JOB_CREATED:
+            raise TimeoutError(timeout)
+        elif response.state != gearman.JOB_COMPLETE:
+            raise RPCError("%s failed (check the logs)".format(ability))
+        payload = cPickle.loads(response.result)
+        if isinstance(payload, dict) and payload.get("error", False):
+            raise RPCServerError(payload)
+        return payload
 
     def execute(self, uuid, choice, uid=None):
         gm_client = gearman.GearmanClient([self.server])
@@ -65,11 +133,11 @@ class MCPClient:
         execution to a single microservice.
         """
         kwargs = {
-            'currentstep': Job.STATUS_AWAITING_DECISION,
-            'sipuuid': unit_id,
+            "currentstep": Job.STATUS_AWAITING_DECISION,
+            "sipuuid": unit_id,
         }
         if mscl_id is not None:
-            kwargs['microservicechainlink_id'] = mscl_id
+            kwargs["microservicechainlink_id"] = mscl_id
         jobs = Job.objects.filter(**kwargs)
         if len(jobs) < 1:
             raise NoJobFoundError()
@@ -96,26 +164,31 @@ class MCPClient:
     def create_package(self, name, type_, accession, access_system_id, path,
                        metadata_set_id, auto_approve=True,
                        wait_until_complete=False, processing_config=None):
-        gm_client = gearman.GearmanClient([self.server])
         data = {
-            'name': name,
-            'type': type_,
-            'accession': accession,
-            'access_system_id': access_system_id,
-            'path': path,
-            'metadata_set_id': metadata_set_id,
-            'auto_approve': auto_approve,
-            'wait_until_complete': wait_until_complete,
+            "name": name,
+            "type": type_,
+            "accession": accession,
+            "access_system_id": access_system_id,
+            "path": path,
+            "metadata_set_id": metadata_set_id,
+            "auto_approve": auto_approve,
+            "wait_until_complete": wait_until_complete,
         }
         if processing_config is not None:
-            data['processing_config'] = processing_config
-        response = gm_client.submit_job('packageCreate',
-                                        cPickle.dumps(data),
-                                        background=False,
-                                        wait_until_complete=True,
-                                        poll_timeout=INFLIGHT_POLL_TIMEOUT)
-        gm_client.shutdown()
-        if response.state == gearman.JOB_COMPLETE:
-            return cPickle.loads(response.result)  # Transfer ID (pickled)
-        elif response.state == gearman.JOB_FAILED:
-            raise RPCError('MCPServer returned an error (check the logs)')
+            data["processing_config"] = processing_config
+        return self._rpc_sync_call("packageCreate", data)
+
+    def approve_transfer_by_path(self, db_transfer_path,
+                                 transfer_type, user_id):
+        """Approve a transfer given its path and transfer type."""
+        data = {
+            "db_transfer_path": db_transfer_path,
+            "transfer_type": transfer_type,
+            "user_id": user_id,
+        }
+        return self._rpc_sync_call("approveTransferByPath", data)
+
+    def approve_partial_reingest(self, sip_uuid, user_id):
+        """Approve a partial reingest awaiting for approval."""
+        data = {"sip_uuid": sip_uuid, "user_id": user_id}
+        return self._rpc_sync_call("approvePartialReingest", data)


### PR DESCRIPTION
We want MCPServer to be the only component interacting with workflow
models. In this commit, MCPServer learns two new functions in order to
approve transfers and reingests. The Dashboard is updated accordingly to
invoke these functions and have the old code removed. With this, the Dashboard
API stops using workflow models.

Our pseudo-RPC interface based on Gearman has been updated so the server
can return error messages to the client. Dashboard's RPC client has been
updated to identify these errors and raise a `RPCServerError` exception.

This is connected to #1101.