### PR TITLE
MCPClient: force inline execution of validate_file

### DIFF
--- a/src/MCPClient/lib/clientScripts/validate_file.py
+++ b/src/MCPClient/lib/clientScripts/validate_file.py
@@ -5,13 +5,17 @@ db, and/or write command-specific stdout to disk.
 
 If a format has no defined validation commands, no command is run.
 
+`concurrent_instances` is intentionally unused in order to mitigate a problem
+where MediaConch (one of the default validation tools) may block forever if
+there are more than one instance running in the same machine. See
+https://github.com/archivematica/Issues/issues/44 for more details.
+
 Arguments:
     [FILE_PATH] [FILE_UUID] [SIP_UUID] [SHARED_PATH] [FILE_TYPE]
 
 """
 
 import ast
-import multiprocessing
 import os
 from pprint import pformat
 import sys
@@ -29,10 +33,6 @@ from dicts import replace_string_values
 
 from django.conf import settings as mcpclient_settings
 from lib import setup_dicts
-
-
-def concurrent_instances():
-    return multiprocessing.cpu_count()
 
 
 SUCCESS_CODE = 0


### PR DESCRIPTION
This commit ensures that we only have one instance of MediaConch at a
time to avoid the problem described in the issue linked below. This is
achieved by removing the `concurrent_instances` attribute from the
client script which forces the code in it to be executed inline by
MCPClient.

A consistent way to reproduce the issue I found it was to start 10 transfers from `SampleTransfers/Multimedia` at once. E.g. using  (`transfer.sh`), in bash:

```
curl https://gist.githubusercontent.com/sevein/917d4401fff45d32c48345bcc9b19b5f/raw/a033c43a1be9e3dbcb497497001a992382b25ef4/create-transfer.sh -O ~/transfer.sh
chmod +x ~/transfer.sh
for i in {0..9}; do ~/transfer.sh; done
```

Connects to https://github.com/archivematica/Issues/issues/44.