### PR TITLE
Migration: dataverse - run policy checks again

### DIFF
--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -8,5 +8,6 @@ gearman==2.0.2
 lxml==3.5.0
 metsrw==0.2.3
 requests==2.18.4
+urllib3==1.23
 unidecode==0.04.19
 opf-fido==1.3.10

--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -3,4 +3,5 @@ bagit==1.5.2
 Django>=1.8,<1.9
 elasticsearch>=1.0.0,<2.0.0
 requests==2.18.4
+urllib3==1.23
 python-dateutil==2.4.2

--- a/src/dashboard/src/main/migrations/0061_create_dataverse_transfer_type.py
+++ b/src/dashboard/src/main/migrations/0061_create_dataverse_transfer_type.py
@@ -118,7 +118,6 @@ EXISTING_MS_RESTRUCTURE_COMPLIANCE = "ea0e8838-ad3a-4bdd-be14-e5dba5a4ae0c"
 EXISTING_MS_VAILIDATE_FORMATS = "a536828c-be65-4088-80bd-eb511a0a063d"
 EXISTING_MS_POLICY_CHECKS = "70fc7040-d4fb-4d19-a0e6-792387ca1006"
 EXISTING_MS_CREATE_TRANSFER_METS = "db99ab43-04d7-44ab-89ec-e09d7bbdc39d"
-EXISTING_MS_EXAMINE_CONTENTS = "dae3c416-a8c2-4515-9081-6dbd7b265388"
 
 # Tasks that we want to reference, but eventually don't need to delete on
 # migration down.
@@ -254,11 +253,12 @@ def create_parse_dataverse_mets_link_pull(apps):
     )
 
     # If linkToParseDataverseMETS is set then goto the configured microservice,
-    # else, goto the default microservice, 'Move to examine contents'.
+    # else, goto the default microservice, 'Perform policy checks on
+    # originals?'.
     create_variable_link_pull(
         apps=apps, link_uuid=NEW_LINK_PULL_CONFIG_PARSE_DV,
         variable="linkToParseDataverseMETS",
-        default_ms_uuid=EXISTING_MS_EXAMINE_CONTENTS,
+        default_ms_uuid=EXISTING_MS_POLICY_CHECKS,
     )
 
     # Break and Update the existing link to connect to our new link.

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -24,6 +24,7 @@ python-dateutil==2.6.0
 ndg-httpsclient
 pyasn1
 requests==2.18.4
+urllib3==1.23
 whitenoise==3.3.0
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
 


### PR DESCRIPTION
We used to run "Perform policy checks for originals?" once "Validate formats" succeeded (exit_code=0).

![image](https://user-images.githubusercontent.com/606459/47052165-1e478480-d15c-11e8-93d5-d91eeb9d242f.png)

The Dataverse work rewrote the exit code of "Validate formats" mentioned above to run "Determine Parse Dataverse METS XML" instead - which never leads to "Perform policy checks for originals?" again.

"Perform policy checks for originals?" became unreachable.

![image](https://user-images.githubusercontent.com/606459/47052236-68306a80-d15c-11e8-9cf9-be145eb032d6.png)

This pull request mitigates the issue by having "Determine Parse Dataverse METS XML" default to "Perform policy checks for originals?".

![image](https://user-images.githubusercontent.com/606459/47052371-ce1cf200-d15c-11e8-9f7d-f6263f29b7ac.png)

This is connected to https://github.com/archivematica/Issues/issues/277
