### PR TITLE
Dashboard: fix glitch with long names

### DIFF
--- a/src/dashboard/src/media/css/directory_picker.css
+++ b/src/dashboard/src/media/css/directory_picker.css
@@ -53,3 +53,16 @@
 .backbone-file-explorer-idle {
   background-image: none;
 }
+
+/* Layout of directory items using CSS Grid */
+
+.backbone-file-explorer-directory {
+  display: -ms-grid;
+  display: grid;
+  -ms-grid-columns: 30px 1fr;
+  grid-template-columns: 30px 1fr;
+}
+
+.backbone-file-explorer-directory > span {
+  height: 100%;
+}


### PR DESCRIPTION
The file browser wasn't handling text overflow properly - the expand
button was being shadowed by the directory name. This commit changes the
layout of directory items so it behaves as a grid where the button and
the text behave as columns within its row.

![image](https://user-images.githubusercontent.com/606459/46758165-06b25c80-cc81-11e8-9b8d-10c2cf1aab86.png)

This connects to https://github.com/archivematica/Issues/issues/53.