### PR TITLE
MCPClient: Fix package extraction

### DIFF
--- a/src/MCPClient/lib/clientScripts/extract_contents.py
+++ b/src/MCPClient/lib/clientScripts/extract_contents.py
@@ -34,12 +34,7 @@ TRANSFER_DIRECTORY = "%transferDirectory%"
 
 
 def suffix_date(file_path, date):
-    if file_path_cache.get(file_path):
-        return file_path_cache[file_path]
-    else:
-        path = file_path + AM_DATE_DELIMITER + date
-        file_path_cache[file_path] = path
-        return path
+    return file_path + AM_DATE_DELIMITER + date
 
 
 def tree(root):
@@ -232,6 +227,7 @@ def main(job, transfer_uuid, sip_directory, date, task_uuid, delete=False):
                     eventType='movement',
                     eventDateTime=date,
                     eventDetail='',
+                    fileUUID=file_.uuid,
                     transferUUID=transfer_uuid,
                     eventOutcomeDetailNote=event_outcome_detail_note)
 

--- a/src/MCPClient/lib/clientScripts/extract_contents.py
+++ b/src/MCPClient/lib/clientScripts/extract_contents.py
@@ -19,7 +19,7 @@ from fileOperations import addFileToTransfer, updateSizeAndChecksum, rename
 from archivematicaFunctions import get_dir_uuids, format_subdir_path
 
 # clientScripts
-from has_packages import already_extracted
+from has_packages import already_extracted, AM_DATE_DELIMITER
 
 file_path_cache = {}
 
@@ -32,7 +32,7 @@ def temporary_directory(file_path, date):
     if file_path_cache.get(file_path):
         return file_path_cache[file_path]
     else:
-        path = file_path + '-' + date
+        path = file_path + AM_DATE_DELIMITER + date
         file_path_cache[file_path] = path
         return path
 
@@ -167,6 +167,8 @@ def main(job, transfer_uuid, sip_directory, date, task_uuid, delete=False):
         # the names we want to preserve in our PREMIS:originalLocation.
         temp_dir = temporary_directory(output_file_path, date)
         rename(output_file_path, temp_dir)
+        file_.currentlocation = temporary_directory(file_.currentlocation, date)
+        file_.save()
 
         # Create the extract packages command.
         if command.script_type == 'command' or command.script_type == 'bashScript':

--- a/src/MCPClient/lib/clientScripts/extract_contents.py
+++ b/src/MCPClient/lib/clientScripts/extract_contents.py
@@ -15,7 +15,12 @@ from main.models import Directory, FileFormatVersion, File, Transfer
 from custom_handlers import get_script_logger
 from executeOrRunSubProcess import executeOrRun
 from databaseFunctions import fileWasRemoved
-from fileOperations import addFileToTransfer, updateSizeAndChecksum, rename
+from fileOperations import (
+    addFileToTransfer,
+    updateSizeAndChecksum,
+    rename,
+    updateFileLocation,
+)
 from archivematicaFunctions import get_dir_uuids, format_subdir_path
 
 # clientScripts
@@ -28,7 +33,7 @@ logger = get_script_logger("archivematica.mcp.client.extractContents")
 TRANSFER_DIRECTORY = "%transferDirectory%"
 
 
-def temporary_directory(file_path, date):
+def suffix_date(file_path, date):
     if file_path_cache.get(file_path):
         return file_path_cache[file_path]
     else:
@@ -162,24 +167,22 @@ def main(job, transfer_uuid, sip_directory, date, task_uuid, delete=False):
         output_file_path = file_.currentlocation.replace(TRANSFER_DIRECTORY,
                                                          sip_directory)
 
-        # Temporarily rename the input package so that when we extract the
+        # Rename the input package so that when we extract the
         # contents we don't extract it to a directory that will conflict with
         # the names we want to preserve in our PREMIS:originalLocation.
-        temp_dir = temporary_directory(output_file_path, date)
-        rename(output_file_path, temp_dir)
-        file_.currentlocation = temporary_directory(file_.currentlocation, date)
-        file_.save()
+        new_package_realpath = suffix_date(output_file_path, date)
+        rename(output_file_path, new_package_realpath)
 
         # Create the extract packages command.
         if command.script_type == 'command' or command.script_type == 'bashScript':
             args = []
             command_to_execute = command.command.replace('%inputFile%',
-                                                         temp_dir)
+                                                         new_package_realpath)
             command_to_execute = command_to_execute.replace('%outputDirectory%',
                                                             output_file_path)
         else:
             command_to_execute = command.command
-            args = [temp_dir, output_file_path]
+            args = [new_package_realpath, output_file_path]
 
         # Make the command clear to users when inspecting stdin/stdout.
         logger.info("Command to execute is: %s", command_to_execute)
@@ -212,11 +215,25 @@ def main(job, transfer_uuid, sip_directory, date, task_uuid, delete=False):
                 create_extracted_dir_uuids(
                     job, transfer_mdl, output_file_path, sip_directory, file_)
 
-            # We may want to remove the original package file after extracting
-            # its contents
             if delete:
+                # Remove the original package file after extracting its contents
                 delete_and_record_package_file(
-                    job, temp_dir, file_.uuid, file_.currentlocation)
+                    job, new_package_realpath, file_.uuid, file_.currentlocation)
+            else:
+                # Or document the moving of the package file.
+                old_currentlocation = file_.currentlocation
+                new_currentlocation = suffix_date(old_currentlocation, date)
+                event_outcome_detail_note = (
+                    'moved from="{}"; moved to="{}"'.format(
+                        old_currentlocation, new_currentlocation))
+                updateFileLocation(
+                    old_currentlocation,
+                    new_currentlocation,
+                    eventType='movement',
+                    eventDateTime=date,
+                    eventDetail='',
+                    transferUUID=transfer_uuid,
+                    eventOutcomeDetailNote=event_outcome_detail_note)
 
     if extracted:
         return 0

--- a/src/MCPClient/lib/clientScripts/has_packages.py
+++ b/src/MCPClient/lib/clientScripts/has_packages.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import os
+
 import django
 django.setup()
 # dashboard
@@ -37,10 +39,11 @@ def already_extracted(f):
     # the previous "current" location of the package (as ``package_name``) by
     # removing this date suffix.
     package_name = f.currentlocation.split(AM_DATE_DELIMITER)[0]
+    package_name_w_slash = os.path.join(package_name, '')
     # Look for files in a directory that starts with ``package_name``
     files = File.objects.filter(
         transfer=f.transfer,
-        currentlocation__startswith=package_name,
+        currentlocation__startswith=package_name_w_slash,
         removedtime__isnull=True).exclude(uuid=f.uuid)
     # Check for unpacking events that reference the package
     if Event.objects.filter(


### PR DESCRIPTION
1. Sets packages' `currentlocation` value to the correct post-extraction (date-suffixed) location in the database.
2. Modifies `extract_contents.py::temporary_directory` to introduce a new delimiter (`'-AM-DATE-SFX-'`) between the package name and the date string suffix.
3. Modifies `has_packages.py::already_extracted` to strip the delimiter and date from the package path prior to searching for extracted files in the database that match that path in order to determine whether the package has already been extracted.

This was connected previously to archivematica/Issues#116, but now [PR 1275](https://github.com/artefactual/archivematica/pull/1275) should resolve that issue.


## Manual tests performed

I tested this by creating an AIP from a directory named `smallzipsanitizee/` which contained a .zip file named `small zip.zip` which, once extracted, contains `smallzip/small/small.txt`.

The resulting AIP has the following directory structure and crucially includes the renamed package file `small_zip.zip-AM-DATE-SFX-2018-08-28T16_53_09.602976_00_00`:

    tue5-5a94a630-8913-4b2b-96b6-aa3a918d6aba
    ├── bag-info.txt
    ├── bagit.txt
    ├── data
    │   ├── METS.5a94a630-8913-4b2b-96b6-aa3a918d6aba.xml
    │   ├── README.html
    │   ├── logs
    │   │   ├── fileFormatIdentification.log
    │   │   ├── filenameCleanup.log
    │   │   └── transfers
    │   │       └── tue5-f19352e5-d80d-4453-922c-1d709620a4fc
    │   │           └── logs
    │   │               ├── extractContents.log
    │   │               ├── fileFormatIdentification.log
    │   │               └── filenameCleanup.log
    │   └── objects
    │       ├── small_zip.zip
    │       │   └── smallzip
    │       │       └── small
    │       │           └── small.txt
    │       ├── small_zip.zip-AM-DATE-SFX-2018-08-28T16_53_09.602976_00_00
    │       └── submissionDocumentation
    │           └── transfer-tue5-f19352e5-d80d-4453-922c-1d709620a4fc
    │               └── METS.xml
    ├── manifest-sha256.txt
    └── tagmanifest-md5.txt

The METS file documents that package file in the physical structmap:

    <mets:structMap ID="structMap_1" LABEL="Archivematica default" TYPE="physical">
      <mets:div LABEL="tue5-5a94a630-8913-4b2b-96b6-aa3a918d6aba" TYPE="Directory" DMDID="dmdSec_1">
        <mets:div LABEL="objects" TYPE="Directory">
          <mets:div LABEL="small_zip.zip" TYPE="Directory">
            <mets:div LABEL="smallzip" TYPE="Directory">
              <mets:div LABEL="small" TYPE="Directory">
                <mets:div LABEL="small.txt" TYPE="Item">
                  <mets:fptr FILEID="file-2e823d72-b7ad-48bc-96a5-8a6bb26b67fd"/>
                </mets:div>
              </mets:div>
            </mets:div>
          </mets:div>
          <mets:div LABEL="small_zip.zip-AM-DATE-SFX-2018-08-28T16_53_09.602976_00_00" TYPE="Item">
            <mets:fptr FILEID="file-0d846675-bf86-46fb-a245-bb027bd4c4cc"/>
          </mets:div>
          <mets:div LABEL="submissionDocumentation" TYPE="Directory">
            <mets:div LABEL="transfer-tue5-f19352e5-d80d-4453-922c-1d709620a4fc" TYPE="Directory">
              <mets:div LABEL="METS.xml" TYPE="Item">
                <mets:fptr FILEID="file-c83d93b9-bdbb-4405-b2fb-a1a5ddc78d90"/>
              </mets:div>
            </mets:div>
          </mets:div>
        </mets:div>
      </mets:div>
    </mets:structMap>

And the corresponding `<mets:amdSec>` documents the original name correctly:

    <premis:originalName>%transferDirectory%objects/small zip.zip</premis:originalName>