### PR TITLE
Fix a typo in create_aic_mets.py

### DIFF
--- a/src/MCPClient/lib/clientScripts/create_aic_mets.py
+++ b/src/MCPClient/lib/clientScripts/create_aic_mets.py
@@ -161,5 +161,5 @@ def call(jobs):
         for job in jobs:
             with job.JobContext():
                 create_mets_v2.initGlobalState()
-                args = parser.parse_args(job.qrgs[1:])
+                args = parser.parse_args(job.args[1:])
                 create_aic_mets(args.aic_uuid, args.aic_dir, job)


### PR DESCRIPTION
This commit fixes a typographical error in create_aic_mets.py which
meant we were trying to access a member variable of the module's
job object that did not exist.

* Resolves archivematica/issues#35