### PR TITLE
 Rewrite writeToFile, use logger

### DIFF
--- a/src/MCPServer/lib/archivematicaMCP.py
+++ b/src/MCPServer/lib/archivematicaMCP.py
@@ -62,7 +62,7 @@ from unitSIP import unitSIP
 from unitDIP import unitDIP
 from unitFile import unitFile
 from unitTransfer import unitTransfer
-from utils import isUUID
+from utils import valid_uuid
 import RPCServer
 
 from archivematicaFunctions import unicodeToStr
@@ -82,7 +82,7 @@ stopSignalReceived = False  # Tracks whether a sigkill has been received or not
 def fetchUUIDFromPath(path):
     # find UUID on end of SIP path
     uuidLen = -36
-    if isUUID(path[uuidLen - 1:-1]):
+    if valid_uuid(path[uuidLen - 1:-1]):
         return path[uuidLen - 1:-1]
 
 

--- a/src/MCPServer/lib/unitTransfer.py
+++ b/src/MCPServer/lib/unitTransfer.py
@@ -24,7 +24,7 @@ import lxml.etree as etree
 import uuid
 
 from unit import unit
-from utils import isUUID
+from utils import valid_uuid
 
 from main.models import Transfer
 from dicts import ReplacementDict
@@ -51,7 +51,7 @@ class unitTransfer(unit):
 
         if not UUID:
             uuidLen = -36
-            if isUUID(currentPath[uuidLen - 1:-1]):
+            if valid_uuid(currentPath[uuidLen - 1:-1]):
                 UUID = currentPath[uuidLen - 1:-1]
             else:
                 UUID = str(uuid.uuid4())

--- a/src/MCPServer/lib/utils.py
+++ b/src/MCPServer/lib/utils.py
@@ -1,4 +1,5 @@
 import logging
+from uuid import UUID
 
 LOGGER = logging.getLogger('archivematica.mcp.server')
 
@@ -18,17 +19,13 @@ def log_exceptions(fn):
     return wrapped
 
 
-def isUUID(uuid):
-    """Return boolean of whether it's string representation of a UUID v4"""
-    split = uuid.split("-")
-    if len(split) != 5 \
-            or len(split[0]) != 8 \
-            or len(split[1]) != 4 \
-            or len(split[2]) != 4 \
-            or len(split[3]) != 4 \
-            or len(split[4]) != 12:
+def valid_uuid(string):
+    """Validate that ``string`` contains a valid UUID, it returns a boolean."""
+    try:
+        ret = UUID(string, version=4)
+    except Exception:
         return False
-    return True
+    return ret.hex == string.replace('-', '')
 
 
 # Maps decision point UUIDs and decision UUIDs to their "canonical"

--- a/src/MCPServer/requirements/test.txt
+++ b/src/MCPServer/requirements/test.txt
@@ -2,5 +2,6 @@
 
 pytest>=2,<3
 pytest-django>=2,<3
+pytest-mock>=1,<2
 pytest-pythonpath
 tox

--- a/src/MCPServer/tests/test_task_group.py
+++ b/src/MCPServer/tests/test_task_group.py
@@ -1,0 +1,20 @@
+from taskGroup import TaskGroup
+
+
+def test__write_file_to_disk(mocker):
+    tg = TaskGroup(None, u"foobar")
+
+    open_ = mocker.mock_open()
+    mocker.patch("taskGroup.open", open_)
+    chmod = mocker.patch("os.chmod")
+
+    # It does nothing when the parameters are not appropiate.
+    tg._write_file_to_disk(None, None)
+    assert not open_.called
+
+    # It writes the contents and set the permissions.
+    tg._write_file_to_disk("path", "contents")
+    open_.assert_called_with("path", "a")
+    fp = open_.return_value.__enter__.return_value
+    fp.write.assert_called_with("contents")
+    chmod.assert_called_with("path", 488)

--- a/src/MCPServer/tests/test_utils.py
+++ b/src/MCPServer/tests/test_utils.py
@@ -1,0 +1,9 @@
+from utils import valid_uuid
+
+
+def test_valid_uuid():
+    # UUIDv4 is validated
+    assert valid_uuid("07dc3d44-2ea3-45f7-a069-4ba1c79fb789") is True
+    # Other versions are not accepted
+    assert valid_uuid("00000000-0000-0000-0000-000000000000") is False
+    assert valid_uuid("77b99cea-8ab4-11e8-96a8-185e0fad6335") is False

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -98,34 +98,6 @@ def addFileToSIP(filePathRelativeToSIP, fileUUID, sipUUID, taskUUID, date, sourc
                      eventOutcome="",
                      eventOutcomeDetailNote="")
 
-# Used to write to file
-# @output - the text to append to the file
-# @fileName - The name of the file to create, or append to.
-# @returns - 0 if ok, non zero if error occured.
-
-
-def writeToFile(output, fileName, writeWhite=False):
-    # print fileName
-    if not writeWhite and output.isspace():
-        return 0
-    if fileName and output:
-        # print "writing to: " + fileName
-        try:
-            f = open(fileName, 'a')
-            f.write(output.__str__())
-            f.close()
-            os.chmod(fileName, 488)
-        except OSError as ose:
-            print("output Error", ose, file=sys.stderr)
-            return -2
-        except IOError as e:
-            (errno, strerror) = e.args
-            print("I/O error({0}): {1}".format(errno, strerror))
-            return -3
-    else:
-        print("No output, or file specified")
-    return 0
-
 
 def rename(source, destination, printfn=print, should_exit=False):
     """Used to move/rename directories. This function was before used to wrap the operation with sudo."""


### PR DESCRIPTION
This commits rewrites the old `fileOperations.writeToFile` and moves it to MCPServer. It updates the implementation so it does not print to standard streams, it uses the logger instead.

The UUID validator is also updated using the `uuid` package. It's probably slower but much more reliable, not just comparing the length of the parts.

This is connected to https://github.com/archivematica/Issues/issues/176.