### PR TITLE
Docker: multi-stage frontend build

### DIFF
--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
This commit changes `dashboard.Dockerfile` so the frontends are built
from a different stage. Intended consequences:

- Reduce the size of the final image (1.42GB -> 1.01GB).
- Avoid issues with shared node_modules in osxfs/docker-for-mac.

It requires Docker 17.05 or newer.

This is connected to https://github.com/artefactual-labs/am/issues/49.
This is connected to https://github.com/artefactual-labs/am/issues/4.