### PR TITLE
Prevent 500 error when called unapproved API endpoint

### DIFF
--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -444,7 +444,7 @@ def approve_transfer(request):
 def get_modified_standard_transfer_path(transfer_type=None):
     path = os.path.join(django_settings.WATCH_DIRECTORY, "activeTransfers")
     if transfer_type is None:
-        return None
+        return path.replace(SHARED_DIRECTORY_ROOT, "%sharedPath%", 1)
     try:
         path = os.path.join(
             path,


### PR DESCRIPTION
Connects to archivematica/Issues#252.

This branch is a slightly different approach to the one used in https://github.com/artefactual/archivematica/pull/1287
Here the get_modified_standard_transfer_path() method is modified to return the path to the activeTransfers folder, if no transfer type is defined, rather than returning None.  

This change prevents calls to api/transfer/unapproved from resulting in a 500 error.  The api/transfer/unapproved api call is used in the automation tools workflow here: https://github.com/artefactual/automation-tools/blob/master/transfers/transfer.py#L393

An alternative to this pull request might be to modify the automation tools, so it no longer calls the api/transfer/unapproved endpoint.  I tried to use the newer transfer_async.py (https://github.com/artefactual/automation-tools/blob/master/transfers/transfer_async.py) in automation tools instead of transfer.py, but I couldn't get that to work quickly.  This PR has been tested at IISH, and is working there.