### PR TITLE
Populate processing config fields in MCPServer

### DIFF
--- a/src/MCPServer/lib/RPCServer.py
+++ b/src/MCPServer/lib/RPCServer.py
@@ -32,6 +32,7 @@ import gearman
 from databaseFunctions import auto_close_db
 from linkTaskManagerChoice import choicesAvailableForUnits
 from package import create_package, get_approve_transfer_chain_id
+from processing_config import get_processing_fields
 from main.models import Job, MicroServiceChainChoice
 
 
@@ -220,6 +221,13 @@ def approve_partial_reingest_handler(*args, **kwargs):
         raise not_found
 
 
+@auto_close_db
+@pickle_result
+@capture_exceptions(raise_exc=False)
+def get_processing_config_fields_handler(*args, **kwargs):
+    return get_processing_fields()
+
+
 def startRPCServer():
     gm_worker = gearman.GearmanWorker([django_settings.GEARMAN_SERVER])
     hostID = gethostname() + "_MCPServer"
@@ -236,6 +244,8 @@ def startRPCServer():
         "approveTransferByPath", approve_transfer_by_path_handler)
     gm_worker.register_task(
         "approvePartialReingest", approve_partial_reingest_handler)
+    gm_worker.register_task(
+        "getProcessingConfigFields", get_processing_config_fields_handler)
 
     failMaxSleep = 30
     failSleep = 1

--- a/src/MCPServer/lib/processing_config.py
+++ b/src/MCPServer/lib/processing_config.py
@@ -1,0 +1,265 @@
+"""Processing configuration.
+
+This module lists the processing configuration fields where the user has the
+ability to establish predefined choices via the user interface.
+"""
+
+from collections import OrderedDict
+
+from django.conf import settings as django_settings
+from django.db import connection
+
+from abilities import choice_is_available
+from main.models import (
+    MicroServiceChainChoice,
+    MicroServiceChoiceReplacementDic
+)
+
+
+# Types of processing fields:
+# - "boolean" (required: "yes_option", "no_option")
+# - "storage_service" (required: "purpose")
+# - "days" (required: "chain")
+# - "replace_dict"
+# - "chain_choice" (optional: "ignored_choices", "find_duplicates")
+processing_fields = OrderedDict()
+processing_fields['bd899573-694e-4d33-8c9b-df0af802437d'] = {
+    'type': 'boolean',
+    'name': 'assign_uuids_to_directories',
+    'yes_option': '2dc3f487-e4b0-4e07-a4b3-6216ed24ca14',
+    'no_option': '891f60d0-1ba8-48d3-b39e-dd0934635d29',
+}
+processing_fields['755b4177-c587-41a7-8c52-015277568302'] = {
+    'type': 'boolean',
+    'name': 'quarantine_transfer',
+    'yes_option': '97ea7702-e4d5-48bc-b4b5-d15d897806ab',
+    'no_option': 'd4404ab1-dc7f-4e9e-b1f8-aa861e766b8e',
+}
+processing_fields['19adb668-b19a-4fcb-8938-f49d7485eaf3'] = {
+    'type': 'days',
+    'name': 'quarantine_expiry_days',
+    'chain': '333643b7-122a-4019-8bef-996443f3ecc5',
+}
+processing_fields['56eebd45-5600-4768-a8c2-ec0114555a3d'] = {
+    'type': 'boolean',
+    'name': 'tree',
+    'yes_option': 'df54fec1-dae1-4ea6-8d17-a839ee7ac4a7',
+    'no_option': 'e9eaef1e-c2e0-4e3b-b942-bfb537162795',
+}
+processing_fields['f09847c2-ee51-429a-9478-a860477f6b8d'] = {
+    'type': 'replace_dict',
+    'name': 'select_format_id_tool_transfer',
+}
+processing_fields['dec97e3c-5598-4b99-b26e-f87a435a6b7f'] = {
+    'type': 'chain_choice',
+    'name': 'extract_packages',
+}
+processing_fields['f19926dd-8fb5-4c79-8ade-c83f61f55b40'] = {
+    'type': 'replace_dict',
+    'name': 'delete_packages',
+}
+processing_fields['70fc7040-d4fb-4d19-a0e6-792387ca1006'] = {
+    'type': 'boolean',
+    'name': 'policy_checks_originals',
+    'yes_option': 'c611a6ff-dfdb-46d1-b390-f366a6ea6f66',
+    'no_option': '3e891cc4-39d2-4989-a001-5107a009a223',
+}
+processing_fields['accea2bf-ba74-4a3a-bb97-614775c74459'] = {
+    'type': 'chain_choice',
+    'name': 'examine',
+}
+processing_fields['bb194013-597c-4e4a-8493-b36d190f8717'] = {
+    'type': 'chain_choice',
+    'name': 'create_sip',
+    'ignored_choices': ['Reject transfer'],
+}
+processing_fields['7a024896-c4f7-4808-a240-44c87c762bc5'] = {
+    'type': 'replace_dict',
+    'name': 'select_format_id_tool_ingest',
+}
+processing_fields['cb8e5706-e73f-472f-ad9b-d1236af8095f'] = {
+    'type': 'chain_choice',
+    'name': 'normalize',
+    'ignored_choices': ['Reject SIP'],
+    'find_duplicates': True,
+    'label': 'Normalize',
+}
+processing_fields['de909a42-c5b5-46e1-9985-c031b50e9d30'] = {
+    'type': 'boolean',
+    'name': 'normalize_transfer',
+    'yes_option': '1e0df175-d56d-450d-8bee-7df1dc7ae815',
+}
+processing_fields['498f7a6d-1b8c-431a-aa5d-83f14f3c5e65'] = {
+    'type': 'replace_dict',
+    'name': 'normalize_thumbnail_mode',
+}
+processing_fields['153c5f41-3cfb-47ba-9150-2dd44ebc27df'] = {
+    'type': 'boolean',
+    'name': 'policy_checks_preservation_derivatives',
+    'yes_option': '3a55f688-eca3-4ebc-a012-4ce68290e7b0',
+    'no_option': 'b7ce05f0-9d94-4b3e-86cc-d4b2c6dba546',
+}
+processing_fields['8ce07e94-6130-4987-96f0-2399ad45c5c2'] = {
+    'type': 'boolean',
+    'name': 'policy_checks_access_derivatives',
+    'yes_option': 'd9760427-b488-4381-832a-de10106de6fe',
+    'no_option': '76befd52-14c3-44f9-838f-15a4e01624b0',
+}
+processing_fields['05357876-a095-4c11-86b5-a7fff01af668'] = {
+    'type': 'boolean',
+    'name': 'bind_pids',
+    'yes_option': '1e79e1b6-cf50-49ff-98a3-fa51d73553dc',
+    'no_option': 'fcfea449-158c-452c-a8ad-4ae009c4eaba',
+}
+processing_fields['d0dfa5fc-e3c2-4638-9eda-f96eea1070e0'] = {
+    'type': 'boolean',
+    'name': 'normative_structmap',
+    'yes_option': '29881c21-3548-454a-9637-ebc5fd46aee0',
+    'no_option': '65273f18-5b4e-4944-af4f-09be175a88e8',
+}
+processing_fields['eeb23509-57e2-4529-8857-9d62525db048'] = {
+    'type': 'chain_choice',
+    'name': 'reminder',
+}
+processing_fields['7079be6d-3a25-41e6-a481-cee5f352fe6e'] = {
+    'type': 'boolean',
+    'name': 'transcribe_file',
+    'yes_option': '5a9985d3-ce7e-4710-85c1-f74696770fa9',
+    'no_option': '1170e555-cd4e-4b2f-a3d6-bfb09e8fcc53',
+}
+processing_fields['087d27be-c719-47d8-9bbb-9a7d8b609c44'] = {
+    'type': 'replace_dict',
+    'name': 'select_format_id_tool_submissiondocs',
+}
+processing_fields['01d64f58-8295-4b7b-9cab-8f1b153a504f'] = {
+    'type': 'replace_dict',
+    'name': 'compression_algo',
+}
+processing_fields['01c651cb-c174-4ba4-b985-1d87a44d6754'] = {
+    'type': 'replace_dict',
+    'name': 'compression_level',
+}
+processing_fields['2d32235c-02d4-4686-88a6-96f4d6c7b1c3'] = {
+    'type': 'boolean',
+    'name': 'store_aip',
+    'yes_option': '9efab23c-31dc-4cbd-a39d-bb1665460cbe',
+}
+processing_fields['b320ce81-9982-408a-9502-097d0daa48fa'] = {
+    'type': 'storage_service',
+    'name': 'store_aip_location',
+    'purpose': 'AS',
+}
+processing_fields['92879a29-45bf-4f0b-ac43-e64474f0f2f9'] = {
+    'type': 'chain_choice',
+    'name': 'upload_dip',
+}
+processing_fields['5e58066d-e113-4383-b20b-f301ed4d751c'] = {
+    'type': 'chain_choice',
+    'name': 'store_dip',
+}
+processing_fields['cd844b6e-ab3c-4bc6-b34f-7103f88715de'] = {
+    'type': 'storage_service',
+    'name': 'store_dip_location',
+    'purpose': 'DS',
+}
+
+
+def get_processing_fields():
+    """Return the list of known processing configuration fields.
+
+    It uses `processing_fields`` defined in this module as a base and extended
+    after some workflow lookups.
+    """
+    for link_id, config in processing_fields.items():
+        if config['type'] == 'replace_dict':
+            config['options'] = _get_options_for_replace_dict(link_id)
+        elif config['type'] == 'chain_choice':
+            config['options'] = _get_options_for_chain_choice(
+                link_id, config.get('ignored_choices', []))
+            _populate_duplicates_chain_choice(config)
+    return processing_fields
+
+
+def _get_options_for_replace_dict(link_id):
+    return list(MicroServiceChoiceReplacementDic.objects.filter(
+        choiceavailableatlink_id=link_id).values_list('id', 'description'))
+
+
+def _get_options_for_chain_choice(link_id, ignored_choices):
+    ret = []
+    chain_choices = MicroServiceChainChoice.objects.filter(
+        choiceavailableatlink_id=link_id)
+    for item in chain_choices:
+        chain = item.chainavailable
+        if chain.description in ignored_choices:
+            continue
+        if not choice_is_available(item, django_settings):
+            continue
+        ret.append((chain.pk, chain.description))
+    return ret
+
+
+def _populate_duplicates_chain_choice(config):
+    """Find and populate chain choice duplicates.
+
+    When the user chooses a value like "Normalize for preservation" in the
+    "Normalize" processing config, this function makes sure that all the
+    matching chain links are listed so the user choise applies to all of them.
+
+    Given the following config item (see `processing_fields` in this module):
+
+        config[find_duplicates] = True
+        config[label] = "Normalize"
+        config[options] = [
+            (2b93cecd4-71f2-4e28-bc39-d32fd62c5a94", "Normalize for preservation and access")
+            (2612e3609-ce9a-4df6-a9a3-63d634d2d934", ...)
+            (2c34bd22a-d077-4180-bf58-01db35bdb644", ...)
+            (289cb80dd-0636-464f-930d-57b61e3928b2", ...)
+            (2a6ed697e-6189-4b4e-9f80-29209abc7937", ...)
+            (2e600b56d-1a43-4031-9d7c-f64f123e5662", ...)
+            (2fb7a326e-1e50-4b48-91b9-4917ff8d0ae8", ...)
+        ]
+
+    This function populates a new property with a list of matching links, e.g.:
+
+        config[duplicates] = {
+            <chain_id> = (chain_desc, (<link_id>, <chain_id>), ...)
+            ...
+        }
+
+    It's used in `administration/forms.py` so we can build configs like the
+    following when the user picks "Normalize for preservation" which has more
+    than one match:
+
+        <!-- Normalize (match 1 for "Normalize for preservation") -->
+        <preconfiguredChoice>
+          <appliesTo>cb8e5706-e73f-472f-ad9b-d1236af8095f</appliesTo>
+          <goToChain>612e3609-ce9a-4df6-a9a3-63d634d2d934</goToChain>
+        </preconfiguredChoice>
+        <!-- Normalize (match 2 for "Normalize for preservation") -->
+        <preconfiguredChoice>
+          <appliesTo>7509e7dc-1e1b-4dce-8d21-e130515fce73</appliesTo>
+          <goToChain>612e3609-ce9a-4df6-a9a3-63d634d2d934</goToChain>
+        </preconfiguredChoice>
+    """
+    if not config.get('find_duplicates', False):
+        return
+    sql = """
+        SELECT
+            MicroServiceChainLinks.pk,
+            MicroServiceChains.pk
+        FROM TasksConfigs
+        LEFT JOIN MicroServiceChainLinks ON (MicroServiceChainLinks.currentTask = TasksConfigs.pk)
+        LEFT JOIN MicroServiceChainChoice ON (MicroServiceChainChoice.choiceAvailableAtLink = MicroServiceChainLinks.pk)
+        LEFT JOIN MicroServiceChains ON (MicroServiceChains.pk = MicroServiceChainChoice.chainAvailable)
+        WHERE
+            TasksConfigs.description = %s
+            AND MicroServiceChains.description = %s;
+    """
+    config['duplicates'] = {}
+    with connection.cursor() as cursor:
+        for chain_id, chain_desc in config['options']:
+            cursor.execute(sql, (config['label'], chain_desc))
+            results = cursor.fetchall()
+            if len(results) > 0:
+                config['duplicates'][chain_id] = (chain_desc, results)

--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -18,25 +18,23 @@ from __future__ import division
 
 import os
 from lxml import etree
-from collections import OrderedDict
 
 from django import forms
 from django.conf import settings
-from django.db import connection
 from django.forms.widgets import TextInput, Select
 from django.utils.translation import ugettext_lazy as _
 
+from contrib.mcp.client import MCPClient
 from components import helpers
 from installer.forms import site_url_field, load_site_url
-from main import models
+from main.models import Agent, TaxonomyTerm
 
-from abilities import choice_is_available
 import storageService as storage_service
 
 
 class AgentForm(forms.ModelForm):
     class Meta:
-        model = models.Agent
+        model = Agent
         fields = ('identifiervalue', 'name', 'agenttype')
         widgets = {
             'identifiervalue': TextInput(attrs=settings.INPUT_ATTRS),
@@ -221,7 +219,7 @@ class ChecksumSettingsForm(SettingsForm):
 
 class TaxonomyTermForm(forms.ModelForm):
     class Meta:
-        model = models.TaxonomyTerm
+        model = TaxonomyTerm
         fields = ('taxonomy', 'term')
         widgets = {
             "term": TextInput(attrs=settings.INPUT_ATTRS)
@@ -235,194 +233,7 @@ class ProcessingConfigurationForm(forms.Form):
     Every processing field in this form requires the following
     properties: type, name, label. In addition, these are some other
     constraints based on the type:
-
-    - type = boolean
-      Required: yes_option or no_option (or both)
-    - type = chain_choice
-      Optional: ignored_choices - list of choices that won't be presented to the user
-      Optional: find_duplicates - persist choice across chain links with the same name
-    - type = storage_service
-      Required: purpose
-    - type = days
-      Required: chain
-      Optional: placeholder, min_value
     """
-
-    # The available processing fields indexed by choice_uuid.
-    processing_fields = OrderedDict()
-    processing_fields['bd899573-694e-4d33-8c9b-df0af802437d'] = {
-        'type': 'boolean',
-        'name': 'assign_uuids_to_directories',
-        'label': _('Assign UUIDs to directories'),
-        'yes_option': '2dc3f487-e4b0-4e07-a4b3-6216ed24ca14',
-        'no_option': '891f60d0-1ba8-48d3-b39e-dd0934635d29',
-    }
-    processing_fields['755b4177-c587-41a7-8c52-015277568302'] = {
-        'type': 'boolean',
-        'name': 'quarantine_transfer',
-        'label': _('Send transfer to quarantine'),
-        'yes_option': '97ea7702-e4d5-48bc-b4b5-d15d897806ab',
-        'no_option': 'd4404ab1-dc7f-4e9e-b1f8-aa861e766b8e',
-    }
-    processing_fields['19adb668-b19a-4fcb-8938-f49d7485eaf3'] = {
-        'type': 'days',
-        'name': 'quarantine_expiry_days',
-        'label': _('Remove from quarantine after (days)'),
-        'placeholder': _('days'),
-        'chain': '333643b7-122a-4019-8bef-996443f3ecc5',
-        'min_value': 0,
-    }
-    processing_fields['56eebd45-5600-4768-a8c2-ec0114555a3d'] = {
-        'type': 'boolean',
-        'name': 'tree',
-        'label': _('Generate transfer structure report'),
-        'yes_option': 'df54fec1-dae1-4ea6-8d17-a839ee7ac4a7',
-        'no_option': 'e9eaef1e-c2e0-4e3b-b942-bfb537162795',
-    }
-    processing_fields['f09847c2-ee51-429a-9478-a860477f6b8d'] = {
-        'type': 'replace_dict',
-        'name': 'select_format_id_tool_transfer',
-        'label': _('Select file format identification command (Transfer)'),
-    }
-    processing_fields['dec97e3c-5598-4b99-b26e-f87a435a6b7f'] = {
-        'type': 'chain_choice',
-        'name': 'extract_packages',
-        'label': _('Extract packages'),
-        'uuid': '01d80b27-4ad1-4bd1-8f8d-f819f18bf685',
-    }
-    processing_fields['f19926dd-8fb5-4c79-8ade-c83f61f55b40'] = {
-        'type': 'replace_dict',
-        'name': 'delete_packages',
-        'label': _('Delete packages after extraction'),
-        'uuid': '85b1e45d-8f98-4cae-8336-72f40e12cbef',
-    }
-    processing_fields['70fc7040-d4fb-4d19-a0e6-792387ca1006'] = {
-        'type': 'boolean',
-        'name': 'policy_checks_originals',
-        'label': _('Perform policy checks on originals'),
-        'yes_option': 'c611a6ff-dfdb-46d1-b390-f366a6ea6f66',
-        'no_option': '3e891cc4-39d2-4989-a001-5107a009a223',
-    }
-    processing_fields['accea2bf-ba74-4a3a-bb97-614775c74459'] = {
-        'type': 'chain_choice',
-        'name': 'examine',
-        'label': _('Examine contents'),
-    }
-    processing_fields['bb194013-597c-4e4a-8493-b36d190f8717'] = {
-        'type': 'chain_choice',
-        'name': 'create_sip',
-        'label': _('Create SIP(s)'),
-        'ignored_choices': ['Reject transfer'],
-    }
-    processing_fields['7a024896-c4f7-4808-a240-44c87c762bc5'] = {
-        'type': 'replace_dict',
-        'name': 'select_format_id_tool_ingest',
-        'label': _('Select file format identification command (Ingest)'),
-    }
-    processing_fields['cb8e5706-e73f-472f-ad9b-d1236af8095f'] = {
-        'type': 'chain_choice',
-        'name': 'normalize',
-        'label': _('Normalize'),
-        'ignored_choices': ['Reject SIP'],
-        'find_duplicates': True,
-    }
-    processing_fields['de909a42-c5b5-46e1-9985-c031b50e9d30'] = {
-        'type': 'boolean',
-        'name': 'normalize_transfer',
-        'label': _('Approve normalization'),
-        'yes_option': '1e0df175-d56d-450d-8bee-7df1dc7ae815',
-    }
-    processing_fields['498f7a6d-1b8c-431a-aa5d-83f14f3c5e65'] = {
-        'type': 'replace_dict',
-        'name': 'normalize_thumbnail_mode',
-        'label': _('Generate thumbnails'),
-    }
-    processing_fields['153c5f41-3cfb-47ba-9150-2dd44ebc27df'] = {
-        'type': 'boolean',
-        'name': 'policy_checks_preservation_derivatives',
-        'label': _('Perform policy checks on preservation derivatives'),
-        'yes_option': '3a55f688-eca3-4ebc-a012-4ce68290e7b0',
-        'no_option': 'b7ce05f0-9d94-4b3e-86cc-d4b2c6dba546',
-    }
-    processing_fields['8ce07e94-6130-4987-96f0-2399ad45c5c2'] = {
-        'type': 'boolean',
-        'name': 'policy_checks_access_derivatives',
-        'label': _('Perform policy checks on access derivatives'),
-        'yes_option': 'd9760427-b488-4381-832a-de10106de6fe',
-        'no_option': '76befd52-14c3-44f9-838f-15a4e01624b0',
-    }
-    processing_fields['05357876-a095-4c11-86b5-a7fff01af668'] = {
-        'type': 'boolean',
-        'name': 'bind_pids',
-        'label': _('Bind PIDs'),
-        'yes_option': '1e79e1b6-cf50-49ff-98a3-fa51d73553dc',
-        'no_option': 'fcfea449-158c-452c-a8ad-4ae009c4eaba',
-    }
-    processing_fields['d0dfa5fc-e3c2-4638-9eda-f96eea1070e0'] = {
-        'type': 'boolean',
-        'name': 'normative_structmap',
-        'label': _('Document empty directories'),
-        'yes_option': '29881c21-3548-454a-9637-ebc5fd46aee0',
-        'no_option': '65273f18-5b4e-4944-af4f-09be175a88e8',
-    }
-    processing_fields['eeb23509-57e2-4529-8857-9d62525db048'] = {
-        'type': 'chain_choice',
-        'name': 'reminder',
-        'label': _('Reminder: add metadata if desired'),
-    }
-    processing_fields['7079be6d-3a25-41e6-a481-cee5f352fe6e'] = {
-        'type': 'boolean',
-        'name': 'transcribe_file',
-        'label': _('Transcribe files (OCR)'),
-        'yes_option': '5a9985d3-ce7e-4710-85c1-f74696770fa9',
-        'no_option': '1170e555-cd4e-4b2f-a3d6-bfb09e8fcc53',
-    }
-    processing_fields['087d27be-c719-47d8-9bbb-9a7d8b609c44'] = {
-        'type': 'replace_dict',
-        'name': 'select_format_id_tool_submissiondocs',
-        'label': _('Select file format identification command (Submission documentation & metadata)'),
-    }
-    processing_fields['01d64f58-8295-4b7b-9cab-8f1b153a504f'] = {
-        'type': 'replace_dict',
-        'name': 'compression_algo',
-        'label': _('Select compression algorithm'),
-    }
-    processing_fields['01c651cb-c174-4ba4-b985-1d87a44d6754'] = {
-        'type': 'replace_dict',
-        'name': 'compression_level',
-        'label': _('Select compression level'),
-    }
-    processing_fields['2d32235c-02d4-4686-88a6-96f4d6c7b1c3'] = {
-        'type': 'boolean',
-        'name': 'store_aip',
-        'label': _('Store AIP'),
-        'yes_option': '9efab23c-31dc-4cbd-a39d-bb1665460cbe',
-    }
-    processing_fields['b320ce81-9982-408a-9502-097d0daa48fa'] = {
-        'type': 'storage_service',
-        'name': 'store_aip_location',
-        'label': _('Store AIP location'),
-        'purpose': 'AS',
-    }
-    processing_fields['92879a29-45bf-4f0b-ac43-e64474f0f2f9'] = {
-        'type': 'chain_choice',
-        'name': 'upload_dip',
-        'label': 'Upload DIP',
-        'ignored_choices': []
-    }
-    processing_fields['5e58066d-e113-4383-b20b-f301ed4d751c'] = {
-        'type': 'chain_choice',
-        'name': 'store_dip',
-        'label': _('Store DIP'),
-        'ignored_choices': []
-    }
-    processing_fields['cd844b6e-ab3c-4bc6-b34f-7103f88715de'] = {
-        'type': 'storage_service',
-        'name': 'store_dip_location',
-        'label': _('Store DIP location'),
-        'purpose': 'DS',
-    }
-
     EMPTY_OPTION_NAME = _('None')
     EMPTY_CHOICES = [
         (None, EMPTY_OPTION_NAME),
@@ -432,49 +243,81 @@ class ProcessingConfigurationForm(forms.Form):
         'initial': None,
     }
 
+    # This extends the fields defined in the processing_config module.
+    # Temporary solution until workflow data can be translated.
+    LABELS = {
+        'bd899573-694e-4d33-8c9b-df0af802437d': _('Assign UUIDs to directories'),
+        '755b4177-c587-41a7-8c52-015277568302': _('Send transfer to quarantine'),
+        '19adb668-b19a-4fcb-8938-f49d7485eaf3': _('Remove from quarantine after (days)'),
+        '56eebd45-5600-4768-a8c2-ec0114555a3d': _('Generate transfer structure report'),
+        'f09847c2-ee51-429a-9478-a860477f6b8d': _('Select file format identification command (Transfer)'),
+        'dec97e3c-5598-4b99-b26e-f87a435a6b7f': _('Extract packages'),
+        'f19926dd-8fb5-4c79-8ade-c83f61f55b40': _('Delete packages after extraction'),
+        '70fc7040-d4fb-4d19-a0e6-792387ca1006': _('Perform policy checks on originals'),
+        'accea2bf-ba74-4a3a-bb97-614775c74459': _('Examine contents'),
+        'bb194013-597c-4e4a-8493-b36d190f8717': _('Create SIP(s)'),
+        '7a024896-c4f7-4808-a240-44c87c762bc5': _('Select file format identification command (Ingest)'),
+        'cb8e5706-e73f-472f-ad9b-d1236af8095f': _('Normalize'),
+        'de909a42-c5b5-46e1-9985-c031b50e9d30': _('Approve normalization'),
+        '498f7a6d-1b8c-431a-aa5d-83f14f3c5e65': _('Generate thumbnails'),
+        '153c5f41-3cfb-47ba-9150-2dd44ebc27df': _('Perform policy checks on preservation derivatives'),
+        '8ce07e94-6130-4987-96f0-2399ad45c5c2': _('Perform policy checks on access derivatives'),
+        '05357876-a095-4c11-86b5-a7fff01af668': _('Bind PIDs'),
+        'd0dfa5fc-e3c2-4638-9eda-f96eea1070e0': _('Document empty directories'),
+        'eeb23509-57e2-4529-8857-9d62525db048': _('Reminder: add metadata if desired'),
+        '7079be6d-3a25-41e6-a481-cee5f352fe6e': _('Transcribe files (OCR)'),
+        '087d27be-c719-47d8-9bbb-9a7d8b609c44': _('Select file format identification command (Submission documentation & metadata)'),
+        '01d64f58-8295-4b7b-9cab-8f1b153a504f': _('Select compression algorithm'),
+        '01c651cb-c174-4ba4-b985-1d87a44d6754': _('Select compression level'),
+        '2d32235c-02d4-4686-88a6-96f4d6c7b1c3': _('Store AIP'),
+        'b320ce81-9982-408a-9502-097d0daa48fa': _('Store AIP location'),
+        '92879a29-45bf-4f0b-ac43-e64474f0f2f9': _('Upload DIP'),
+        '5e58066d-e113-4383-b20b-f301ed4d751c': _('Store DIP'),
+        'cd844b6e-ab3c-4bc6-b34f-7103f88715de': _('Store DIP location'),
+    }
+
     name = forms.RegexField(max_length=16, regex=r'^\w+$', required=True)
     name.widget.attrs['class'] = 'form-control'
 
     def __init__(self, *args, **kwargs):
         super(ProcessingConfigurationForm, self).__init__(*args, **kwargs)
+        self._load_processing_config_fields()
         for choice_uuid, field in self.processing_fields.items():
             ftype = field['type']
             opts = self.DEFAULT_FIELD_OPTS.copy()
-            if 'label' in field:
-                opts['label'] = field['label']
+            opts['label'] = field['label']
+
             if ftype == 'days':
-                if 'min_value' in field:
-                    opts['min_value'] = field['min_value']
+                opts['min_value'] = 0
                 self.fields[choice_uuid] = forms.IntegerField(**opts)
-                if 'placeholder' in field:
-                    self.fields[choice_uuid].widget.attrs['placeholder'] = field['placeholder']
-                self.fields[choice_uuid].widget.attrs['class'] = 'form-control'
-            else:
-                choices = opts['choices'] = list(self.EMPTY_CHOICES)
-                if ftype == 'boolean':
-                    if 'yes_option' in field:
-                        choices.append((field['yes_option'], _('Yes')))
-                    if 'no_option' in field:
-                        choices.append((field['no_option'], _('No')))
-                elif ftype == 'chain_choice':
-                    chain_choices = models.MicroServiceChainChoice.objects.filter(choiceavailableatlink_id=choice_uuid)
-                    ignored_choices = field.get('ignored_choices', [])
-                    for item in chain_choices:
-                        chain = item.chainavailable
-                        if ((chain.description in ignored_choices) or
-                                (not choice_is_available(item, settings))):
-                            continue
-                        choices.append((chain.pk, chain.description))
-                elif ftype == 'replace_dict':
-                    replace_dicts = models.MicroServiceChoiceReplacementDic.objects.filter(choiceavailableatlink_id=choice_uuid)
-                    for item in replace_dicts:
-                        choices.append((item.pk, item.description))
-                elif ftype == 'storage_service':
-                    choices.append(('/api/v2/location/default/{}/'.format(field['purpose']), _('Default location')))
-                    for loc in get_storage_locations(purpose=field['purpose']):
-                        choices.append((loc['resource_uri'], loc['description']))
-                self.fields[choice_uuid] = forms.ChoiceField(widget=Select(attrs={'class': 'form-control'}),
-                                                             **opts)
+                widget = self.fields[choice_uuid].widget
+                widget.attrs['placeholder'] = _('days')
+                widget.attrs['class'] = 'form-control'
+                continue
+
+            choices = opts['choices'] = list(self.EMPTY_CHOICES)
+            if ftype == 'boolean':
+                if 'yes_option' in field:
+                    choices.append((field['yes_option'], _('Yes')))
+                if 'no_option' in field:
+                    choices.append((field['no_option'], _('No')))
+            elif ftype in ('chain_choice', 'replace_dict'):
+                choices.extend(field['options'])
+            elif ftype == 'storage_service':
+                choices.append((
+                    '/api/v2/location/default/{}/'.format(field['purpose']),
+                    _('Default location'))
+                )
+                for loc in get_storage_locations(purpose=field['purpose']):
+                    choices.append((loc['resource_uri'], loc['description']))
+            self.fields[choice_uuid] = forms.ChoiceField(
+                widget=Select(attrs={'class': 'form-control'}), **opts)
+
+    def _load_processing_config_fields(self):
+        client = MCPClient()
+        self.processing_fields = client.get_processing_config_fields()
+        for choice_uuid, field in self.processing_fields.items():
+            field['label'] = self.LABELS[choice_uuid]
 
     def load_config(self, name):
         """
@@ -519,42 +362,14 @@ class ProcessingConfigurationForm(forms.Form):
                     continue
                 delay = str(float(value) * (24 * 60 * 60))
                 config.add_choice(choice_uuid, fprops['chain'], delay_duration=delay, comment=fprops['label'])
-            elif fprops['type'] == 'chain_choice' and fprops.get('find_duplicates', False):
-                # Persist the choice made by the user for each of the existing
-                # chain links with the same name. See #10216 for more details.
-                try:
-                    choice_name = models.MicroServiceChain.objects.get(id=value).description
-                except models.MicroServiceChainLink.DoesNotExist:
-                    pass
-                else:
-                    for i, item in enumerate(get_duplicated_choices(fprops['label'], choice_name)):
-                        comment = '{} (match {} for "{}")'.format(fprops['label'], i + 1, choice_name)
-                        config.add_choice(item[0], item[1], comment=comment)
+            elif fprops['type'] == 'chain_choice' and 'duplicates' in fprops:
+                desc, matches = fprops['duplicates'][value]
+                for i, match in enumerate(matches):
+                    comment = '{} (match {} for "{}")'.format(fprops['label'], i + 1, desc)
+                    config.add_choice(match[0], match[1], comment=comment)
             else:
                 config.add_choice(choice_uuid, value, comment=fprops['label'])
         config.save(config_path)
-
-
-def get_duplicated_choices(choice_chain_name, choice_link_name):
-    """
-    Given the name of a choice chain and one of its choices, return a list
-    of matching links as doubles (tuples): UUID of chain, UUID of choice.
-    """
-    sql = """
-        SELECT
-            MicroServiceChainLinks.pk,
-            MicroServiceChains.pk
-        FROM TasksConfigs
-        LEFT JOIN MicroServiceChainLinks ON (MicroServiceChainLinks.currentTask = TasksConfigs.pk)
-        LEFT JOIN MicroServiceChainChoice ON (MicroServiceChainChoice.choiceAvailableAtLink = MicroServiceChainLinks.pk)
-        LEFT JOIN MicroServiceChains ON (MicroServiceChains.pk = MicroServiceChainChoice.chainAvailable)
-        WHERE
-            TasksConfigs.description = %s
-            AND MicroServiceChains.description = %s;
-    """
-    with connection.cursor() as cursor:
-        cursor.execute(sql, [choice_chain_name, choice_link_name])
-        return cursor.fetchall()
 
 
 def get_storage_locations(purpose):

--- a/src/dashboard/src/contrib/mcp/client.py
+++ b/src/dashboard/src/contrib/mcp/client.py
@@ -92,7 +92,7 @@ class MCPClient(object):
     def __init__(self):
         self.server = settings.GEARMAN_SERVER
 
-    def _rpc_sync_call(self, ability, data, timeout=INFLIGHT_POLL_TIMEOUT):
+    def _rpc_sync_call(self, ability, data=None, timeout=INFLIGHT_POLL_TIMEOUT):
         """Invoke remote method synchronously and with a deadline.
 
         When successful, it returns the payload of the response. Otherwise, it
@@ -100,6 +100,8 @@ class MCPClient(object):
         ``RPCError`` when the worker failed abruptly, ``RPCServerError`` when
         the worker returned an error.
         """
+        if data is None:
+            data = b""
         client = gearman.GearmanClient([self.server])
         response = client.submit_job(
             ability, cPickle.dumps(data),
@@ -192,3 +194,6 @@ class MCPClient(object):
         """Approve a partial reingest awaiting for approval."""
         data = {"sip_uuid": sip_uuid, "user_id": user_id}
         return self._rpc_sync_call("approvePartialReingest", data)
+
+    def get_processing_config_fields(self):
+        return self._rpc_sync_call("getProcessingConfigFields")


### PR DESCRIPTION
Similar to #1238, we want MCPServer to be the only component interacting
with workflow models. In this commit, the processing configuration form
is updated so all the workflow-related data is pulled from MCPServer via
the RPC interface.

To support this, MCPServer learns a new RPC `getProcessingConfigFields`
and a new `processing_config` module.

The user-facing functionality should not be any different. I've also compared that the XML documents generated are the same. These are only internal implementation changes.

This is connected to #1101.