### PR TITLE
MCPClient: stop extract_contents from renaming packages

### DIFF
--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -498,11 +498,10 @@ class Directory(models.Model):
         for dir_ in dir_paths_uuids:
             dir_path = dir_.get("currentLocation")
             dir_uuid = dir_.get("uuid")
-            orig_path = dir_.get("originalLocation")
+            orig_path = dir_.get("originalLocation", dir_path)
             paths.append(cls(**{'uuid': dir_uuid,
                                 unit_type: unit_mdl,
-                                'originallocation': dir_path if not orig_path
-                                else orig_path,
+                                'originallocation': orig_path,
                                 'currentlocation': dir_path}))
         return cls.objects.bulk_create(paths)
 


### PR DESCRIPTION
Previously, the `extract_contents` client script would rename a package, e.g., `package.zip`, by appending a timestamp, e.g., `package.zip-2018-09-28T19_12_10.754775_00_00`. The extraction target was also previously set to a new directory with the same name as the original package, e.g., `package.zip/`. 

With the current change, the original package, e.g., `package.zip`, retains its original name and the extraction target directory is given the timestamp suffix, e.g., `package.zip-2018-09-28T19_12_10.754775_00_00/`. This reverts Archivematica's behaviour to how it was prior to the merge of [PR 1178](https://github.com/artefactual/archivematica/pull/1178/).

However, this commit should also resolve #1094. That is, it should prevent the undesired normalization of `premis:originalName` values in the METS file.

Connected to archivematica/Issues#201
Connected to archivematica/Issues#116
Connected to #1094