### PR TITLE
Adds check for removable files

### DIFF
--- a/src/MCPClient/lib/clientScripts/verify_aip.py
+++ b/src/MCPClient/lib/clientScripts/verify_aip.py
@@ -156,13 +156,14 @@ def verify_checksums(job, bag, sip_uuid):
     is_reingest = 'REIN' in SIP.objects.get(uuid=sip_uuid).sip_type
     checksum_type = get_setting(
         'checksum_type', mcpclient_settings.DEFAULT_CHECKSUM_ALGORITHM)
+    removableFiles = [e.strip() for e in mcpclient_settings.REMOVABLE_FILES.split(',')]
     try:
         manifest_path = get_manifest_path(job, bag, sip_uuid, checksum_type)
         path2checksum = parse_manifest(job, manifest_path, sip_uuid, checksum_type)
         verification_count = 0
         verification_skipped_because_reingest = 0
         for file_ in File.objects.filter(sip_id=sip_uuid):
-            if not file_.currentlocation.startswith('%SIPDirectory%objects/'):
+            if (os.path.basename(file_.originallocation) in removableFiles) or (not file_.currentlocation.startswith('%SIPDirectory%objects/')):
                 continue
             file_path = file_.currentlocation.replace('%SIPDirectory%', '', 1)
             assert_checksum_types_match(job, file_, sip_uuid, checksum_type)

--- a/src/MCPClient/lib/clientScripts/verify_and_restructure_transfer_bag.py
+++ b/src/MCPClient/lib/clientScripts/verify_and_restructure_transfer_bag.py
@@ -57,7 +57,7 @@ def restructureBagForComplianceFileUUIDsAssigned(job, unitPath, unitIdentifier, 
         else:
             if not os.path.isdir(dirPath):
                 job.pyprint("creating: ", dir)
-                os.makedirs(dirPath)
+                os.mkdir(dirPath)
     for item in os.listdir(unitPath):
         src = os.path.join(unitPath, item)
         if os.path.isfile(src):

--- a/src/MCPClient/lib/clientScripts/verify_and_restructure_transfer_bag.py
+++ b/src/MCPClient/lib/clientScripts/verify_and_restructure_transfer_bag.py
@@ -57,7 +57,7 @@ def restructureBagForComplianceFileUUIDsAssigned(job, unitPath, unitIdentifier, 
         else:
             if not os.path.isdir(dirPath):
                 job.pyprint("creating: ", dir)
-                os.mkdir(dirPath)
+                os.makedirs(dirPath)
     for item in os.listdir(unitPath):
         src = os.path.join(unitPath, item)
         if os.path.isfile(src):


### PR DESCRIPTION
Adds a check in AIP verification which skips files identified in `ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_REMOVABLEFILES`.

Fixes archivematica/Issues#214