### PR TITLE
Docker: update MCPClient to bionic

### DIFF
--- a/src/MCPClient-base.Dockerfile
+++ b/src/MCPClient-base.Dockerfile
@@ -1,4 +1,20 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV PYTHONUNBUFFERED 1
+
+RUN set -ex \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		apt-transport-https \
+		curl \
+		git \
+		gpg-agent \
+		locales \
+		software-properties-common \
+		libldap2-dev \
+		libsasl2-dev \
+	&& rm -rf /var/lib/apt/lists/*
 
 # Set the locale
 RUN locale-gen en_US.UTF-8
@@ -6,92 +22,66 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV PYTHONUNBUFFERED 1
-
-RUN set -ex \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-    apt-transport-https \
-    curl \
-    git \
-    python-software-properties \
-    software-properties-common \
-    libldap2-dev \
-    libsasl2-dev \
-  && rm -rf /var/lib/apt/lists/*
-
 # OS dependencies
 RUN set -ex \
-  && curl -s https://packages.archivematica.org/GPG-KEY-archivematica | apt-key add - \
-  && add-apt-repository "deb [arch=amd64] http://packages.archivematica.org/1.7.x/ubuntu-externals trusty main" \
-  && add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty multiverse" \
-  && add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty-security universe" \
-  && add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty-updates multiverse" \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-    atool \
-    bagit \
-    bulk-extractor \
-    clamav \
-    ffmpeg \
-    ghostscript \
-    libavcodec-extra-56 \
-    fits \
-    imagemagick \
-    inkscape \
-    jhove \
-    libimage-exiftool-perl \
-    libevent-dev \
-    libjansson4 \
-    libxml2-utils \
-    md5deep \
-    mediainfo \
-    nailgun-client \
-    openjdk-7-jre-headless \
-    p7zip-full \
-    pbzip2 \
-    readpst \
-    rsync \
-    siegfried \
-    sleuthkit \
-    tesseract-ocr \
-    tree \
-    ufraw \
-    unrar-free \
-    uuid \
-  && rm -rf /var/lib/apt/lists/*
+	&& curl -s https://packages.archivematica.org/GPG-KEY-archivematica | apt-key add - \
+	&& add-apt-repository --no-update --yes "deb [arch=amd64] http://packages.archivematica.org/1.8.x/ubuntu-externals bionic main" \
+	&& add-apt-repository --no-update --yes "deb http://archive.ubuntu.com/ubuntu/ bionic multiverse" \
+	&& add-apt-repository --no-update --yes "deb http://archive.ubuntu.com/ubuntu/ bionic-security universe" \
+	&& add-apt-repository --no-update --yes "deb http://archive.ubuntu.com/ubuntu/ bionic-updates multiverse" \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		atool \
+		bagit \
+		bulk-extractor \
+		clamav \
+		ffmpeg \
+		ghostscript \
+		hashdeep \
+		libavcodec-extra \
+		fits \
+		imagemagick \
+		inkscape \
+		jhove \
+		libimage-exiftool-perl \
+		libevent-dev \
+		libjansson4 \
+		libxml2-utils \
+		mediainfo \
+		mediaconch \
+		nailgun \
+		openjdk-8-jre-headless \
+		p7zip-full \
+		pbzip2 \
+		pst-utils \
+		rsync \
+		siegfried \
+		sleuthkit \
+		tesseract-ocr \
+		tree \
+		ufraw \
+		unrar-free \
+		uuid \
+	&& rm -rf /var/lib/apt/lists/*
 
 # Download ClamAV virus signatures
 RUN freshclam --quiet
 
 # Build dependencies
 RUN set -ex \
-  && curl -s https://bootstrap.pypa.io/get-pip.py | python \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-    build-essential \
-    python-dev \
-    libmysqlclient-dev \
-    libffi-dev \
-    libyaml-dev \
-    libssl-dev \
-    libxml2-dev \
-    libxslt-dev \
-  && rm -rf /var/lib/apt/lists/*
-
-# OS dependencies from .deb files
-RUN set -ex \
-  && curl -s https://mediaarea.net/download/binary/libzen0/0.4.37/libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb --output libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb \
-  && curl -s https://mediaarea.net/download/binary/libmediainfo0/18.03/libmediainfo0_18.03-1_amd64.xUbuntu_14.04.deb --output libmediainfo0_18.03-1_amd64.xUbuntu_14.04.deb \
-  && curl -s https://mediaarea.net/download/binary/mediaconch/18.03/mediaconch_18.03-1_amd64.xUbuntu_14.04.deb --output mediaconch_18.03-1_amd64.xUbuntu_14.04.deb \
-  && dpkg -i libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb \
-  && dpkg -i libmediainfo0_18.03-1_amd64.xUbuntu_14.04.deb \
-  && dpkg -i mediaconch_18.03-1_amd64.xUbuntu_14.04.deb \
-  && rm libzen0_0.4.37-1_amd64.xUbuntu_14.04.deb \
-  && rm libmediainfo0_18.03-1_amd64.xUbuntu_14.04.deb \
-  && rm mediaconch_18.03-1_amd64.xUbuntu_14.04.deb
+	&& curl -s https://bootstrap.pypa.io/get-pip.py | python \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		build-essential \
+		python-dev \
+		libmysqlclient-dev \
+		libffi-dev \
+		libyaml-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxslt-dev \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN set -ex \
-  && groupadd --gid 333 --system archivematica \
-  && useradd -m --uid 333 --gid 333 --system archivematica
+	&& groupadd --gid 333 --system archivematica \
+	&& useradd -m --uid 333 --gid 333 --system archivematica

--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -1,4 +1,4 @@
-FROM artefactual/archivematica-mcp-client-base:20180326.01.253a998c
+FROM artefactual/archivematica-mcp-client-base:20180924.01.aa9649a1
 
 ENV DJANGO_SETTINGS_MODULE settings.common
 ENV PYTHONPATH /src/MCPClient/lib/:/src/archivematicaCommon/lib/:/src/dashboard/src/


### PR DESCRIPTION
Moving away from Ubuntu Trusty because it's not going to be supported anymore.

This is experimental, further changes may be required.

Changes:
- Install `gpg-agent` (not installed by default in `ubuntu:18.04`)
- Install `locales` (not installed by default in `ubuntu:18.04`)
- Stop installing `python-software-properties` (not needed / not available in `ubuntu:18.04`)
- Use `ubuntu-extras` from both `bionic`
- Install `openjdk-8-jre-headless` instead of `openjdk-7-jre-headless` (the latter not available in `ubuntu:18.04`)
- Install `pst-utils` instead of `readpst` (the latter not available in `ubuntu:18.04`)
- Install `mediaconch` via `packages.archivematica.org`
- Install `hashdeep` instead of dummy `md5deep`
- Install `nailgun` instead of our own now unneeded `nailgun-client`

This is connected to https://github.com/archivematica/Issues/issues/162.

**Image published:** `artefactual/archivematica-mcp-client-base-20180924.01.aa9649a1`