### PR TITLE
osdeps: remove mariadb-devel

### DIFF
--- a/src/archivematicaCommon/osdeps/CentOS-7.json
+++ b/src/archivematicaCommon/osdeps/CentOS-7.json
@@ -4,7 +4,8 @@
     "(ref. http://stackoverflow.com/questions/244777/can-comments-be-used-in-json)",
     "(ref. http://stackoverflow.com/questions/2392766/multiline-strings-in-json)",
     "epel-release: required for some dependencies (TODO: specify )",
-    "gcc: required to build some pip dependencies"
+    "gcc: required to build some pip dependencies",
+    "mariadb-devel: removed due to dependency conflicts ref. https://github.com/archivematica/Issues/issues/22"
   ],
   "osdeps_repokeys": [
   ],
@@ -14,8 +15,7 @@
    { "name": "epel-release", "state": "latest"}
   ],
   "osdeps_packages_2": [
-   { "name": "gcc", "state": "latest"},
-   { "name": "mariadb-devel", "state": "latest"}
+   { "name": "gcc", "state": "latest"}
   ]
 
 }

--- a/src/archivematicaCommon/osdeps/RedHat-7.json
+++ b/src/archivematicaCommon/osdeps/RedHat-7.json
@@ -4,7 +4,8 @@
     "(ref. http://stackoverflow.com/questions/244777/can-comments-be-used-in-json)",
     "(ref. http://stackoverflow.com/questions/2392766/multiline-strings-in-json)",
     "epel-release: required for some dependencies (TODO: specify )",
-    "gcc: required to build some pip dependencies"
+    "gcc: required to build some pip dependencies",
+    "mariadb-devel: removed due to dependency conflicts ref. https://github.com/archivematica/Issues/issues/22"
   ],
   "osdeps_repokeys": [
   ],
@@ -14,8 +15,7 @@
    { "name": "epel-release", "state": "latest"}
   ],
   "osdeps_packages_2": [
-   { "name": "gcc", "state": "latest"},
-   { "name": "mariadb-devel", "state": "latest"}
+   { "name": "gcc", "state": "latest"}
   ]
 
 }


### PR DESCRIPTION
Remove mariadb-devel due to dependency conflicts when using a database
server different from MariaDB.

Connected to https://github.com/archivematica/Issues/issues/22