### PR TITLE
Add tests to MCPServer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_script:
 
 script: tox
 
+install: true
+
 notifications:
   email: false
 
@@ -17,11 +19,23 @@ matrix:
   fast_finish: true
   include:
 
+    # Dashboard
+
     - python: "2.7"
       env: TOXENV=py27
 
     - python: "3.6"
       env: TOXENV=py36
+
+    # MCPServer
+
+    - python: "2.7"
+      env: TOXENV=mcpserver
+
+    - python: "3.6"
+      env: TOXENV=mcpserver
+
+    # Linters
 
     - python: "2.7"
       env: TOXENV=py27-flake8
@@ -33,3 +47,6 @@ matrix:
 
     - python: "3.6"
       env: TOXENV=py36
+
+    - python: "3.6"
+      env: TOXENV=mcpserver

--- a/src/MCPServer/lib/executor.py
+++ b/src/MCPServer/lib/executor.py
@@ -1,0 +1,35 @@
+"""Application thread pool used for local concurrency."""
+
+from multiprocessing.pool import ThreadPool
+
+from django.conf import settings as django_settings
+
+
+class Executor(object):
+    _instance = None
+
+    @staticmethod
+    def init():
+        """Initialize Executor."""
+        Executor._instance = Executor()
+
+    def __init__(self):
+        self.pool = ThreadPool(django_settings.LIMIT_TASK_THREADS)
+
+    @staticmethod
+    def apply(func, args=(), kwds={}):
+        """Run callable and block until it returns.
+
+        Equivalent of `func(*args, **kwds)`.
+        Pool must be running.
+        """
+        return Executor._instance.pool.apply(func, args, kwds)
+
+    @staticmethod
+    def apply_async(func, args=(), kwds={}, callback=None):
+        """Asynchronous version of `apply()` method.
+
+        It returns an instance of `ApplyResult`.
+        """
+        return Executor._instance.pool.apply_async(
+            func, args, kwds, callback)

--- a/src/MCPServer/lib/linkTaskManagerFiles.py
+++ b/src/MCPServer/lib/linkTaskManagerFiles.py
@@ -49,6 +49,9 @@ class linkTaskManagerFiles(LinkTaskManager):
     def __init__(self, jobChainLink, pk, unit):
         super(linkTaskManagerFiles, self).__init__(jobChainLink, pk, unit)
 
+        if jobChainLink.reloadFileList:
+            unit.reloadFileList()
+
         # The list of task groups we'll be executing for this batch of files
         self.taskGroupsLock = threading.Lock()
         self.taskGroups = {}

--- a/src/MCPServer/lib/package.py
+++ b/src/MCPServer/lib/package.py
@@ -26,9 +26,9 @@ from uuid import uuid4
 
 from django.conf import settings as django_settings
 
-from archivematicaMCP import taskThreadPool
 from archivematicaFunctions import unicodeToStr
 from databaseFunctions import auto_close_db
+from executor import Executor
 from jobChain import jobChain
 from main.models import Transfer, TransferMetadataSet
 import storageService as storage_service
@@ -311,7 +311,7 @@ def create_package(name, type_, accession, access_system_id, path,
             os.chmod(tmpdir, 0o770)  # Needs to be writeable by the SS.
 
     getattr(
-        taskThreadPool,
+        Executor,
         'apply' if wait_until_complete else 'apply_async',
     )(_start, (transfer, name, type_, path))
 

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -125,6 +125,16 @@ DATABASES = {
     }
 }
 
+# These are all the apps that we need so we can use the models in the
+# Dashboard.
+INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'main',
+    'components.administration',
+    'fpr',
+)
+
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = config.get(
     'secret_key', default='e7b-$#-3fgu)j1k01)3tp@^e0=yv1hlcc4k-b6*ap^zezv2$48')

--- a/src/MCPServer/lib/settings/test.py
+++ b/src/MCPServer/lib/settings/test.py
@@ -1,0 +1,37 @@
+# flake8: noqa
+
+# This file is part of Archivematica.
+#
+# Copyright 2010-2018 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test settings and globals."""
+
+from __future__ import absolute_import
+
+from .common import *
+
+
+# IN-MEMORY TEST DATABASE
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+    },
+}

--- a/src/MCPServer/lib/taskGroupRunner.py
+++ b/src/MCPServer/lib/taskGroupRunner.py
@@ -77,12 +77,8 @@ class TaskGroupRunner():
     TaskGroupJob = collections.namedtuple('Job', ['task_group', 'finished_callback'])
 
     @staticmethod
-    def _init():
-        """
-        Create a singleton instance of our TaskGroupRunner and start its poll
-        thread.
-        """
-
+    def init():
+        """Initialize TaskGroupRunner and start its poll thread."""
         TaskGroupRunner._instance = TaskGroupRunner()
         TaskGroupRunner._instance._start_polling()
 
@@ -309,6 +305,3 @@ class TaskGroupRunner():
             LOGGER.error(msg)
             for task in task_group.tasks():
                 task.results['exitCode'] = 1
-
-
-TaskGroupRunner._init()

--- a/src/MCPServer/tests/test_package.py
+++ b/src/MCPServer/tests/test_package.py
@@ -1,0 +1,39 @@
+import pytest
+
+from package import _determine_transfer_paths
+
+
+@pytest.mark.parametrize("name,path,tmpdir,expected", [
+    (
+        "TransferName",
+        "a00a29b6-7530-4f09-b3df-fd88d9e478b1:home/username/archive.zip",
+        "/tmp/tmp.WXA9V7LCy1",
+        (
+            # copy_to
+            "/tmp/tmp.WXA9V7LCy1",
+            # final_location
+            "/tmp/tmp.WXA9V7LCy1/archive.zip",
+            # copy_from
+            "a00a29b6-7530-4f09-b3df-fd88d9e478b1:home/username/archive.zip",
+        ),
+    ),
+    (
+        "TransferName",
+        "a00a29b6-7530-4f09-b3df-fd88d9e478b2:home/username/dir",
+        "/tmp/tmp.WXA9V7LCy2",
+        (
+            # copy_to
+            "/tmp/tmp.WXA9V7LCy2/TransferName",
+            # final_location
+            "/tmp/tmp.WXA9V7LCy2/TransferName",
+            # copy_from
+            "a00a29b6-7530-4f09-b3df-fd88d9e478b2:home/username/dir/.",
+        ),
+    )
+])
+@pytest.mark.django_db
+def test__determine_transfer_paths(name, path, tmpdir, expected):
+    results = _determine_transfer_paths(name, path, tmpdir)
+    assert results[0] == expected[0], "name mismatch"
+    assert results[1] == expected[1], "path mismatch"
+    assert results[2] == expected[2], "tmpdir mismatch"

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,29 @@
 [tox]
 skipsdist = True
 minversion = 2.7.0
-envlist = {py27,py36}{,-flake8}
+envlist = {py27,py36}{,-flake8}, mcpserver
 
 [testenv]
 skip_install = True
 setenv =
+    DJANGO_SETTINGS_MODULE = settings.test
     PYTHONPATH = src/archivematicaCommon/lib:src/dashboard/src
 commands =
     pip install -q -r src/archivematicaCommon/requirements/test.txt
     pip install -q -r src/MCPClient/requirements/test.txt
     pip install -q -r src/dashboard/src/requirements/test.txt
-    py.test {posargs}
+    py.test --ignore=src/MCPServer {posargs}
+
+[testenv:mcpserver]
+skip_install = True
+setenv =
+    DJANGO_SETTINGS_MODULE = settings.test
+    PYTHONPATH = src/archivematicaCommon/lib:src/MCPServer/lib:src/dashboard/src
+commands =
+    pip install -q -r src/archivematicaCommon/requirements/test.txt
+    pip install -q -r src/dashboard/src/requirements/test.txt
+    pip install -q -r src/MCPServer/requirements/test.txt
+    py.test --ignore=src/dashboard/tests --ignore=src/MCPClient/tests --ignore=src/archivematicaCommon/tests {posargs}
 
 [testenv:py27-flake8]
 basepython = python2.7


### PR DESCRIPTION
This pull request makes changes to our code so it's possible to add tests to MCPServer. It also updates the configuration of Travis CI and tox so the tests are executed. I've added a simple test to prove that it's working. For our Compose users, `make test-mcp-server` can now be used. Also, for faster runs:

    docker-compose run \
        --no-deps --workdir /src/MCPServer --rm \
        --user=root --entrypoint=py.test \
            archivematica-mcp-server --reuse-db -vv

If `pytest-cov` is installed (it is in the MCPServer container as a side effect of installing the requirements of the Dashboard) you can also add flags like `--cov=/src/MCPServer/lib` or even `--cov-report html:cov_html`.

This is connected to https://github.com/archivematica/Issues/issues/88.