### PR TITLE
Processing: fix new config button

### DIFF
--- a/src/dashboard/src/components/administration/tests.py
+++ b/src/dashboard/src/components/administration/tests.py
@@ -248,3 +248,35 @@ class TestProcessingConfig(TestCase):
         self.assertEquals(
             response.content,
             '<!DOCTYPE _[<!ELEMENT _ EMPTY>]><_/>')
+
+    def test_edit_new_config(self):
+        url = reverse("components.administration.views_processing.edit")
+        response = self.client.get(url)
+
+        self.assertEquals(url, "/administration/processing/add/")
+        self.assertEquals(response.status_code, 200)
+        self.assertNotIn("name", response.context["form"].initial)
+
+    @mock.patch('components.administration.forms.'
+                'ProcessingConfigurationForm.load_config')
+    def test_edit_not_found_config(self, load_config):
+        load_config.side_effect = IOError()
+        url = reverse(
+            "components.administration.views_processing.edit",
+            args=["not_found_config"])
+        response = self.client.get(url)
+
+        self.assertEquals(url, "/administration/processing/"
+                               "edit/not_found_config/")
+        self.assertEquals(response.status_code, 404)
+        load_config.assert_called_once_with("not_found_config")
+
+    @mock.patch('components.administration.forms.'
+                'ProcessingConfigurationForm.load_config')
+    def test_edit_found_config(self, load_config):
+        response = self.client.get(reverse(
+            "components.administration.views_processing.edit",
+            args=["found_config"]))
+
+        self.assertEquals(response.status_code, 200)
+        load_config.assert_called_once_with("found_config")

--- a/src/dashboard/src/components/administration/views_processing.py
+++ b/src/dashboard/src/components/administration/views_processing.py
@@ -80,7 +80,11 @@ def edit(request, name=None):
         messages.info(request, _('Saved!'))
         return redirect('components.administration.views_processing.list')
 
-    # Process form load.
+    # New configuration.
+    if name is None:
+        return _render_form()
+
+    # Load existing configuration.
     try:
         form.load_config(name)
     except IOError:


### PR DESCRIPTION
A recent change broke the ability to add a new processing configuration because it was trying to load from disk when the name of the config was `None` which always returned a 404 as a reaction to `IOError`. In this commit, the form is rendered without initial data when `name` equals `None`.

Connects to https://github.com/archivematica/Issues/issues/242.