### PR TITLE
Include dc.json in SIP to load transfer metadata

### DIFF
--- a/src/MCPClient/lib/clientScripts/create_sip_from_transfer_objects.py
+++ b/src/MCPClient/lib/clientScripts/create_sip_from_transfer_objects.py
@@ -130,6 +130,15 @@ def call(jobs):
 
                 archivematicaFunctions.create_directories(archivematicaFunctions.MANUAL_NORMALIZATION_DIRECTORIES, basepath=tmpSIPDir)
 
+                # Copy the JSON metadata file, if present; this contains a
+                # serialized copy of DC metadata entered in the dashboard UI
+                # during the transfer.
+                src = os.path.normpath(os.path.join(
+                    objectsDirectory, "..", "metadata", "dc.json"))
+                dst = os.path.join(tmpSIPDir, "metadata", "dc.json")
+                if os.path.exists(src):
+                    shutil.copy(src, dst)
+
                 # Copy processingMCP.xml file
                 src = os.path.join(os.path.dirname(objectsDirectory[:-1]), "processingMCP.xml")
                 dst = os.path.join(tmpSIPDir, "processingMCP.xml")

--- a/src/MCPClient/lib/clientScripts/load_dublin_core.py
+++ b/src/MCPClient/lib/clientScripts/load_dublin_core.py
@@ -32,6 +32,15 @@ def main(job, sip_uuid, dc_path):
             job.pyprint("Invalid DC attribute:", key, file=sys.stderr)
 
     dc.save()
+
+    # ``dc.json`` was copied to ingest so the code above could read it, but we
+    # don't need it anymore so we're removing it.
+    try:
+        job.pyprint('Removing "dc.json":', dc_path)
+        os.remove(dc_path)
+    except Exception as err:
+        job.pyprint('Unable to remove "dc.json":', err)
+
     return 0
 
 


### PR DESCRIPTION
PR #676 stopped including the `dc.json` in the created SIP with the
unintended consequence of breaking `load_dublin_core`, i.e. DC metadata
introduced in Transfer would never make it to the METS.

This commits changes Archivematica so `dc.json` is instead removed from
`load_dublin_core` once the metadata has been populated into the
database. `copy_transfer_metadata_and_logs` is untouched - `dc.json` is
still included in the transfer metadata folder of the AIP, e.g.:

    /data/objects/metadata/transfers/Transfer1234-2d08bb8d-58ab-40f1-8d63-818ce400320d/dc.json

Connects to archivematica/Issues#140.