### PR TITLE
Allow Zipped bag transfers to be started via API call

### DIFF
--- a/src/MCPServer/lib/RPCServer.py
+++ b/src/MCPServer/lib/RPCServer.py
@@ -172,7 +172,7 @@ def approve_transfer_by_path_handler(*args, **kwargs):
         currentstep=Job.STATUS_AWAITING_DECISION
     ).first()
     if not job:
-        raise NotFoundError("There is no job awaiting for a decision.")
+        raise NotFoundError("There is no job awaiting a decision.")
     chain_id = get_approve_transfer_chain_id(transfer_type)
     try:
         choicesAvailableForUnits[job.pk].proceedWithChoice(

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -424,7 +424,10 @@ def approve_transfer(request):
     if modified_transfer_path is None:
         return _error_response("Invalid transfer type.", status_code=500)
 
-    db_transfer_path = os.path.join(modified_transfer_path, directory, "")
+    if transfer_type == 'zipped bag':
+        db_transfer_path = os.path.join(modified_transfer_path, directory)
+    else:
+        db_transfer_path = os.path.join(modified_transfer_path, directory, "")
 
     try:
         client = MCPClient()


### PR DESCRIPTION
Adds a check to see if the transfer type is a zipped bag so that the `db_transfer_path` can be correctly formed. In cases where the transfer is _not_ a directory (ie when it's a zipped bag) a trailing slash should not be appended to this path.

Connected to archivematica/Issues#221