### PR TITLE
Create a Dataverse transfer type

### DIFF
--- a/src/MCPClient/lib/archivematicaClientModules
+++ b/src/MCPClient/lib/archivematicaClientModules
@@ -1,7 +1,7 @@
 # This file is part of Archivematica.
 #
 # Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
-# 
+#
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -135,3 +135,7 @@ upload-qubit_v0.0 = upload_qubit
 upload-archivesspace_v0.0 = upload_archivesspace
 copyThumbnailsToDIPDirectory_v0.0 = copy_thumbnails_to_dip_directory
 removeDirectories_v0.0 = remove_directories
+
+# Dataverse Scripts
+convertDataverseStructure_v0.0 = convert_dataverse_structure
+parseDataverse_v0.0 = parse_dataverse_mets

--- a/src/MCPClient/lib/clientScripts/convert_dataverse_structure.py
+++ b/src/MCPClient/lib/clientScripts/convert_dataverse_structure.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+"""Given a transfer type Dataverse, read the metadata submission object
+``dataset.json`` to generate a Dataverse METS.xml file. This METS file will
+then later be used to create a Transfer METS.xml document as part of the
+Archivematica submission information package (SIP).
+
+The METS.xml will reflect various properties of the ``dataset.json`` file. An
+example of a specific feature of Dataverse is the existence of Bundle objects
+for Tabular data. Bundles contain derivatives of a tabular data file that are
+created by Dataverse to enable the data to be interacted with using as wide a
+range of tools as possible. These Derivatives are transcribed to the Dataverse
+METS.xml.
+
+More information about Dataverse in Archivematica can be found here:
+https://wiki.archivematica.org/Dataverse
+"""
+
+import json
+import os
+import uuid
+
+from lxml import etree
+
+# databaseFunctions requires Django to be set up
+import django
+django.setup()
+
+from custom_handlers import get_script_logger
+import metsrw
+
+
+logger = get_script_logger("archivematica.mcp.client.convert_dataverse_struct")
+
+
+class ConvertDataverseError(Exception):
+    """Exception class for failures that might occur during the execution of
+    this script.
+    """
+
+
+# Mapping from originalFormatLabel in dataset.json to file extension. The
+# values here are associated with Dataverse Bundles, created when Tabular data
+# is ingested, see: http://guides.dataverse.org/en/latest/user/dataset-management.html?highlight=bundle
+# The formats supported for tabluar data ingests are here:
+# http://guides.dataverse.org/en/latest/user/tabulardataingest/supportedformats.html
+EXTENSION_MAPPING = {
+    "Comma Separated Values": ".csv",
+    "MS Excel (XLSX)": ".xlsx",
+    "R Data": ".RData",
+    "SPSS Portable": ".por",
+    "SPSS SAV": ".sav",
+    "Stata Binary": ".dta",
+    "Stata 13 Binary": ".dta",
+    "UNKNOWN": "UNKNOWN",
+}
+
+
+def get_ddi_title_author(dataset_md_latest):
+    """Retrieve the title and the author of the dataset for the DDI XML
+    snippet to be included in the METS file.
+    """
+    title_text = author_text = None
+    citation = dataset_md_latest.get("metadataBlocks", {}).get("citation")
+    fields = citation.get("fields", None)
+    if fields:
+        for field in fields:
+            if field.get("typeName") == "title":
+                title_text = field.get("value")
+            if field.get("typeName") == "author":
+                author_text = field.get("value")[0].get("authorName")\
+                    .get("value")
+        return title_text.strip(), author_text.strip()
+    raise ConvertDataverseError(
+        "Unable to retrieve MD fields from dataset.json")
+
+
+def create_ddi(job, json_metadata, dataset_md_latest):
+    """Create the DDI dmdSec from the JSON metadata."""
+    ddi_elems = {}
+
+    try:
+        ddi_elems["Title"], \
+            ddi_elems["Author"] = get_ddi_title_author(dataset_md_latest)
+    except TypeError as err:
+        logger.error(
+            "Unable to gather citation data from dataset.json: %s", err)
+        return None
+    except ConvertDataverseError as err:
+        logger.error(err)
+        return None
+
+    ddi_elems["PID Type"] = json_metadata.get("protocol", "")
+    ddi_elems["IDNO"] = json_metadata.get("persistentUrl", "")
+    ddi_elems["Version Date"] = dataset_md_latest.get("releaseTime", "")
+    ddi_elems["Version Type"] = dataset_md_latest.get("versionState", "")
+    ddi_elems["Version Number"] = "{}.{}".format(
+        dataset_md_latest.get("versionNumber", ""),
+        dataset_md_latest.get("versionMinorNumber", "")
+    )
+    ddi_elems["Restriction Text"] = dataset_md_latest.get("termsOfUse", "")
+    ddi_elems["Distributor Text"] = json_metadata.get("publisher", "")
+
+    draft = False
+    job.pyprint("Fields retrieved from Dataverse:")
+    for ddi_k, ddi_v in ddi_elems.iteritems():
+        if ddi_k == "Version Type" and ddi_v == "DRAFT":
+            draft = True
+        job.pyprint("{}: {}".format(ddi_k, ddi_v))
+
+    if draft:
+        job.pyprint(
+            "Dataset is in a DRAFT state and may not transfer correctly")
+        logger.error(
+            "Dataset is in a DRAFT state and may not transfer correctly")
+
+    # Create XML.
+    nsmap = {"ddi": "http://www.icpsr.umich.edu/DDI"}
+    ddins = "{" + nsmap["ddi"] + "}"
+    ddi_root = etree.Element(ddins + "codebook", nsmap=nsmap)
+    ddi_root.attrib["version"] = "2.5"
+
+    root_ns = "{http://www.w3.org/2001/XMLSchema-instance}schemaLocation"
+    dv_ns = (
+        "http://www.ddi:codebook:2_5 "
+        "http://www.ddialliance.org/Specification/DDI-Codebook/2.5/"
+        "XMLSchema/codebook.xsd"
+    )
+    ddi_root.attrib[root_ns] = dv_ns
+
+    stdydscr = etree.SubElement(ddi_root, ddins + "stdyDscr", nsmap=nsmap)
+    citation = etree.SubElement(stdydscr, ddins + "citation", nsmap=nsmap)
+
+    titlstmt = etree.SubElement(citation, ddins + "titlStmt", nsmap=nsmap)
+    etree.SubElement(titlstmt, ddins + "titl", nsmap=nsmap).text \
+        = ddi_elems["Title"]
+
+    etree.SubElement(
+        titlstmt, ddins + "IDNo", agency=ddi_elems["PID Type"]).text \
+        = ddi_elems["IDNO"]
+
+    rspstmt = etree.SubElement(citation, ddins + "rspStmt")
+    etree.SubElement(rspstmt, ddins + "AuthEnty").text \
+        = ddi_elems["Author"]
+
+    diststmt = etree.SubElement(citation, ddins + "distStmt")
+    etree.SubElement(diststmt, ddins + "distrbtr").text \
+        = ddi_elems["Distributor Text"]
+
+    verstmt = etree.SubElement(citation, ddins + "verStmt")
+    etree.SubElement(
+        verstmt, ddins + "version", date=ddi_elems["Version Date"],
+        type=ddi_elems["Version Type"]
+    ).text = ddi_elems["Version Number"]
+
+    dataaccs = etree.SubElement(stdydscr, ddins + "dataAccs")
+    usestmt = etree.SubElement(dataaccs, ddins + "useStmt")
+    etree.SubElement(usestmt, ddins + "restrctn").text \
+        = ddi_elems["Restriction Text"]
+
+    return ddi_root
+
+
+def display_checksum_for_user(job, fname, checksum_value, checksum_type="MD5"):
+    """Provide some feedback to the user that enables them to understand what
+    this script is doing in the Dataverse workflow.
+    """
+    job.pyprint(
+        "Checksum for '{}' retrieved from dataset.json: {} ({})"
+        .format(fname, checksum_value, checksum_type))
+
+
+def create_bundle(job, tabfile_json):
+    """Create the FSEntry objects for the various files in a Dataverse bundle
+    identified initially by a ```.tab``` file being requested from the
+    Dataverse API.
+
+    A bundle is a collection of multiple representations of a tabular data
+    file. Bundles are created by Dataverse to allow interaction with as wide a
+    range of tools as possible.
+
+    Documentation on Bundles can be found on the Dataverse pages:
+
+       * http://guides.dataverse.org/en/latest/user/dataset-management.html?highlight=bundle
+    """
+    # Base name is .tab with suffix stripped
+    tabfile_name = tabfile_json.get("label")
+    if tabfile_name is None:
+        return None
+
+    # Else, continue processing.
+    job.pyprint("Creating entries for tabfile bundle {}"
+                .format(tabfile_name))
+    base_name = tabfile_name[:-4]
+    bundle = metsrw.FSEntry(path=base_name, type="Directory")
+    # Find the original file and add it to the METS FS Entries.
+    tabfile_datafile = tabfile_json.get("dataFile")
+    fname = None
+    ext = EXTENSION_MAPPING.get(
+        tabfile_datafile.get("originalFormatLabel", ""), "UNKNOWN")
+    logger.info("Retrieved extension mapping value: %s", ext)
+    logger.info(
+        "Original file format listed as %s",
+        tabfile_datafile.get("originalFileFormat", "None"))
+    if ext == "UNKNOWN":
+        fname = tabfile_datafile.get("filename")
+        logger.info(
+            "Original Format Label is UNKNOWN, using filename: %s",
+            fname)
+    if fname is None:
+        fname = "{}{}".format(base_name, ext)
+    checksum_value = tabfile_datafile.get("md5")
+    if checksum_value is None:
+        return None
+    display_checksum_for_user(job, fname, checksum_value)
+    original_file = metsrw.FSEntry(
+        path="{}/{}".format(base_name, fname),
+        use="original",
+        file_uuid=str(uuid.uuid4()),
+        checksumtype="MD5",
+        checksum=checksum_value,
+    )
+    bundle.add_child(original_file)
+    if tabfile_datafile.get("originalFormatLabel") != "R Data":
+        # RData derivative
+        fsentry = metsrw.FSEntry(
+            path="{}/{}.RData".format(base_name, base_name),
+            use="derivative",
+            derived_from=original_file,
+            file_uuid=str(uuid.uuid4()),
+        )
+        bundle.add_child(fsentry)
+
+    # Bundle contents described earlier in this module are expected to remain
+    # consistent. Among the additional data files in support of a table-based
+    # dataset there are supposed to be three citation files. These are added
+    # as FSEntry objects below.
+
+    # Tabfile
+    fsentry = metsrw.FSEntry(
+        path="{}/{}".format(base_name, tabfile_datafile.get("filename")),
+        use="derivative",
+        derived_from=original_file,
+        file_uuid=str(uuid.uuid4()),
+    )
+    fsentry.add_dmdsec(
+        md="{}/{}-ddi.xml".format(base_name, base_name),
+        mdtype="DDI",
+        mode="mdref",
+        label="{}-ddi.xml".format(base_name),
+        loctype="OTHER",
+        otherloctype="SYSTEM",
+    )
+    bundle.add_child(fsentry)
+    # -ddi.xml
+    fsentry = metsrw.FSEntry(
+        path="{}/{}-ddi.xml".format(base_name, base_name),
+        use="metadata",
+        derived_from=original_file,
+        file_uuid=str(uuid.uuid4()),
+    )
+    bundle.add_child(fsentry)
+    # citation - endnote
+    fsentry = metsrw.FSEntry(
+        path="{}/{}citation-endnote.xml".format(base_name, base_name),
+        use="metadata",
+        derived_from=original_file,
+        file_uuid=str(uuid.uuid4()),
+    )
+    bundle.add_child(fsentry)
+    # citation - ris
+    fsentry = metsrw.FSEntry(
+        path="{}/{}citation-ris.ris".format(base_name, base_name),
+        use="metadata",
+        derived_from=original_file,
+        file_uuid=str(uuid.uuid4()),
+    )
+    bundle.add_child(fsentry)
+    # citation - bib
+    fsentry = metsrw.FSEntry(
+        path="{}/{}citation-bib.bib".format(base_name, base_name),
+        use="metadata",
+        derived_from=original_file,
+        file_uuid=str(uuid.uuid4()),
+    )
+    bundle.add_child(fsentry)
+    return bundle
+
+
+def retrieve_terms_of_access(dataset_md_latest):
+    """Return a tuple that can be used to direct users to information about a
+    dataset if it is restricted.
+    """
+    return dataset_md_latest.get("termsOfAccess")
+
+
+def test_if_zip_in_name(fname):
+    """Check if a file-path ends in a .zip extension. If so, return true. This
+    helps us to log some information about the characteristics of the package
+    as we go.
+    """
+    ext_ = os.path.splitext(fname)[1]
+    if ext_.lower() == '.zip':
+        return True
+    return False
+
+
+def add_ddi_xml(job, sip, json_metadata, dataset_md_latest):
+    """Create a DDI XML data block and add this to the METS."""
+    ddi_root = create_ddi(job, json_metadata, dataset_md_latest)
+    if ddi_root is None:
+        return None
+    sip.add_dmdsec(md=ddi_root, mdtype="DDI")
+    return sip
+
+
+def add_metadata_ref(sip, md_name, md_loc):
+    """Add a single mdref to the METS file."""
+    sip.add_dmdsec(
+        md=md_loc,
+        mdtype="OTHER",
+        mode="mdref",
+        label=md_name,
+        loctype="OTHER",
+        otherloctype="SYSTEM",
+    )
+    return sip
+
+
+def add_md_dir_to_structmap(sip):
+    """Add the metadata directory to the structmap."""
+    md_dir = metsrw.FSEntry(path="metadata", use=None, type="Directory")
+    sip.add_child(md_dir)
+    # Add dataset.json to the fileSec output.
+    fsentry = metsrw.FSEntry(
+        path="metadata/dataset.json", use="metadata",
+        file_uuid=str(uuid.uuid4())
+    )
+    # Add dataset.json to the metadata fileSec group.
+    md_dir.add_child(fsentry)
+    return sip
+
+
+def add_dataset_files_to_md(job, sip, dataset_md_latest, contact_information):
+    """Add file entries to the Dataverse METS document."""
+
+    # Add original files to the METS document.
+    files = dataset_md_latest.get('files')
+    if not files:
+        return None
+
+    # Signal to users the existence of zip files in this transfer.
+    zipped_file = False
+
+    # Signal to users that this transfer might consist of metadata only.
+    if len(files) is 0:
+        logger.info(
+            "Metadata only transfer? There are no file entries in this "
+            "transfer's metadata.")
+
+    for file_json in files:
+        is_restricted = file_json.get("restricted")
+        if is_restricted is True and contact_information:
+            logger.error(
+                "Restricted dataset files may not have transferred "
+                "correctly: %s", contact_information)
+
+        data_file = file_json.get("dataFile", {})
+        if data_file.get("filename", "").endswith(".tab"):
+            # A Tabular Data File from Dataverse will consist of an original
+            # tabular format submitted by the researcher plus multiple
+            # different representations. We need to map that here.
+            bundle = create_bundle(job, file_json)
+            if bundle:
+                sip.add_child(bundle)
+            else:
+                logger.error(
+                    "Create Dataverse transfer METS failed. "
+                    "Bundle returned: %s", bundle)
+                return None
+        else:
+            path_ = None
+            if data_file:
+                path_ = data_file.get("filename")
+            if path_:
+                if test_if_zip_in_name(path_):
+                    # provide some additional logging around the contents of the
+                    # dataset we're processing.
+                    if not zipped_file:
+                        zipped_file = True
+                        logger.info(
+                            "Non-bundle .zip file found in the dataset.")
+                checksum_value = data_file.get("md5")
+                if checksum_value is None:
+                    return None
+                display_checksum_for_user(job, path_, checksum_value)
+                f = metsrw.FSEntry(
+                    path=path_,
+                    use="original",
+                    file_uuid=str(uuid.uuid4()),
+                    checksumtype="MD5",
+                    checksum=checksum_value,
+                )
+                sip.add_child(f)
+            else:
+                logger.error(
+                    "Problem retrieving filename from metadata, returned "
+                    "datafile: %s, path: %s", data_file, path_)
+                return None
+    return sip
+
+
+def write_mets_to_file(sip, unit_path, output_md_path, output_md_name):
+    """Write METS to file."""
+    metadata_path = output_md_path
+    if metadata_path is None:
+        metadata_path = os.path.join(unit_path, "metadata")
+    if not os.path.exists(metadata_path):
+        os.makedirs(metadata_path)
+
+    metadata_name = output_md_name
+    if metadata_name is None:
+        metadata_name = "METS.xml"
+    mets_path = os.path.join(metadata_path, metadata_name)
+
+    # Write the data structure out to a file and ensure that the encoding is
+    # purposely set to UTF-8. This pattern is used in ```create_mets_v2.py```.
+    # Given the opportunity we should add an encoding feature to the metsrw
+    # package.
+    mets_f = metsrw.METSDocument()
+    mets_f.append_file(sip)
+    with open(mets_path, 'w') as xml_file:
+        xml_file.write(etree.tostring(
+            mets_f.serialize(), pretty_print=True, encoding="utf-8",
+            xml_declaration=True))
+
+
+def load_md_and_return_json(unit_path, dataset_md_name):
+    """Load and parse Dataverse metadata from disk. Return JSON to calling
+    function.
+    """
+    json_path = os.path.join(unit_path, "metadata", dataset_md_name)
+    logger.info("Metadata directory exists %s", os.path.exists(json_path))
+    try:
+        with open(json_path, "r") as md_file:
+            return json.load(md_file)
+    except IOError as err:
+        logger.error("Error opening dataset metadata: %s", err)
+        return None
+
+
+def convert_dataverse_to_mets(
+        job, unit_path, dataset_md_name="dataset.json", output_md_path=None,
+        output_md_name=None):
+    """Create a transfer METS file from a Dataverse's dataset.json file"""
+    logger.info(
+        "Convert Dataverse structure called with '%s' unit directory",
+        unit_path)
+
+    json_metadata = load_md_and_return_json(unit_path, dataset_md_name)
+    if json_metadata is None:
+        raise ConvertDataverseError(
+            "Unable to the load Dataverse metadata file")
+    dataset_md_latest = get_latest_version_metadata(json_metadata)
+    if dataset_md_latest is None:
+        raise ConvertDataverseError(
+            "Unable to find the dataset metadata section from dataset.json")
+
+    # If a dataset is restricted we may not have access to all the files. We
+    # may also want to flag this dataset to the users of this service. We
+    # can do this here and below. We do not yet know whether this microservice
+    # should fail because we don't know how all datasets behave when some
+    # restrictions are placed on them.
+    contact_information = retrieve_terms_of_access(dataset_md_latest)
+
+    # Create METS
+    try:
+        sip = metsrw.FSEntry(
+            path="None", label=get_ddi_title_author(dataset_md_latest)[0],
+            use=None, type="Directory"
+        )
+    except TypeError as err:
+        citation_msg = (
+            "Unable to gather citation data from dataset.json: %s", err)
+        logger.error(citation_msg)
+        raise ConvertDataverseError(citation_msg)
+
+    sip = add_ddi_xml(job, sip, json_metadata, dataset_md_latest)
+    if sip is None:
+        raise ConvertDataverseError("Error creating SIP from Dataverse DDI")
+
+    sip = add_metadata_ref(
+        sip, dataset_md_name, "metadata/{}".format(dataset_md_name))
+
+    sip = add_dataset_files_to_md(
+        job, sip, dataset_md_latest, contact_information)
+    if sip is None:
+        raise ConvertDataverseError("Error adding Dataset files to METS")
+
+    # On success of the following two functions, the module will return None
+    # to JobContext which expects non-zero as a failure code only.
+    sip = add_md_dir_to_structmap(sip)
+    write_mets_to_file(sip, unit_path, output_md_path, output_md_name)
+
+
+def get_latest_version_metadata(json_metadata):
+    """If the datatset has been downloaded from the Dataverse web ui then there
+    is a slightly different structure. While the structure is different, the
+    majority of fields should remain the same and work with Archivematica. Just
+    in case, we log the version here and inform the user of potential
+    compatibility issues.
+
+    Ref: https://github.com/IQSS/dataverse/issues/4715
+    """
+    dataset_version = json_metadata.get("datasetVersion")
+    if dataset_version:
+        logger.info(
+            "Dataset seems to have been downloaded from the Dataverse Web UI."
+            "Some features of this method may be incompatible with "
+            "Archivematica at present.")
+        return dataset_version
+    return json_metadata.get("latestVersion")
+
+
+def init_convert_dataverse(job):
+    """Extract the arguments provided to the script and call the primary
+    function concerned with converting the Dataverse metadata JSON.
+    """
+    try:
+        transfer_dir = job.args[1]
+        logger.info("Convert Dataverse Structure with dir: '%s'", transfer_dir)
+        return convert_dataverse_to_mets(job, unit_path=transfer_dir)
+    except IndexError:
+        convert_dv_msg = (
+            "Problem with the supplied arguments to the function len: {}"
+            .format(len(job.args)))
+        logger.error(convert_dv_msg)
+        raise ConvertDataverseError(convert_dv_msg)
+
+
+def call(jobs):
+    """Primary entry point for MCP Client script."""
+    for job in jobs:
+        with job.JobContext(logger=logger):
+            job.set_status(init_convert_dataverse(job))

--- a/src/MCPClient/lib/clientScripts/create_mets_dataverse_v2.py
+++ b/src/MCPClient/lib/clientScripts/create_mets_dataverse_v2.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# This file is part of Archivematica.
+#
+# Copyright 2010-2018 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.    If not, see <http://www.gnu.org/licenses/>.
+
+"""Maps Dataverse specific elements into the AIP METS file generated on ingest.
+"""
+
+from __future__ import print_function
+import sys
+
+import archivematicaFunctions
+from custom_handlers import get_script_logger
+
+import metsrw
+
+
+# Create a module level logger.
+logger = get_script_logger("archivematica.mcp.client.createMETSDataverse")
+
+
+def create_dataverse_sip_dmdsec(job, sip_path):
+    """
+    Return SIP-level Dataverse dmdSecs for inclusion in the AIP METS.
+
+    :param str sip_path: ...
+    :return: List of dmdSec Elements
+    """
+    logger.info("Create dataverse sip dmdsec %s", sip_path)
+    # Retrieve METS.xml from the file system.
+    metadata_mets_paths = archivematicaFunctions.find_metadata_files(
+        sip_path, 'METS.xml', only_transfers=True)
+    if not metadata_mets_paths:
+        return []
+    ret = []
+    for metadata_path in metadata_mets_paths:
+        try:
+            mets = metsrw.METSDocument.fromfile(metadata_path)
+        except mets.MetsError:
+            job.pyprint('Could not parse external METS (Dataverse)',
+                        metadata_path, file=sys.stderr)
+            continue
+        # Retrieve all directory DMDSecs from the METS.xml.
+        for f in mets.all_files():
+            if f.type == "Directory" and f.dmdsecs:
+                # Serialize
+                ret += [d.serialize() for d in f.dmdsecs]
+    return ret
+
+
+def create_dataverse_tabfile_dmdsec(job, sip_path, tabfile):
+    """
+    Returns dmdSec associated with the given tabfile, if one exists.
+    """
+    logger.info("Create Dataverse tabfile dmdsec %s", sip_path)
+    # Retrieve METS.xml from the file system.
+    metadata_mets_paths = archivematicaFunctions.find_metadata_files(
+        sip_path, 'METS.xml', only_transfers=True)
+    if not metadata_mets_paths:
+        return []
+    ret = []
+    for metadata_path in metadata_mets_paths:
+        try:
+            mets = metsrw.METSDocument.fromfile(metadata_path)
+        except mets.MetsError:
+            job.pyprint('Could not parse external METS (Dataverse)',
+                        metadata_path, file=sys.stderr)
+            continue
+        # Retrieve all Item DMDSecs from the METS.xml.
+        for f in mets.all_files():
+            if f.type == "Item" and f.path.endswith(tabfile):
+                # Found the correct tabfile
+                return [d.serialize() for d in f.dmdsecs]
+    return ret

--- a/src/MCPClient/lib/clientScripts/parse_dataverse_mets.py
+++ b/src/MCPClient/lib/clientScripts/parse_dataverse_mets.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Parse the transfer METS file created as part of a Dataverse transfer and
+validate against the objects expected to be part of the SIP generated during
+transfer.
+"""
+
+import json
+import os
+import uuid
+
+# databaseFunctions requires Django to be set up
+import django
+django.setup()
+from django.utils import timezone
+
+# archivematicaCommon
+from archivematicaFunctions import get_file_checksum
+from custom_handlers import get_script_logger
+import databaseFunctions
+from main.models import Agent, File
+import metsrw
+
+logger = get_script_logger("archivematica.mcp.client.parse_dataverse_mets")
+transfer_objects_directory = "%transferDirectory%objects"
+
+
+class ParseDataverseError(Exception):
+    """Exception class for failures that might occur during the execution of
+    this script.
+    """
+
+
+def get_db_objects(job, mets, transfer_uuid):
+    """
+    Get DB objects for files in METS.
+
+    This also validates that files exist for each file asserted in the
+    structMap
+
+    :param mets: Parse METS file
+    :return: Dict where key is the FSEntry and value is the DB object
+    """
+    mapping = {}
+    for entry in mets.all_files():
+        if entry.type == 'Directory' or entry.label == 'dataset.json':
+            continue
+        # Retrieve the item name from the database. The proof-of-concept for
+        # Dataverse extracts objects from a bundle (zip) which can then be
+        # found on the root path of the transfer (the objects folder), but
+        # that means the initial lookup of the file might not resolve as
+        # anticipated as the directory structure of the bundle is reflected in
+        # the original path. We try the base name for the item below.
+        file_entry = None
+        try:
+            item_path = os.path.join(
+                transfer_objects_directory, entry.path)
+            logger.info(
+                "Looking for file type: '%s' using relative path: %s",
+                entry.type, item_path)
+            file_entry = File.objects.get(
+                originallocation=item_path, transfer_id=transfer_uuid)
+        except File.DoesNotExist:
+            logger.info(
+                "Could not find file type: '%s' in the database: %s",
+                entry.type, entry.path)
+        except File.MultipleObjectsReturned as err:
+            logger.info("Multiple entries for `%s` found. Exception: %s",
+                        entry.path, err)
+        try:
+            # Attempt to find the original location through just its filename
+            # as it may be sitting in the root item/objects directory of the
+            # transfer.
+            if file_entry is None:
+                base_name = os.path.basename(entry.path)
+                item_path = os.path.join(transfer_objects_directory, base_name)
+                logger.info("Looking for file type: '%s' using "
+                            "base name: %s", entry.type, item_path)
+                file_entry = File.objects.get(
+                    originallocation=item_path,
+                    transfer_id=transfer_uuid)
+        except File.DoesNotExist:
+            logger.error(
+                "Could not find file type: '%s' in the database: %s. "
+                "Checksum: '%s'", entry.type, base_name, entry.checksum)
+            return None
+        except File.MultipleObjectsReturned as err:
+            logger.info("Multiple entries for `%s` found. Exception: %s",
+                        base_name, err)
+            return None
+        job.pyprint(
+            "Adding mapping dict [{}] entry: {}".format(entry, file_entry))
+        mapping[entry] = file_entry
+    return mapping
+
+
+def update_file_use(job, mapping):
+    """
+    Update the file's use for files in mets.
+
+    :param mapping: Dataverse objects/use mapping from Database
+    :return: None
+    """
+    for entry, file_entry in mapping.items():
+        file_entry.filegrpuse = entry.use
+        job.pyprint(entry.label, 'file group use set to', entry.use)
+        file_entry.save()
+
+
+def add_external_agents(job, unit_path):
+    """
+    Add external agent(s).
+
+    :return: ID of the first agent, assuming that's the Dataverse agent.
+    """
+    agents_jsonfile = os.path.join(unit_path, 'metadata', 'agents.json')
+    try:
+        with open(agents_jsonfile, 'r') as agents_file:
+            agents_json = json.load(agents_file)
+    except (OSError, IOError):
+        return None
+
+    agent_id = None
+    for agent in agents_json:
+        agent_entry, created = Agent.objects.get_or_create(
+            identifiertype=agent['agentIdentifierType'],
+            identifiervalue=agent['agentIdentifierValue'],
+            name=agent['agentName'],
+            agenttype=agent['agentType'],
+        )
+        if created:
+            job.pyprint('Added agent', agent)
+        else:
+            job.pyprint('Agent already exists', agent)
+        agent_id = agent_id or agent_entry.id
+
+    return agent_id
+
+
+def create_db_entries(job, mapping, dataverse_agent_id):
+    """
+    Create event and derivatives entries for the derived tabular data in the
+    database.
+    """
+    for entry, file_entry in mapping.items():
+        if entry.derived_from and entry.use == 'derivative':
+            original_uuid = mapping[entry.derived_from].uuid
+            event_uuid = uuid.uuid4()
+            # Add event
+            databaseFunctions.insertIntoEvents(
+                original_uuid,
+                eventIdentifierUUID=event_uuid,
+                eventType="derivation",
+                eventDateTime=None,  # From Dataverse?
+                eventDetail="",  # From Dataverse?
+                eventOutcome="",  # From Dataverse?
+                eventOutcomeDetailNote=file_entry.currentlocation,
+                agents=[dataverse_agent_id],
+            )
+            # Add derivation
+            databaseFunctions.insertIntoDerivations(
+                sourceFileUUID=original_uuid,
+                derivedFileUUID=file_entry.uuid,
+                relatedEventUUID=event_uuid,
+            )
+            job.pyprint(
+                'Added derivation from', original_uuid, 'to', file_entry.uuid)
+
+
+def validate_checksums(job, mapping, unit_path):
+    """Validate the checksums for the files in the Dataverse transfer."""
+    date = timezone.now().isoformat(' ')
+    for entry, file_entry in mapping.items():
+        if entry.checksum and entry.checksumtype:
+            job.pyprint(
+                'Checking checksum', entry.checksum, 'for', entry.label)
+            if file_entry.currentlocation is None \
+                    and file_entry.removedtime is not None:
+                logger.info(
+                    "File: %s removed by extract packages?", entry.label)
+                continue
+            path_ = file_entry.currentlocation.replace(
+                '%transferDirectory%', unit_path)
+            if os.path.isdir(path_):
+                continue
+            verify_checksum(
+                job=job,
+                file_uuid=file_entry.uuid,
+                path=path_,
+                checksum=entry.checksum,
+                checksumtype=entry.checksumtype,
+                date=date,
+            )
+
+
+def verify_checksum(job, file_uuid, path, checksum, checksumtype,
+                    event_id=None, date=None):
+    """
+    Verify the checksum of a given file, and create a fixity event.
+
+    :param str file_uuid: UUID of the file to verify
+    :param str path: Path of the file to verify
+    :param str checksum: Checksum to compare against
+    :param str checksumtype: Type of the provided checksum (md5, sha256, etc)
+    :param str event_id: Event ID
+    :param str date: Date of the event
+    """
+    if event_id is None:
+        event_id = str(uuid.uuid4())
+    if date is None:
+        date = timezone.now().isoformat(' ')
+
+    checksumtype = checksumtype.lower()
+    generated_checksum = get_file_checksum(path, checksumtype)
+    event_detail = ('program="python"; '
+                    'module="hashlib.{}()"'.format(checksumtype))
+    if checksum != generated_checksum:
+        job.pyprint('Checksum failed')
+        event_outcome = "Fail"
+        detail_note = 'Dataverse checksum %s verification failed' % checksum
+    else:
+        job.pyprint('Checksum passed')
+        event_outcome = "Pass"
+        detail_note = 'Dataverse checksum %s verified' % checksum
+
+    databaseFunctions.insertIntoEvents(
+        fileUUID=file_uuid,
+        eventIdentifierUUID=event_id,
+        eventType='fixity check',
+        eventDateTime=date,
+        eventDetail=event_detail,
+        eventOutcome=event_outcome,
+        eventOutcomeDetailNote=detail_note,
+    )
+
+
+def parse_dataverse_mets(job, unit_path, unit_uuid):
+    """Access the existing METS file and extract and validate its components.
+    """
+    dataverse_mets_path = os.path.join(unit_path, 'metadata', 'METS.xml')
+    mets = metsrw.METSDocument.fromfile(dataverse_mets_path)
+    mapping = get_db_objects(job, mets, unit_uuid)
+    if mapping is None:
+        no_map = ("Exiting. Returning the database objects for our Dataverse "
+                  "files has failed.")
+        logger.error(no_map)
+        raise ParseDataverseError(no_map)
+    update_file_use(job, mapping)
+    agent = add_external_agents(job, unit_path)
+    create_db_entries(job, mapping, agent)
+    validate_checksums(job, mapping, unit_path)
+
+
+def init_parse_dataverse_mets(job):
+    """Extract the arguments provided to the script and call the primary
+    function concerned with parsing Dataverse METS.
+    """
+    try:
+        transfer_dir = job.args[1]
+        transfer_uuid = job.args[2]
+        logger.info("Parse Dataverse METS with dir: '%s' and transfer "
+                    "uuid: %s", transfer_dir, transfer_uuid)
+        return parse_dataverse_mets(job, transfer_dir, transfer_uuid)
+    except IndexError:
+        arg_err = (
+            "Problem with the supplied arguments to the function len: %s",
+            len(job.args))
+        logger.error(arg_err)
+        raise ParseDataverseError(arg_err)
+
+
+def call(jobs):
+    """Primary entry point for MCP Client script."""
+    for job in jobs:
+        with job.JobContext(logger=logger):
+            job.set_status(init_parse_dataverse_mets(job))

--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -6,7 +6,7 @@ django-extensions==1.1.1
 mysqlclient==1.3.9
 gearman==2.0.2
 lxml==3.5.0
-metsrw==0.2.1
+metsrw==0.2.3
 requests==2.18.4
 unidecode==0.04.19
 opf-fido==1.3.10

--- a/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/api_demo.dataverse.org.doi.10.5072.4.json
+++ b/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/api_demo.dataverse.org.doi.10.5072.4.json
@@ -1,0 +1,171 @@
+{
+    "authority": "10.5072/FK2",
+    "id": 574,
+    "identifier": "6PPJ6Y",
+    "latestVersion": {
+        "UNF": "UNF:6:IgxkjKXUlveGP0Darp1fYg==",
+        "createTime": "2018-05-09T20:33:36Z",
+        "files": [
+            {
+                "dataFile": {
+                    "UNF": "UNF:6:IgxkjKXUlveGP0Darp1fYg==",
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "ddb3bc08ca0b5826efef8c87a277475f"
+                    },
+                    "contentType": "text/tab-separated-values",
+                    "description": "A table with drinks data",
+                    "filename": "Drinks.tab",
+                    "filesize": 233,
+                    "id": 575,
+                    "md5": "ddb3bc08ca0b5826efef8c87a277475f",
+                    "originalFileFormat": "text/csv",
+                    "originalFormatLabel": "Comma Separated Values",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "163469b1673-1e6c95ea2b41"
+                },
+                "datasetVersionId": 227,
+                "description": "A table with drinks data",
+                "label": "Drinks.tab",
+                "restricted": false,
+                "version": 2
+            }
+        ],
+        "id": 227,
+        "lastUpdateTime": "2018-05-09T20:45:27Z",
+        "license": "CC0",
+        "metadataBlocks": {
+            "citation": {
+                "displayName": "Citation Metadata",
+                "fields": [
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "title",
+                        "value": "A study of my afternoon drinks "
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "author",
+                        "value": [
+                            {
+                                "authorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorAffiliation",
+                                    "value": "Artefactual"
+                                },
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Tester, Archivematica"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "datasetContact",
+                        "value": [
+                            {
+                                "datasetContactAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactAffiliation",
+                                    "value": "Artefactual"
+                                },
+                                "datasetContactEmail": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactEmail",
+                                    "value": "joel@walnutdigital.com"
+                                },
+                                "datasetContactName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactName",
+                                    "value": "Tester, Archivematica"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "dsDescription",
+                        "value": [
+                            {
+                                "dsDescriptionDate": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "dsDescriptionDate",
+                                    "value": "2018-05-01"
+                                },
+                                "dsDescriptionValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "dsDescriptionValue",
+                                    "value": "Photos with my drinks, and a tabular file with some data on drinks. \r\n"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "controlledVocabulary",
+                        "typeName": "subject",
+                        "value": [
+                            "Arts and Humanities"
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "keyword",
+                        "value": [
+                            {
+                                "keywordValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "keywordValue",
+                                    "value": "Drinks"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "notesText",
+                        "value": "My first test dataset\r\n"
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "depositor",
+                        "value": "Tester, Archivematica"
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "dateOfDeposit",
+                        "value": "2018-05-09"
+                    }
+                ]
+            }
+        },
+        "productionDate": "Production Date",
+        "releaseTime": "2018-05-09T20:45:27Z",
+        "termsOfUse": "CC0 Waiver",
+        "versionMinorNumber": 0,
+        "versionNumber": 1,
+        "versionState": "RELEASED"
+    },
+    "persistentUrl": "https://doi.org/10.5072/FK2/6PPJ6Y",
+    "protocol": "doi",
+    "publicationDate": "2018-05-09",
+    "publisher": "Root Dataverse"
+}

--- a/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/api_demo.dataverse.org.doi.10.5072.5.json
+++ b/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/api_demo.dataverse.org.doi.10.5072.5.json
@@ -1,0 +1,279 @@
+{
+    "authority": "10.5072/FK2",
+    "id": 34,
+    "identifier": "8KDUHM",
+    "latestVersion": {
+        "createTime": "2017-01-04T21:31:57Z",
+        "files": [
+            {
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "91725d755356dd3961c4165bd45faefe"
+                    },
+                    "contentType": "image/tiff",
+                    "filename": "TRT00001454.tif",
+                    "filesize": 28762385,
+                    "id": 42,
+                    "md5": "91725d755356dd3961c4165bd45faefe",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "1596b5a1bb9-610728527853"
+                },
+                "datasetVersionId": 9,
+                "label": "TRT00001454.tif",
+                "restricted": true,
+                "version": 1
+            },
+            {
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "5bf104854cad87f8ac62b1664ab1c17e"
+                    },
+                    "contentType": "text/xml",
+                    "filename": "TRT00001454.xml",
+                    "filesize": 1166,
+                    "id": 36,
+                    "md5": "5bf104854cad87f8ac62b1664ab1c17e",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "1596b5a1cf1-c1dd53996bc0"
+                },
+                "datasetVersionId": 9,
+                "label": "TRT00001454.xml",
+                "restricted": true,
+                "version": 1
+            },
+            {
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "73f05fc278ec672747573eccf146fc15"
+                    },
+                    "contentType": "image/tiff",
+                    "filename": "TRT00001741.tif",
+                    "filesize": 30287712,
+                    "id": 37,
+                    "md5": "73f05fc278ec672747573eccf146fc15",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "1596b5a1cfb-cf3c75e38b71"
+                },
+                "datasetVersionId": 9,
+                "label": "TRT00001741.tif",
+                "restricted": true,
+                "version": 1
+            },
+            {
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "1efa5ab42f8d34783d937e32887d8698"
+                    },
+                    "contentType": "text/xml",
+                    "filename": "TRT00001741.xml",
+                    "filesize": 1195,
+                    "id": 35,
+                    "md5": "1efa5ab42f8d34783d937e32887d8698",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "1596b5a1e47-69ac7755618d"
+                },
+                "datasetVersionId": 9,
+                "label": "TRT00001741.xml",
+                "restricted": true,
+                "version": 1
+            },
+            {
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "64c7219020a53da543a7a8f6ebd8c697"
+                    },
+                    "contentType": "image/tiff",
+                    "filename": "TRT00001919.tif",
+                    "filesize": 30525019,
+                    "id": 41,
+                    "md5": "64c7219020a53da543a7a8f6ebd8c697",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "1596b5a1e51-f5ef67bb880d"
+                },
+                "datasetVersionId": 9,
+                "label": "TRT00001919.tif",
+                "restricted": true,
+                "version": 1
+            },
+            {
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "9c6ef383d39ced23242591986705e12c"
+                    },
+                    "contentType": "text/xml",
+                    "filename": "TRT00001919.xml",
+                    "filesize": 1209,
+                    "id": 40,
+                    "md5": "9c6ef383d39ced23242591986705e12c",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "1596b5a1ff6-385c1079cced"
+                },
+                "datasetVersionId": 9,
+                "label": "TRT00001919.xml",
+                "restricted": true,
+                "version": 1
+            },
+            {
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "7ca1b595703655a1d47bfc1dd9039db3"
+                    },
+                    "contentType": "image/tiff",
+                    "filename": "TRT00001920.tif",
+                    "filesize": 30524375,
+                    "id": 38,
+                    "md5": "7ca1b595703655a1d47bfc1dd9039db3",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "1596b5a1ffe-4fabf5fc1e39"
+                },
+                "datasetVersionId": 9,
+                "label": "TRT00001920.tif",
+                "restricted": true,
+                "version": 1
+            },
+            {
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "538a6212b530c1e1a03808efdfaf3c68"
+                    },
+                    "contentType": "text/xml",
+                    "filename": "TRT00001920.xml",
+                    "filesize": 1231,
+                    "id": 39,
+                    "md5": "538a6212b530c1e1a03808efdfaf3c68",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "1596b5a21b2-441ae194899f"
+                },
+                "datasetVersionId": 9,
+                "label": "TRT00001920.xml",
+                "restricted": true,
+                "version": 1
+            }
+        ],
+        "id": 9,
+        "lastUpdateTime": "2017-01-04T21:32:02Z",
+        "license": "CC0",
+        "metadataBlocks": {
+            "citation": {
+                "displayName": "Citation Metadata",
+                "fields": [
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "title",
+                        "value": "Botanical Test"
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "author",
+                        "value": [
+                            {
+                                "authorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorAffiliation",
+                                    "value": "OTHER"
+                                },
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Admin, Dataverse"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "datasetContact",
+                        "value": [
+                            {
+                                "datasetContactAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactAffiliation",
+                                    "value": "OTHER"
+                                },
+                                "datasetContactEmail": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactEmail",
+                                    "value": "amber@scholarsportal.info"
+                                },
+                                "datasetContactName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactName",
+                                    "value": "Admin, Dataverse"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "dsDescription",
+                        "value": [
+                            {
+                                "dsDescriptionValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "dsDescriptionValue",
+                                    "value": "test batch upload of ZIP "
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "controlledVocabulary",
+                        "typeName": "subject",
+                        "value": [
+                            "Other"
+                        ]
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "depositor",
+                        "value": "Admin, Dataverse"
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "dateOfDeposit",
+                        "value": "2017-01-04"
+                    }
+                ]
+            }
+        },
+        "productionDate": "Production Date",
+        "releaseTime": "2017-01-04T21:32:02Z",
+        "termsOfUse": "CC0 Waiver",
+        "versionMinorNumber": 1,
+        "versionNumber": 1,
+        "versionState": "RELEASED"
+    },
+    "persistentUrl": "https://doi.org/10.5072/FK2/8KDUHM",
+    "protocol": "doi",
+    "publicationDate": "2017-01-04",
+    "publisher": "Root Dataverse"
+}

--- a/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/api_demo.dataverse.org.doi.10.5072.6.json
+++ b/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/api_demo.dataverse.org.doi.10.5072.6.json
@@ -1,0 +1,625 @@
+{
+    "authority": "10864",
+    "id": 584,
+    "identifier": "11651",
+    "latestVersion": {
+        "citationRequirements": "The publishing of analysis and results from research using this data is permitted in research communications such as scholarly papers, journals and the like. The authors of these communications are required to cite the author as the source of\nthe data and to indicate that the results or views expresses are those of the author/authorized user.",
+        "contactForAccess": "academic.services@queensu.ca",
+        "createTime": "2018-03-22T12:40:37Z",
+        "disclaimer": "The original collector of the data bears no responsibility for use of this collection or for interpretation or inference upon such use.",
+        "files": [
+            {
+                "categories": [
+                    "Papers / Posters"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "5bd57f812772238c485527d35248d551"
+                    },
+                    "contentType": "application/pdf",
+                    "description": "\"From Coast to Coast: Canadian Collaboration in a Changing RDM Seascape\" Paper presented at the IATUL 2016 Conference",
+                    "filename": "From Coast to Coast Canadian Collaboration in a Changing RDM Seascape.pdf",
+                    "filesize": 991201,
+                    "id": 37786,
+                    "md5": "5bd57f812772238c485527d35248d551",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "42047"
+                },
+                "datasetVersionId": 3589,
+                "description": "\"From Coast to Coast: Canadian Collaboration in a Changing RDM Seascape\" Paper presented at the IATUL 2016 Conference",
+                "label": "From Coast to Coast Canadian Collaboration in a Changing RDM Seascape.pdf",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "Data"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "d51b7f99c4e948ebe0623daa3553a087"
+                    },
+                    "contentType": "text/plain; charset=US-ASCII",
+                    "description": "Data file - CSV",
+                    "filename": "Queens-EngSci-Survey-march2016-public.csv",
+                    "filesize": 101903,
+                    "id": 41050,
+                    "md5": "d51b7f99c4e948ebe0623daa3553a087",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "45644"
+                },
+                "datasetVersionId": 3589,
+                "description": "Data file - CSV",
+                "label": "Queens-EngSci-Survey-march2016-public.csv",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "Data"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "af2776afe1107caaaa5eae24f837a927"
+                    },
+                    "contentType": "text/plain; charset=US-ASCII",
+                    "description": "Data file - ascii",
+                    "filename": "Queens-EngSci-Survey-march2016-public.dat",
+                    "filesize": 107712,
+                    "id": 41048,
+                    "md5": "af2776afe1107caaaa5eae24f837a927",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "45645"
+                },
+                "datasetVersionId": 3589,
+                "description": "Data file - ascii",
+                "label": "Queens-EngSci-Survey-march2016-public.dat",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "Documentation"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "3d29ad205a8f0c5afca60d83a5fbaa68"
+                    },
+                    "contentType": "text/x-spss-syntax; charset=US-ASCII",
+                    "description": "Syntax File",
+                    "filename": "Queens-EngSci-Survey-march2016-public.sps",
+                    "filesize": 23943,
+                    "id": 41049,
+                    "md5": "3d29ad205a8f0c5afca60d83a5fbaa68",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "45646"
+                },
+                "datasetVersionId": 3589,
+                "description": "Syntax File",
+                "label": "Queens-EngSci-Survey-march2016-public.sps",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "Data"
+                ],
+                "dataFile": {
+                    "UNF": "UNF:5:jWmH+8lhx6vzFjnGrpgmSQ==",
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "e51f5cd6e75570b4d0b49ca9223e041c"
+                    },
+                    "contentType": "text/tab-separated-values",
+                    "description": "Data file - SPSS",
+                    "filename": "Queens-EngSci-Survey-march2016-public.tab",
+                    "filesize": 97092,
+                    "id": 41052,
+                    "md5": "e51f5cd6e75570b4d0b49ca9223e041c",
+                    "originalFileFormat": "application/x-spss-sav",
+                    "originalFormatLabel": "SPSS SAV",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "45643"
+                },
+                "datasetVersionId": 3589,
+                "description": "Data file - SPSS",
+                "label": "Queens-EngSci-Survey-march2016-public.tab",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "Documentation"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "84a11f475c4518c4882d0e47caa8a4b4"
+                    },
+                    "contentType": "application/pdf",
+                    "description": "User Guide and Codebook",
+                    "filename": "QueensU-RDM-EngSci-Survey-ug-cdbk.pdf",
+                    "filesize": 977460,
+                    "id": 41051,
+                    "md5": "84a11f475c4518c4882d0e47caa8a4b4",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "45647"
+                },
+                "datasetVersionId": 3589,
+                "description": "User Guide and Codebook",
+                "label": "QueensU-RDM-EngSci-Survey-ug-cdbk.pdf",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "Documentation"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "fb6a572f5cd841512a8356537901fe9c"
+                    },
+                    "contentType": "application/pdf",
+                    "description": "Report on Research Data Management Survey of Queen's Engineering and Science Departments",
+                    "filename": "QueensU-Report-RDM-EngSci-Survey-May2016.pdf",
+                    "filesize": 1617376,
+                    "id": 37756,
+                    "md5": "fb6a572f5cd841512a8356537901fe9c",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "42015"
+                },
+                "datasetVersionId": 3589,
+                "description": "Report on Research Data Management Survey of Queen's Engineering and Science Departments",
+                "label": "QueensU-Report-RDM-EngSci-Survey-May2016.pdf",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "Papers / Posters"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "3b65d93723442f6cbe75f64e299d59df"
+                    },
+                    "contentType": "application/pdf",
+                    "description": "\"Research Data Management (RDM) Needs of Science and Engineering Researchers: A View from Canada\" Poster presented at the IASSIST 2016 Conference",
+                    "filename": "Research Data Management (RDM) Needs of Science and Engineering Researchers A View  from Canada.pdf",
+                    "filesize": 879550,
+                    "id": 37785,
+                    "md5": "3b65d93723442f6cbe75f64e299d59df",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "42048"
+                },
+                "datasetVersionId": 3589,
+                "description": "\"Research Data Management (RDM) Needs of Science and Engineering Researchers: A View from Canada\" Poster presented at the IASSIST 2016 Conference",
+                "label": "Research Data Management (RDM) Needs of Science and Engineering Researchers A View  from Canada.pdf",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "Documentation"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "d1901773cd166a36e01ed60b3b214494"
+                    },
+                    "contentType": "application/pdf",
+                    "description": "Questionnaire",
+                    "filename": "survey_queens-rdm-survey_20151120.pdf",
+                    "filesize": 425237,
+                    "id": 27964,
+                    "md5": "d1901773cd166a36e01ed60b3b214494",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "31584"
+                },
+                "datasetVersionId": 3589,
+                "description": "Questionnaire",
+                "label": "survey_queens-rdm-survey_20151120.pdf",
+                "restricted": false,
+                "version": 2
+            }
+        ],
+        "id": 3589,
+        "lastUpdateTime": "2018-03-22T12:48:57Z",
+        "license": "NONE",
+        "metadataBlocks": {
+            "citation": {
+                "displayName": "Citation Metadata",
+                "fields": [
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "title",
+                        "value": "Research Data Management (RDM) Survey of Queen's University's Engineering and Science Departments"
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "author",
+                        "value": [
+                            {
+                                "authorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorAffiliation",
+                                    "value": "Queen's University Library. Engineering &amp; Science Library"
+                                },
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Tatiana Zaraiskaya"
+                                }
+                            },
+                            {
+                                "authorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorAffiliation",
+                                    "value": "Queen's University Library. Data Services"
+                                },
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Alexandra Cooper"
+                                }
+                            },
+                            {
+                                "authorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorAffiliation",
+                                    "value": "Queen's University Library. Data Services"
+                                },
+                                "authorIdentifier": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorIdentifier",
+                                    "value": "0000-0001-6167-7064 "
+                                },
+                                "authorIdentifierScheme": {
+                                    "multiple": false,
+                                    "typeClass": "controlledVocabulary",
+                                    "typeName": "authorIdentifierScheme",
+                                    "value": "ORCID"
+                                },
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Jeff Moon"
+                                }
+                            },
+                            {
+                                "authorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorAffiliation",
+                                    "value": "Queen's University Library. Academic Services"
+                                },
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Sharon Murphy"
+                                }
+                            },
+                            {
+                                "authorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorAffiliation",
+                                    "value": "Queen's University Library. Engineering &amp; Science Library"
+                                },
+                                "authorIdentifier": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorIdentifier",
+                                    "value": "0000-0002-6942-7390"
+                                },
+                                "authorIdentifierScheme": {
+                                    "multiple": false,
+                                    "typeClass": "controlledVocabulary",
+                                    "typeName": "authorIdentifierScheme",
+                                    "value": "ORCID"
+                                },
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Nasser Saleh"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "datasetContact",
+                        "value": [
+                            {
+                                "datasetContactAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactAffiliation",
+                                    "value": "Queen's University Library"
+                                },
+                                "datasetContactEmail": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactEmail",
+                                    "value": "open.scholarship.services@queensu.ca"
+                                },
+                                "datasetContactName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactName",
+                                    "value": "Data Services"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "dsDescription",
+                        "value": [
+                            {
+                                "dsDescriptionValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "dsDescriptionValue",
+                                    "value": "In order to become better prepared to support Research Data Management (RDM) practices in sciences and engineering, Queen\u2019s University Library, together with the University Research Services, conducted a research study of all ranks of faculty members, as well as postdoctoral fellows and graduate students at the Faculty of Engineering\r\n& Applied Science, Departments of Chemistry, Computer Science, Geological Sciences and Geological Engineering, Mathematics and Statistics, Physics, Engineering Physics & Astronomy, School of Environmental Studies, and Geography & Planning in the Faculty of Arts and Science."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "controlledVocabulary",
+                        "typeName": "subject",
+                        "value": [
+                            "Engineering"
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "keyword",
+                        "value": [
+                            {
+                                "keywordValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "keywordValue",
+                                    "value": "Data Storage"
+                                }
+                            },
+                            {
+                                "keywordValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "keywordValue",
+                                    "value": "Research data management (RDM)"
+                                }
+                            },
+                            {
+                                "keywordValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "keywordValue",
+                                    "value": "Big data"
+                                }
+                            },
+                            {
+                                "keywordValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "keywordValue",
+                                    "value": "Program script"
+                                }
+                            },
+                            {
+                                "keywordValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "keywordValue",
+                                    "value": "Data sharing"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "producer",
+                        "value": [
+                            {
+                                "producerAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "producerAffiliation",
+                                    "value": "Queen's University"
+                                },
+                                "producerName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "producerName",
+                                    "value": "Queen's University Library"
+                                },
+                                "producerURL": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "producerURL",
+                                    "value": "http://library.queensu.ca"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "productionPlace",
+                        "value": "Queen's University, Kingston, Ontario"
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "distributor",
+                        "value": [
+                            {
+                                "distributorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "distributorAffiliation",
+                                    "value": "Queen's University Library"
+                                },
+                                "distributorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "distributorName",
+                                    "value": "Data Services"
+                                },
+                                "distributorURL": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "distributorURL",
+                                    "value": "http://library.queensu.ca/data"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "dateOfDeposit",
+                        "value": "2016-04-25"
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "dateOfCollection",
+                        "value": [
+                            {
+                                "dateOfCollectionEnd": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "dateOfCollectionEnd",
+                                    "value": "2015-12-31"
+                                },
+                                "dateOfCollectionStart": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "dateOfCollectionStart",
+                                    "value": "2015-11-24"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "geospatial": {
+                "displayName": "Geospatial Metadata",
+                "fields": [
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "geographicCoverage",
+                        "value": [
+                            {
+                                "country": {
+                                    "multiple": false,
+                                    "typeClass": "controlledVocabulary",
+                                    "typeName": "country",
+                                    "value": "Canada"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "journal": {
+                "displayName": "Journal Metadata",
+                "fields": []
+            },
+            "socialscience": {
+                "displayName": "Social Science and Humanities Metadata",
+                "fields": [
+                    {
+                        "multiple": true,
+                        "typeClass": "primitive",
+                        "typeName": "unitOfAnalysis",
+                        "value": [
+                            "Indivduals"
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "primitive",
+                        "typeName": "universe",
+                        "value": [
+                            "Participants included all ranks of faculty members,  postdoctoral fellows,  research fellows, research associates, lecturers, and graduate students at master\u2019s and doctoral levels from the Faculty of Engineering\r\n& Applied Science, and the Faculty of Arts & Sciences. The following departments participated in this survey: Chemical Engineering, Civil Engineering, Electrical and Computer Engineering, Mechanical and Materials Engineering, Robert M. Buchan Department of Mining, Biology, Chemistry, Computer Science, Geological Sciences and Geological Engineering, Mathematics and Statistics, Physics, Engineering Physics & Astronomy, School of Environmental Studies, and Geography & Planning."
+                        ]
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "dataCollector",
+                        "value": "Queen's University Library"
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "collectionMode",
+                        "value": "Online survey"
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "researchInstrument",
+                        "value": "FluidSurveys"
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "dataCollectionSituation",
+                        "value": "The survey was distributed using the subscription-based FluidSurveys service. An email distribution list was compiled from information provided on the departmental websites. Personalized invitations were sent to 1393 unique email addresses via the FluidSurveys service. In some cases, graduate students\u2019 emails were not available from departmental websites; in these instances, the survey team requested email lists from these departments. Three departments (Mechanical\r\n& Materials Engineering, Math and Stats, and Mining) did not provide lists of graduate students\u2019 emails due to privacy considerations. In these cases, the survey was distributed through departmental administrative offices; as such, the exact number of survey recipients is unknown."
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "responseRate",
+                        "value": "The total number of responses to the survey was 396, the number of completed survey responses received was 210, and the number of partially completed responses was 145. A total of 41 respondents decided to terminate the survey. Here, \u201cpartially completed\u201d refers to a survey where some questions were answered but the respondent never terminated the survey by clicking the terminate button, or never finished the survey by clicking the submit button. A survey was counted as completed if the respondent answered all required questions and clicked the submit button. Both completed and partially completed survey responses (355 in total) were included in the analysis. Considering the number of initially sent invitations was 1393, the response rate was calculated to be 25.5%."
+                    }
+                ]
+            }
+        },
+        "productionDate": "Production Date",
+        "releaseTime": "2018-03-22T12:48:57Z",
+        "versionMinorNumber": 1,
+        "versionNumber": 6,
+        "versionState": "RELEASED"
+    },
+    "persistentUrl": "https://hdl.handle.net/10864/11651",
+    "protocol": "hdl",
+    "publicationDate": "2016-04-25",
+    "publisher": "Scholars Portal Dataverse"
+}

--- a/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/api_demo.dataverse.org.doi.10.5072.7.json
+++ b/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/api_demo.dataverse.org.doi.10.5072.7.json
@@ -1,0 +1,149 @@
+{
+	"publisher": "Root Dataverse",
+	"protocol": "doi",
+	"authority": "10.5072/FK2",
+	"publicationDate": "2018-05-09",
+	"persistentUrl": "https://doi.org/10.5072/FK2/6PPJ6Y",
+	"latestVersion": {
+		"files": [{
+			"dataFile": {
+				"originalFormatLabel": "Comma Separated Values",
+				"contentType": "text/tab-separated-values",
+				"description": "A table with drinks data",
+				"rootDataFileId": -1,
+				"originalFileFormat": "text/csv",
+				"checksum": {
+					"type": "MD5",
+					"value": "ddb3bc08ca0b5826efef8c87a277475f"
+				},
+				"filename": "Drinks.tab",
+				"filesize": 233,
+				"UNF": "UNF:6:IgxkjKXUlveGP0Darp1fYg==",
+				"md5": "ddb3bc08ca0b5826efef8c87a277475f",
+				"id": 575,
+				"storageIdentifier": "163469b1673-1e6c95ea2b41"
+			},
+			"datasetVersionId": 227,
+			"description": "A table with drinks data",
+			"restricted": false,
+			"label": "Drinks.tab",
+			"version": 2
+		}],
+		"metadataBlocks": {
+			"citation": {
+				"fields": [{
+					"typeName": "title",
+					"multiple": false,
+					"value": "A study of my afternoon drinks ",
+					"typeClass": "primitive"
+				}, {
+					"typeName": "author",
+					"multiple": true,
+					"value": [{
+						"authorAffiliation": {
+							"typeName": "authorAffiliation",
+							"multiple": false,
+							"value": "Artefactual",
+							"typeClass": "primitive"
+						},
+						"authorName": {
+							"typeName": "authorName",
+							"multiple": false,
+							"value": "Tester, Archivematica",
+							"typeClass": "primitive"
+						}
+					}],
+					"typeClass": "compound"
+				}, {
+					"typeName": "datasetContact",
+					"multiple": true,
+					"value": [{
+						"datasetContactEmail": {
+							"typeName": "datasetContactEmail",
+							"multiple": false,
+							"value": "joel@walnutdigital.com",
+							"typeClass": "primitive"
+						},
+						"datasetContactAffiliation": {
+							"typeName": "datasetContactAffiliation",
+							"multiple": false,
+							"value": "Artefactual",
+							"typeClass": "primitive"
+						},
+						"datasetContactName": {
+							"typeName": "datasetContactName",
+							"multiple": false,
+							"value": "Tester, Archivematica",
+							"typeClass": "primitive"
+						}
+					}],
+					"typeClass": "compound"
+				}, {
+					"typeName": "dsDescription",
+					"multiple": true,
+					"value": [{
+						"dsDescriptionValue": {
+							"typeName": "dsDescriptionValue",
+							"multiple": false,
+							"value": "Photos with my drinks, and a tabular file with some data on drinks. \r\n",
+							"typeClass": "primitive"
+						},
+						"dsDescriptionDate": {
+							"typeName": "dsDescriptionDate",
+							"multiple": false,
+							"value": "2018-05-01",
+							"typeClass": "primitive"
+						}
+					}],
+					"typeClass": "compound"
+				}, {
+					"typeName": "subject",
+					"multiple": true,
+					"value": ["Arts and Humanities"],
+					"typeClass": "controlledVocabulary"
+				}, {
+					"typeName": "keyword",
+					"multiple": true,
+					"value": [{
+						"keywordValue": {
+							"typeName": "keywordValue",
+							"multiple": false,
+							"value": "Drinks",
+							"typeClass": "primitive"
+						}
+					}],
+					"typeClass": "compound"
+				}, {
+					"typeName": "notesText",
+					"multiple": false,
+					"value": "My first test dataset\r\n",
+					"typeClass": "primitive"
+				}, {
+					"typeName": "depositor",
+					"multiple": false,
+					"value": "Tester, Archivematica",
+					"typeClass": "primitive"
+				}, {
+					"typeName": "dateOfDeposit",
+					"multiple": false,
+					"value": "2018-05-09",
+					"typeClass": "primitive"
+				}],
+				"displayName": "Citation Metadata"
+			}
+		},
+		"license": "CC0",
+		"lastUpdateTime": "2018-05-09T20:45:27Z",
+		"versionMinorNumber": 0,
+		"createTime": "2018-05-09T20:33:36Z",
+		"termsOfUse": "CC0 Waiver",
+		"versionNumber": 1,
+		"UNF": "UNF:6:IgxkjKXUlveGP0Darp1fYg==",
+		"versionState": "RELEASED",
+		"productionDate": "Production Date",
+		"id": 227,
+		"releaseTime": "2018-05-09T20:45:27Z"
+	},
+	"identifier": "6PPJ6Y",
+	"id": 574
+}

--- a/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/api_demo.dataverse.org.doi.10.5072.8.json
+++ b/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/api_demo.dataverse.org.doi.10.5072.8.json
@@ -1,0 +1,197 @@
+{
+    "authority": "10.5072/FK2",
+    "id": 115,
+    "identifier": "NNTESQ",
+    "latestVersion": {
+        "UNF": "UNF:6:08UsvQXuLqTKseBaQf77Xw==",
+        "createTime": "2017-08-09T17:51:19Z",
+        "files": [
+            {
+                "dataFile": {
+                    "UNF": "UNF:6:08UsvQXuLqTKseBaQf77Xw==",
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "5fecac4095dbb6374cb32dd70811d2ce"
+                    },
+                    "contentType": "text/tab-separated-values",
+                    "filename": "depress.tab",
+                    "filesize": 5400,
+                    "id": 116,
+                    "md5": "5fecac4095dbb6374cb32dd70811d2ce",
+                    "originalFileFormat": "application/x-spss-sav",
+                    "originalFormatLabel": "SPSS SAV",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "15dc81eb3aa-927d0c6e8e93"
+                },
+                "datasetVersionId": 43,
+                "label": "depress.tab",
+                "restricted": true,
+                "version": 3
+            }
+        ],
+        "id": 43,
+        "lastUpdateTime": "2017-08-09T17:59:02Z",
+        "license": "CC0",
+        "metadataBlocks": {
+            "citation": {
+                "displayName": "Citation Metadata",
+                "fields": [
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "title",
+                        "value": "Depress"
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "author",
+                        "value": [
+                            {
+                                "authorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorAffiliation",
+                                    "value": "Ryerson University"
+                                },
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Manuel, Kevin"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "datasetContact",
+                        "value": [
+                            {
+                                "datasetContactAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactAffiliation",
+                                    "value": "Ryerson University"
+                                },
+                                "datasetContactEmail": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactEmail",
+                                    "value": "kevin.manuel@ryerson.ca"
+                                },
+                                "datasetContactName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactName",
+                                    "value": "Manuel, Kevin"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "dsDescription",
+                        "value": [
+                            {
+                                "dsDescriptionValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "dsDescriptionValue",
+                                    "value": "Depressing data"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "controlledVocabulary",
+                        "typeName": "subject",
+                        "value": [
+                            "Arts and Humanities"
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "keyword",
+                        "value": [
+                            {
+                                "keywordValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "keywordValue",
+                                    "value": "Depress"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "topicClassification",
+                        "value": [
+                            {
+                                "topicClassValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "topicClassValue",
+                                    "value": "Depress"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "controlledVocabulary",
+                        "typeName": "language",
+                        "value": [
+                            "English",
+                            "Esperanto"
+                        ]
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "depositor",
+                        "value": "Manuel, Kevin"
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "dateOfDeposit",
+                        "value": "2017-08-09"
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "software",
+                        "value": [
+                            {
+                                "softwareName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "softwareName",
+                                    "value": "SPSS"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "productionDate": "Production Date",
+        "releaseTime": "2017-08-09T17:59:02Z",
+        "termsOfAccess": "Please contact owner for access",
+        "termsOfUse": "CC0 Waiver",
+        "versionMinorNumber": 0,
+        "versionNumber": 1,
+        "versionState": "RELEASED"
+    },
+    "persistentUrl": "https://doi.org/10.5072/FK2/NNTESQ",
+    "protocol": "doi",
+    "publicationDate": "2017-08-09",
+    "publisher": "Root Dataverse"
+}

--- a/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/web_ui_demo.dataverse.org.doi.10.5072.1.json
+++ b/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/web_ui_demo.dataverse.org.doi.10.5072.1.json
@@ -1,0 +1,223 @@
+{
+    "authority": "10.5072/FK2",
+    "datasetVersion": {
+        "citation": "Admin, Dataverse, 2016, \"Test Dataset\", doi:10.5072/FK2/XSAZXH, Demo Dataverse, V1",
+        "createTime": "2016-03-10T14:55:44Z",
+        "files": [
+            {
+                "dataFile": {
+                    "contentType": "application/pdf",
+                    "filename": "00169Fiske-Longitudinal-BoxCoverSheets.pdf",
+                    "id": 2387,
+                    "md5": "0552b8380b966bd22487b43bba7d0b1c",
+                    "originalFormatLabel": "UNKNOWN",
+                    "storageIdentifier": "15360f6d891-af5e353b12b4"
+                },
+                "datasetVersionId": 679,
+                "label": "00169Fiske-Longitudinal-BoxCoverSheets.pdf",
+                "version": 2
+            },
+            {
+                "dataFile": {
+                    "contentType": "application/pdf",
+                    "description": "Great documentation codebook.",
+                    "filename": "00169Fiske-Longitudinal-Codebook.pdf",
+                    "id": 2388,
+                    "md5": "585528ddab313c820ebded435f830237",
+                    "originalFormatLabel": "UNKNOWN",
+                    "storageIdentifier": "15360f6f841-06199689c844"
+                },
+                "datasetVersionId": 679,
+                "description": "Great documentation codebook.",
+                "label": "00169Fiske-Longitudinal-Codebook.pdf",
+                "version": 1
+            },
+            {
+                "dataFile": {
+                    "contentType": "image/jpeg",
+                    "filename": "20150610_091644_dataversecommunitymeeting2015-1668.jpg",
+                    "id": 2391,
+                    "md5": "56e737e80105b3d8efb7657eeb629ac5",
+                    "originalFormatLabel": "UNKNOWN",
+                    "storageIdentifier": "15360f6d8b6-30f66bbb425b"
+                },
+                "datasetVersionId": 679,
+                "label": "20150610_091644_dataversecommunitymeeting2015-1668.jpg",
+                "version": 1
+            },
+            {
+                "dataFile": {
+                    "contentType": "text/tab-separated-values",
+                    "filename": "50by1000.tab",
+                    "id": 2389,
+                    "md5": "c03212f91e707f28711e72fb683d9bd7",
+                    "originalFormatLabel": "UNKNOWN",
+                    "storageIdentifier": "15360f6d8a9-f64d477f2c52"
+                },
+                "datasetVersionId": 679,
+                "label": "50by1000.tab",
+                "version": 1
+            },
+            {
+                "dataFile": {
+                    "contentType": "image/png",
+                    "filename": "dataverse_project_logo_1.png",
+                    "id": 2390,
+                    "md5": "4fbdaa3792c057ba86fa62882a3dbae6",
+                    "originalFormatLabel": "UNKNOWN",
+                    "storageIdentifier": "15360f6d68f-f4d157c9d1e1"
+                },
+                "datasetVersionId": 679,
+                "label": "dataverse_project_logo_1.png",
+                "version": 1
+            }
+        ],
+        "id": 679,
+        "lastUpdateTime": "2016-03-10T14:56:07Z",
+        "license": "CC0",
+        "metadataBlocks": {
+            "citation": {
+                "displayName": "Citation Metadata",
+                "fields": [
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "title",
+                        "value": "Test Dataset"
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "author",
+                        "value": [
+                            {
+                                "authorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorAffiliation",
+                                    "value": "Dataverse.org"
+                                },
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Admin, Dataverse"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "datasetContact",
+                        "value": [
+                            {
+                                "datasetContactAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactAffiliation",
+                                    "value": "Dataverse.org"
+                                },
+                                "datasetContactEmail": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactEmail",
+                                    "value": "admin@mailinator.com"
+                                },
+                                "datasetContactName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactName",
+                                    "value": "Admin, Dataverse"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "dsDescription",
+                        "value": [
+                            {
+                                "dsDescriptionValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "dsDescriptionValue",
+                                    "value": "Test dataset"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "controlledVocabulary",
+                        "typeName": "subject",
+                        "value": [
+                            "Social Sciences"
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "keyword",
+                        "value": [
+                            {
+                                "keywordValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "keywordValue",
+                                    "value": "test"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "depositor",
+                        "value": "Admin, Dataverse"
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "dateOfDeposit",
+                        "value": "2016-03-10"
+                    }
+                ]
+            },
+            "geospatial": {
+                "displayName": "Geospatial Metadata",
+                "fields": [
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "geographicCoverage",
+                        "value": [
+                            {
+                                "country": {
+                                    "multiple": false,
+                                    "typeClass": "controlledVocabulary",
+                                    "typeName": "country",
+                                    "value": "United Kingdom"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "productionDate": "Production Date",
+        "releaseTime": "2016-03-10T14:56:07Z",
+        "termsOfAccess": "Must be a member of Manchester Dataverse group.",
+        "termsOfUse": "CC0 Waiver",
+        "versionMinorNumber": 2,
+        "versionNumber": 1,
+        "versionState": "RELEASED"
+    },
+    "id": 2386,
+    "identifier": "XSAZXH",
+    "persistentUrl": "http://dx.doi.org/10.5072/FK2/XSAZXH",
+    "protocol": "doi",
+    "publicationDate": "2016-03-10",
+    "publisher": "Demo Dataverse"
+}

--- a/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/web_ui_demo.dataverse.org.doi.10.5072.2.json
+++ b/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/web_ui_demo.dataverse.org.doi.10.5072.2.json
@@ -1,0 +1,770 @@
+{
+    "authority": "10.5072/FK2",
+    "datasetVersion": {
+        "UNF": "UNF:6:e0YCXa2mdX74Kw7YA+71XA==",
+        "citation": "Nicolas Bala; Suzanne Hunt; Carrie McCarney; Erin Gwynne; Christine Ashborne, 2018, \"Bala Parental Alienation Study: Canada, United Kingdom, and Australia 1984-2012 [test]\", https://doi.org/10.5072/FK2/UNMEZF, Root Dataverse, V1, UNF:6:e0YCXa2mdX74Kw7YA+71XA==",
+        "createTime": "2018-05-16T17:54:01Z",
+        "distributionDate": "2013-01-23",
+        "files": [
+            {
+                "categories": [
+                    "2012",
+                    "Documents"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "5f62252a609ceafef247549443560273"
+                    },
+                    "contentType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                    "description": "Parental Alienation, Contact Problems and the Family Justice System [PowerPoint presentation]",
+                    "filename": "Alienation Aust Bala AIFS 2012.pptx",
+                    "filesize": 1429732,
+                    "id": 854,
+                    "md5": "5f62252a609ceafef247549443560273",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "163698139ba-36fd492c9f73"
+                },
+                "datasetVersionId": 279,
+                "description": "Parental Alienation, Contact Problems and the Family Justice System [PowerPoint presentation]",
+                "label": "Alienation Aust Bala AIFS 2012.pptx",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "2010",
+                    "Documents"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "8ae304c4cab6ee78d20b906e59079f37"
+                    },
+                    "contentType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                    "description": "The Alienated Child: Myths, Realities and Effective Responses [PowerPoint presentation",
+                    "filename": "Alienation Bala SCJ May 2010.pptx",
+                    "filesize": 301875,
+                    "id": 859,
+                    "md5": "8ae304c4cab6ee78d20b906e59079f37",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "163698139c8-77b5f6c12d71"
+                },
+                "datasetVersionId": 279,
+                "description": "The Alienated Child: Myths, Realities and Effective Responses [PowerPoint presentation",
+                "label": "Alienation Bala SCJ May 2010.pptx",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "2012",
+                    "Documents"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "0cec6f7b7a028715edcf1e0651d10b89"
+                    },
+                    "contentType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                    "description": "Recognizing and Responding to Parental Alienation: Why have English Courts Been So Slow?",
+                    "filename": "Alienation London June 27 2012 (Bala) .pptx",
+                    "filesize": 1647626,
+                    "id": 851,
+                    "md5": "0cec6f7b7a028715edcf1e0651d10b89",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "163698139db-7039ed455cb9"
+                },
+                "datasetVersionId": 279,
+                "description": "Recognizing and Responding to Parental Alienation: Why have English Courts Been So Slow?",
+                "label": "Alienation London June 27 2012 (Bala) .pptx",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "1984-2011",
+                    "Data"
+                ],
+                "dataFile": {
+                    "UNF": "UNF:6:q2Avm3TwI/lWz71+rbtTcw==",
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "cea791d8230607e14dda1f520244704c"
+                    },
+                    "contentType": "text/tab-separated-values",
+                    "description": "Parental alienation cases for Australia, 1984-2011, by date",
+                    "filename": "PA-Cases-Australia-by-date.tab",
+                    "filesize": 10242,
+                    "id": 862,
+                    "md5": "cea791d8230607e14dda1f520244704c",
+                    "originalFileFormat": "text/csv",
+                    "originalFormatLabel": "Comma Separated Values",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "163698139e5-2f6d2e9ebb37"
+                },
+                "datasetVersionId": 279,
+                "description": "Parental alienation cases for Australia, 1984-2011, by date",
+                "label": "PA-Cases-Australia-by-date.tab",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "1984-2011",
+                    "Data"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "c037aa14a87b1148b8e3faf367d2f71c"
+                    },
+                    "contentType": "text/comma-separated-values",
+                    "description": "Parental alienation cases for Australia, 1984-2011, summary",
+                    "filename": "PA-Cases-Australia-summary.csv",
+                    "filesize": 98174,
+                    "id": 848,
+                    "md5": "c037aa14a87b1148b8e3faf367d2f71c",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "163698139ea-06dd7e2cc23f"
+                },
+                "datasetVersionId": 279,
+                "description": "Parental alienation cases for Australia, 1984-2011, summary",
+                "label": "PA-Cases-Australia-summary.csv",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "1984-2011",
+                    "Data"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "1ee6960c8257b918f0c84dfd3a64ab98"
+                    },
+                    "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "description": "Parental alienation cases for Australia, 1984-2011",
+                    "filename": "PA-Cases-Australia.xlsx",
+                    "filesize": 71835,
+                    "id": 857,
+                    "md5": "1ee6960c8257b918f0c84dfd3a64ab98",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "163698139f0-dafd0e574c7c"
+                },
+                "datasetVersionId": 279,
+                "description": "Parental alienation cases for Australia, 1984-2011",
+                "label": "PA-Cases-Australia.xlsx",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "1989-2008",
+                    "Data"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "ea7ffcdec6a3ad25ff0f3e8666851438"
+                    },
+                    "contentType": "text/csv",
+                    "description": "Parental alienation cases for Canada, 1989-2008, by date",
+                    "filename": "PA-Cases-Canada-by-date.csv",
+                    "filesize": 80057,
+                    "id": 853,
+                    "md5": "ea7ffcdec6a3ad25ff0f3e8666851438",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "163698139f4-ea37961c2384"
+                },
+                "datasetVersionId": 279,
+                "description": "Parental alienation cases for Canada, 1989-2008, by date",
+                "label": "PA-Cases-Canada-by-date.csv",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "1989-2008",
+                    "Data"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "f76904c605ca9beed382faaa4b3db4f9"
+                    },
+                    "contentType": "text/comma-separated-values",
+                    "description": "Parental alienation cases for Canada, 1989-2008, PA found",
+                    "filename": "PA-Cases-Canada-pa-found.csv",
+                    "filesize": 20184,
+                    "id": 861,
+                    "md5": "f76904c605ca9beed382faaa4b3db4f9",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "163698139f9-6a4ba9a97ddd"
+                },
+                "datasetVersionId": 279,
+                "description": "Parental alienation cases for Canada, 1989-2008, PA found",
+                "label": "PA-Cases-Canada-pa-found.csv",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "1989-2008",
+                    "Data"
+                ],
+                "dataFile": {
+                    "UNF": "UNF:6:YLOG7cUWw9LlB/2D2gccag==",
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "6297f043f866b60befc921f84e4ccd11"
+                    },
+                    "contentType": "text/tab-separated-values",
+                    "description": "Parental alienation cases for Canada, 1989-2008",
+                    "filename": "PA-Cases-Canada.tab",
+                    "filesize": 22902,
+                    "id": 850,
+                    "md5": "6297f043f866b60befc921f84e4ccd11",
+                    "originalFileFormat": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "originalFormatLabel": "MS Excel (XLSX)",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "163698139fe-6a64e0f90ec1"
+                },
+                "datasetVersionId": 279,
+                "description": "Parental alienation cases for Canada, 1989-2008",
+                "label": "PA-Cases-Canada.tab",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "1986-2008",
+                    "Data"
+                ],
+                "dataFile": {
+                    "UNF": "UNF:6:YkvpoCo3OSqXeLvUqSRUzQ==",
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "9078645e064e760d3031d0a6aa45326f"
+                    },
+                    "contentType": "text/tab-separated-values",
+                    "description": "Parental alienation cases for United Kingdom, 1996-2008",
+                    "filename": "PA-Cases-UK-1996-2008.tab",
+                    "filesize": 14612,
+                    "id": 847,
+                    "md5": "9078645e064e760d3031d0a6aa45326f",
+                    "originalFileFormat": "text/csv",
+                    "originalFormatLabel": "Comma Separated Values",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "16369813a02-0a93eba4cb0a"
+                },
+                "datasetVersionId": 279,
+                "description": "Parental alienation cases for United Kingdom, 1996-2008",
+                "label": "PA-Cases-UK-1996-2008.tab",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "2008-2011",
+                    "Data"
+                ],
+                "dataFile": {
+                    "UNF": "UNF:6:9AN16WYddUZo/etN3tjHCA==",
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "40ebe25763f9b82acf8e128c2004f78b"
+                    },
+                    "contentType": "text/tab-separated-values",
+                    "description": "Parental alienation cases for United Kingdom, 2008-2011",
+                    "filename": "PA-Cases-UK-2000-2011.tab",
+                    "filesize": 46679,
+                    "id": 852,
+                    "md5": "40ebe25763f9b82acf8e128c2004f78b",
+                    "originalFileFormat": "text/csv",
+                    "originalFormatLabel": "Comma Separated Values",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "16369813a08-4de2b1814bbc"
+                },
+                "datasetVersionId": 279,
+                "description": "Parental alienation cases for United Kingdom, 2008-2011",
+                "label": "PA-Cases-UK-2000-2011.tab",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "1996-2012",
+                    "Data"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "8779d98af2d1e94b25ee68704a5d7bc6"
+                    },
+                    "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "description": "Parental alienation cases for United Kingdom, 1996-2012",
+                    "filename": "PA-Cases-UK.xlsx",
+                    "filesize": 42823,
+                    "id": 855,
+                    "md5": "8779d98af2d1e94b25ee68704a5d7bc6",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "16369813a0d-e39a02633d74"
+                },
+                "datasetVersionId": 279,
+                "description": "Parental alienation cases for United Kingdom, 1996-2012",
+                "label": "PA-Cases-UK.xlsx",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "1997-2011",
+                    "Summary of Data"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "04867d3ba45394dfd0a56883f1a88496"
+                    },
+                    "contentType": "application/pdf",
+                    "description": "Australia Summary, 1997-2011",
+                    "filename": "PA-Summary-Australia-1997 -2011.pdf",
+                    "filesize": 581806,
+                    "id": 856,
+                    "md5": "04867d3ba45394dfd0a56883f1a88496",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "16369813a18-0499aa4ba30c"
+                },
+                "datasetVersionId": 279,
+                "description": "Australia Summary, 1997-2011",
+                "label": "PA-Summary-Australia-1997 -2011.pdf",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "1988-2008",
+                    "Summary of Data"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "cd720d05a7744a0da4c48bb227bf53ef"
+                    },
+                    "contentType": "application/pdf",
+                    "description": "Canada Summary, 1988-2008",
+                    "filename": "PA-Summary-Canada-1988-2008.pdf",
+                    "filesize": 163271,
+                    "id": 849,
+                    "md5": "cd720d05a7744a0da4c48bb227bf53ef",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "16369813a20-fea7e670a8a2"
+                },
+                "datasetVersionId": 279,
+                "description": "Canada Summary, 1988-2008",
+                "label": "PA-Summary-Canada-1988-2008.pdf",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "2008",
+                    "Summary of Data"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "a25ea872f6e0dd83407a6db7ff869eb1"
+                    },
+                    "contentType": "application/pdf",
+                    "description": "Canada Summary, 2009",
+                    "filename": "PA-Summary-Canada-2009.pdf",
+                    "filesize": 148169,
+                    "id": 860,
+                    "md5": "a25ea872f6e0dd83407a6db7ff869eb1",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "16369813a25-2a5fa912125d"
+                },
+                "datasetVersionId": 279,
+                "description": "Canada Summary, 2009",
+                "label": "PA-Summary-Canada-2009.pdf",
+                "restricted": false,
+                "version": 2
+            },
+            {
+                "categories": [
+                    "1984-2012",
+                    "Documents"
+                ],
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "c78b5c37cfcf5834bef135e34a09f532"
+                    },
+                    "contentType": "application/pdf",
+                    "description": "User Guide",
+                    "filename": "pa-user-guide.pdf",
+                    "filesize": 321835,
+                    "id": 863,
+                    "md5": "c78b5c37cfcf5834bef135e34a09f532",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "16369813a2d-41556d7c6f3a"
+                },
+                "datasetVersionId": 279,
+                "description": "User Guide",
+                "label": "pa-user-guide.pdf",
+                "restricted": false,
+                "version": 2
+            }
+        ],
+        "id": 279,
+        "lastUpdateTime": "2018-05-16T17:54:08Z",
+        "license": "CC0",
+        "metadataBlocks": {
+            "citation": {
+                "displayName": "Citation Metadata",
+                "fields": [
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "title",
+                        "value": "Bala Parental Alienation Study: Canada, United Kingdom, and Australia 1984-2012 [test]"
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "author",
+                        "value": [
+                            {
+                                "authorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorAffiliation",
+                                    "value": "Queen's University"
+                                },
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Nicolas Bala"
+                                }
+                            },
+                            {
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Suzanne Hunt"
+                                }
+                            },
+                            {
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Carrie McCarney"
+                                }
+                            },
+                            {
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Erin Gwynne"
+                                }
+                            },
+                            {
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Christine Ashborne"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "datasetContact",
+                        "value": [
+                            {
+                                "datasetContactAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactAffiliation",
+                                    "value": "Queen's University"
+                                },
+                                "datasetContactEmail": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactEmail",
+                                    "value": "meghan.goodchild@queensu.ca"
+                                },
+                                "datasetContactName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactName",
+                                    "value": "Data and Government Information Centre"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "dsDescription",
+                        "value": [
+                            {
+                                "dsDescriptionDate": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "dsDescriptionDate",
+                                    "value": "2013-01-23"
+                                },
+                                "dsDescriptionValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "dsDescriptionValue",
+                                    "value": "Using databases of judicial decisions from Canada, Australia, and the United Kingdom, from 1984-2012, searching terms \"parental alienation\", \"alienated child\", \"alienated\", etc., cases were combed through to determine whether they represented cases where the court dealt with an issue of alienation. Those cases that were found to have dealt with parental alienation were studied and analyzed."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "controlledVocabulary",
+                        "typeName": "subject",
+                        "value": [
+                            "Social Sciences"
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "keyword",
+                        "value": [
+                            {
+                                "keywordValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "keywordValue",
+                                    "value": "Parental alienation"
+                                }
+                            },
+                            {
+                                "keywordValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "keywordValue",
+                                    "value": "Alienated child"
+                                }
+                            },
+                            {
+                                "keywordValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "keywordValue",
+                                    "value": "Estrangement"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "publication",
+                        "value": [
+                            {
+                                "publicationCitation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "publicationCitation",
+                                    "value": "Bala, Hunt and McCarney, \"Parental Alienation: Canadian Court Cases 1989-2008\" (2010) 48 Family Court Review 162-177.\r\n\r\nFidler, Bala and Saini, Children Resisting Post-Separation Contact: A Differential Approach for Legal and Mental Professionals (New York: Oxford University Press, 2012)"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "controlledVocabulary",
+                        "typeName": "language",
+                        "value": [
+                            "English"
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "producer",
+                        "value": [
+                            {
+                                "producerAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "producerAffiliation",
+                                    "value": "Queen's University Faculty of Law"
+                                },
+                                "producerName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "producerName",
+                                    "value": "Nicolas Bala"
+                                },
+                                "producerURL": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "producerURL",
+                                    "value": "http://law.queensu.ca/ "
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "productionDate",
+                        "value": "2013-01"
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "grantNumber",
+                        "value": [
+                            {
+                                "grantNumberAgency": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "grantNumberAgency",
+                                    "value": "Social Sciences and Humanities Research Council (SSHRC) "
+                                }
+                            },
+                            {
+                                "grantNumberAgency": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "grantNumberAgency",
+                                    "value": "Law Foundation of Ontario "
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "distributor",
+                        "value": [
+                            {
+                                "distributorAbbreviation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "distributorAbbreviation",
+                                    "value": "DGIC"
+                                },
+                                "distributorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "distributorAffiliation",
+                                    "value": "Queen's University"
+                                },
+                                "distributorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "distributorName",
+                                    "value": "Data and Government Information Centre"
+                                },
+                                "distributorURL": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "distributorURL",
+                                    "value": "http://library.queensu.ca/webdoc/ "
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "distributionDate",
+                        "value": "2013-01-23"
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "depositor",
+                        "value": "Goodchild, Meghan"
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "dateOfDeposit",
+                        "value": "2018-05-16"
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "timePeriodCovered",
+                        "value": [
+                            {
+                                "timePeriodCoveredEnd": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "timePeriodCoveredEnd",
+                                    "value": "2012"
+                                },
+                                "timePeriodCoveredStart": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "timePeriodCoveredStart",
+                                    "value": "1984"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "primitive",
+                        "typeName": "relatedMaterial",
+                        "value": [
+                            "Bala, N. Managing Cases of Children Resistant to Parental Contact and Alienated Children - International and UK Experiences. Family Law Seminar, The Palace of Westminster, 27 June 2012. [PowerPoint presentation]\r\n\r\nBala, N. Parental Alienation, Contact Problems and the Family Justice System. Australian Institute of Family Studies, Melbourne, Australia, 20 February 2012. [PowerPoint presentation]\r\n\r\nBala, N. The Alienated Child: Myths, Realities and Effective Responses. Superior Cour t of Justice: Family Law Program, Niagara-on-the-Falls, Ontario, 5 May 2010. [PowerPoint presentation]"
+                        ]
+                    }
+                ]
+            },
+            "geospatial": {
+                "displayName": "Geospatial Metadata",
+                "fields": []
+            },
+            "journal": {
+                "displayName": "Journal Metadata",
+                "fields": []
+            }
+        },
+        "productionDate": "Production Date",
+        "releaseTime": "2018-05-16T17:54:08Z",
+        "termsOfUse": "CC0 Waiver",
+        "versionMinorNumber": 1,
+        "versionNumber": 1,
+        "versionState": "RELEASED"
+    },
+    "id": 784,
+    "identifier": "UNMEZF",
+    "persistentUrl": "https://doi.org/10.5072/FK2/UNMEZF",
+    "protocol": "doi",
+    "publicationDate": "2018-05-16",
+    "publisher": "Root Dataverse"
+}

--- a/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/web_ui_demo.dataverse.org.doi.10.5072.3.json
+++ b/src/MCPClient/tests/fixtures/dataverse/dataverse_sources/metadata/web_ui_demo.dataverse.org.doi.10.5072.3.json
@@ -1,0 +1,192 @@
+{
+    "authority": "10.5072/FK2",
+    "datasetVersion": {
+        "citation": "Tester, Archivematica, 2018, \"A study with restricted data\", https://doi.org/10.5072/FK2/WZTJWN, Root Dataverse, V1",
+        "createTime": "2018-05-09T21:26:07Z",
+        "files": [
+            {
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "770d1b51aee0644ea1dbc2c588c91265"
+                    },
+                    "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "description": "Some data on cats",
+                    "filename": "CatDatabase.xlsx",
+                    "filesize": 24455,
+                    "id": 578,
+                    "md5": "770d1b51aee0644ea1dbc2c588c91265",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "16346cbc5dc-a870f236ec8f"
+                },
+                "datasetVersionId": 228,
+                "description": "Some data on cats",
+                "label": "CatDatabase.xlsx",
+                "restricted": true,
+                "version": 2
+            },
+            {
+                "dataFile": {
+                    "checksum": {
+                        "type": "MD5",
+                        "value": "2236b2e60aeb6d0d28fd99ce7a5e1aa4"
+                    },
+                    "contentType": "application/pdf",
+                    "description": "A photo saved in PDF",
+                    "filename": "lightingPhoto.pdf",
+                    "filesize": 866439,
+                    "id": 579,
+                    "md5": "2236b2e60aeb6d0d28fd99ce7a5e1aa4",
+                    "originalFormatLabel": "UNKNOWN",
+                    "rootDataFileId": -1,
+                    "storageIdentifier": "16346c7f1f9-388794a74e06"
+                },
+                "datasetVersionId": 228,
+                "description": "A photo saved in PDF",
+                "label": "lightingPhoto.pdf",
+                "restricted": false,
+                "version": 1
+            }
+        ],
+        "id": 228,
+        "lastUpdateTime": "2018-05-09T21:27:17Z",
+        "license": "CC0",
+        "metadataBlocks": {
+            "citation": {
+                "displayName": "Citation Metadata",
+                "fields": [
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "title",
+                        "value": "A study with restricted data"
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "author",
+                        "value": [
+                            {
+                                "authorAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorAffiliation",
+                                    "value": "Artefactual"
+                                },
+                                "authorName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "authorName",
+                                    "value": "Tester, Archivematica"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "datasetContact",
+                        "value": [
+                            {
+                                "datasetContactAffiliation": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactAffiliation",
+                                    "value": "Artefactual"
+                                },
+                                "datasetContactEmail": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactEmail",
+                                    "value": "joel@walnutdigital.com"
+                                },
+                                "datasetContactName": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "datasetContactName",
+                                    "value": "Tester, Archivematica"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "dsDescription",
+                        "value": [
+                            {
+                                "dsDescriptionDate": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "dsDescriptionDate",
+                                    "value": "2017-01-01"
+                                },
+                                "dsDescriptionValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "dsDescriptionValue",
+                                    "value": "A test with restricted data"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "controlledVocabulary",
+                        "typeName": "subject",
+                        "value": [
+                            "Other"
+                        ]
+                    },
+                    {
+                        "multiple": true,
+                        "typeClass": "compound",
+                        "typeName": "keyword",
+                        "value": [
+                            {
+                                "keywordValue": {
+                                    "multiple": false,
+                                    "typeClass": "primitive",
+                                    "typeName": "keywordValue",
+                                    "value": "Restricted"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "notesText",
+                        "value": "Some restricted data files\r\n"
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "depositor",
+                        "value": "Tester, Archivematica"
+                    },
+                    {
+                        "multiple": false,
+                        "typeClass": "primitive",
+                        "typeName": "dateOfDeposit",
+                        "value": "2018-05-09"
+                    }
+                ]
+            }
+        },
+        "productionDate": "Production Date",
+        "releaseTime": "2018-05-09T21:27:17Z",
+        "termsOfAccess": "This is made up data, but restricted for test purposes.",
+        "termsOfUse": "CC0 Waiver",
+        "versionMinorNumber": 0,
+        "versionNumber": 1,
+        "versionState": "RELEASED"
+    },
+    "id": 577,
+    "identifier": "WZTJWN",
+    "persistentUrl": "https://doi.org/10.5072/FK2/WZTJWN",
+    "protocol": "doi",
+    "publicationDate": "2018-05-09",
+    "publisher": "Root Dataverse"
+}

--- a/src/MCPClient/tests/test_create_dataverse_mets.py
+++ b/src/MCPClient/tests/test_create_dataverse_mets.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Unit tests against the Convert Dataverse Structure MCP Client script."""
+
+from __future__ import print_function
+from collections import namedtuple
+import os
+import sys
+
+import pytest
+
+import metsrw
+from job import Job
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(
+    os.path.abspath(os.path.join(THIS_DIR, '../lib/clientScripts')))
+
+import convert_dataverse_structure
+
+# List of dataverse metadata fixtures. We use a namedtuple to provide some
+# structure to this index so that we can keep track of information regarding
+# dataverse over time, e.g. dataverse version number, the dataset uri and so
+# forth.
+DataverseMDIndex = namedtuple('DataverseMDIndex',
+                              'dv_version, ddi_title, pid_value, pid_type, '
+                              'fname, all_file_count, dir_count, item_count, '
+                              'ddi_count')
+
+dv_1 = DataverseMDIndex("4.8.6",
+                        "Test Dataset",
+                        "http://dx.doi.org/10.5072/FK2/XSAZXH",
+                        "doi",
+                        "web_ui_demo.dataverse.org.doi.10.5072.1.json",
+                        14, 3, 11, 1)
+dv_2 = DataverseMDIndex("4.8.6",
+                        "Bala Parental Alienation Study: Canada, United "
+                        "Kingdom, and Australia 1984-2012 [test]",
+                        "https://doi.org/10.5072/FK2/UNMEZF",
+                        "doi",
+                        "web_ui_demo.dataverse.org.doi.10.5072.2.json",
+                        47, 6, 41, 5)
+dv_3 = DataverseMDIndex("4.8.6",
+                        "A study with restricted data",
+                        "https://doi.org/10.5072/FK2/WZTJWN",
+                        "doi",
+                        "web_ui_demo.dataverse.org.doi.10.5072.3.json",
+                        5, 2, 3, 1)
+dv_4 = DataverseMDIndex("4.8.6",
+                        "A study of my afternoon drinks",
+                        "https://doi.org/10.5072/FK2/6PPJ6Y",
+                        "doi",
+                        "api_demo.dataverse.org.doi.10.5072.4.json",
+                        11, 3, 8, 2)
+dv_5 = DataverseMDIndex("4.8.6",
+                        "Botanical Test",
+                        "https://doi.org/10.5072/FK2/8KDUHM",
+                        "doi",
+                        "api_demo.dataverse.org.doi.10.5072.5.json",
+                        11, 2, 9, 1)
+dv_6 = DataverseMDIndex("4.8.6",
+                        "Research Data Management (RDM) Survey of Queen's "
+                        "University's Engineering and Science Departments",
+                        "https://hdl.handle.net/10864/11651",
+                        "hdl",
+                        "api_demo.dataverse.org.doi.10.5072.6.json",
+                        19, 3, 16, 2)
+dv_7 = DataverseMDIndex("4.8.6",
+                        "A study of my afternoon drinks",
+                        "https://doi.org/10.5072/FK2/6PPJ6Y",
+                        "doi",
+                        "api_demo.dataverse.org.doi.10.5072.7.json",
+                        11, 3, 8, 2)
+dv_8 = DataverseMDIndex("4.8.6",
+                        "Depress",
+                        "https://doi.org/10.5072/FK2/NNTESQ",
+                        "doi",
+                        "api_demo.dataverse.org.doi.10.5072.8.json",
+                        11, 3, 8, 2)
+
+
+class TestDataverseExample(object):
+    """Dataverse test runner class."""
+
+    write_dir = "fixtures/dataverse/dataverse_sources/dataverse_mets/"
+    fixture_path = "fixtures/dataverse/dataverse_sources"
+
+    THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+    FIXTURES_DIR = os.path.join(THIS_DIR, fixture_path)
+
+    def _create_mets(self, fname, tmpdir):
+        mets_file_name = "METS.{}.dataverse.xml".format(fname)
+        job = Job("stub", "stub", ["", ""])
+        convert_dataverse_structure.convert_dataverse_to_mets(
+            job=job, unit_path=self.FIXTURES_DIR,
+            dataset_md_name=fname, output_md_path=str(tmpdir),
+            output_md_name=mets_file_name)
+        return str(tmpdir.join(mets_file_name))
+
+    @pytest.mark.parametrize(
+        "fixture", [dv_1, dv_2, dv_3, dv_4, dv_5, dv_6, dv_7, dv_8])
+    def test_generated_mets_(self, fixture, tmpdir):
+        """Understand whether all the file and directory elements appear in the
+        METS as anticipated. A high-level test to quickly understand if
+        something has gone wrong while refactoring.
+        """
+        mets_path = self._create_mets(fixture.fname, tmpdir)
+        if not os.path.isfile(mets_path):
+            pytest.fail("Fixtures were not previously setup correctly.")
+
+        try:
+            mets = metsrw.METSDocument.fromfile(mets_path)
+        except mets.MetsError:
+            pytest.fail("Could not parse mets {}".format(mets_path))
+
+        assert len(mets.all_files()) == \
+            fixture.all_file_count, (
+                "File count incorrect: '{}', expected '{}'"
+                .format(len(mets.all_files()), fixture.all_file_count))
+
+        dir_counter = 0
+        item_counter = 0
+        for file_ in mets.all_files():
+            if file_.type == "Directory":
+                dir_counter += 1
+            if file_.type == "Item":
+                item_counter += 1
+
+        assert dir_counter == \
+            fixture.dir_count, (
+                "Directory count incorrect: '{}', expected: '{}'"
+                .format(dir_counter, fixture.dir_count))
+        assert item_counter == \
+            fixture.item_count, (
+                "Item count incorrect: '{}', expected: '{}'"
+                .format(item_counter, fixture.item_count))
+
+    @pytest.mark.parametrize(
+        "fixture", [dv_1, dv_2, dv_3, dv_4, dv_5, dv_6, dv_7, dv_8])
+    def test_mets_content(self, fixture, tmpdir):
+        """Cherry-pick certain important elements in the content of the
+        Dataverse METS that needs to be consistently output by the convert
+        Dataverse METS script.
+        """
+        mets_path = self._create_mets(fixture.fname, tmpdir)
+        if not os.path.isfile(mets_path):
+            pytest.fail("Fixtures were not previously setup correctly.")
+
+        try:
+            mets = metsrw.METSDocument.fromfile(mets_path)
+        except mets.MetsError:
+            pytest.fail("Could not parse mets {}".format(mets_path))
+
+        mets_root = mets.serialize()
+
+        # Setup namespaces to search for in the document.
+        namespace = {'ddi': 'http://www.icpsr.umich.edu/DDI'}
+
+        # Test for a single instance of the ddi codebook.
+        codebook = mets_root.findall('.//ddi:codebook', namespace)
+        assert len(codebook) == 1, ("Incorrect number of codebook entries "
+                                    "discovered: '{}' expected 1."
+                                    .format(len(codebook)))
+
+        # Test that we have a single title instance and the title matches what
+        # is expected.
+        title = mets_root.findall('.//ddi:titl', namespace)
+        assert len(title) == 1
+        assert title[0].text == \
+            fixture.ddi_title, (
+                "DDI title: '{}' is not what was expected: '{}'"
+                .format(title[0].text, fixture.ddi_title))
+
+        # Test that we have a single PID and that it matches what is expected.
+        pid = mets_root.findall('.//ddi:IDNo', namespace)
+        assert len(pid) == 1
+        # Agency is synonymous with Type in our use of the PID Agency value.
+        # N.B. The agency providing the persistent identifier.
+        pid_agency = pid[0].get("agency")
+        assert pid_agency == \
+            fixture.pid_type, ("PID type: '{}' is not what was expected: '{}'"
+                               .format(pid_agency, fixture.pid_type))
+        assert pid[0].text == \
+            fixture.pid_value, ("PID value: '{}' is not what was expected: '{}"
+                                .format(pid[0].text, fixture.pid_value))
+
+        # Title is used in three other locations in the METS. Make sure that
+        # they are found as well.
+        for map_ in mets_root.findall("{http://www.loc.gov/METS/}structMap"):
+            for entry in map_:
+                if entry.get("Type") == "Directory" and \
+                        entry.get("DMDID") is not None:
+                    assert entry.get("LABEL") == fixture.ddi_title, \
+                        ("Title not found in METS struct maps where expected")
+
+        # Test that the MDRef count is what is expected.
+        refs = mets_root.findall('.//{http://www.loc.gov/METS/}mdRef')
+        # Test to make sure that refs is not empty.
+        assert refs
+        # Test to make sure ddi_count is >= the length of refs.
+        assert fixture.ddi_count >= len(refs)
+
+        # Assert that at least one mdref points to our dataset.json file and
+        # that if we find any other mdrefs that they point to ddi files.
+        dataset_json = False
+        for ref in refs:
+            if ref.get("LABEL") == fixture.fname:
+                dataset_json = True
+            elif ref.get("MDTYPE") != "DDI":
+                pytest.fail("Unexpected MDREF found in metadata: {}"
+                            .format(ref.get("LABEL")))
+        assert dataset_json is True

--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -272,6 +272,7 @@ def created_shared_directory_structure():
         "watchedDirectories/activeTransfers",
         "watchedDirectories/activeTransfers/baggitDirectory",
         "watchedDirectories/activeTransfers/baggitZippedDirectory",
+        "watchedDirectories/activeTransfers/dataverseTransfer",
         "watchedDirectories/activeTransfers/Dspace",
         "watchedDirectories/activeTransfers/maildir",
         "watchedDirectories/activeTransfers/standardTransfer",

--- a/src/MCPServer/lib/package.py
+++ b/src/MCPServer/lib/package.py
@@ -97,6 +97,15 @@ PACKAGE_TYPE_STARTING_POINTS = {
         chain='e4a59e3e-3dba-4eb5-9cf1-c1fb3ae61fa9',
         link='2483c25a-ade8-4566-a259-c6c37350d0d6',
     ),
+    'dataverse': StartingPoint(
+        watched_dir=os.path.join(
+            django_settings.WATCH_DIRECTORY,
+            'activeTransfers/dataverseTransfer'),
+        # Approve Dataverse Transfer Chain
+        chain='10c00bc8-8fc2-419f-b593-cf5518695186',
+        # Chain link setting transfer-type: Dataverse
+        link='0af6b163-5455-4a76-978b-e35cc9ee445f',
+    ),
 }
 
 
@@ -259,7 +268,8 @@ def create_package(name, type_, accession, access_system_id, path,
     if type_ is None or type_ == 'disk image':
         type_ = 'standard'
     if type_ not in PACKAGE_TYPE_STARTING_POINTS:
-        raise ValueError('Unexpected type of package provided')
+        raise ValueError("Unexpected type of package provided '{}'"
+                         .format(type_))
     if not path:
         raise ValueError('No path provided.')
     if isinstance(auto_approve, bool) is False:

--- a/src/dashboard/frontend/transfer-browser/app/front_page/content.html
+++ b/src/dashboard/frontend/transfer-browser/app/front_page/content.html
@@ -8,6 +8,7 @@
     <option value="zipped bag">{{ "Zipped bag" | translate }}</option>
     <option value="dspace">{{ "DSpace" | translate }}</option>
     <option value="disk image">{{ "Disk image" | translate }}</option>
+    <option value="dataverse">{{ "Dataverse" | translate }}</option>
   </select>
   <div class="help-block">{{ "Transfer type" | translate }}</div>
   </div>

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -58,7 +58,8 @@ TRANSFER_TYPE_DIRECTORIES = {
     'zipped bag': 'baggitZippedDirectory',
     'dspace': 'Dspace',
     'maildir': 'maildir',
-    'TRIM': 'TRIM'
+    'TRIM': 'TRIM',
+    'dataverse': 'dataverseTransfer',
 }
 
 
@@ -84,6 +85,8 @@ def _prepare_browse_response(response):
         logger.debug('Properties for %s: %s', entry, prop)
         if 'levelOfDescription' in prop:
             prop['display_string'] = prop['levelOfDescription']
+        elif 'verbose name' in prop:
+            prop['display_string'] = prop['verbose name'].strip()
         elif 'object count' in prop:
             try:
                 prop['display_string'] = ungettext(

--- a/src/dashboard/src/main/migrations/0061_create_dataverse_transfer_type.py
+++ b/src/dashboard/src/main/migrations/0061_create_dataverse_transfer_type.py
@@ -1,0 +1,729 @@
+# -*- coding: utf-8 -*-
+"""Migration to create a Dataverse Transfer Type.
+
+This migration introduces a new transfer type for Dataverse,
+https://dataverse.org/ datasets.
+
+The migration also introduces two new microservices:
+
+* Convert Dataverse Structure
+* Parse Dataverse METS
+
+In order to do that, the transfer workflow requires two signals in the form
+of unit variables to read from when the new microservice tasks need to be
+performed.
+
+Once the tasks have completed, the workflow is picked up from where it would
+normally for a standard transfer type.
+"""
+
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+# We can't use apps.get_model for this model as we need to access class
+# attributes.
+from main.models import Job
+
+# The usual default next MS in Archivematica is the failed transfer MS. The
+# task that this points to is Email Fail Report.
+DEFAULT_NEXT_MS_TASK_FAILED = "61c316a6-0a50-4f65-8767-1f44b1eeb6dd"
+
+# Task types that we'll create entries for in this migration.
+TASK_TYPE_LINK_PULL = "c42184a3-1a7f-4c4d-b380-15d8d97fdd11"
+TASK_TYPE_SINGLE_INSTANCE = "36b2e239-4a57-4aa5-8ebc-7a29139baca6"
+TASK_TYPE_SET_UNIT_VAR = "6f0b612c-867f-4dfd-8e43-5b35b7f882d7"
+TASK_TYPE_USER_CHOICE = "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c"
+
+# New tasks created in this migration starting with user-choices.
+NEW_CHOICE_TASK_APPROVE_DV_TRANSFER = "477bc37e-b6a7-440a-9088-85672b3b38a7"
+
+# Tasks to set unit variables.
+NEW_UNIT_VAR_TASK_CONVERT_DATAVERSE = "2b2042d4-548f-4c63-a394-bf14b5faa5d1"
+NEW_UNIT_VAR_TASK_PARSE_DV_METS = "7d1872fc-d90e-4354-a5c9-97d24bbdf629"
+
+# Standard task runners.
+NEW_STD_TASK_SET_TRANSFER_TYPE_DV = "4d36c35a-0829-4b2d-ba3d-0a30a3e837f9"
+NEW_STD_TASK_CONVERT_DATAVERSE = "ab6c6e52-10c5-449e-ae92-89cf7903e6bc"
+NEW_STD_TASK_PARSE_DATAVERSE_METS = "e593507e-f4bf-4346-8652-32a832524782"
+
+# New task configurations required to process a Dataverse transfer.
+NEW_STD_TASK_CONFIG_SET_DV_TRANSFER = "ed3cda67-94b6-457e-9d00-c58f413dbfce"
+NEW_STD_TASK_CONFIG_CONVERT_DV = "286b4b17-d382-48eb-bdbe-ca3b2a32568b"
+NEW_STD_TASK_CONFIG_PARSE_DV = "58988b82-7b65-40f3-94a7-f2f3e13b8700"
+
+# Configuration UUIDs for our Dataverse unit variables. These help determine
+# the direction of the transfer workflow based on being able to identify a
+# transfer as Dataverse.
+NEW_UNIT_VAR_CONFIG_CONVERT_DV = "f5908626-38be-4c2b-9c09-a389585e9f6c"
+NEW_UNIT_VAR_CONFIG_PARSE_DV = "3fcc6e42-0117-4786-9cd4-e773f6f71296"
+
+# Tasks to make use of unit variables.
+NEW_LINK_PULL_CONVERT_DATAVERSE = "7eade269-0bc3-4a6a-9801-e8e4d8babb55"
+NEW_LINK_PULL_PARSE_DATAVERSE_METS = "355c22ae-ba5b-408b-a9b6-a01372d158b5"
+
+# Configuration UUIDs for our Dataverse link pulls. These are used to direct
+# the workflow based on previously set unit variables, if set.
+NEW_LINK_PULL_CONFIG_CONVERT_DV = "5b11c0a9-6f62-4d7e-ad48-2905e75ff419"
+NEW_LINK_PULL_CONFIG_PARSE_DV = "6f7a2ebd-bd88-44b7-b146-c552ac4e40cb"
+
+# New chain choices to approve and reject a Dataverse transfer.
+NEW_CHAIN_CHOICE_REJECT_DV_TRANSFER = "77bb4993-9f5b-4e60-bbe9-0039a6f5934e"
+NEW_CHAIN_CHOICE_APPROVE_DV_TRANSFER = "dc9b59b3-dd5f-4cd6-8e97-ee1d83734c4c"
+
+# New Microservices that we're creating.
+NEW_MS_APPROVE_DV_TRANSFER = "246943e4-d203-48e1-ac84-4865520e7c30"
+NEW_MS_MOVE_TO_PROCESSING_DIR = "fdb12ea6-22aa-46c8-a591-a2bcf5d42e5e"
+NEW_MS_SET_DV_TRANSFER_TYPE = "0af6b163-5455-4a76-978b-e35cc9ee445f"
+NEW_MS_SET_CONVERT_DV_UNIT_VAR = "213fe743-f170-4695-8b3e-77886a31a89d"
+NEW_MS_SET_PARSE_DV_UNIT_VAR = "364ac694-6440-4e45-8b2a-d3715c524970"
+NEW_MS_DETERMINE_CONVERT_DV = "2a0a7afb-d09b-414b-a7ae-625f162103c1"
+NEW_MS_CONVERT_DV_STRUCTURE = "9ec31d55-f053-4695-b86d-8c2a8abdb0fc"
+NEW_MS_DETERMINE_PARSE_DV = "ec3c965c-c056-47e3-a551-ad1966e00824"
+NEW_MS_PARSE_DV_METS = "fba1fd92-150a-4969-84fb-f2c6097855cf"
+
+# New Microservice Exit Codes that we want to create.
+NEW_MS_EXIT_PROCESS_DIR_TO_DV_TRANSFER_TYPE = \
+    "f7e3753c-4df9-43fe-9c32-0d11c511308c"
+NEW_MS_EXIT_SET_TTYPE_DV_TO_SET_CONV_DV = \
+    "da46e870-290b-4fd4-8f84-194b9177d8c0"
+NEW_MS_EXIT_SET_CONV_DV_TO_SET_PARSE_DV = \
+    "4ce6a3bd-026b-4ce7-beae-809844bae289"
+NEW_MS_EXIT_SET_PARSE_DV_TO_REMOVE_HIDDEN = \
+    "84647820-e56a-45cc-94a1-9f74de375ba8"
+NEW_MS_EXIT_CONV_DV_TO_RESTRUCT_COMPLIANCE = \
+    "d515821d-b1f6-4ce9-b4e4-0503fa99c8cf"
+NEW_MS_EXIT_PARSE_DV_PULL_TO_CREATE_METS = \
+    "5d37e917-f77b-44fa-b103-144a38722774"
+NEW_MS_EXIT_PARSE_DV_TO_CREATE_METS = \
+    "d10e1118-4d6c-4d3c-a9a8-1307a2931a32"
+
+# New microservice chains that we're creating.
+NEW_MS_CHAIN_DV_IN_PROGRESS = "35a26b59-dcf3-45ec-b963-ba7bfaa8304f"
+NEW_MS_CHAIN_APPROVE_DV_TRANSFER = "10c00bc8-8fc2-419f-b593-cf5518695186"
+
+# New watched directories that we are creating.
+NEW_WATCHED_DIR_DATAVERSE = "3901db52-dd1d-4b44-9d86-4285ddc5c022"
+
+# Existing exit codes that we want to modify.
+EXISTING_EXIT_CODE_UNNEEDED_TO_RESTRUCTURE = \
+    "9cb81a5c-a7a1-43a8-8eb6-3e999923e03c"
+EXISTING_EXIT_CODE_VALIDATE_TO_POLICY = "434066e6-8205-4832-a71f-cc9cd8b539d2"
+
+# Existing microservices that we want to reference, but eventually don't need
+# to delete on migration down.
+EXISTING_MS_REMOVE_HIDDEN = "50b67418-cb8d-434d-acc9-4a8324e7fdd2"
+EXISTING_MS_REMOVE_UNNEEDED = "5d780c7d-39d0-4f4a-922b-9d1b0d217bca"
+EXISTING_MS_RESTRUCTURE_COMPLIANCE = "ea0e8838-ad3a-4bdd-be14-e5dba5a4ae0c"
+EXISTING_MS_VAILIDATE_FORMATS = "a536828c-be65-4088-80bd-eb511a0a063d"
+EXISTING_MS_POLICY_CHECKS = "70fc7040-d4fb-4d19-a0e6-792387ca1006"
+EXISTING_MS_CREATE_TRANSFER_METS = "db99ab43-04d7-44ab-89ec-e09d7bbdc39d"
+EXISTING_MS_EXAMINE_CONTENTS = "dae3c416-a8c2-4515-9081-6dbd7b265388"
+
+# Tasks that we want to reference, but eventually don't need to delete on
+# migration down.
+EXISTING_TASK_MOVE_TO_PROCESSING_DIR = "7c02a87b-7113-4851-97cd-2cf9d3fc0010"
+
+# Chains that we want to reference, but eventually don't need to delete on
+# migration down.
+EXISTING_CHAIN_REJECT_TRANSFER = "1b04ec43-055c-43b7-9543-bd03c6a778ba"
+
+# Watched directory type for transfers.
+EXISTING_WATCHED_DIR_TYPE_TRANSFER = "f9a3a93b-f184-4048-8072-115ffac06b5d"
+
+
+def create_variable_link_pull(
+        apps, link_uuid, variable, default_ms_uuid=None):
+    """Create a new variable link pull in the database."""
+    apps.get_model("main", model_name="TaskConfigUnitVariableLinkPull") \
+        .objects.create(
+        id=link_uuid,
+        variable=variable,
+        defaultmicroservicechainlink_id=default_ms_uuid,
+    )
+
+
+def create_set_unit_variable(
+        apps, var_uuid, variable_name, variable_value=None, ms_uuid=None):
+    """Create a new unit variable in the database."""
+    apps.get_model("main", model_name="TaskConfigSetUnitVariable") \
+        .objects.create(
+        id=var_uuid,
+        variable=variable_name,
+        variablevalue=variable_value,
+        microservicechainlink_id=ms_uuid,
+    )
+
+
+def create_standard_task_config(apps, task_uuid, execute_string, args):
+    """Create a task configuration, inc. the command and args and write to the
+    database.
+    """
+    apps.get_model("main", model_name="StandardTaskConfig").objects.create(
+        id=task_uuid, execute=execute_string, arguments=args,
+    )
+
+
+def create_task(
+        apps, task_type_uuid, task_uuid, task_desc, task_config=None):
+    """Create a new task configuration entry in the database."""
+    apps.get_model("main", model_name='TaskConfig').objects.create(
+        id=task_uuid, description=task_desc, tasktype_id=task_type_uuid,
+        tasktypepkreference=task_config,
+    )
+
+
+def create_ms_chain_link(
+        apps, ms_uuid, group, task_uuid, ms_exit_message=Job.STATUS_FAILED,
+        default_next_link=DEFAULT_NEXT_MS_TASK_FAILED):
+    """Create a microservice chainlink in the database."""
+    apps.get_model("main", model_name="MicroServiceChainLink").objects.create(
+        id=ms_uuid,
+        microservicegroup=group,
+        defaultexitmessage=ms_exit_message,
+        currenttask_id=task_uuid,
+        defaultnextchainlink_id=default_next_link,
+    )
+
+
+def create_ms_chain(apps, chain_uuid, ms_uuid, chain_description):
+    """Create a new chain in the database."""
+    apps.get_model("main", model_name="MicroServiceChain").objects.create(
+        id=chain_uuid,
+        startinglink_id=ms_uuid,
+        description=chain_description,
+    )
+
+
+def create_ms_choice(apps, choice_uuid, chain_uuid, link_uuid):
+    """Create a choice in the database."""
+    apps.get_model('main', model_name='MicroServiceChainChoice').objects.create(
+        id=choice_uuid,
+        chainavailable_id=chain_uuid,
+        choiceavailableatlink_id=link_uuid,
+    )
+
+
+def create_watched_dir(
+        apps, watched_uuid, dir_path, expected_type, chain_uuid):
+    """Create a new watched directory in the database."""
+    apps.get_model('main', model_name="WatchedDirectory").objects.create(
+        id=watched_uuid, watched_directory_path=dir_path,
+        expected_type_id=expected_type, chain_id=chain_uuid,
+    )
+
+
+def create_ms_exit_codes(
+        apps, exit_code_uuid, ms_in, ms_out,
+        ms_exit_message=Job.STATUS_COMPLETED_SUCCESSFULLY, update=False):
+    """Create an exit code entry in the database."""
+    if not update:
+        apps.get_model("main", model_name="MicroServiceChainLinkExitCode") \
+            .objects.create(
+            id=exit_code_uuid,
+            microservicechainlink_id=ms_in,
+            nextmicroservicechainlink_id=ms_out,
+            exitmessage=ms_exit_message,
+        )
+        return
+    apps.get_model("main", "MicroServiceChainLinkExitCode").objects\
+        .filter(id=exit_code_uuid)\
+        .update(nextmicroservicechainlink_id=ms_out)
+
+
+def create_parse_dataverse_mets_link_pull(apps):
+    """Enable Archivematica to detect that it needs to run the 'Parse Dataverse
+    METS' microservice given a Dataverse transfer type.
+    """
+
+    # 355c22ae (Determine Parse Dataverse METS XML) task to associate with
+    # a MicroServiceChainLink.
+    create_task(
+        apps=apps, task_type_uuid=TASK_TYPE_LINK_PULL,
+        task_uuid=NEW_LINK_PULL_PARSE_DATAVERSE_METS,
+        task_desc="Determine Parse Dataverse METS XML",
+        task_config=NEW_LINK_PULL_CONFIG_PARSE_DV,
+    )
+
+    # ec3c965c (Determine Parse Dataverse METS XML).
+    create_ms_chain_link(
+        apps=apps, ms_uuid=NEW_MS_DETERMINE_PARSE_DV,
+        group="Parse External Files",
+        task_uuid=NEW_LINK_PULL_PARSE_DATAVERSE_METS,
+        ms_exit_message=Job.STATUS_COMPLETED_SUCCESSFULLY,
+    )
+
+    # If linkToParseDataverseMETS is set then goto the configured microservice,
+    # else, goto the default microservice, 'Move to examine contents'.
+    create_variable_link_pull(
+        apps=apps, link_uuid=NEW_LINK_PULL_CONFIG_PARSE_DV,
+        variable="linkToParseDataverseMETS",
+        default_ms_uuid=EXISTING_MS_EXAMINE_CONTENTS,
+    )
+
+    # Break and Update the existing link to connect to our new link.
+    # Original: 434066e6-8205-4832-a71f-cc9cd8b539d2
+    # ms_1: a536828c-be65-4088-80bd-eb511a0a063d
+    #       (Validate Formats)
+    # ms_2: 70fc7040-d4fb-4d19-a0e6-792387ca1006
+    #       (Perform policy checks on originals?)
+    # New: 434066e6-8205-4832-a71f-cc9cd8b539d2
+    # a536828c (Validate Formats)
+    # ec3c965c (Determine Parse Dataverse METS XML)
+    create_ms_exit_codes(
+        apps=apps, exit_code_uuid=EXISTING_EXIT_CODE_VALIDATE_TO_POLICY,
+        ms_in=EXISTING_MS_VAILIDATE_FORMATS,
+        ms_out=NEW_MS_DETERMINE_PARSE_DV,
+        update=True,
+    )
+
+    # Create a new link now we have broken the original.
+    # ec3c965c (Determine Parse Dataverse METS XML)
+    # db99ab43 (Create transfer metadata XML)
+    create_ms_exit_codes(
+        apps=apps, exit_code_uuid=NEW_MS_EXIT_PARSE_DV_PULL_TO_CREATE_METS,
+        ms_in=NEW_MS_DETERMINE_PARSE_DV,
+        ms_out=EXISTING_MS_CREATE_TRANSFER_METS,
+    )
+
+
+def create_convert_dataverse_link_pull(apps):
+    """Enable Archivematica to detect that it needs to run the 'Convert
+    Dataverse Structure' microservice given a Dataverse transfer type.
+    """
+
+    # 7eade269 (Determine Dataverse Conversion) task to associate with
+    # a MicroServiceChainLink.
+    create_task(
+        apps=apps, task_type_uuid=TASK_TYPE_LINK_PULL,
+        task_uuid=NEW_LINK_PULL_CONVERT_DATAVERSE,
+        task_desc="Determine Dataverse conversion",
+        task_config=NEW_LINK_PULL_CONFIG_CONVERT_DV,
+    )
+
+    # 7eade269 (Determine Dataverse Conversion).
+    create_ms_chain_link(
+        apps=apps, ms_uuid=NEW_MS_DETERMINE_CONVERT_DV,
+        group="Verify transfer compliance",
+        task_uuid=NEW_LINK_PULL_CONVERT_DATAVERSE,
+        ms_exit_message=Job.STATUS_COMPLETED_SUCCESSFULLY,
+    )
+
+    # If linkToConvertDataverseStructure is set then goto the configured
+    # microservice, else, goto the default microservice.
+    create_variable_link_pull(
+        apps=apps, link_uuid=NEW_LINK_PULL_CONFIG_CONVERT_DV,
+        variable="linkToConvertDataverseStructure",
+        default_ms_uuid=EXISTING_MS_RESTRUCTURE_COMPLIANCE,
+    )
+
+    # Break and Update the existing link to connect to our new link.
+    # Original: 9cb81a5c-a7a1-43a8-8eb6-3e999923e03c
+    # ms_1: 5d780c7d-39d0-4f4a-922b-9d1b0d217bca
+    #       (Remove unneeded files)
+    # ms_2: ea0e8838-ad3a-4bdd-be14-e5dba5a4ae0c
+    #       (Attempt restructure for compliance)
+    # New: 9cb81a5c-a7a1-43a8-8eb6-3e999923e03c
+    # 5d780c7d (Remove Unneeded Files) connects to:
+    # 2a0a7afb (Determine Dataverse Conversion)
+    create_ms_exit_codes(
+        apps=apps, exit_code_uuid=EXISTING_EXIT_CODE_UNNEEDED_TO_RESTRUCTURE,
+        ms_in=EXISTING_MS_REMOVE_UNNEEDED,
+        ms_out=NEW_MS_DETERMINE_CONVERT_DV,
+        update=True,
+    )
+
+    # Create a new link now we have broken the original.
+    # 9ec31d55 (Convert Dataverse Structure) connects to:
+    # ea0e8838 (Attempt Restructure For Compliance)
+    create_ms_exit_codes(
+        apps=apps, exit_code_uuid=NEW_MS_EXIT_CONV_DV_TO_RESTRUCT_COMPLIANCE,
+        ms_in=NEW_MS_CONVERT_DV_STRUCTURE,
+        ms_out=EXISTING_MS_RESTRUCTURE_COMPLIANCE,
+    )
+
+
+def create_parse_dataverse_mets_microservice(apps):
+    """Create the database rows specific to the parse Dataverse METS
+    microservice.
+    """
+
+    # Pointer to the parse Dataverse client script.
+    create_standard_task_config(
+        apps=apps, task_uuid=NEW_STD_TASK_CONFIG_PARSE_DV,
+        execute_string="parseDataverse_v0.0",
+        args="%SIPDirectory% %SIPUUID%",
+    )
+
+    # e593507e (Parse Dataverse METS XML) task to be associated with a
+    # MicroServiceChainLink.
+    create_task(
+        apps=apps, task_type_uuid=TASK_TYPE_SINGLE_INSTANCE,
+        task_uuid=NEW_STD_TASK_PARSE_DATAVERSE_METS,
+        task_desc="Parse Dataverse METS XML",
+        task_config=NEW_STD_TASK_CONFIG_PARSE_DV,
+    )
+
+    # fba1fd92 (Parse Dataverse METS XML) Chainlink.
+    create_ms_chain_link(
+        apps=apps, ms_uuid=NEW_MS_PARSE_DV_METS,
+        group="Parse External Files",
+        task_uuid=NEW_STD_TASK_PARSE_DATAVERSE_METS,
+    )
+
+    # Create a new link now we have broken the original.
+    # fba1fd92 (Parse Dataverse METS XML) connects to:
+    # db99ab43 (Create transfer metadata XML)
+    create_ms_exit_codes(
+        apps=apps, exit_code_uuid=NEW_MS_EXIT_PARSE_DV_TO_CREATE_METS,
+        ms_in=NEW_MS_PARSE_DV_METS,
+        ms_out=EXISTING_MS_CREATE_TRANSFER_METS,
+    )
+
+
+def create_dataverse_unit_variables_and_initial_tasks(apps):
+    """Once the Dataverse transfer has started then the Archivematica
+    workflow needs to know how to route itself. We set two unit variables
+    here which are used later in the workflow, and we set the first Dataverse
+    specific microservice to run, 'Convert Dataverse Structure'
+    """
+
+    # Create a Task that creates a unit variable to instruct Archivematica to
+    # convert a Dataverse metadata structure to METS.
+    create_task(
+        apps=apps, task_type_uuid=TASK_TYPE_SET_UNIT_VAR,
+        task_uuid=NEW_UNIT_VAR_TASK_CONVERT_DATAVERSE,
+        task_desc="Set Convert Dataverse Structure",
+        task_config=NEW_UNIT_VAR_CONFIG_CONVERT_DV,
+    )
+
+    # Create a Task that creates a unit variable to instruct Archivematica to
+    # process an external Dataverse METS.
+    create_task(
+        apps=apps, task_type_uuid=TASK_TYPE_SET_UNIT_VAR,
+        task_uuid=NEW_UNIT_VAR_TASK_PARSE_DV_METS,
+        task_desc="Set Parse Dataverse Mets",
+        task_config=NEW_UNIT_VAR_CONFIG_PARSE_DV,
+    )
+
+    # Create a MicroServiceChainLink to point to the 'Set Dataverse Transfer'
+    # Create Unit Variable Task.
+    create_ms_chain_link(
+        apps=apps, ms_uuid=NEW_MS_SET_CONVERT_DV_UNIT_VAR,
+        group="Verify transfer compliance",
+        task_uuid=NEW_UNIT_VAR_TASK_CONVERT_DATAVERSE,
+    )
+
+    # Create a MicroServiceChainLink to point to the 'Set Parse Dataverse METS'
+    # Create Unit Variable Task.
+    create_ms_chain_link(
+        apps=apps, ms_uuid=NEW_MS_SET_PARSE_DV_UNIT_VAR,
+        group="Verify transfer compliance",
+        task_uuid=NEW_UNIT_VAR_TASK_PARSE_DV_METS,
+    )
+
+    # Create the MicroServiceChainLinks required to ask Archivematica to
+    # process a transfer as a Dataverse one.
+
+    # Pointer to the convert Dataverse structure MCP Client script.
+    create_standard_task_config(
+        apps=apps, task_uuid=NEW_STD_TASK_CONFIG_CONVERT_DV,
+        execute_string="convertDataverseStructure_v0.0",
+        args="%SIPDirectory%",
+    )
+
+    # ab6c6e52 (Convert Dataverse Structure) task to be associated with a
+    # MicroServiceChainLink.
+    create_task(
+        apps=apps, task_type_uuid=TASK_TYPE_SINGLE_INSTANCE,
+        task_uuid=NEW_STD_TASK_CONVERT_DATAVERSE,
+        task_desc="Convert Dataverse Structure",
+        task_config=NEW_STD_TASK_CONFIG_CONVERT_DV,
+    )
+
+    # ab6c6e52 (Convert Dataverse Structure) Chainlink.
+    create_ms_chain_link(
+        apps=apps, ms_uuid=NEW_MS_CONVERT_DV_STRUCTURE,
+        group="Verify transfer compliance",
+        task_uuid=NEW_STD_TASK_CONVERT_DATAVERSE,
+    )
+
+    # Create a set of unit variables to enable Archivematica to see this as a
+    # Dataverse transfer and process the contents downloaded via the Storage
+    # Service appropriately.
+    create_set_unit_variable(
+        apps=apps, var_uuid=NEW_UNIT_VAR_CONFIG_CONVERT_DV,
+        variable_name="linkToConvertDataverseStructure",
+        ms_uuid=NEW_MS_CONVERT_DV_STRUCTURE,
+    )
+
+    # Create a unit variable to determine that the external METS file created
+    # for Dataverse will be parsed later on in the process by Archivematica.
+    create_set_unit_variable(
+        apps=apps, var_uuid=NEW_UNIT_VAR_CONFIG_PARSE_DV,
+        variable_name="linkToParseDataverseMETS",
+        ms_uuid=NEW_MS_PARSE_DV_METS,
+    )
+
+    # Break and Update the existing link to connect to our new link.
+    # 0af6b163 (Set Transfer Type: Dataverse) connects to:
+    # 213fe743 (Set Convert Dataverse Structure (Unit Variable))
+    create_ms_exit_codes(
+        apps=apps, exit_code_uuid=NEW_MS_EXIT_SET_TTYPE_DV_TO_SET_CONV_DV,
+        ms_in=NEW_MS_SET_DV_TRANSFER_TYPE,
+        ms_out=NEW_MS_SET_CONVERT_DV_UNIT_VAR,
+        update=True,
+    )
+
+    # Create a new link now we have broken the original.
+    # 213fe743 (Set Convert Dataverse Structure) connects to:
+    # 364ac694 (Set Parse Dataverse METS (Unit Variable))
+    create_ms_exit_codes(
+        apps=apps, exit_code_uuid=NEW_MS_EXIT_SET_CONV_DV_TO_SET_PARSE_DV,
+        ms_in=NEW_MS_SET_CONVERT_DV_UNIT_VAR,
+        ms_out=NEW_MS_SET_PARSE_DV_UNIT_VAR,
+    )
+
+    # Create a new link now we have broken the original.
+    # 364ac694 (Set Parse Dataverse (Unit Variable)) connects to:
+    # 50b67418 (Remove hidden files and directories).
+    create_ms_exit_codes(
+        apps=apps, exit_code_uuid=NEW_MS_EXIT_SET_PARSE_DV_TO_REMOVE_HIDDEN,
+        ms_in=NEW_MS_SET_PARSE_DV_UNIT_VAR,
+        ms_out=EXISTING_MS_REMOVE_HIDDEN,
+    )
+
+
+def create_dataverse_transfer_type(apps):
+    """Create the database rows required to create a new transfer type in
+    Archivematica.
+    """
+
+    # Configuration of transfer initiation tasks.
+    create_standard_task_config(
+        apps=apps, task_uuid=NEW_STD_TASK_CONFIG_SET_DV_TRANSFER,
+        execute_string="archivematicaSetTransferType_v0.0",
+        args="\"%SIPUUID%\" \"Dataverse\"",
+    )
+
+    # Create tasks related to the initiation of a new Dataverse transfer.
+    create_task(
+        apps=apps, task_type_uuid=TASK_TYPE_USER_CHOICE,
+        task_uuid=NEW_CHOICE_TASK_APPROVE_DV_TRANSFER,
+        task_desc="Approve Dataverse Transfer",
+    )
+    create_task(
+        apps=apps, task_type_uuid=TASK_TYPE_SINGLE_INSTANCE,
+        task_uuid=NEW_STD_TASK_SET_TRANSFER_TYPE_DV,
+        task_desc="Set transfer type: Dataverse",
+        task_config=NEW_STD_TASK_CONFIG_SET_DV_TRANSFER,
+    )
+
+    # 246943e4 (Approve Dataverse transfer)
+    create_ms_chain_link(
+        apps=apps, ms_uuid=NEW_MS_APPROVE_DV_TRANSFER,
+        group="Approve Dataverse transfer",
+        task_uuid=NEW_CHOICE_TASK_APPROVE_DV_TRANSFER,
+    )
+
+    # fdb12ea6 (Move to processing directory)
+    create_ms_chain_link(
+        apps=apps, ms_uuid=NEW_MS_MOVE_TO_PROCESSING_DIR,
+        group="Verify transfer compliance",
+        task_uuid=EXISTING_TASK_MOVE_TO_PROCESSING_DIR,
+    )
+
+    # 0af6b163 (Set transfer type: Dataverse)
+    create_ms_chain_link(
+        apps=apps, ms_uuid=NEW_MS_SET_DV_TRANSFER_TYPE,
+        group="Verify transfer compliance",
+        task_uuid=NEW_STD_TASK_SET_TRANSFER_TYPE_DV,
+    )
+
+    # Create chains for the initiation of Dataverse transfers.
+    create_ms_chain(
+        apps=apps, chain_uuid=NEW_MS_CHAIN_DV_IN_PROGRESS,
+        ms_uuid=NEW_MS_APPROVE_DV_TRANSFER,
+        chain_description="Dataverse Transfers in Progress",
+    )
+    create_ms_chain(
+        apps=apps, chain_uuid=NEW_MS_CHAIN_APPROVE_DV_TRANSFER,
+        ms_uuid=NEW_MS_MOVE_TO_PROCESSING_DIR,
+        chain_description="Approve Dataverse transfer",
+    )
+
+    # Approve Dataverse transfer
+    create_ms_choice(
+        apps=apps, choice_uuid=NEW_CHAIN_CHOICE_APPROVE_DV_TRANSFER,
+        chain_uuid=NEW_MS_CHAIN_APPROVE_DV_TRANSFER,
+        link_uuid=NEW_MS_APPROVE_DV_TRANSFER,
+    )
+
+    # Reject Dataverse transfer
+    create_ms_choice(
+        apps=apps, choice_uuid=NEW_CHAIN_CHOICE_REJECT_DV_TRANSFER,
+        chain_uuid=EXISTING_CHAIN_REJECT_TRANSFER,
+        link_uuid=NEW_MS_APPROVE_DV_TRANSFER,
+    )
+
+    # Create a watched directory which will be where transfers can be
+    # initiated.
+    create_watched_dir(
+        apps=apps, watched_uuid=NEW_WATCHED_DIR_DATAVERSE,
+        dir_path="%watchDirectoryPath%activeTransfers/dataverseTransfer",
+        expected_type=EXISTING_WATCHED_DIR_TYPE_TRANSFER,
+        chain_uuid=NEW_MS_CHAIN_DV_IN_PROGRESS,
+    )
+
+    # Create a new link now we have broken the original.
+    # fdb12ea6 (Move to processing directory) connects to:
+    # 0af6b163 (Set transfer type: Dataverse)
+    create_ms_exit_codes(
+        apps=apps, exit_code_uuid=NEW_MS_EXIT_PROCESS_DIR_TO_DV_TRANSFER_TYPE,
+        ms_in=NEW_MS_MOVE_TO_PROCESSING_DIR,
+        ms_out=NEW_MS_SET_DV_TRANSFER_TYPE,
+    )
+
+    # Create a new link now we have broken the original.
+    # 0af6b163 (Set transfer type: Dataverse) connects to:
+    # 50b67418 (Remove hidden files and directories)
+    create_ms_exit_codes(
+        apps=apps, exit_code_uuid=NEW_MS_EXIT_SET_TTYPE_DV_TO_SET_CONV_DV,
+        ms_in=NEW_MS_SET_DV_TRANSFER_TYPE,
+        ms_out=EXISTING_MS_REMOVE_HIDDEN,
+    )
+
+
+def data_migration_up(apps, schema_editor):
+    """Run the various groupings of migration functions for the Dataverse
+    specific transfer type.
+    """
+    create_dataverse_transfer_type(apps)
+    create_parse_dataverse_mets_microservice(apps)
+    create_dataverse_unit_variables_and_initial_tasks(apps)
+    create_convert_dataverse_link_pull(apps)
+    create_parse_dataverse_mets_link_pull(apps)
+
+
+def data_migration_down(apps, schema_editor):
+    """Reverse the changes made to the database in order to create a Dataverse
+    transfer type.
+    """
+
+    # Fix the originally broken chain links:
+    # Original: 9cb81a5c-a7a1-43a8-8eb6-3e999923e03c
+    # ms_1: 5d780c7d-39d0-4f4a-922b-9d1b0d217bca
+    #       (Remove unneeded files)
+    # ms_2: ea0e8838-ad3a-4bdd-be14-e5dba5a4ae0c
+    #       (Attempt restructure for compliance)
+    create_ms_exit_codes(
+        apps=apps, exit_code_uuid=EXISTING_EXIT_CODE_UNNEEDED_TO_RESTRUCTURE,
+        ms_in=EXISTING_MS_REMOVE_UNNEEDED,
+        ms_out=EXISTING_MS_RESTRUCTURE_COMPLIANCE,
+        update=True,
+    )
+
+    # Original: 434066e6-8205-4832-a71f-cc9cd8b539d2
+    # ms_1: a536828c-be65-4088-80bd-eb511a0a063d
+    #       (Validate Formats)
+    # ms_2: 70fc7040-d4fb-4d19-a0e6-792387ca1006
+    #       (Perform policy checks on originals?)
+    create_ms_exit_codes(
+        apps=apps, exit_code_uuid=EXISTING_EXIT_CODE_VALIDATE_TO_POLICY,
+        ms_in=EXISTING_MS_VAILIDATE_FORMATS,
+        ms_out=EXISTING_MS_POLICY_CHECKS,
+        update=True,
+    )
+
+    # Once we've fixed the previous chains, we can delete the extraneous pieces
+    # introduced by the attempt to create the transfer type here.
+
+    # Remove WatchedDirectories
+    apps.get_model("main", model_name="WatchedDirectory").objects.filter(
+        id=NEW_WATCHED_DIR_DATAVERSE).delete()
+
+    # Remove MicroServiceChains
+    for uuid_ in [NEW_MS_CHAIN_APPROVE_DV_TRANSFER,
+                  NEW_MS_CHAIN_DV_IN_PROGRESS]:
+        apps.get_model("main", model_name='MicroServiceChain') \
+            .objects.filter(
+            id=uuid_).delete()
+
+    # Remove MicroServiceExitCodes
+    for uuid_ in [NEW_MS_EXIT_SET_TTYPE_DV_TO_SET_CONV_DV,
+                  NEW_MS_EXIT_SET_CONV_DV_TO_SET_PARSE_DV,
+                  NEW_MS_EXIT_SET_PARSE_DV_TO_REMOVE_HIDDEN,
+                  NEW_MS_EXIT_CONV_DV_TO_RESTRUCT_COMPLIANCE,
+                  NEW_MS_EXIT_PROCESS_DIR_TO_DV_TRANSFER_TYPE,
+                  NEW_MS_EXIT_PARSE_DV_TO_CREATE_METS,
+                  NEW_MS_EXIT_PARSE_DV_PULL_TO_CREATE_METS,
+                  ]:
+        apps.get_model("main", model_name="MicroServiceChainLinkExitCode") \
+            .objects.filter(id=uuid_).delete()
+
+    # Remove MicroServiceChainLinks
+    for uuid_ in [NEW_MS_APPROVE_DV_TRANSFER,
+                  NEW_MS_SET_DV_TRANSFER_TYPE,
+                  NEW_MS_MOVE_TO_PROCESSING_DIR,
+                  NEW_MS_SET_CONVERT_DV_UNIT_VAR,
+                  NEW_MS_SET_PARSE_DV_UNIT_VAR,
+                  NEW_MS_DETERMINE_CONVERT_DV,
+                  NEW_MS_CONVERT_DV_STRUCTURE,
+                  NEW_MS_DETERMINE_PARSE_DV,
+                  NEW_MS_PARSE_DV_METS,
+                  ]:
+        apps.get_model("main", model_name='MicroServiceChainLink').objects.filter(
+            id=uuid_).delete()
+
+    # Remove MicroServiceChain Choices
+    for uuid_ in [NEW_CHAIN_CHOICE_APPROVE_DV_TRANSFER,
+                  NEW_CHAIN_CHOICE_REJECT_DV_TRANSFER,
+                  ]:
+        apps.get_model("main", model_name='MicroServiceChainChoice').objects.filter(
+            id=uuid_).delete()
+
+    # Remove Standard Task Configurations
+    for uuid_ in [NEW_STD_TASK_CONFIG_SET_DV_TRANSFER,
+                  NEW_STD_TASK_CONFIG_CONVERT_DV,
+                  NEW_STD_TASK_CONFIG_PARSE_DV,
+                  ]:
+        apps.get_model("main", model_name="StandardTaskConfig") \
+            .objects.filter(id=uuid_).delete()
+
+    # Remove Task Configurations
+    for uuid_ in [NEW_UNIT_VAR_TASK_CONVERT_DATAVERSE,
+                  NEW_UNIT_VAR_TASK_PARSE_DV_METS,
+                  NEW_STD_TASK_CONVERT_DATAVERSE,
+                  NEW_LINK_PULL_CONVERT_DATAVERSE,
+                  NEW_CHOICE_TASK_APPROVE_DV_TRANSFER,
+                  NEW_STD_TASK_SET_TRANSFER_TYPE_DV,
+                  NEW_STD_TASK_PARSE_DATAVERSE_METS,
+                  NEW_LINK_PULL_PARSE_DATAVERSE_METS,
+                  ]:
+        apps.get_model("main", model_name='TaskConfig').objects.filter(
+            id=uuid_).delete()
+
+    # Remove Set Unit Variables
+    for uuid_ in [NEW_UNIT_VAR_CONFIG_CONVERT_DV,
+                  NEW_UNIT_VAR_CONFIG_PARSE_DV,
+                  ]:
+        apps.get_model("main", model_name='TaskConfigSetUnitVariable') \
+            .objects.filter(id=uuid_).delete()
+
+    # Remove Variable Link Pulls
+    for uuid_ in [NEW_LINK_PULL_CONFIG_CONVERT_DV,
+                  NEW_LINK_PULL_CONFIG_PARSE_DV,
+                  ]:
+        apps.get_model("main", model_name='TaskConfigUnitVariableLinkPull') \
+            .objects.filter(id=uuid_).delete()
+
+
+class Migration(migrations.Migration):
+    """Run the migration to create a Dataverse Transfer Type."""
+    dependencies = [
+        ('main', '0060_delete_orphan_mscl'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration_up, data_migration_down),
+    ]


### PR DESCRIPTION
This work introduces a new transfer type for Dataverse, https://dataverse.org/ datasets.

The migration also introduces two new microservices:

* Convert Dataverse Structure
* Parse Dataverse METS

In order to do that, the transfer workflow requires two signals in the form of unit variables to read from when the new microservice tasks need to be performed.

Once the tasks have completed, the workflow is picked up from where it would normally for a standard transfer type.

The migration has a down migration component which does seem to function as anticipated but the code-reviewer may want to test that out as well. 

Further elements you will see in the PR as you look through the commits are the introduction of unit tests for `convert_dataverse_structure.py`. The tests have been introduced to enable refactor of that script over time. It seemed to conform least to AM coding guidelines having been ported from the automation tools. The other script changes have been made as minimal as possible and it is hoped any issues in these scripts can be ironed out over time. 

Comments have been left in code where compromises have been made around scope given the time we have on this work left. 

This work requires storage service `qa/0.x` and (I believe) eventually `stable/0.13` to function. 

Resolves #1147 
Resolves #1163 
Resolves #1149 
Resolves #1121 
Resolves #1119 
Resolves #1148 
Resolves archivematica/issues#59
Resolves archivematica/issues#152
Resolves archivematica/issues#187

Connected to #1147  
Connected to archivematica/issues#104 (Creates a Convert Dataverse Structure set of tests)
Connected to archivematica/issues#57 (Add logging to Dataverse scripts)
Connected to archivematica/issues#131 (AIP Validation)

Replaces https://github.com/artefactual/archivematica/pull/1218.