### PR TITLE
Enable removal of duplicate files from uploadDIP watched directory

### DIFF
--- a/src/MCPClient/lib/clientScripts/storeAIP.py
+++ b/src/MCPClient/lib/clientScripts/storeAIP.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 from annoying.functions import get_object_or_None
 import argparse
 import os
+import shutil
 import sys
 from uuid import uuid4
 
@@ -55,6 +56,21 @@ def get_upload_dip_path(aip_path):
         else:
             new_aip_path.append(part)
     return os.path.sep + os.path.join(*new_aip_path)
+
+
+def rmtree_upload_dip_transitory_loc(package_type, unit_path):
+    """If a DIP has been stored but still exists in the DIP Upload watched
+    directory then it needs to be deleted.
+    """
+    if package_type != "DIP":
+        return
+    unit_path = get_upload_dip_path(unit_path)
+    LOGGER.info(
+        "DIP stored. Removing duplicates in watched directory: %s", unit_path)
+    try:
+        shutil.rmtree(unit_path)
+    except OSError as e:
+        LOGGER.error("Directory removal failed with: %s", e)
 
 
 class StorageServiceCreateFileError(Exception):
@@ -197,6 +213,11 @@ def store_aip(aip_destination_uri, aip_path, sip_uuid, sip_name, sip_type):
     message = "Storage service created {}: {}".format(sip_type, new_file)
     LOGGER.info(message)
     print(message)
+
+    # Once the DIP is stored, remove it from the uploadDIP watched directory as
+    # it will no longer need to be referenced from there by the user or the
+    # system.
+    rmtree_upload_dip_transitory_loc(package_type, aip_path)
     return 0
 
     # FIXME this should be moved to the storage service and areas that rely


### PR DESCRIPTION
This commit clears the uploadDIP watched directory once a DIP has
been pushed to the Storage Service.

* Resolves archivematica/issues#112
* Connected to archivematica/Issues#112

This PR needs to be tested with two-scenarios (this text needs to be copied into the issues as well):

1. No DIP upload but Store DIP
2. Failed DIP upload but Store DIP*

***NB.** This fix will only remove the duplicate files if it is requested that the DIP is stored. 

Output will look as follows:

**No upload DIP -> Store DIP**

![image](https://user-images.githubusercontent.com/1880412/44554124-5cdd3780-a6f5-11e8-8f00-eeb6d1c8d960.png)

**Upload DIP Failure -> Store DIP**

![image](https://user-images.githubusercontent.com/1880412/44554141-6bc3ea00-a6f5-11e8-8527-66d8ead05704.png)

Further, the tasks table in the database should show no additional entries relating to dip upload. 

* The uploadDIP directory should also be empty in both scenarios
* The uploadedDIPs directory should contain a copy of the failed upload in the failed scenario
* The storage service should have a copy of both DIPS

This PR only addresses the `stable/1.7.x` branch. A different solution might be more appropriate in `qa/1.x`.