### PR TITLE
Enable the introduction of third-party identifiers as PREMIS objects

### DIFF
--- a/src/MCPClient/lib/clientScripts/bind_pid.py
+++ b/src/MCPClient/lib/clientScripts/bind_pid.py
@@ -59,6 +59,12 @@ from archivematicaFunctions import str2bool
 logger = get_script_logger('archivematica.mcp.client.bind_pid')
 
 
+# REMOVE THIS CODE BEFORE REBASE
+# REMOVE THIS CODE BEFORE REBASE
+# REMOVE THIS CODE BEFORE REBASE
+def concurrent_instances(): return 1
+
+
 class BindPIDException(Exception):
     """If I am raised, return 1."""
     exit_code = 1

--- a/src/MCPClient/lib/clientScripts/bind_pid.py
+++ b/src/MCPClient/lib/clientScripts/bind_pid.py
@@ -100,6 +100,11 @@ def _get_bind_pid_config(file_uuid):
     _args = {'entity_type': 'file',
              'desired_pid': file_uuid}
     _args.update(DashboardSetting.objects.get_dict('handle'))
+
+    # ADD VALIDATION CODE FROM PID HELPERS HERE
+    # ADD VALIDATION CODE FROM PID HELPERS HERE
+    # ADD VALIDATION CODE FROM PID HELPERS HERE
+
     _args['pid_request_verify_certs'] = str2bool(
         _args.get('pid_request_verify_certs', 'True'))
     return _args
@@ -122,6 +127,11 @@ def _update_file_mdl(file_uuid, naming_authority, resolver_url):
         matches = [True for id_ in existing_ids
                    if id_.type == id_type and id_.value == id_val]
         if len(matches) == 0:
+
+            # REPLACE WITH PID HELPER CODE FOR UPDATING MODEL
+            # REPLACE WITH PID HELPER CODE FOR UPDATING MODEL
+            # REPLACE WITH PID HELPER CODE FOR UPDATING MODEL
+
             idfr = Identifier.objects.create(type=id_type, value=id_val)
             file_mdl.identifiers.add(idfr)
 

--- a/src/MCPClient/lib/clientScripts/bind_pid.py
+++ b/src/MCPClient/lib/clientScripts/bind_pid.py
@@ -49,9 +49,11 @@ from django.db import transaction
 import django
 django.setup()
 # dashboard
-from main.models import DashboardSetting, File, Identifier
+from main.models import DashboardSetting, File
 # archivematicaCommon
 import bindpid
+from bind_pid_helpers import validate_handle_server_config, \
+    _add_custom_pid_to_mdl_identifiers
 from custom_handlers import get_script_logger
 from archivematicaFunctions import str2bool
 
@@ -100,11 +102,8 @@ def _get_bind_pid_config(file_uuid):
     _args = {'entity_type': 'file',
              'desired_pid': file_uuid}
     _args.update(DashboardSetting.objects.get_dict('handle'))
-
-    # ADD VALIDATION CODE FROM PID HELPERS HERE
-    # ADD VALIDATION CODE FROM PID HELPERS HERE
-    # ADD VALIDATION CODE FROM PID HELPERS HERE
-
+    if not validate_handle_server_config(_args):
+        raise BindPIDWarning
     _args['pid_request_verify_certs'] = str2bool(
         _args.get('pid_request_verify_certs', 'True'))
     return _args
@@ -127,13 +126,8 @@ def _update_file_mdl(file_uuid, naming_authority, resolver_url):
         matches = [True for id_ in existing_ids
                    if id_.type == id_type and id_.value == id_val]
         if len(matches) == 0:
-
-            # REPLACE WITH PID HELPER CODE FOR UPDATING MODEL
-            # REPLACE WITH PID HELPER CODE FOR UPDATING MODEL
-            # REPLACE WITH PID HELPER CODE FOR UPDATING MODEL
-
-            idfr = Identifier.objects.create(type=id_type, value=id_val)
-            file_mdl.identifiers.add(idfr)
+            _add_custom_pid_to_mdl_identifiers(
+                mdl=file_mdl, scheme=id_type, value=id_val)
 
 
 @exit_on_known_exception

--- a/src/MCPClient/lib/clientScripts/bind_pid_helpers.py
+++ b/src/MCPClient/lib/clientScripts/bind_pid_helpers.py
@@ -71,5 +71,9 @@ def _add_pid_to_mdl_identifiers(mdl, pid, purl):
 
 
 def _add_custom_pid_to_mdl_identifiers(mdl, scheme, value):
+    """Create an identifier with scheme:value and add the row to the
+    Identifiers table. Reference the new identifier in the given model (mdl)
+    table.
+    """
     identifier = Identifier.objects.create(type=scheme, value=value)
     mdl.identifiers.add(identifier)

--- a/src/MCPClient/lib/clientScripts/bind_pid_helpers.py
+++ b/src/MCPClient/lib/clientScripts/bind_pid_helpers.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Archivematica.
+#
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Where third party PID values are provided to Archivematica in the
+``identifiers.json`` file update the ``Identifiers`` model to also include the
+values supplied in that file.
+"""
+from main.models import Identifier
+
+
+class BindPIDsException(Exception):
+    """If I am raised, return 1."""
+    exit_code = 1
+
+
+class BindPIDsWarning(Exception):
+    """If I am raised, return 0."""
+    exit_code = 0
+
+
+def validate_handle_server_config(handle_config, logger=None):
+    """While the handle server form is configured with required fields, the
+    default form in Archivematica is blank which means the Bind PID service
+    can fail if a user has selected to Bind PIDs without entering configuration
+    values. Validate the configuration dictionary to handle this situation
+    gracefully.
+    """
+    fields = [
+        'resolve_url_template_archive',
+        'resolve_url_template_file',
+        'handle_resolver_url',
+        'naming_authority',
+        'pid_web_service_key',
+        'pid_web_service_endpoint',
+    ]
+    for field in fields:
+        try:
+            handle_config[field]
+        except KeyError:
+            if logger:
+                logger.warning("Handle server configuration is incomplete")
+            return False
+    return True
+
+
+def _add_pid_to_mdl_identifiers(mdl, pid, purl):
+    """Add a newly minted handle/PID to the ``SIP`` or ``Directory`` model as
+    an identifier in its m2m ``identifiers`` attribute. Also add the PURL (URL
+    constructed out of the PID) as a URI-type identifier.
+    """
+    hdl_identifier = Identifier.objects.create(type='hdl', value=pid)
+    purl_identifier = Identifier.objects.create(type='URI', value=purl)
+    mdl.identifiers.add(hdl_identifier)
+    mdl.identifiers.add(purl_identifier)
+
+
+def _add_custom_pid_to_mdl_identifiers(mdl, scheme, value):
+    identifier = Identifier.objects.create(type=scheme, value=value)
+    mdl.identifiers.add(identifier)

--- a/src/MCPClient/lib/clientScripts/bind_pids.py
+++ b/src/MCPClient/lib/clientScripts/bind_pids.py
@@ -206,6 +206,11 @@ def main(job, sip_uuid, shared_path, bind_pids_switch):
     handle_config['pid_request_verify_certs'] = str2bool(
         handle_config.get('pid_request_verify_certs', 'True'))
     if validate_handle_server_config(handle_config, logger):
+        # Given the opportunity, a happy path here would test to see if the
+        # handle configuration was set correctly, and then raise an exception
+        # if not. We don't want to exit the script this early, however, to we
+        # test for the positive existence of a config and run that path
+        # instead.
         for mdl in chain([_get_sip(sip_uuid)],
                          Directory.objects.filter(sip_id=sip_uuid).all()):
             _bind_pid_to_model(job, mdl, shared_path, handle_config)

--- a/src/MCPClient/lib/clientScripts/bind_pids.py
+++ b/src/MCPClient/lib/clientScripts/bind_pids.py
@@ -205,17 +205,17 @@ def main(job, sip_uuid, shared_path, bind_pids_switch):
 
     # If there are user provided identifiers
     # insert them into the database
-    # and skip connecting to the pid server 
+    # and skip connecting to the pid server
     try:
         identifiers_loc = File.objects.get(
             sip_id=sip_uuid,
             currentlocation__endswith=bind_third_party_pids.IDENTIFIERS_JSON)
+    except File.DoesNotExist:
+        logger.info("Custom `identifiers.json` not provided with transfer")
+    if identifiers_loc:
         bind_third_party_pids.load_identifiers_json(
             job, logger, sip_uuid, identifiers_loc, shared_path)
         return
-    except File.DoesNotExist:
-        logger.info("Custom `identifiers.json` not provided with transfer")
-
     handle_config = DashboardSetting.objects.get_dict('handle')
     handle_config['pid_request_verify_certs'] = str2bool(
         handle_config.get('pid_request_verify_certs', 'True'))

--- a/src/MCPClient/lib/clientScripts/bind_third_party_pids.py
+++ b/src/MCPClient/lib/clientScripts/bind_third_party_pids.py
@@ -63,6 +63,11 @@ def parse_identifiers_json(job, logger, json_data, sip_loc, sip_uuid):
         except KeyError:
             # Assume that other files in ``identifiers.json`` may still match.
             continue
+        # Don't assume that there is an objects folder in the metadata supplied
+        # by the user.
+        obj_check = path.split(object_path)[0]
+        if obj_check != "objects":
+            object_path = path.join("objects", object_path)
         abs_object_path = create_absolute_objects_path(object_path, sip_loc)
         sip_object_path = create_sip_objects_path(object_path, sip_loc)
         logger.error("Looking for object: %s", sip_object_path)

--- a/src/MCPClient/lib/clientScripts/bind_third_party_pids.py
+++ b/src/MCPClient/lib/clientScripts/bind_third_party_pids.py
@@ -65,9 +65,12 @@ def parse_identifiers_json(job, logger, json_data, sip_loc, sip_uuid):
             continue
         # Don't assume that there is an objects folder in the metadata supplied
         # by the user.
+        logger.info("1. VAR %s", object_path)
         obj_check = path.split(object_path)[0]
         if obj_check != "objects":
+            logger.info("2. VAR adding objects %s", object_path)
             object_path = path.join("objects", object_path)
+        logger.info("3. VAR %s", object_path)
         abs_object_path = create_absolute_objects_path(object_path, sip_loc)
         sip_object_path = create_sip_objects_path(object_path, sip_loc)
         logger.error("Looking for object: %s", sip_object_path)

--- a/src/MCPClient/lib/clientScripts/bind_third_party_pids.py
+++ b/src/MCPClient/lib/clientScripts/bind_third_party_pids.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# This file is part of Archivematica.
+#
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Where third party PID values are provided to Archivematica in the
+``identifiers.json`` file update the ``Identifiers`` model to also include the
+values supplied in that file.
+"""
+from os import path
+
+import archivematicaFunctions
+from dicts import ReplacementDict
+from custom_handlers import get_script_logger
+
+from main.models import Directory, File, SIP
+
+logger = get_script_logger('archivematica.mcp.client.bind_third_party_pids')
+
+IDENTIFIERS_JSON = "identifiers.json"
+
+
+class ThirdPartyPIDsException(Exception):
+    """If I am raised, return 1."""
+    exit_code = 1
+
+
+def parse_identifiers_json(job, sip_uuid, identifiers_loc, shared_path):
+    try:
+        sip_loc = SIP.objects.get(uuid=sip_uuid).currentpath\
+            .replace("%sharedPath%", shared_path)
+    except SIP.DoesNotExist:
+        ThirdPartyPIDsException("Cannot find SIP %s", sip_uuid)
+    identifiers_loc = \
+        identifiers_loc.currentlocation.replace(
+            "%SIPDirectory%", sip_loc)
+    if path.exists(identifiers_loc):
+        job.pyprint("Let's do some work with the JSON here")

--- a/src/MCPClient/lib/clientScripts/create_mets_v2.py
+++ b/src/MCPClient/lib/clientScripts/create_mets_v2.py
@@ -59,6 +59,9 @@ import namespaces as ns
 from bagit import Bag, BagError
 
 
+def concurrent_instances(): return 1
+
+
 class ErrorAccumulator(object):
 
     def __init__(self):
@@ -685,10 +688,12 @@ def getIncludedStructMap(job, baseDirectoryPath, state):
                 structMap.set("ID", "structMap_2")
             ret.append(structMap)
             for item in structMap.findall(".//" + ns.metsBNS + "fptr"):
-                fileName = item.get("FILEID")
-                if fileName in state.fileNameToFileID:
-                    # print fileName, " -> ", state.fileNameToFileID[fileName]
-                    item.set("FILEID", state.fileNameToFileID[fileName])
+                fileName = item.get("CONTENTIDS")
+                job.pyprint(state.fileNameToFileID)
+                if os.path.basename(fileName) in state.fileNameToFileID:
+                    item.set(
+                        "FILEID",
+                        state.fileNameToFileID[os.path.basename(fileName)])
                 else:
                     job.pyprint("error: no fileUUID for ", fileName, file=sys.stderr)
                     state.error_accumulator.error_count += 1

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -444,7 +444,7 @@ def approve_transfer(request):
 def get_modified_standard_transfer_path(transfer_type=None):
     path = os.path.join(django_settings.WATCH_DIRECTORY, "activeTransfers")
     if transfer_type is None:
-        return None
+        return path.replace(SHARED_DIRECTORY_ROOT, "%sharedPath%", 1)
     try:
         path = os.path.join(
             path,


### PR DESCRIPTION
:construction: :construction: :construction: 

Enable the introduction of third-party identifiers as PREMIS objects via a metadata file called `identifiers.json`. 

Connected to archivematica/issues#285
Connected to IISH/Archivematica#1