### PR TITLE
osdeps: use 1.7.x repository for bionic

### DIFF
--- a/src/MCPClient/osdeps/Ubuntu-18.json
+++ b/src/MCPClient/osdeps/Ubuntu-18.json
@@ -11,7 +11,7 @@
   ],
   "osdeps_repos": [
     "deb [arch=amd64] http://packages.archivematica.org/1.7.x/ubuntu-externals xenial main",
-    "deb [arch=amd64] http://packages.archivematica.org/1.8.x/ubuntu-externals bionic main",
+    "deb [arch=amd64] http://packages.archivematica.org/1.7.x/ubuntu-externals bionic main",
     "deb http://archive.ubuntu.com/ubuntu/ bionic multiverse",
     "deb http://archive.ubuntu.com/ubuntu/ bionic-security universe",
     "deb http://archive.ubuntu.com/ubuntu/ bionic-updates multiverse"


### PR DESCRIPTION
The repository for 1.8.x shouldn't be use in 1.7.2.

This connects to archivematica/Issues#119.