### PR TITLE
Handle multiple occurrences of bag-info metadata elements

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -1102,21 +1102,16 @@ def create_object_metadata(struct_map, baseDirectoryPath):
         xmldata = etree.SubElement(mdwrap, ns.metsBNS + 'xmlData')
         bag_metadata = etree.SubElement(xmldata, "transfer_metadata")
         for key, value in bagdata.items():
-            if isinstance(value, (list,)):
-                for v in value:
-                    try:
-                        bag_tag = etree.SubElement(bag_metadata, key)
-                    except ValueError:
-                        print("Skipping bag key {}; not a valid XML tag name".format(key), file=sys.stderr)
-                        continue
-                    bag_tag.text = v
-            else:
+            if not isinstance(value, list):
+                value = [value]
+            for v in value:
                 try:
                     bag_tag = etree.SubElement(bag_metadata, key)
                 except ValueError:
-                    print("Skipping bag key {}; not a valid XML tag name".format(key), file=sys.stderr)
+                    print("Skipping bag key {}; not a"
+                          " valid XML tag name".format(key), file=sys.stderr)
                     continue
-                bag_tag.text = value
+                bag_tag.text = v
 
     return el
 

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -1102,12 +1102,21 @@ def create_object_metadata(struct_map, baseDirectoryPath):
         xmldata = etree.SubElement(mdwrap, ns.metsBNS + 'xmlData')
         bag_metadata = etree.SubElement(xmldata, "transfer_metadata")
         for key, value in bagdata.items():
-            try:
-                bag_tag = etree.SubElement(bag_metadata, key)
-            except ValueError:
-                print("Skipping bag key {}; not a valid XML tag name".format(key), file=sys.stderr)
-                continue
-            bag_tag.text = value
+            if isinstance(value, (list,)):
+                for v in value:
+                    try:
+                        bag_tag = etree.SubElement(bag_metadata, key)
+                    except ValueError:
+                        job.pyprint("Skipping bag key {}; not a valid XML tag name".format(key), file=sys.stderr)
+                        continue
+                    bag_tag.text = v
+            else:
+                try:
+                    bag_tag = etree.SubElement(bag_metadata, key)
+                except ValueError:
+                    job.pyprint("Skipping bag key {}; not a valid XML tag name".format(key), file=sys.stderr)
+                    continue
+                bag_tag.text = value
 
     return el
 

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETS2.py
@@ -1107,14 +1107,14 @@ def create_object_metadata(struct_map, baseDirectoryPath):
                     try:
                         bag_tag = etree.SubElement(bag_metadata, key)
                     except ValueError:
-                        job.pyprint("Skipping bag key {}; not a valid XML tag name".format(key), file=sys.stderr)
+                        print("Skipping bag key {}; not a valid XML tag name".format(key), file=sys.stderr)
                         continue
                     bag_tag.text = v
             else:
                 try:
                     bag_tag = etree.SubElement(bag_metadata, key)
                 except ValueError:
-                    job.pyprint("Skipping bag key {}; not a valid XML tag name".format(key), file=sys.stderr)
+                    print("Skipping bag key {}; not a valid XML tag name".format(key), file=sys.stderr)
                     continue
                 bag_tag.text = value
 


### PR DESCRIPTION
This adds a loop to check if the value returned from a bag-info key is a list. 

It's not a very DRY approach, but breaking that loop out into a separate function caused the Update METS.xml document microservice (in Transfer) to fail, and I couldn't get any meaningful debug messages out of Archivematica to help me figure out where things went wrong. Any advice would be more than welcome!

Connects to archivematica/Issues#173.