### PR TITLE
Use os.makedirs() to create intermediate directories

### DIFF
--- a/src/MCPClient/lib/clientScripts/verify_and_restructure_transfer_bag.py
+++ b/src/MCPClient/lib/clientScripts/verify_and_restructure_transfer_bag.py
@@ -57,7 +57,7 @@ def restructureBagForComplianceFileUUIDsAssigned(job, unitPath, unitIdentifier, 
         else:
             if not os.path.isdir(dirPath):
                 job.pyprint("creating: ", dir)
-                os.mkdir(dirPath)
+                os.makedirs(dirPath)
     for item in os.listdir(unitPath):
         src = os.path.join(unitPath, item)
         if os.path.isfile(src):


### PR DESCRIPTION
Creates intermediate directories for Zipped bag transfers. Fixes archivematica/Issues#220