### PR TITLE
Fix crash when creating a SIP from a Transfer with UUIDs assigned to directories

### DIFF
--- a/src/MCPClient/lib/clientScripts/createSIPfromTransferObjects.py
+++ b/src/MCPClient/lib/clientScripts/createSIPfromTransferObjects.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
     # Create row in SIPs table if one doesn't already exist
     lookup_path = destSIPDir.replace(sharedPath, '%sharedPath%')
     try:
-        sip = SIP.objects.get(currentpath=lookup_path).uuid
+        sip = SIP.objects.get(currentpath=lookup_path)
         if diruuids:
             sip.diruuids = True
             sip.save()


### PR DESCRIPTION
Please feel free to apply this patch manually instead of merging.  I am not sure this small change merits going through the entire contribution process including the signing of a contributor's agreement.

Connects to https://github.com/archivematica/Issues/issues/192