### PR TITLE
MCPServer: use daemon thread in Gearman client loop

### DIFF
--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -25,4 +25,4 @@ COPY archivematicaCommon/lib/externals/fiwalk_plugins/ /usr/lib/archivematica/ar
 
 USER archivematica
 
-ENTRYPOINT /src/MCPClient/lib/archivematicaClient.py
+ENTRYPOINT ["/src/MCPClient/lib/archivematicaClient.py"]

--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -17,8 +17,8 @@ RUN set -ex \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Set the locale
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 COPY archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/
@@ -42,4 +42,4 @@ RUN set -ex \
 
 USER archivematica
 
-ENTRYPOINT /src/MCPServer/lib/archivematicaMCP.py
+ENTRYPOINT ["/src/MCPServer/lib/archivematicaMCP.py"]

--- a/src/MCPServer/lib/taskGroupRunner.py
+++ b/src/MCPServer/lib/taskGroupRunner.py
@@ -149,6 +149,7 @@ class TaskGroupRunner():
                     time.sleep(5)
 
         self.poll_thread = threading.Thread(target=event_loop)
+        self.poll_thread.daemon = True
         self.poll_thread.start()
 
     def _finish_task_group_job(self, task_group_job):

--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -20,9 +20,9 @@ RUN set -ex \
 		locales-all \
 	&& rm -rf /var/lib/apt/lists/*
 
-# Set the locale  
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
+# Set the locale
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 COPY archivematicaCommon/requirements/ /src/archivematicaCommon/requirements/
@@ -60,4 +60,4 @@ RUN env \
 
 EXPOSE 8000
 
-ENTRYPOINT /usr/local/bin/gunicorn --config=/etc/archivematica/dashboard.gunicorn-config.py wsgi:application
+ENTRYPOINT ["/usr/local/bin/gunicorn", "--config=/etc/archivematica/dashboard.gunicorn-config.py", "wsgi:application"]


### PR DESCRIPTION
MCPServer: use daemon thread in Gearman client loop

This one thread was preventing MCPServer to exit successfully when the
process receives the `TERM` signal. This will stop happening by
converting it into a daemon thread. We recognize that there are better ways
to exit gracefully and we're hoping to address that soon.

The entry points in the Docker images have been updated so they don't use
the shell form. This makes much easier for the developer to test signal handling.

Connects to https://github.com/archivematica/Issues/issues/182.