### PR TITLE
MCPServer: automate upload DIP config retrieval

### DIFF
--- a/src/dashboard/src/main/migrations/0062_atom_upload_exit_code.py
+++ b/src/dashboard/src/main/migrations/0062_atom_upload_exit_code.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""Migration to ensure that a job associated to the ``Choose config for AtoM
+DIP upload`` link is marked as completed successfully when the exit code is
+``0``.
+"""
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from main.models import Job
+
+
+ATOM_DIP_UPLOAD_CONFIG_EXIT_CODE_ZERO = 'c9e90d83-533f-44c3-8220-083a6eb91751'
+
+
+def data_migration_up(apps, schema_editor):
+    """Fix ``MicroServiceChainLinkExitCode.exitmessage``.
+
+    In ``Choose config for AtoM DIP upload`` the value in ``exitmessage`` is
+    a string (``Completed successfully``) instead of its corresponding Job
+    status ID (``Job.STATUS_COMPLETED_SUCCESSFULLY``).
+    """
+    MicroServiceChainLinkExitCode = apps.get_model(
+        'main', 'MicroServiceChainLinkExitCode')
+
+    MicroServiceChainLinkExitCode.objects.filter(
+        id=ATOM_DIP_UPLOAD_CONFIG_EXIT_CODE_ZERO).update(
+            exitmessage=Job.STATUS_COMPLETED_SUCCESSFULLY)
+
+
+def data_migration_down(apps, schema_editor):
+    MicroServiceChainLinkExitCode = apps.get_model(
+        'main', 'MicroServiceChainLinkExitCode')
+
+    MicroServiceChainLinkExitCode.objects.filter(
+        id=ATOM_DIP_UPLOAD_CONFIG_EXIT_CODE_ZERO).update(
+            exitmessage='Completed successfully')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0061_create_dataverse_transfer_type'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration_up, data_migration_down),
+    ]


### PR DESCRIPTION
This pull request updates the `linkTaskManagerReplacementDicFromChoice` task manager to ensure that the user is not prompted when the DIP is ready to be uploaded and the configuration needs to be retrieved from ``DashboardSetting``. We assume that there is only one configuration, MCPServer retrieves it, updates `passVar` and moves on without interrupting the user unnecessarily.

It also includes a small migration to fix the status assigned to the job responsible for retrieving the configuration for AtoM so it's not marked as "Unknown" but "Completed successfully".

This is connected to https://github.com/archivematica/Issues/issues/55.