### PR TITLE
api.views: fix get_unit_status for SIPs

### DIFF
--- a/src/dashboard/tests/fixtures/am17-jobs-sip-complete-clean-up-last.json
+++ b/src/dashboard/tests/fixtures/am17-jobs-sip-complete-clean-up-last.json
@@ -1,0 +1,2365 @@
+[
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:20Z",
+            "createdtimedec": "0.5427310000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Determine which files to identify",
+            "microservicechainlink": "c3269a0a-91db-44e8-96d0-9c748cf80177",
+            "microservicegroup": "Identify file format",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "02f66d06-b8bd-44d2-b3f1-bc0f81837666"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:26Z",
+            "createdtimedec": "0.7195350000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Assign file UUIDs to objects",
+            "microservicechainlink": "dc144ff4-ad74-4a6e-ac15-b0beedcaf662",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "032d98c0-e1a1-4fca-953d-4adff85cd7a2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:38Z",
+            "createdtimedec": "0.0267800000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "8f639582-8881-4a8b-8574-d2f86dc4db3d",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "056de8fd-7beb-470a-9fb2-d7746ef5e9d8"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:13Z",
+            "createdtimedec": "0.8350570000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move submission documentation into objects directory",
+            "microservicechainlink": "173d310c-8e40-4669-9a69-6d4c8ffd0396",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "06e6b83f-e588-4aca-94b6-b8fc464d8f82"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:11Z",
+            "createdtimedec": "0.6488010000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Normalization report",
+            "microservicechainlink": "3a70bc05-fa82-4067-a069-a56b6006be0a",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "07c2e8e9-930f-438d-9505-786b5caa82d4"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:16Z",
+            "createdtimedec": "0.0190110000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Select file format identification command",
+            "microservicechainlink": "087d27be-c719-47d8-9bbb-9a7d8b609c44",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "07c55247-6d31-46b8-9076-93a66377af5a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:40Z",
+            "createdtimedec": "0.5357840000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Create SIP from transfer objects",
+            "microservicechainlink": "39a128e3-c35d-40b7-9363-87f75091e1ff",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "10ceb599-3616-4cfb-b63d-122366920f70"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:23Z",
+            "createdtimedec": "0.6966680000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Remove hidden files and directories",
+            "microservicechainlink": "50b67418-cb8d-434d-acc9-4a8324e7fdd2",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "11df9cfd-8920-4eaf-b735-cb7eb1705514"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:07Z",
+            "createdtimedec": "0.3753750000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Validate preservation derivatives",
+            "microservicechainlink": "5b0042a2-2244-475c-85d5-41e4b11e65d6",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "13cf0ce1-6693-4f8f-8c04-5a241d9e3a2c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:15Z",
+            "createdtimedec": "0.1398700000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Scan for viruses in submission documentation",
+            "microservicechainlink": "1ba589db-88d1-48cf-bb1a-a5f9d2b17378",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "17785dd9-7bc3-4434-8cc8-3004e0897a3b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:56Z",
+            "createdtimedec": "0.3686860000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/storeAIP/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Retrieve AIP Storage Locations",
+            "microservicechainlink": "49cbcc4d-067b-4cd5-b52e-faf50857b35a",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "1893035d-26b3-4983-aac1-2517b5ec7552"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:41Z",
+            "createdtimedec": "0.6224460000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Select file format identification command",
+            "microservicechainlink": "f09847c2-ee51-429a-9478-a860477f6b8d",
+            "microservicegroup": "Identify file format",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "1b951918-5074-47f5-a8da-5fa04349b589"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:39Z",
+            "createdtimedec": "0.7504730000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to select file ID tool",
+            "microservicechainlink": "d1b27e9e-73c8-4954-832c-36bd1e00c802",
+            "microservicegroup": "Identify file format",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "1cbc80bb-8d1d-42aa-b213-5fd9b5bf88d9"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:30Z",
+            "createdtimedec": "0.1673790000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to workFlowDecisions-quarantineSIP directory",
+            "microservicechainlink": "03ee1136-f6ad-4184-8dcb-34872f843e14",
+            "microservicegroup": "Quarantine",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "1d33ea6b-cf00-4f50-b7fc-9af9aea82219"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:18Z",
+            "createdtimedec": "0.2101350000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Remove files without linking information (failed normalization artifacts etc.)",
+            "microservicechainlink": "576f1f43-a130-4c15-abeb-c272ec458d33",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "1f08af4a-0eaf-4b9f-9676-b488ab54d362"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:33Z",
+            "createdtimedec": "0.7190840000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Add README file",
+            "microservicechainlink": "523c97cc-b267-4cfb-8209-d99e523bf4b3",
+            "microservicegroup": "Add README file",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "2023b0cf-4824-489c-a3cb-f86ea9219db6"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:24Z",
+            "createdtimedec": "0.3203370000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Bind PIDs?",
+            "microservicechainlink": "05357876-a095-4c11-86b5-a7fff01af668",
+            "microservicegroup": "Bind PIDs",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "206b0996-b17f-475f-8751-2fbc7f006170"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:42Z",
+            "createdtimedec": "0.3817950000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/storeAIP/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Store AIP",
+            "microservicechainlink": "2d32235c-02d4-4686-88a6-96f4d6c7b1c3",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "223340aa-f296-4c13-a2ac-266e35de482a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:32Z",
+            "createdtimedec": "0.3263090000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Scan for viruses",
+            "microservicechainlink": "1c2550f1-3fc0-45d8-8bc4-4c06d720283b",
+            "microservicegroup": "Scan for viruses",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "2415bc3e-6935-4615-83ff-3a31bf39c30f"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:32Z",
+            "createdtimedec": "0.6702130000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/quarantineTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "d7e6404a-a186-4806-a130-7e6d27179a15",
+            "microservicegroup": "Scan for viruses",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "24df04cb-e491-444a-9d7a-7a71b92c1996"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:21Z",
+            "createdtimedec": "0.7304290000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move metadata to objects directory",
+            "microservicechainlink": "e4b0c713-988a-4606-82ea-4b565936d9a7",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "24e9e5d1-d3fe-4abc-bde5-e8039ee8c62c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:17Z",
+            "createdtimedec": "0.0827810000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Characterize and extract metadata on submission documentation",
+            "microservicechainlink": "33d7ac55-291c-43ae-bb42-f599ef428325",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "2516263f-df1a-4537-abe9-ffa133695269"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:29Z",
+            "createdtimedec": "0.6044150000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to examine contents",
+            "microservicechainlink": "dae3c416-a8c2-4515-9081-6dbd7b265388",
+            "microservicegroup": "Examine contents",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "295cba6c-b9ee-4d3d-92fa-5b25a6f2808a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:21Z",
+            "createdtimedec": "0.8291130000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Assign file UUIDs to metadata",
+            "microservicechainlink": "dc9d4991-aefa-4d7e-b7b5-84e3c4336e74",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "2c559104-d3db-41a8-ac9b-4ead8a297eb3"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:20Z",
+            "createdtimedec": "0.9849860000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Copy transfers metadata and logs",
+            "microservicechainlink": "ee438694-815f-4b74-97e1-8e7dde2cc6d5",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "2c709f00-d63e-4f94-a5d9-f1a56aa4d493"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:06Z",
+            "createdtimedec": "0.8405990000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Normalize for preservation",
+            "microservicechainlink": "8ce378a5-1418-4184-bf02-328a06e1d3be",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "38495c1b-82bd-444c-98e5-32f58b8bd4f0"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:21Z",
+            "createdtimedec": "0.7911650000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to extract packages",
+            "microservicechainlink": "cc16178b-b632-4624-9091-822dd802a2c6",
+            "microservicegroup": "Extract packages",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "3ad3bbbd-6803-4521-9851-0617d0bb14e4"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:22Z",
+            "createdtimedec": "0.8702550000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Set transfer type: Standard",
+            "microservicechainlink": "045c43ae-d6cf-44f7-97d6-c8a602748565",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "3b8e7b23-51b2-4f06-9f08-8e15a30123f4"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:24Z",
+            "createdtimedec": "0.3766060000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Bind PID",
+            "microservicechainlink": "87e93d08-36e4-4c81-99a8-beea00b18400",
+            "microservicegroup": "Bind PIDs",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "436d6906-255a-4867-a99f-6032a98aeca5"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:32Z",
+            "createdtimedec": "0.9357270000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Generate METS.xml document",
+            "microservicechainlink": "ccf8ec5c-3a9a-404a-a7e7-8f567d3b36a0",
+            "microservicegroup": "Generate AIP METS",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "44375381-62a7-4f4f-89ff-e34acd84b22d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:33Z",
+            "createdtimedec": "0.0793740000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Check transfer directory for objects",
+            "microservicechainlink": "032cdc54-0b9b-4caf-86e8-10d63efbaec0",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "461d6635-9302-4ccc-aadc-16238d86de44"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:23Z",
+            "createdtimedec": "0.0994520000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Add processed structMap to METS.xml document",
+            "microservicechainlink": "307edcde-ad10-401c-92c4-652917c993ed",
+            "microservicegroup": "Update METS.xml document",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "49810cf7-9349-406e-ae09-3be36f921841"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:46Z",
+            "createdtimedec": "0.9716820000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Check for Access directory",
+            "microservicechainlink": "67b44f8f-bc97-4cb3-b6dd-09dba3c99d30",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "4b1620d4-6153-4003-9b62-29ef80b009bc"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:25Z",
+            "createdtimedec": "0.0731150000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Assign UUIDs to directories",
+            "microservicechainlink": "6441980c-b64b-447e-abc7-9351a2547f6a",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "4b914124-a56a-4cf6-a533-658381737fca"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:48Z",
+            "createdtimedec": "0.2230970000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Identify file format",
+            "microservicechainlink": "2dd53959-8106-457d-a385-fee57fc93aa9",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "4be57373-fa9b-4b10-9062-08c8404b4ce1"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:27Z",
+            "createdtimedec": "0.5324160000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Load labels from metadata/file_labels.csv",
+            "microservicechainlink": "1b1a4565-b501-407b-b40f-2f20889423f1",
+            "microservicegroup": "Characterize and extract metadata",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "4ca707b5-3e38-4297-ad93-39e2dff63a67"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:37Z",
+            "createdtimedec": "0.6034120000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Check for manual normalized files",
+            "microservicechainlink": "78b7adff-861d-4450-b6dd-3fabe96a849e",
+            "microservicegroup": "Process manually normalized files",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "4d0a376e-4886-417a-b7b2-194ff920fb11"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:13Z",
+            "createdtimedec": "0.7517680000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Check for submission documentation",
+            "microservicechainlink": "47dd6ea6-1ee7-4462-8b84-3fc4c1eeeb7f",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "4db028ff-493e-4191-9ec8-2853093b4527"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:38Z",
+            "createdtimedec": "0.3096780000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Reminder: add metadata if desired",
+            "microservicechainlink": "eeb23509-57e2-4529-8857-9d62525db048",
+            "microservicegroup": "Add final metadata",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "4e501091-59d4-48a7-ae48-ccb0f1b03ef0"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:24Z",
+            "createdtimedec": "0.1660600000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Verify mets_structmap.xml compliance",
+            "microservicechainlink": "d0c463c2-da4c-4a70-accb-c4ce96ac5194",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "5291a050-7953-4642-89e0-48f927613b1f"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:41Z",
+            "createdtimedec": "0.1915440000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Check transfer directory for objects",
+            "microservicechainlink": "032cdc54-0b9b-4caf-86e8-10d63efbaec0",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "537c7eef-7662-4e73-872f-73a9e294acc1"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:37Z",
+            "createdtimedec": "0.6922600000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Perform policy checks on preservation derivatives?",
+            "microservicechainlink": "153c5f41-3cfb-47ba-9150-2dd44ebc27df",
+            "microservicegroup": "Policy checks for derivatives",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "555489e4-9553-4bdf-8ba9-79d743783a5a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:47Z",
+            "createdtimedec": "0.7724690000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to select file ID tool",
+            "microservicechainlink": "a2173b55-abff-4d8f-97b9-79cc2e0a64fa",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "57310ac5-b70b-40fe-862d-8ee5c9213e14"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:24Z",
+            "createdtimedec": "0.0793030000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Verify transfer compliance",
+            "microservicechainlink": "438dc1cf-9813-44b5-a0a3-58e09ae73b8a",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "580a5130-51b6-4b17-8a28-3a7c35378c12"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:25Z",
+            "createdtimedec": "0.2945910000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Characterize and extract metadata",
+            "microservicechainlink": "303a65f6-a16f-4a06-807b-cb3425a30201",
+            "microservicegroup": "Characterize and extract metadata",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "583b3191-26ae-4b8f-a6f2-aac0f05d445c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:12Z",
+            "createdtimedec": "0.1096010000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Copy transfer submission documentation",
+            "microservicechainlink": "f574b2a0-6e0b-4c74-ac5b-a73ddb9593a0",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "5845ae60-2b13-4e68-8ac2-b1f741af85bb"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:47Z",
+            "createdtimedec": "0.7363690000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Grant normalization options for no pre-existing DIP",
+            "microservicechainlink": "74665638-5d8f-43f3-b7c9-98c4c8889766",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "58687a80-de4a-4fa4-8b4c-4ce8f09cfa1b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:39Z",
+            "createdtimedec": "0.8340470000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Serialize Dublin Core metadata to disk",
+            "microservicechainlink": "f378ec85-adcc-4ee6-ada2-bc90cfe20efb",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "5a631730-1fb5-47f4-9302-0040b6f85103"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:23Z",
+            "createdtimedec": "0.4701380000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Attempt restructure for compliance",
+            "microservicechainlink": "ea0e8838-ad3a-4bdd-be14-e5dba5a4ae0c",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "5a697064-e8bd-45f5-bb0a-e6eb41aca692"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:28Z",
+            "createdtimedec": "0.1733820000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Assign checksums and file sizes to objects",
+            "microservicechainlink": "370aca94-65ab-4f2a-9d7d-294a62c8b7ba",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "5c2de7de-fd76-44a2-bed8-dad0b63699f2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:25Z",
+            "createdtimedec": "0.9311930000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Include default Transfer processingMCP.xml",
+            "microservicechainlink": "0c96c798-9ace-4c05-b3cf-243cdad796b7",
+            "microservicegroup": "Include default Transfer processingMCP.xml",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "5c9d3277-2543-4677-bc4a-35b370a5f6ee"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:43Z",
+            "createdtimedec": "0.1356100000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Remove cache files",
+            "microservicechainlink": "f3be1ee1-8881-465d-80a6-a6f093d40ec2",
+            "microservicegroup": "Remove cache files",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "5e0a2224-19d2-4214-8a8a-b6a0197d7fdb"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:23:15Z",
+            "createdtimedec": "0.9668910000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Verify AIP",
+            "microservicechainlink": "3f543585-fa4f-4099-9153-dd6d53572f5c",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "5e8c16ee-b559-4ad4-9dec-4c1210411b66"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:13Z",
+            "createdtimedec": "0.9227640000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Assign file UUIDs to submission documentation",
+            "microservicechainlink": "4edfe7e4-82ff-4c0a-ba5f-29f1ee14e17a",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "6021d2d2-e2b5-4705-846a-9c8c3dd9347e"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:37Z",
+            "createdtimedec": "0.3796090000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Sanitize object's file and directory names",
+            "microservicechainlink": "2584b25c-8d98-44b7-beca-2b3ea2ea2505",
+            "microservicegroup": "Clean up names",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "6433037e-68e1-4e8c-ae22-0ec15a724d6b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:37Z",
+            "createdtimedec": "0.6164480000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/createTree/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "6eca2676-b4ed-48d9-adb0-374e1d5c6e71",
+            "microservicegroup": "Generate transfer structure report",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "65aff125-02b2-4b17-85aa-ba582274cfc8"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:23:25Z",
+            "createdtimedec": "0.7292530000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Clean up after storing AIP",
+            "microservicechainlink": "b7cf0d9a-504f-4f4e-9930-befa817d67ff",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "66c74e9c-c737-4837-9305-e69744b097f4"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:30Z",
+            "createdtimedec": "0.1265730000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Parse external METS",
+            "microservicechainlink": "675acd22-828d-4949-adc7-1888240f5e3d",
+            "microservicegroup": "Complete transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "6c7b8dcc-73eb-43d0-ba3d-7c2afd89c689"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:49Z",
+            "createdtimedec": "0.0214560000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Resume after normalization file identification tool selected.",
+            "microservicechainlink": "83484326-7be7-4f9f-b252-94553cd42370",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "6efe129a-229a-4f67-9acf-31ecf3a63adf"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:41Z",
+            "createdtimedec": "0.1691920000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/system/autoProcessSIP/KSTest/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "70669a5b-01e4-4ea0-ac70-10292f87da05",
+            "microservicegroup": "Verify SIP compliance",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "7348f7b5-87df-4031-981a-efa385b84235"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:32Z",
+            "createdtimedec": "0.6373420000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/quarantineTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Workflow decision - send transfer to quarantine",
+            "microservicechainlink": "755b4177-c587-41a7-8c52-015277568302",
+            "microservicegroup": "Quarantine",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "7518c215-8875-4b62-8982-b1152de353db"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:41Z",
+            "createdtimedec": "0.5427050000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Removed bagged files",
+            "microservicechainlink": "746b1f47-2dad-427b-8915-8b0cb7acccd8",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "77aca213-6c52-401b-aa7c-9cc582bef053"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:22Z",
+            "createdtimedec": "0.0646500000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Determine if transfer contains packages",
+            "microservicechainlink": "b944ec7f-7f99-491f-986d-58914c9bb4fa",
+            "microservicegroup": "Extract packages",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "77ce5e1d-c9c0-42cb-877b-0ef8231cd69b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:05Z",
+            "createdtimedec": "0.7997020000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Normalize for thumbnails",
+            "microservicechainlink": "180ae3d0-aa6c-4ed4-ab94-d0a2121e7f21",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "78b6ab8a-5bc2-45a1-9aa6-b4ccb128dffb"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:42Z",
+            "createdtimedec": "0.1188490000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Check if SIP is from Maildir Transfer",
+            "microservicechainlink": "b3d11842-0090-420a-8919-52d7039d50e6",
+            "microservicegroup": "Rename SIP directory with SIP UUID",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "78bdd63f-48af-4641-9506-b99a5df7ce43"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:21Z",
+            "createdtimedec": "0.8723570000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Assign checksums and file sizes to metadata ",
+            "microservicechainlink": "b6b0fe37-aa26-40bd-8be8-d3acebf3ccf8",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "7914eedc-fa38-4b08-bccb-4397dd51b8b2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:57Z",
+            "createdtimedec": "0.3865000000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/storeAIP/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Store AIP location",
+            "microservicechainlink": "b320ce81-9982-408a-9502-097d0daa48fa",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "81eace71-e71e-49bf-8b67-81eb6bf55ed3"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:14Z",
+            "createdtimedec": "0.7617530000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Assign checksums and file sizes to submissionDocumentation",
+            "microservicechainlink": "2a62f025-83ec-4f23-adb4-11d5da7ad8c2",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "83c2f5f1-50d5-42b6-9497-bd8634c717a9"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:04Z",
+            "createdtimedec": "0.9524960000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "6b39088b-683e-48bd-ab89-9dab47f4e9e0",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "85f99e73-76ba-4e7e-9dc0-1ab3db3c1993"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:30Z",
+            "createdtimedec": "0.1317910000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Designate to process as a standard transfer",
+            "microservicechainlink": "9071c352-aed5-444c-ac3f-b6c52dfb65ac",
+            "microservicegroup": "Quarantine",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "8e7a0cbb-42b5-411c-9d97-81481cad1c36"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:35Z",
+            "createdtimedec": "0.3804210000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Select compression algorithm",
+            "microservicechainlink": "01d64f58-8295-4b7b-9cab-8f1b153a504f",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "900259c8-6abf-439e-b886-8d4d26a58425"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:30Z",
+            "createdtimedec": "0.0716960000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Examine contents?",
+            "microservicechainlink": "accea2bf-ba74-4a3a-bb97-614775c74459",
+            "microservicegroup": "Examine contents",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "92291243-2d4f-40e6-80fa-48446905f811"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:14Z",
+            "createdtimedec": "0.4946540000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Sanitize file and directory names in submission documentation",
+            "microservicechainlink": "11033dbd-e4d4-4dd6-8bcf-48c424e222e3",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "93fdc858-d114-47be-ab3a-9a99f877279e"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:25Z",
+            "createdtimedec": "0.5899110000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Load rights",
+            "microservicechainlink": "1a136608-ae7b-42b4-bf2f-de0e514cfd47",
+            "microservicegroup": "Characterize and extract metadata",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "94a02094-f788-40ed-a632-c9e5255b7173"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:40Z",
+            "createdtimedec": "0.3450850000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Set bag file permissions",
+            "microservicechainlink": "5fbc344c-19c8-48be-a753-02dac987428c",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "95638549-560b-4c21-8f0a-9d45ce317d88"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:45Z",
+            "createdtimedec": "0.6168830000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Load Dublin Core metadata from disk",
+            "microservicechainlink": "970b7d17-7a6b-4d51-808b-c94b78c0d97f",
+            "microservicegroup": "Clean up names",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "95a5c777-4a00-4562-b297-38c477daef44"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:22Z",
+            "createdtimedec": "0.3593480000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Verify checksums generated on ingest",
+            "microservicechainlink": "88807d68-062e-4d1a-a2d5-2d198c88d8ca",
+            "microservicegroup": "Verify checksums",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "95d022de-98f7-4abc-b797-8ffb4b5f325a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:11Z",
+            "createdtimedec": "0.7153410000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Transcribe",
+            "microservicechainlink": "2900f6d8-b64c-4f2a-8f7f-bb60a57394f6",
+            "microservicegroup": "Transcribe SIP contents",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "95dfaf50-3985-4abf-95e1-3d2e7813e60a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:48Z",
+            "createdtimedec": "0.1705820000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Select pre-normalize file format identification command",
+            "microservicechainlink": "7a024896-c4f7-4808-a240-44c87c762bc5",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "99e2a78d-922c-4750-8190-2694fd216ccf"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:37Z",
+            "createdtimedec": "0.7222670000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Perform policy checks on access derivatives?",
+            "microservicechainlink": "8ce07e94-6130-4987-96f0-2399ad45c5c2",
+            "microservicegroup": "Policy checks for derivatives",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "9a32cf25-0df8-4385-bcb7-134c316a4b9c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:33Z",
+            "createdtimedec": "0.1938000000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Load options to create SIPs",
+            "microservicechainlink": "b04e9232-2aea-49fc-9560-27349c8eba4e",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "9f17e882-ab5d-4dd4-b086-d18ceb377602"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:23:24Z",
+            "createdtimedec": "0.5592290000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Remove the processing directory",
+            "microservicechainlink": "d5a2ef60-a757-483c-a71a-ccbffe6b80da",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "9f9fbd1a-dff0-47ae-992f-ae1e714f5f59"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:31Z",
+            "createdtimedec": "0.8643220000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Create transfer metadata XML",
+            "microservicechainlink": "db99ab43-04d7-44ab-89ec-e09d7bbdc39d",
+            "microservicegroup": "Complete transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "a0badcea-23d6-4f01-983e-862fc7448a0a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:42Z",
+            "createdtimedec": "0.2753270000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Rename SIP directory with SIP UUID",
+            "microservicechainlink": "e3a6d178-fa65-4086-a4aa-6533e8f12d51",
+            "microservicegroup": "Rename SIP directory with SIP UUID",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "a0d62ce3-ed9f-42f3-8e77-1c8f7eeb359c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:33Z",
+            "createdtimedec": "0.8002500000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Check if DIP should be generated",
+            "microservicechainlink": "f1e286f9-4ec7-4e19-820c-dae7b8ea7d09",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "a2254b32-47ed-4811-88b0-c46ef6350acf"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:35Z",
+            "createdtimedec": "0.4658500000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Compress AIP",
+            "microservicechainlink": "d55b42c8-c7c5-4a40-b626-d248d2bd883f",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "a7122654-fc95-46db-aa27-f35132214f30"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:40Z",
+            "createdtimedec": "0.2503110000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Copy submission documentation",
+            "microservicechainlink": "0a63befa-327d-4655-a021-341b639ee9ed",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "ab36f811-397b-47eb-b681-4a7e12902d70"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:33Z",
+            "createdtimedec": "0.8788140000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Prepare AIP",
+            "microservicechainlink": "3e25bda6-5314-4bb4-aa1e-90900dce887d",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "ab5c51cc-da06-401b-b9f5-9f6de5520cf7"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:42Z",
+            "createdtimedec": "0.0148580000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Verify mets_structmap.xml compliance",
+            "microservicechainlink": "d1018160-aaab-4d92-adce-d518880d7c7d",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "ac2db5fa-3b20-43b4-bc34-9d3e4eb305dc"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:12Z",
+            "createdtimedec": "0.2711900000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/approveNormalization/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Approve normalization",
+            "microservicechainlink": "de909a42-c5b5-46e1-9985-c031b50e9d30",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "ae11ed26-6352-4668-945d-87d0aebf1bb6"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:35Z",
+            "createdtimedec": "0.6692350000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to compressionAIPDecisions directory",
+            "microservicechainlink": "002716a1-ae29-4f36-98ab-0d97192669c4",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "b1c6c1d3-9e85-4705-b732-cbc7f4e67d5b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:23Z",
+            "createdtimedec": "0.8197780000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Remove unneeded files",
+            "microservicechainlink": "5d780c7d-39d0-4f4a-922b-9d1b0d217bca",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "b3849af1-b62e-49be-9ce5-b84442e97de0"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:24Z",
+            "createdtimedec": "0.2520570000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Rename with transfer UUID",
+            "microservicechainlink": "ef6332ee-a890-4e1b-88de-986efc4269fb",
+            "microservicegroup": "Rename with transfer UUID",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "b46eec8a-ca28-416d-a13a-9495147dad8e"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:40Z",
+            "createdtimedec": "0.4347160000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Check if AIP is a file or directory",
+            "microservicechainlink": "91dc1ab1-487e-4121-a6c5-d8441da7a422",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "b56d0698-85e0-426b-8ac3-e7dbb284baf2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:47Z",
+            "createdtimedec": "0.7013380000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Set remove preservation and access normalized files to renormalize link.",
+            "microservicechainlink": "5d6a103c-9a5d-4010-83a8-6f4c61eb1478",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "b6173de1-c28b-4f3a-b7a3-1e792afe2e13"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:08:56Z",
+            "createdtimedec": "0.3720660000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/activeTransfers/standardTransfer/KSTest/",
+            "hidden": false,
+            "jobtype": "Approve standard transfer",
+            "microservicechainlink": "0c94e6b5-4714-4bec-82c8-e187e0c04d77",
+            "microservicegroup": "Approve transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "b6902af2-0145-46d4-b2e0-72f2e12ab50e"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:43Z",
+            "createdtimedec": "0.0369990000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Include default SIP processingMCP.xml",
+            "microservicechainlink": "df02cac1-f582-4a86-b7cf-da98a58e279e",
+            "microservicegroup": "Include default SIP processingMCP.xml",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "bb6b4fbd-77e4-4b2f-873c-418097fb735b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:32Z",
+            "createdtimedec": "0.6121970000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/quarantineTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Find type to process as",
+            "microservicechainlink": "55de1490-f3a0-4e1e-a25b-38b75f4f05e3",
+            "microservicegroup": "Quarantine",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "bbac97d4-ac0d-4f17-8972-5614815036ea"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:22Z",
+            "createdtimedec": "0.5777750000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Scan for viruses in metadata",
+            "microservicechainlink": "8bc92801-4308-4e3b-885b-1a89fdcd3014",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "bbbc08c5-8893-44a7-a4e7-a718728f725e"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:23:14Z",
+            "createdtimedec": "0.2375650000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/storeAIP/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "5f213529-ced4-49b0-9e30-be4e0c9b81d5",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "bdbabad3-0caf-49c5-a2f7-3f4938b4eab7"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:32Z",
+            "createdtimedec": "0.9055380000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Document empty directories?",
+            "microservicechainlink": "d0dfa5fc-e3c2-4638-9eda-f96eea1070e0",
+            "microservicegroup": "Generate AIP METS",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "bf5b806d-bb80-4999-a0ab-3cd7526c9f69"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:05Z",
+            "createdtimedec": "0.7290170000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Create thumbnails directory",
+            "microservicechainlink": "35c8763a-0430-46be-8198-9ecb23f895c8",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "bf6e1ffb-868a-4efb-b935-902cb32c7f7d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:21Z",
+            "createdtimedec": "0.9076210000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Sanitize file and directory names in metadata",
+            "microservicechainlink": "b21018df-f67d-469a-9ceb-ac92ac68654e",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "c150d996-a829-4449-8bbb-c623d612e33c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:20Z",
+            "createdtimedec": "0.5737730000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Identify file format",
+            "microservicechainlink": "2522d680-c7d9-4d06-8b11-a28d8bd8a71f",
+            "microservicegroup": "Identify file format",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "c1b09f8f-8df8-489e-ba64-711854d83d7b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:29Z",
+            "createdtimedec": "0.4886240000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Generate METS.xml document",
+            "microservicechainlink": "3409b898-e532-49d3-98ff-a2a1f9d988fa",
+            "microservicegroup": "Generate METS.xml document",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "c1ff2d99-795a-4a8b-b9a4-39fe46bd0c6f"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:30Z",
+            "createdtimedec": "0.1047880000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Check for specialized processing",
+            "microservicechainlink": "192315ea-a1bf-44cf-8cb4-0b3edd1522a6",
+            "microservicegroup": "Examine contents",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "c679242b-6b8e-4ef8-b72a-1d228f362b4a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:37Z",
+            "createdtimedec": "0.7626620000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to metadata reminder",
+            "microservicechainlink": "54b73077-a062-41cc-882c-4df1eba447d9",
+            "microservicegroup": "Add final metadata",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "c73b6753-ea24-4b35-946b-c56a1ece9404"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:11Z",
+            "createdtimedec": "0.4960140000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to approve normalization directory",
+            "microservicechainlink": "c2e6600d-cd26-42ed-bed5-95d41c06e37b",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "c7fb3317-becf-4ab4-b13f-f3fc3b5826c2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:45Z",
+            "createdtimedec": "0.2796500000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Identify manually normalized files",
+            "microservicechainlink": "15a2df8a-7b45-4c11-b6fa-884c9b7e5c67",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "ca3291d8-a759-440b-8947-3ccc8b8ccf3d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:23:22Z",
+            "createdtimedec": "0.5534130000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Index AIP",
+            "microservicechainlink": "48703fad-dc44-4c8e-8f47-933df3ef6179",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "cb7a8f1a-6aba-4292-8004-43bbd97f7933"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:33Z",
+            "createdtimedec": "0.2246000000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Create SIP(s)",
+            "microservicechainlink": "bb194013-597c-4e4a-8493-b36d190f8717",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "cbe76bcf-c088-4a9f-b81b-3e1872332752"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:20Z",
+            "createdtimedec": "0.4467290000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/activeTransfers/standardTransfer/KSTest/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "b4567e89-9fea-4256-99f5-a88987026488",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "cdba0e5b-410e-4a20-94ca-9619f234238d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:11Z",
+            "createdtimedec": "0.6642910000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Transcribe SIP contents",
+            "microservicechainlink": "7079be6d-3a25-41e6-a481-cee5f352fe6e",
+            "microservicegroup": "Transcribe SIP contents",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "cdf68aa7-d34a-472f-9965-74bd0d264fa2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:31Z",
+            "createdtimedec": "0.0937180000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Bind PIDs",
+            "microservicechainlink": "7677d1cd-2211-4969-8c10-5ec2a93d5c2f",
+            "microservicegroup": "Bind PIDs",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "cfa19fa6-d0f4-4bff-9b20-32002fb1b684"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:21Z",
+            "createdtimedec": "0.6442560000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Process JSON metadata",
+            "microservicechainlink": "b0ffcd90-eb26-4caf-8fab-58572d205f04",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "d7de4140-af49-48d9-b5ab-14594b7c1e9d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:42Z",
+            "createdtimedec": "0.8936860000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Verify SIP compliance",
+            "microservicechainlink": "208d441b-6938-44f9-b54a-bd73f05bc764",
+            "microservicegroup": "Verify SIP compliance",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "d8e20b56-caef-43b0-bc86-8ff6786e77a6"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:37Z",
+            "createdtimedec": "0.3513060000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Generate transfer structure report",
+            "microservicechainlink": "56eebd45-5600-4768-a8c2-ec0114555a3d",
+            "microservicegroup": "Generate transfer structure report",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "d9c8b5aa-b1e6-4b2c-8ad3-cdad229084c2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:32Z",
+            "createdtimedec": "0.0507840000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to SIP creation directory for completed transfers",
+            "microservicechainlink": "d27fd07e-d3ed-4767-96a5-44a2251c6d0a",
+            "microservicegroup": "Complete transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "d9efca69-7c25-4da8-9304-df4ee8469c9d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:29Z",
+            "createdtimedec": "0.3408160000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Process transfer JSON metadata",
+            "microservicechainlink": "8c8bac29-4102-4fd2-9d0a-a3bd2e607566",
+            "microservicegroup": "Reformat metadata files",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "da71e137-8a84-42d8-b3b9-67d84bdb6e7c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:45Z",
+            "createdtimedec": "0.3134570000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Check for Service directory",
+            "microservicechainlink": "1cd3b36a-5252-4a69-9b1c-3b36829288ab",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "da845f03-335b-4265-80c2-be6706b52b62"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:35Z",
+            "createdtimedec": "0.3703750000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to generate transfer tree",
+            "microservicechainlink": "559d9b14-05bf-4136-918a-de74a821b759",
+            "microservicegroup": "Generate transfer structure report",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "db9c6493-e15b-4c4c-b6d4-e050fbd263b2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:41Z",
+            "createdtimedec": "0.6980450000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to the store AIP approval directory",
+            "microservicechainlink": "7c44c454-e3cc-43d4-abe0-885f93d693c6",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "dcdef821-a146-4dd1-80da-e9237f16f28d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:29Z",
+            "createdtimedec": "0.5637820000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Perform policy checks on originals?",
+            "microservicechainlink": "70fc7040-d4fb-4d19-a0e6-792387ca1006",
+            "microservicegroup": "Validation",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "dd594c55-0bbd-4044-b93a-a67fbe685e0c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:36Z",
+            "createdtimedec": "0.8579920000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/approveNormalization/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "0f0c1f33-29f2-49ae-b413-3e043da5df61",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "debb3be5-047a-40de-83d7-2097291164cf"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:23:20Z",
+            "createdtimedec": "0.8111650000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Store the AIP",
+            "microservicechainlink": "20515483-25ed-4133-b23e-5bb14cab8e22",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "e19715cb-3d34-4bde-ab52-50d21d8cfeb7"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:24Z",
+            "createdtimedec": "0.9129470000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Store file modification dates",
+            "microservicechainlink": "f8ef02c4-f585-4b0d-9b6f-3cef6fbe527f",
+            "microservicegroup": "Characterize and extract metadata",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "e20d4f42-0b38-450b-8d78-418bd106fbb7"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:16Z",
+            "createdtimedec": "0.0643610000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Identify file format",
+            "microservicechainlink": "1dce8e21-7263-4cc4-aa59-968d9793b5f2",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "e332a1ae-4826-46c4-86b2-411ec1943fd1"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:09Z",
+            "createdtimedec": "0.3939950000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Remove files without linking information (failed normalization artifacts etc.)",
+            "microservicechainlink": "dba3028d-2029-4a87-9992-f6335d890528",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "e4d142a1-5b2e-43c7-bc37-93fed861de48"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:49Z",
+            "createdtimedec": "0.0433480000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Normalize",
+            "microservicechainlink": "cb8e5706-e73f-472f-ad9b-d1236af8095f",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "e8a8a3f2-d77e-4539-856c-e70523a826d6"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:22Z",
+            "createdtimedec": "0.6130460000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Identify file format of metadata files",
+            "microservicechainlink": "b2444a6e-c626-4487-9abc-1556dd89a8ae",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "e9a4dbc7-50b1-48a7-8128-e81f6132e507"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:40Z",
+            "createdtimedec": "0.2967730000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to SIP creation directory for completed transfers",
+            "microservicechainlink": "3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "ec3cefde-7249-4312-8c48-4846f68c4e08"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:25Z",
+            "createdtimedec": "0.0170100000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Assign UUIDs to directories?",
+            "microservicechainlink": "bd899573-694e-4d33-8c9b-df0af802437d",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "ef6ca33a-581c-4e85-89b9-f5f7618decf1"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:44Z",
+            "createdtimedec": "0.9175170000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Sanitize SIP name",
+            "microservicechainlink": "a46e95fe-4a11-4d3c-9b76-c5d8ea0b094d",
+            "microservicegroup": "Clean up names",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "f07b1d23-865d-4f77-9a1d-a16a267af779"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:22Z",
+            "createdtimedec": "0.6787230000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Remove empty manual normalization directories",
+            "microservicechainlink": "75fb5d67-5efa-4232-b00b-d85236de0d3f",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "f21d058e-d5ef-404c-a5a3-dafd68c8d68d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:35Z",
+            "createdtimedec": "0.4234930000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Select compression level",
+            "microservicechainlink": "01c651cb-c174-4ba4-b985-1d87a44d6754",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "f344a9d3-1bc2-4891-ad7b-c7e4a3a72887"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:29Z",
+            "createdtimedec": "0.4191930000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Verify metadata directory checksums",
+            "microservicechainlink": "f1bfce12-b637-443f-85f8-b6450ca01a13",
+            "microservicegroup": "Verify transfer checksums",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "f510164e-b3a8-494b-921b-52d280444e2d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:22Z",
+            "createdtimedec": "0.6469110000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Characterize and extract metadata on metadata files",
+            "microservicechainlink": "04493ab2-6cad-400d-8832-06941f121a96",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "f6f48c94-16c0-4bea-8ed5-b2b3c321820a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:38Z",
+            "createdtimedec": "0.0737080000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Sanitize Transfer name",
+            "microservicechainlink": "a329d39b-4711-4231-b54e-b5958934dccb",
+            "microservicegroup": "Clean up names",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "f9e7525e-6d6a-4ab0-b771-b9fb8d72a6f1"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:27Z",
+            "createdtimedec": "0.1562540000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Validate formats",
+            "microservicechainlink": "a536828c-be65-4088-80bd-eb511a0a063d",
+            "microservicegroup": "Validation",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "fd7eefe6-0095-43a6-b9b7-c3277b851f93"
+    }
+]

--- a/src/dashboard/tests/fixtures/am17-jobs-sip-complete.json
+++ b/src/dashboard/tests/fixtures/am17-jobs-sip-complete.json
@@ -1,0 +1,2365 @@
+[
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:20Z",
+            "createdtimedec": "0.5427310000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Determine which files to identify",
+            "microservicechainlink": "c3269a0a-91db-44e8-96d0-9c748cf80177",
+            "microservicegroup": "Identify file format",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "02f66d06-b8bd-44d2-b3f1-bc0f81837666"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:26Z",
+            "createdtimedec": "0.7195350000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Assign file UUIDs to objects",
+            "microservicechainlink": "dc144ff4-ad74-4a6e-ac15-b0beedcaf662",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "032d98c0-e1a1-4fca-953d-4adff85cd7a2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:38Z",
+            "createdtimedec": "0.0267800000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "8f639582-8881-4a8b-8574-d2f86dc4db3d",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "056de8fd-7beb-470a-9fb2-d7746ef5e9d8"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:13Z",
+            "createdtimedec": "0.8350570000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move submission documentation into objects directory",
+            "microservicechainlink": "173d310c-8e40-4669-9a69-6d4c8ffd0396",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "06e6b83f-e588-4aca-94b6-b8fc464d8f82"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:11Z",
+            "createdtimedec": "0.6488010000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Normalization report",
+            "microservicechainlink": "3a70bc05-fa82-4067-a069-a56b6006be0a",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "07c2e8e9-930f-438d-9505-786b5caa82d4"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:16Z",
+            "createdtimedec": "0.0190110000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Select file format identification command",
+            "microservicechainlink": "087d27be-c719-47d8-9bbb-9a7d8b609c44",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "07c55247-6d31-46b8-9076-93a66377af5a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:40Z",
+            "createdtimedec": "0.5357840000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Create SIP from transfer objects",
+            "microservicechainlink": "39a128e3-c35d-40b7-9363-87f75091e1ff",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "10ceb599-3616-4cfb-b63d-122366920f70"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:23Z",
+            "createdtimedec": "0.6966680000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Remove hidden files and directories",
+            "microservicechainlink": "50b67418-cb8d-434d-acc9-4a8324e7fdd2",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "11df9cfd-8920-4eaf-b735-cb7eb1705514"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:07Z",
+            "createdtimedec": "0.3753750000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Validate preservation derivatives",
+            "microservicechainlink": "5b0042a2-2244-475c-85d5-41e4b11e65d6",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "13cf0ce1-6693-4f8f-8c04-5a241d9e3a2c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:15Z",
+            "createdtimedec": "0.1398700000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Scan for viruses in submission documentation",
+            "microservicechainlink": "1ba589db-88d1-48cf-bb1a-a5f9d2b17378",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "17785dd9-7bc3-4434-8cc8-3004e0897a3b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:56Z",
+            "createdtimedec": "0.3686860000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/storeAIP/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Retrieve AIP Storage Locations",
+            "microservicechainlink": "49cbcc4d-067b-4cd5-b52e-faf50857b35a",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "1893035d-26b3-4983-aac1-2517b5ec7552"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:41Z",
+            "createdtimedec": "0.6224460000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Select file format identification command",
+            "microservicechainlink": "f09847c2-ee51-429a-9478-a860477f6b8d",
+            "microservicegroup": "Identify file format",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "1b951918-5074-47f5-a8da-5fa04349b589"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:39Z",
+            "createdtimedec": "0.7504730000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to select file ID tool",
+            "microservicechainlink": "d1b27e9e-73c8-4954-832c-36bd1e00c802",
+            "microservicegroup": "Identify file format",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "1cbc80bb-8d1d-42aa-b213-5fd9b5bf88d9"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:30Z",
+            "createdtimedec": "0.1673790000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to workFlowDecisions-quarantineSIP directory",
+            "microservicechainlink": "03ee1136-f6ad-4184-8dcb-34872f843e14",
+            "microservicegroup": "Quarantine",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "1d33ea6b-cf00-4f50-b7fc-9af9aea82219"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:18Z",
+            "createdtimedec": "0.2101350000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Remove files without linking information (failed normalization artifacts etc.)",
+            "microservicechainlink": "576f1f43-a130-4c15-abeb-c272ec458d33",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "1f08af4a-0eaf-4b9f-9676-b488ab54d362"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:33Z",
+            "createdtimedec": "0.7190840000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Add README file",
+            "microservicechainlink": "523c97cc-b267-4cfb-8209-d99e523bf4b3",
+            "microservicegroup": "Add README file",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "2023b0cf-4824-489c-a3cb-f86ea9219db6"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:24Z",
+            "createdtimedec": "0.3203370000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Bind PIDs?",
+            "microservicechainlink": "05357876-a095-4c11-86b5-a7fff01af668",
+            "microservicegroup": "Bind PIDs",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "206b0996-b17f-475f-8751-2fbc7f006170"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:42Z",
+            "createdtimedec": "0.3817950000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/storeAIP/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Store AIP",
+            "microservicechainlink": "2d32235c-02d4-4686-88a6-96f4d6c7b1c3",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "223340aa-f296-4c13-a2ac-266e35de482a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:32Z",
+            "createdtimedec": "0.3263090000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Scan for viruses",
+            "microservicechainlink": "1c2550f1-3fc0-45d8-8bc4-4c06d720283b",
+            "microservicegroup": "Scan for viruses",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "2415bc3e-6935-4615-83ff-3a31bf39c30f"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:32Z",
+            "createdtimedec": "0.6702130000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/quarantineTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "d7e6404a-a186-4806-a130-7e6d27179a15",
+            "microservicegroup": "Scan for viruses",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "24df04cb-e491-444a-9d7a-7a71b92c1996"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:21Z",
+            "createdtimedec": "0.7304290000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move metadata to objects directory",
+            "microservicechainlink": "e4b0c713-988a-4606-82ea-4b565936d9a7",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "24e9e5d1-d3fe-4abc-bde5-e8039ee8c62c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:17Z",
+            "createdtimedec": "0.0827810000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Characterize and extract metadata on submission documentation",
+            "microservicechainlink": "33d7ac55-291c-43ae-bb42-f599ef428325",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "2516263f-df1a-4537-abe9-ffa133695269"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:29Z",
+            "createdtimedec": "0.6044150000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to examine contents",
+            "microservicechainlink": "dae3c416-a8c2-4515-9081-6dbd7b265388",
+            "microservicegroup": "Examine contents",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "295cba6c-b9ee-4d3d-92fa-5b25a6f2808a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:21Z",
+            "createdtimedec": "0.8291130000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Assign file UUIDs to metadata",
+            "microservicechainlink": "dc9d4991-aefa-4d7e-b7b5-84e3c4336e74",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "2c559104-d3db-41a8-ac9b-4ead8a297eb3"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:20Z",
+            "createdtimedec": "0.9849860000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Copy transfers metadata and logs",
+            "microservicechainlink": "ee438694-815f-4b74-97e1-8e7dde2cc6d5",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "2c709f00-d63e-4f94-a5d9-f1a56aa4d493"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:06Z",
+            "createdtimedec": "0.8405990000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Normalize for preservation",
+            "microservicechainlink": "8ce378a5-1418-4184-bf02-328a06e1d3be",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "38495c1b-82bd-444c-98e5-32f58b8bd4f0"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:21Z",
+            "createdtimedec": "0.7911650000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to extract packages",
+            "microservicechainlink": "cc16178b-b632-4624-9091-822dd802a2c6",
+            "microservicegroup": "Extract packages",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "3ad3bbbd-6803-4521-9851-0617d0bb14e4"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:22Z",
+            "createdtimedec": "0.8702550000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Set transfer type: Standard",
+            "microservicechainlink": "045c43ae-d6cf-44f7-97d6-c8a602748565",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "3b8e7b23-51b2-4f06-9f08-8e15a30123f4"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:24Z",
+            "createdtimedec": "0.3766060000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Bind PID",
+            "microservicechainlink": "87e93d08-36e4-4c81-99a8-beea00b18400",
+            "microservicegroup": "Bind PIDs",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "436d6906-255a-4867-a99f-6032a98aeca5"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:32Z",
+            "createdtimedec": "0.9357270000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Generate METS.xml document",
+            "microservicechainlink": "ccf8ec5c-3a9a-404a-a7e7-8f567d3b36a0",
+            "microservicegroup": "Generate AIP METS",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "44375381-62a7-4f4f-89ff-e34acd84b22d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:33Z",
+            "createdtimedec": "0.0793740000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Check transfer directory for objects",
+            "microservicechainlink": "032cdc54-0b9b-4caf-86e8-10d63efbaec0",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "461d6635-9302-4ccc-aadc-16238d86de44"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:23Z",
+            "createdtimedec": "0.0994520000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Add processed structMap to METS.xml document",
+            "microservicechainlink": "307edcde-ad10-401c-92c4-652917c993ed",
+            "microservicegroup": "Update METS.xml document",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "49810cf7-9349-406e-ae09-3be36f921841"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:46Z",
+            "createdtimedec": "0.9716820000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Check for Access directory",
+            "microservicechainlink": "67b44f8f-bc97-4cb3-b6dd-09dba3c99d30",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "4b1620d4-6153-4003-9b62-29ef80b009bc"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:25Z",
+            "createdtimedec": "0.0731150000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Assign UUIDs to directories",
+            "microservicechainlink": "6441980c-b64b-447e-abc7-9351a2547f6a",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "4b914124-a56a-4cf6-a533-658381737fca"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:48Z",
+            "createdtimedec": "0.2230970000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Identify file format",
+            "microservicechainlink": "2dd53959-8106-457d-a385-fee57fc93aa9",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "4be57373-fa9b-4b10-9062-08c8404b4ce1"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:27Z",
+            "createdtimedec": "0.5324160000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Load labels from metadata/file_labels.csv",
+            "microservicechainlink": "1b1a4565-b501-407b-b40f-2f20889423f1",
+            "microservicegroup": "Characterize and extract metadata",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "4ca707b5-3e38-4297-ad93-39e2dff63a67"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:37Z",
+            "createdtimedec": "0.6034120000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Check for manual normalized files",
+            "microservicechainlink": "78b7adff-861d-4450-b6dd-3fabe96a849e",
+            "microservicegroup": "Process manually normalized files",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "4d0a376e-4886-417a-b7b2-194ff920fb11"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:13Z",
+            "createdtimedec": "0.7517680000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Check for submission documentation",
+            "microservicechainlink": "47dd6ea6-1ee7-4462-8b84-3fc4c1eeeb7f",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "4db028ff-493e-4191-9ec8-2853093b4527"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:38Z",
+            "createdtimedec": "0.3096780000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Reminder: add metadata if desired",
+            "microservicechainlink": "eeb23509-57e2-4529-8857-9d62525db048",
+            "microservicegroup": "Add final metadata",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "4e501091-59d4-48a7-ae48-ccb0f1b03ef0"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:24Z",
+            "createdtimedec": "0.1660600000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Verify mets_structmap.xml compliance",
+            "microservicechainlink": "d0c463c2-da4c-4a70-accb-c4ce96ac5194",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "5291a050-7953-4642-89e0-48f927613b1f"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:41Z",
+            "createdtimedec": "0.1915440000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Check transfer directory for objects",
+            "microservicechainlink": "032cdc54-0b9b-4caf-86e8-10d63efbaec0",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "537c7eef-7662-4e73-872f-73a9e294acc1"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:37Z",
+            "createdtimedec": "0.6922600000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Perform policy checks on preservation derivatives?",
+            "microservicechainlink": "153c5f41-3cfb-47ba-9150-2dd44ebc27df",
+            "microservicegroup": "Policy checks for derivatives",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "555489e4-9553-4bdf-8ba9-79d743783a5a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:47Z",
+            "createdtimedec": "0.7724690000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to select file ID tool",
+            "microservicechainlink": "a2173b55-abff-4d8f-97b9-79cc2e0a64fa",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "57310ac5-b70b-40fe-862d-8ee5c9213e14"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:24Z",
+            "createdtimedec": "0.0793030000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Verify transfer compliance",
+            "microservicechainlink": "438dc1cf-9813-44b5-a0a3-58e09ae73b8a",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "580a5130-51b6-4b17-8a28-3a7c35378c12"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:25Z",
+            "createdtimedec": "0.2945910000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Characterize and extract metadata",
+            "microservicechainlink": "303a65f6-a16f-4a06-807b-cb3425a30201",
+            "microservicegroup": "Characterize and extract metadata",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "583b3191-26ae-4b8f-a6f2-aac0f05d445c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:12Z",
+            "createdtimedec": "0.1096010000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Copy transfer submission documentation",
+            "microservicechainlink": "f574b2a0-6e0b-4c74-ac5b-a73ddb9593a0",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "5845ae60-2b13-4e68-8ac2-b1f741af85bb"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:47Z",
+            "createdtimedec": "0.7363690000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Grant normalization options for no pre-existing DIP",
+            "microservicechainlink": "74665638-5d8f-43f3-b7c9-98c4c8889766",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "58687a80-de4a-4fa4-8b4c-4ce8f09cfa1b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:39Z",
+            "createdtimedec": "0.8340470000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Serialize Dublin Core metadata to disk",
+            "microservicechainlink": "f378ec85-adcc-4ee6-ada2-bc90cfe20efb",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "5a631730-1fb5-47f4-9302-0040b6f85103"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:23Z",
+            "createdtimedec": "0.4701380000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Attempt restructure for compliance",
+            "microservicechainlink": "ea0e8838-ad3a-4bdd-be14-e5dba5a4ae0c",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "5a697064-e8bd-45f5-bb0a-e6eb41aca692"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:28Z",
+            "createdtimedec": "0.1733820000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Assign checksums and file sizes to objects",
+            "microservicechainlink": "370aca94-65ab-4f2a-9d7d-294a62c8b7ba",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "5c2de7de-fd76-44a2-bed8-dad0b63699f2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:25Z",
+            "createdtimedec": "0.9311930000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Include default Transfer processingMCP.xml",
+            "microservicechainlink": "0c96c798-9ace-4c05-b3cf-243cdad796b7",
+            "microservicegroup": "Include default Transfer processingMCP.xml",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "5c9d3277-2543-4677-bc4a-35b370a5f6ee"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:43Z",
+            "createdtimedec": "0.1356100000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Remove cache files",
+            "microservicechainlink": "f3be1ee1-8881-465d-80a6-a6f093d40ec2",
+            "microservicegroup": "Remove cache files",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "5e0a2224-19d2-4214-8a8a-b6a0197d7fdb"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:23:15Z",
+            "createdtimedec": "0.9668910000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Verify AIP",
+            "microservicechainlink": "3f543585-fa4f-4099-9153-dd6d53572f5c",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "5e8c16ee-b559-4ad4-9dec-4c1210411b66"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:13Z",
+            "createdtimedec": "0.9227640000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Assign file UUIDs to submission documentation",
+            "microservicechainlink": "4edfe7e4-82ff-4c0a-ba5f-29f1ee14e17a",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "6021d2d2-e2b5-4705-846a-9c8c3dd9347e"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:37Z",
+            "createdtimedec": "0.3796090000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Sanitize object's file and directory names",
+            "microservicechainlink": "2584b25c-8d98-44b7-beca-2b3ea2ea2505",
+            "microservicegroup": "Clean up names",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "6433037e-68e1-4e8c-ae22-0ec15a724d6b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:37Z",
+            "createdtimedec": "0.6164480000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/createTree/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "6eca2676-b4ed-48d9-adb0-374e1d5c6e71",
+            "microservicegroup": "Generate transfer structure report",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "65aff125-02b2-4b17-85aa-ba582274cfc8"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:23:23Z",
+            "createdtimedec": "0.7292530000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Clean up after storing AIP",
+            "microservicechainlink": "b7cf0d9a-504f-4f4e-9930-befa817d67ff",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "66c74e9c-c737-4837-9305-e69744b097f4"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:30Z",
+            "createdtimedec": "0.1265730000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Parse external METS",
+            "microservicechainlink": "675acd22-828d-4949-adc7-1888240f5e3d",
+            "microservicegroup": "Complete transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "6c7b8dcc-73eb-43d0-ba3d-7c2afd89c689"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:49Z",
+            "createdtimedec": "0.0214560000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Resume after normalization file identification tool selected.",
+            "microservicechainlink": "83484326-7be7-4f9f-b252-94553cd42370",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "6efe129a-229a-4f67-9acf-31ecf3a63adf"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:41Z",
+            "createdtimedec": "0.1691920000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/system/autoProcessSIP/KSTest/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "70669a5b-01e4-4ea0-ac70-10292f87da05",
+            "microservicegroup": "Verify SIP compliance",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "7348f7b5-87df-4031-981a-efa385b84235"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:32Z",
+            "createdtimedec": "0.6373420000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/quarantineTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Workflow decision - send transfer to quarantine",
+            "microservicechainlink": "755b4177-c587-41a7-8c52-015277568302",
+            "microservicegroup": "Quarantine",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "7518c215-8875-4b62-8982-b1152de353db"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:41Z",
+            "createdtimedec": "0.5427050000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Removed bagged files",
+            "microservicechainlink": "746b1f47-2dad-427b-8915-8b0cb7acccd8",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "77aca213-6c52-401b-aa7c-9cc582bef053"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:22Z",
+            "createdtimedec": "0.0646500000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Determine if transfer contains packages",
+            "microservicechainlink": "b944ec7f-7f99-491f-986d-58914c9bb4fa",
+            "microservicegroup": "Extract packages",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "77ce5e1d-c9c0-42cb-877b-0ef8231cd69b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:05Z",
+            "createdtimedec": "0.7997020000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Normalize for thumbnails",
+            "microservicechainlink": "180ae3d0-aa6c-4ed4-ab94-d0a2121e7f21",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "78b6ab8a-5bc2-45a1-9aa6-b4ccb128dffb"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:42Z",
+            "createdtimedec": "0.1188490000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Check if SIP is from Maildir Transfer",
+            "microservicechainlink": "b3d11842-0090-420a-8919-52d7039d50e6",
+            "microservicegroup": "Rename SIP directory with SIP UUID",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "78bdd63f-48af-4641-9506-b99a5df7ce43"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:21Z",
+            "createdtimedec": "0.8723570000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Assign checksums and file sizes to metadata ",
+            "microservicechainlink": "b6b0fe37-aa26-40bd-8be8-d3acebf3ccf8",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "7914eedc-fa38-4b08-bccb-4397dd51b8b2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:57Z",
+            "createdtimedec": "0.3865000000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/storeAIP/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Store AIP location",
+            "microservicechainlink": "b320ce81-9982-408a-9502-097d0daa48fa",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "81eace71-e71e-49bf-8b67-81eb6bf55ed3"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:14Z",
+            "createdtimedec": "0.7617530000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Assign checksums and file sizes to submissionDocumentation",
+            "microservicechainlink": "2a62f025-83ec-4f23-adb4-11d5da7ad8c2",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "83c2f5f1-50d5-42b6-9497-bd8634c717a9"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:04Z",
+            "createdtimedec": "0.9524960000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "6b39088b-683e-48bd-ab89-9dab47f4e9e0",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "85f99e73-76ba-4e7e-9dc0-1ab3db3c1993"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:30Z",
+            "createdtimedec": "0.1317910000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Designate to process as a standard transfer",
+            "microservicechainlink": "9071c352-aed5-444c-ac3f-b6c52dfb65ac",
+            "microservicegroup": "Quarantine",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "8e7a0cbb-42b5-411c-9d97-81481cad1c36"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:35Z",
+            "createdtimedec": "0.3804210000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Select compression algorithm",
+            "microservicechainlink": "01d64f58-8295-4b7b-9cab-8f1b153a504f",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "900259c8-6abf-439e-b886-8d4d26a58425"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:30Z",
+            "createdtimedec": "0.0716960000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Examine contents?",
+            "microservicechainlink": "accea2bf-ba74-4a3a-bb97-614775c74459",
+            "microservicegroup": "Examine contents",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "92291243-2d4f-40e6-80fa-48446905f811"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:14Z",
+            "createdtimedec": "0.4946540000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Sanitize file and directory names in submission documentation",
+            "microservicechainlink": "11033dbd-e4d4-4dd6-8bcf-48c424e222e3",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "93fdc858-d114-47be-ab3a-9a99f877279e"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:25Z",
+            "createdtimedec": "0.5899110000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Load rights",
+            "microservicechainlink": "1a136608-ae7b-42b4-bf2f-de0e514cfd47",
+            "microservicegroup": "Characterize and extract metadata",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "94a02094-f788-40ed-a632-c9e5255b7173"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:40Z",
+            "createdtimedec": "0.3450850000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Set bag file permissions",
+            "microservicechainlink": "5fbc344c-19c8-48be-a753-02dac987428c",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "95638549-560b-4c21-8f0a-9d45ce317d88"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:45Z",
+            "createdtimedec": "0.6168830000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Load Dublin Core metadata from disk",
+            "microservicechainlink": "970b7d17-7a6b-4d51-808b-c94b78c0d97f",
+            "microservicegroup": "Clean up names",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "95a5c777-4a00-4562-b297-38c477daef44"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:22Z",
+            "createdtimedec": "0.3593480000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Verify checksums generated on ingest",
+            "microservicechainlink": "88807d68-062e-4d1a-a2d5-2d198c88d8ca",
+            "microservicegroup": "Verify checksums",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "95d022de-98f7-4abc-b797-8ffb4b5f325a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:11Z",
+            "createdtimedec": "0.7153410000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Transcribe",
+            "microservicechainlink": "2900f6d8-b64c-4f2a-8f7f-bb60a57394f6",
+            "microservicegroup": "Transcribe SIP contents",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "95dfaf50-3985-4abf-95e1-3d2e7813e60a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:48Z",
+            "createdtimedec": "0.1705820000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Select pre-normalize file format identification command",
+            "microservicechainlink": "7a024896-c4f7-4808-a240-44c87c762bc5",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "99e2a78d-922c-4750-8190-2694fd216ccf"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:37Z",
+            "createdtimedec": "0.7222670000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Perform policy checks on access derivatives?",
+            "microservicechainlink": "8ce07e94-6130-4987-96f0-2399ad45c5c2",
+            "microservicegroup": "Policy checks for derivatives",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "9a32cf25-0df8-4385-bcb7-134c316a4b9c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:33Z",
+            "createdtimedec": "0.1938000000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Load options to create SIPs",
+            "microservicechainlink": "b04e9232-2aea-49fc-9560-27349c8eba4e",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "9f17e882-ab5d-4dd4-b086-d18ceb377602"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:23:24Z",
+            "createdtimedec": "0.5592290000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Remove the processing directory",
+            "microservicechainlink": "d5a2ef60-a757-483c-a71a-ccbffe6b80da",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "9f9fbd1a-dff0-47ae-992f-ae1e714f5f59"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:31Z",
+            "createdtimedec": "0.8643220000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Create transfer metadata XML",
+            "microservicechainlink": "db99ab43-04d7-44ab-89ec-e09d7bbdc39d",
+            "microservicegroup": "Complete transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "a0badcea-23d6-4f01-983e-862fc7448a0a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:42Z",
+            "createdtimedec": "0.2753270000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Rename SIP directory with SIP UUID",
+            "microservicechainlink": "e3a6d178-fa65-4086-a4aa-6533e8f12d51",
+            "microservicegroup": "Rename SIP directory with SIP UUID",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "a0d62ce3-ed9f-42f3-8e77-1c8f7eeb359c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:33Z",
+            "createdtimedec": "0.8002500000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Check if DIP should be generated",
+            "microservicechainlink": "f1e286f9-4ec7-4e19-820c-dae7b8ea7d09",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "a2254b32-47ed-4811-88b0-c46ef6350acf"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:35Z",
+            "createdtimedec": "0.4658500000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Compress AIP",
+            "microservicechainlink": "d55b42c8-c7c5-4a40-b626-d248d2bd883f",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "a7122654-fc95-46db-aa27-f35132214f30"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:40Z",
+            "createdtimedec": "0.2503110000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Copy submission documentation",
+            "microservicechainlink": "0a63befa-327d-4655-a021-341b639ee9ed",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "ab36f811-397b-47eb-b681-4a7e12902d70"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:33Z",
+            "createdtimedec": "0.8788140000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Prepare AIP",
+            "microservicechainlink": "3e25bda6-5314-4bb4-aa1e-90900dce887d",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "ab5c51cc-da06-401b-b9f5-9f6de5520cf7"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:42Z",
+            "createdtimedec": "0.0148580000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Verify mets_structmap.xml compliance",
+            "microservicechainlink": "d1018160-aaab-4d92-adce-d518880d7c7d",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "ac2db5fa-3b20-43b4-bc34-9d3e4eb305dc"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:12Z",
+            "createdtimedec": "0.2711900000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/approveNormalization/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Approve normalization",
+            "microservicechainlink": "de909a42-c5b5-46e1-9985-c031b50e9d30",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "ae11ed26-6352-4668-945d-87d0aebf1bb6"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:35Z",
+            "createdtimedec": "0.6692350000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to compressionAIPDecisions directory",
+            "microservicechainlink": "002716a1-ae29-4f36-98ab-0d97192669c4",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "b1c6c1d3-9e85-4705-b732-cbc7f4e67d5b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:23Z",
+            "createdtimedec": "0.8197780000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Remove unneeded files",
+            "microservicechainlink": "5d780c7d-39d0-4f4a-922b-9d1b0d217bca",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "b3849af1-b62e-49be-9ce5-b84442e97de0"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:24Z",
+            "createdtimedec": "0.2520570000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Rename with transfer UUID",
+            "microservicechainlink": "ef6332ee-a890-4e1b-88de-986efc4269fb",
+            "microservicegroup": "Rename with transfer UUID",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "b46eec8a-ca28-416d-a13a-9495147dad8e"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:40Z",
+            "createdtimedec": "0.4347160000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Check if AIP is a file or directory",
+            "microservicechainlink": "91dc1ab1-487e-4121-a6c5-d8441da7a422",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "b56d0698-85e0-426b-8ac3-e7dbb284baf2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:47Z",
+            "createdtimedec": "0.7013380000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Set remove preservation and access normalized files to renormalize link.",
+            "microservicechainlink": "5d6a103c-9a5d-4010-83a8-6f4c61eb1478",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "b6173de1-c28b-4f3a-b7a3-1e792afe2e13"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:08:56Z",
+            "createdtimedec": "0.3720660000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/activeTransfers/standardTransfer/KSTest/",
+            "hidden": false,
+            "jobtype": "Approve standard transfer",
+            "microservicechainlink": "0c94e6b5-4714-4bec-82c8-e187e0c04d77",
+            "microservicegroup": "Approve transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "b6902af2-0145-46d4-b2e0-72f2e12ab50e"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:43Z",
+            "createdtimedec": "0.0369990000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Include default SIP processingMCP.xml",
+            "microservicechainlink": "df02cac1-f582-4a86-b7cf-da98a58e279e",
+            "microservicegroup": "Include default SIP processingMCP.xml",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "bb6b4fbd-77e4-4b2f-873c-418097fb735b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:32Z",
+            "createdtimedec": "0.6121970000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/quarantineTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Find type to process as",
+            "microservicechainlink": "55de1490-f3a0-4e1e-a25b-38b75f4f05e3",
+            "microservicegroup": "Quarantine",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "bbac97d4-ac0d-4f17-8972-5614815036ea"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:22Z",
+            "createdtimedec": "0.5777750000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Scan for viruses in metadata",
+            "microservicechainlink": "8bc92801-4308-4e3b-885b-1a89fdcd3014",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "bbbc08c5-8893-44a7-a4e7-a718728f725e"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:23:14Z",
+            "createdtimedec": "0.2375650000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/storeAIP/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "5f213529-ced4-49b0-9e30-be4e0c9b81d5",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "bdbabad3-0caf-49c5-a2f7-3f4938b4eab7"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:32Z",
+            "createdtimedec": "0.9055380000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Document empty directories?",
+            "microservicechainlink": "d0dfa5fc-e3c2-4638-9eda-f96eea1070e0",
+            "microservicegroup": "Generate AIP METS",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "bf5b806d-bb80-4999-a0ab-3cd7526c9f69"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:05Z",
+            "createdtimedec": "0.7290170000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Create thumbnails directory",
+            "microservicechainlink": "35c8763a-0430-46be-8198-9ecb23f895c8",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "bf6e1ffb-868a-4efb-b935-902cb32c7f7d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:21Z",
+            "createdtimedec": "0.9076210000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Sanitize file and directory names in metadata",
+            "microservicechainlink": "b21018df-f67d-469a-9ceb-ac92ac68654e",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "c150d996-a829-4449-8bbb-c623d612e33c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:20Z",
+            "createdtimedec": "0.5737730000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolTransfer/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Identify file format",
+            "microservicechainlink": "2522d680-c7d9-4d06-8b11-a28d8bd8a71f",
+            "microservicegroup": "Identify file format",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "c1b09f8f-8df8-489e-ba64-711854d83d7b"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:29Z",
+            "createdtimedec": "0.4886240000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Generate METS.xml document",
+            "microservicechainlink": "3409b898-e532-49d3-98ff-a2a1f9d988fa",
+            "microservicegroup": "Generate METS.xml document",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "c1ff2d99-795a-4a8b-b9a4-39fe46bd0c6f"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:30Z",
+            "createdtimedec": "0.1047880000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Check for specialized processing",
+            "microservicechainlink": "192315ea-a1bf-44cf-8cb4-0b3edd1522a6",
+            "microservicegroup": "Examine contents",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "c679242b-6b8e-4ef8-b72a-1d228f362b4a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:37Z",
+            "createdtimedec": "0.7626620000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to metadata reminder",
+            "microservicechainlink": "54b73077-a062-41cc-882c-4df1eba447d9",
+            "microservicegroup": "Add final metadata",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "c73b6753-ea24-4b35-946b-c56a1ece9404"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:11Z",
+            "createdtimedec": "0.4960140000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to approve normalization directory",
+            "microservicechainlink": "c2e6600d-cd26-42ed-bed5-95d41c06e37b",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "c7fb3317-becf-4ab4-b13f-f3fc3b5826c2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:45Z",
+            "createdtimedec": "0.2796500000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Identify manually normalized files",
+            "microservicechainlink": "15a2df8a-7b45-4c11-b6fa-884c9b7e5c67",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "ca3291d8-a759-440b-8947-3ccc8b8ccf3d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:23:22Z",
+            "createdtimedec": "0.5534130000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Index AIP",
+            "microservicechainlink": "48703fad-dc44-4c8e-8f47-933df3ef6179",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "cb7a8f1a-6aba-4292-8004-43bbd97f7933"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:33Z",
+            "createdtimedec": "0.2246000000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Create SIP(s)",
+            "microservicechainlink": "bb194013-597c-4e4a-8493-b36d190f8717",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "cbe76bcf-c088-4a9f-b81b-3e1872332752"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:20Z",
+            "createdtimedec": "0.4467290000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/activeTransfers/standardTransfer/KSTest/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "b4567e89-9fea-4256-99f5-a88987026488",
+            "microservicegroup": "Verify transfer compliance",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "cdba0e5b-410e-4a20-94ca-9619f234238d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:11Z",
+            "createdtimedec": "0.6642910000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Transcribe SIP contents",
+            "microservicechainlink": "7079be6d-3a25-41e6-a481-cee5f352fe6e",
+            "microservicegroup": "Transcribe SIP contents",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "cdf68aa7-d34a-472f-9965-74bd0d264fa2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:31Z",
+            "createdtimedec": "0.0937180000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Bind PIDs",
+            "microservicechainlink": "7677d1cd-2211-4969-8c10-5ec2a93d5c2f",
+            "microservicegroup": "Bind PIDs",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "cfa19fa6-d0f4-4bff-9b20-32002fb1b684"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:21Z",
+            "createdtimedec": "0.6442560000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Process JSON metadata",
+            "microservicechainlink": "b0ffcd90-eb26-4caf-8fab-58572d205f04",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "d7de4140-af49-48d9-b5ab-14594b7c1e9d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:42Z",
+            "createdtimedec": "0.8936860000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest/",
+            "hidden": false,
+            "jobtype": "Verify SIP compliance",
+            "microservicechainlink": "208d441b-6938-44f9-b54a-bd73f05bc764",
+            "microservicegroup": "Verify SIP compliance",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "d8e20b56-caef-43b0-bc86-8ff6786e77a6"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:37Z",
+            "createdtimedec": "0.3513060000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Generate transfer structure report",
+            "microservicechainlink": "56eebd45-5600-4768-a8c2-ec0114555a3d",
+            "microservicegroup": "Generate transfer structure report",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "d9c8b5aa-b1e6-4b2c-8ad3-cdad229084c2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:32Z",
+            "createdtimedec": "0.0507840000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/examineContentsChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to SIP creation directory for completed transfers",
+            "microservicechainlink": "d27fd07e-d3ed-4767-96a5-44a2251c6d0a",
+            "microservicegroup": "Complete transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "d9efca69-7c25-4da8-9304-df4ee8469c9d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:29Z",
+            "createdtimedec": "0.3408160000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Process transfer JSON metadata",
+            "microservicechainlink": "8c8bac29-4102-4fd2-9d0a-a3bd2e607566",
+            "microservicegroup": "Reformat metadata files",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "da71e137-8a84-42d8-b3b9-67d84bdb6e7c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:45Z",
+            "createdtimedec": "0.3134570000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Check for Service directory",
+            "microservicechainlink": "1cd3b36a-5252-4a69-9b1c-3b36829288ab",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "da845f03-335b-4265-80c2-be6706b52b62"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:35Z",
+            "createdtimedec": "0.3703750000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to generate transfer tree",
+            "microservicechainlink": "559d9b14-05bf-4136-918a-de74a821b759",
+            "microservicegroup": "Generate transfer structure report",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "db9c6493-e15b-4c4c-b6d4-e050fbd263b2"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:41Z",
+            "createdtimedec": "0.6980450000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to the store AIP approval directory",
+            "microservicechainlink": "7c44c454-e3cc-43d4-abe0-885f93d693c6",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "dcdef821-a146-4dd1-80da-e9237f16f28d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:29Z",
+            "createdtimedec": "0.5637820000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Perform policy checks on originals?",
+            "microservicechainlink": "70fc7040-d4fb-4d19-a0e6-792387ca1006",
+            "microservicegroup": "Validation",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "dd594c55-0bbd-4044-b93a-a67fbe685e0c"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:36Z",
+            "createdtimedec": "0.8579920000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/approveNormalization/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Move to processing directory",
+            "microservicechainlink": "0f0c1f33-29f2-49ae-b413-3e043da5df61",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "debb3be5-047a-40de-83d7-2097291164cf"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:23:20Z",
+            "createdtimedec": "0.8111650000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Store the AIP",
+            "microservicechainlink": "20515483-25ed-4133-b23e-5bb14cab8e22",
+            "microservicegroup": "Store AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "e19715cb-3d34-4bde-ab52-50d21d8cfeb7"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:24Z",
+            "createdtimedec": "0.9129470000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Store file modification dates",
+            "microservicechainlink": "f8ef02c4-f585-4b0d-9b6f-3cef6fbe527f",
+            "microservicegroup": "Characterize and extract metadata",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "e20d4f42-0b38-450b-8d78-418bd106fbb7"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:16Z",
+            "createdtimedec": "0.0643610000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Identify file format",
+            "microservicechainlink": "1dce8e21-7263-4cc4-aa59-968d9793b5f2",
+            "microservicegroup": "Process submission documentation",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "e332a1ae-4826-46c4-86b2-411ec1943fd1"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:21:09Z",
+            "createdtimedec": "0.3939950000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Remove files without linking information (failed normalization artifacts etc.)",
+            "microservicechainlink": "dba3028d-2029-4a87-9992-f6335d890528",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "e4d142a1-5b2e-43c7-bc37-93fed861de48"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:49Z",
+            "createdtimedec": "0.0433480000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/selectFormatIDToolIngest/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Normalize",
+            "microservicechainlink": "cb8e5706-e73f-472f-ad9b-d1236af8095f",
+            "microservicegroup": "Normalize",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "e8a8a3f2-d77e-4539-856c-e70523a826d6"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:22Z",
+            "createdtimedec": "0.6130460000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Identify file format of metadata files",
+            "microservicechainlink": "b2444a6e-c626-4487-9abc-1556dd89a8ae",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "e9a4dbc7-50b1-48a7-8128-e81f6132e507"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:40Z",
+            "createdtimedec": "0.2967730000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Move to SIP creation directory for completed transfers",
+            "microservicechainlink": "3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5",
+            "microservicegroup": "Create SIP from Transfer",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "ec3cefde-7249-4312-8c48-4846f68c4e08"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:25Z",
+            "createdtimedec": "0.0170100000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Assign UUIDs to directories?",
+            "microservicechainlink": "bd899573-694e-4d33-8c9b-df0af802437d",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "ef6ca33a-581c-4e85-89b9-f5f7618decf1"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:19:44Z",
+            "createdtimedec": "0.9175170000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Sanitize SIP name",
+            "microservicechainlink": "a46e95fe-4a11-4d3c-9b76-c5d8ea0b094d",
+            "microservicegroup": "Clean up names",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "f07b1d23-865d-4f77-9a1d-a16a267af779"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:22Z",
+            "createdtimedec": "0.6787230000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Remove empty manual normalization directories",
+            "microservicechainlink": "75fb5d67-5efa-4232-b00b-d85236de0d3f",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "f21d058e-d5ef-404c-a5a3-dafd68c8d68d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:35Z",
+            "createdtimedec": "0.4234930000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/compressionAIPDecisions/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Select compression level",
+            "microservicechainlink": "01c651cb-c174-4ba4-b985-1d87a44d6754",
+            "microservicegroup": "Prepare AIP",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "f344a9d3-1bc2-4891-ad7b-c7e4a3a72887"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:29Z",
+            "createdtimedec": "0.4191930000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Verify metadata directory checksums",
+            "microservicechainlink": "f1bfce12-b637-443f-85f8-b6450ca01a13",
+            "microservicegroup": "Verify transfer checksums",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "f510164e-b3a8-494b-921b-52d280444e2d"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:22:22Z",
+            "createdtimedec": "0.6469110000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/metadataReminder/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "hidden": false,
+            "jobtype": "Characterize and extract metadata on metadata files",
+            "microservicechainlink": "04493ab2-6cad-400d-8832-06941f121a96",
+            "microservicegroup": "Process metadata directory",
+            "sipuuid": "535b4469-221b-41bb-aeaa-a78c5791c1c4",
+            "subjobof": "",
+            "unittype": "unitSIP"
+        },
+        "model": "main.job",
+        "pk": "f6f48c94-16c0-4bea-8ed5-b2b3c321820a"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:12:38Z",
+            "createdtimedec": "0.0737080000",
+            "currentstep": 2,
+            "directory": "%sharedPath%currentlyProcessing/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Sanitize Transfer name",
+            "microservicechainlink": "a329d39b-4711-4231-b54e-b5958934dccb",
+            "microservicegroup": "Clean up names",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "f9e7525e-6d6a-4ab0-b771-b9fb8d72a6f1"
+    },
+    {
+        "fields": {
+            "createdtime": "2018-10-17T20:18:27Z",
+            "createdtimedec": "0.1562540000",
+            "currentstep": 2,
+            "directory": "%sharedPath%watchedDirectories/workFlowDecisions/extractPackagesChoice/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "hidden": false,
+            "jobtype": "Validate formats",
+            "microservicechainlink": "a536828c-be65-4088-80bd-eb511a0a063d",
+            "microservicegroup": "Validation",
+            "sipuuid": "cea636e5-0e6f-4f9e-80ac-06039fec247d",
+            "subjobof": "",
+            "unittype": "unitTransfer"
+        },
+        "model": "main.job",
+        "pk": "fd7eefe6-0095-43a6-b9b7-c3277b851f93"
+    }
+]

--- a/src/dashboard/tests/fixtures/am17-microservicechainlink.json
+++ b/src/dashboard/tests/fixtures/am17-microservicechainlink.json
@@ -1,0 +1,4500 @@
+[
+    {
+        "fields": {
+            "currenttask": "18dceb0a-dfb1-4b18-81a7-c6c5c578c5f1",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-11-07T22:51:34Z",
+            "microservicegroup": "Prepare AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "002716a1-ae29-4f36-98ab-0d97192669c4"
+    },
+    {
+        "fields": {
+            "currenttask": "c2c7edcc-0e65-4df7-812f-a2ee5b5d52b6",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "e19f8eed-faf9-4e04-bf1f-e9418f2b2b11",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "01b30826-bfc4-4e07-8ca2-4263debad642"
+    },
+    {
+        "fields": {
+            "currenttask": "2f6947ee-5d92-416a-bade-b1079767e641",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Prepare AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "01c651cb-c174-4ba4-b985-1d87a44d6754"
+    },
+    {
+        "fields": {
+            "currenttask": "8a291152-729c-42f2-ab2e-c53b9f357799",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Prepare AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "01d64f58-8295-4b7b-9cab-8f1b153a504f"
+    },
+    {
+        "fields": {
+            "currenttask": "7c02a87b-7113-4851-97cd-2cf9d3fc0010",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "01fd7a29-deb9-4dd1-8e28-1c48fc1ac41b"
+    },
+    {
+        "fields": {
+            "currenttask": "8cda5b7a-fb44-4a61-a865-6ad01af5a150",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Create SIP from Transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "032cdc54-0b9b-4caf-86e8-10d63efbaec0"
+    },
+    {
+        "fields": {
+            "currenttask": "3e70f50d-5056-413e-a3d1-7b4b13d2b821",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "03ee1136-f6ad-4184-8dcb-34872f843e14"
+    },
+    {
+        "fields": {
+            "currenttask": "6511ac58-d68e-4381-9cf3-01f2637acb4c",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "75fb5d67-5efa-4232-b00b-d85236de0d3f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Process metadata directory",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "04493ab2-6cad-400d-8832-06941f121a96"
+    },
+    {
+        "fields": {
+            "currenttask": "48929c19-c0c7-41b2-8bd0-552b22e2d86f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "50b67418-cb8d-434d-acc9-4a8324e7fdd2",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "045c43ae-d6cf-44f7-97d6-c8a602748565"
+    },
+    {
+        "fields": {
+            "currenttask": "02b44c99-f499-42d4-8742-3576c0d52804",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "87e93d08-36e4-4c81-99a8-beea00b18400",
+            "lastmodified": "2018-05-16T18:06:04Z",
+            "microservicegroup": "Bind PIDs",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "05357876-a095-4c11-86b5-a7fff01af668"
+    },
+    {
+        "fields": {
+            "currenttask": "f3567a6d-8a45-4174-b302-a629cdbfbe92",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "05f99ffd-abf2-4f5a-9ec8-f80a59967b89"
+    },
+    {
+        "fields": {
+            "currenttask": "0c95f944-837f-4ada-a396-2c7a818806c6",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Process submission documentation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "087d27be-c719-47d8-9bbb-9a7d8b609c44"
+    },
+    {
+        "fields": {
+            "currenttask": "a8489361-b731-4d4a-861d-f4da1767665f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "bcabd5e2-c93e-4aaa-af6a-9a74d54e8bf0",
+            "lastmodified": "2013-11-15T00:31:31Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "092b47db-6f77-4072-aed3-eb248ab69e9c"
+    },
+    {
+        "fields": {
+            "currenttask": "21f8f2b6-d285-490a-9276-bfa87a0a4fb9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-01-10T22:49:48Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "09b85517-e5f5-415b-a950-1a60ee285242"
+    },
+    {
+        "fields": {
+            "currenttask": "2894f4ea-0d11-431f-a7de-c2f765bd55a6",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "5fbc344c-19c8-48be-a753-02dac987428c",
+            "lastmodified": "2015-05-25T16:33:14Z",
+            "microservicegroup": "Prepare AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0a63befa-327d-4655-a021-341b639ee9ed"
+    },
+    {
+        "fields": {
+            "currenttask": "21f8f2b6-d285-490a-9276-bfa87a0a4fb9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "153c5f41-3cfb-47ba-9150-2dd44ebc27df",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0a6558cf-cf5f-4646-977e-7d6b4fde47e8"
+    },
+    {
+        "fields": {
+            "currenttask": "acd5e136-11ed-46fe-bf67-dc108f115d6b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "f6fdd1a7-f0c5-4631-b5d3-19421155bd7a",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0b92a510-a290-44a8-86d8-6b7139be29df"
+    },
+    {
+        "fields": {
+            "currenttask": "3ae4931e-886e-4e0a-9a85-9b047c9983ac",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Prepare AIC",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0c2c9c9a-25b2-4a2d-a790-103da79f9604"
+    },
+    {
+        "fields": {
+            "currenttask": "1b8b596f-b6ee-440f-b59c-5e8b39a2b46d",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0c94e6b5-4714-4bec-82c8-e187e0c04d77"
+    },
+    {
+        "fields": {
+            "currenttask": "a73b3690-ac75-4030-bb03-0c07576b649b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Include default Transfer processingMCP.xml",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0c96c798-9ace-4c05-b3cf-243cdad796b7"
+    },
+    {
+        "fields": {
+            "currenttask": "be4e3ee6-9be3-465f-93f0-77a4ccdfd1db",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2013-03-27T20:12:26Z",
+            "microservicegroup": "Reject AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0d7f5dc2-b9af-43bf-b698-10fdcc5b014d"
+    },
+    {
+        "fields": {
+            "currenttask": "7c02a87b-7113-4851-97cd-2cf9d3fc0010",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0e06d968-4b5b-4084-aab4-053a2a8d1679"
+    },
+    {
+        "fields": {
+            "currenttask": "7c02a87b-7113-4851-97cd-2cf9d3fc0010",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0e1a8a6b-abcc-4ed6-b4fb-cbccfdc23ef5"
+    },
+    {
+        "fields": {
+            "currenttask": "7c02a87b-7113-4851-97cd-2cf9d3fc0010",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Clean up names",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0e379b19-771e-4d90-a7e5-1583e4893c56"
+    },
+    {
+        "fields": {
+            "currenttask": "a75ee667-3a1c-4950-9194-e07d0e6bf545",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "95616c10-a79f-48ca-a352-234cc91eaf08",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Identify file format",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0e41c244-6c3e-46b9-a554-65e66e5c9324"
+    },
+    {
+        "fields": {
+            "currenttask": "74146fe4-365d-4f14-9aae-21eafa7d8393",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-01-03T02:10:39Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0f0c1f33-29f2-49ae-b413-3e043da5df61"
+    },
+    {
+        "fields": {
+            "currenttask": "0b90715c-50bc-4cb7-a390-771a7cc8180f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-11-30T19:55:47Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0fc3c795-dc68-4aa0-86fc-cbd6af3302fa"
+    },
+    {
+        "fields": {
+            "currenttask": "1dd8e61f-0579-4a87-bfec-60bedb355048",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "8ce07e94-6130-4987-96f0-2399ad45c5c2",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "microservicegroup": "Policy checks for derivatives",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "0fd20984-db3c-492b-a512-eedd74bacc82"
+    },
+    {
+        "fields": {
+            "currenttask": "869c4c44-6e7d-4473-934d-80c7b95a8310",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "192315ea-a1bf-44cf-8cb4-0b3edd1522a6",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Examine contents",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "100a75f4-9d2a-41bf-8dd0-aec811ae1077"
+    },
+    {
+        "fields": {
+            "currenttask": "68920df3-66aa-44fc-b221-710dbe97680a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-01-03T02:10:38Z",
+            "microservicegroup": "Process manually normalized files",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "10c40e41-fb10-48b5-9d01-336cd958afe8"
+    },
+    {
+        "fields": {
+            "currenttask": "f23a22b8-a3b0-440b-bf4e-fb6e8e6e6b14",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Process submission documentation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "11033dbd-e4d4-4dd6-8bcf-48c424e222e3"
+    },
+    {
+        "fields": {
+            "currenttask": "8ed6f0e4-cd5c-4c4b-bce0-e8949ea696cd",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2015-05-25T16:33:14Z",
+            "microservicegroup": "Prepare DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "1401c4d0-fb6f-42ef-94d3-c884c25800b2"
+    },
+    {
+        "fields": {
+            "currenttask": "741a09ee-8143-4216-8919-1046571af3e9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Prepare AIC",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "142d0a36-2b88-4b98-8a33-d809f667ecef"
+    },
+    {
+        "fields": {
+            "currenttask": "a4aad773-480a-422a-8e61-124fc7487572",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": null,
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "microservicegroup": "Policy checks for derivatives",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "153c5f41-3cfb-47ba-9150-2dd44ebc27df"
+    },
+    {
+        "fields": {
+            "currenttask": "243b67e9-4d0b-4c38-8fa4-0fa3df8a5b86",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "15402367-2d3f-475e-b251-55532347a3c2"
+    },
+    {
+        "fields": {
+            "currenttask": "76729a40-dfa1-4c1a-adbf-01fb362324f5",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "154dd501-a344-45a9-97e3-b30093da35f5"
+    },
+    {
+        "fields": {
+            "currenttask": "f0c4abd3-1947-4d11-b78b-a55078460100",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "960f6db0-5b41-417c-bedc-a0eb75a82227",
+            "lastmodified": "2018-05-16T18:06:06Z",
+            "microservicegroup": "Include default Transfer processingMCP.xml",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "1563f22f-f5f7-4dfe-a926-6ab50d408832"
+    },
+    {
+        "fields": {
+            "currenttask": "602e9b26-5839-4940-b230-0264bb873fe7",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-02-19T00:52:52Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "15a2df8a-7b45-4c11-b6fa-884c9b7e5c67"
+    },
+    {
+        "fields": {
+            "currenttask": "9371ba25-b600-485d-b2d8-cef2f39c35ed",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-12-04T22:46:47Z",
+            "microservicegroup": "Create SIP from Transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "16415d2f-5642-496d-a46d-00028ef6eb0a"
+    },
+    {
+        "fields": {
+            "currenttask": "73e12d44-ec3d-41a9-b138-80ec7e31ede5",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Process submission documentation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "173d310c-8e40-4669-9a69-6d4c8ffd0396"
+    },
+    {
+        "fields": {
+            "currenttask": "a8489361-b731-4d4a-861d-f4da1767665f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "8ce378a5-1418-4184-bf02-328a06e1d3be",
+            "lastmodified": "2013-11-15T00:31:31Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "180ae3d0-aa6c-4ed4-ab94-d0a2121e7f21"
+    },
+    {
+        "fields": {
+            "currenttask": "5ba69f6a-1605-42a5-a53a-4d5179613e12",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2018-05-16T18:06:06Z",
+            "microservicegroup": "Generate AIP METS",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "18c37bff-fce9-4b40-a50a-022ea0386f1a"
+    },
+    {
+        "fields": {
+            "currenttask": "3649f0f4-2174-44af-aef9-31ebeddeb73b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Examine contents",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "192315ea-a1bf-44cf-8cb4-0b3edd1522a6"
+    },
+    {
+        "fields": {
+            "currenttask": "ad1f1ae6-658f-4281-abc2-fe2f6c5d5e8e",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "19adb668-b19a-4fcb-8938-f49d7485eaf3"
+    },
+    {
+        "fields": {
+            "currenttask": "2d8f4aa1-76ad-4c88-af81-f7f494780628",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "3467d003-1603-49e3-b085-e58aa693afed",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Reject SIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "19c94543-14cb-4158-986b-1d2b55723cd8"
+    },
+    {
+        "fields": {
+            "currenttask": "637cc23a-c5f5-4df5-a352-5d47014be63b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2017-08-18T10:07:10Z",
+            "microservicegroup": "Characterize and extract metadata",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "1a136608-ae7b-42b4-bf2f-de0e514cfd47"
+    },
+    {
+        "fields": {
+            "currenttask": "7beb3689-02a7-4f56-a6d1-9c9399f06842",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "a536828c-be65-4088-80bd-eb511a0a063d",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Characterize and extract metadata",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "1b1a4565-b501-407b-b40f-2f20889423f1"
+    },
+    {
+        "fields": {
+            "currenttask": "256e18ca-1bcd-4b14-b3d5-4efbad5663fc",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-11-30T19:55:48Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "1b737a9b-b4c0-4230-aa92-1e88067534b9"
+    },
+    {
+        "fields": {
+            "currenttask": "fecb3fe4-5c5c-4796-b9dc-c7d7cf33a9f3",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Process submission documentation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "1ba589db-88d1-48cf-bb1a-a5f9d2b17378"
+    },
+    {
+        "fields": {
+            "currenttask": "3c002fb6-a511-461e-ad16-0d2c46649374",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Scan for viruses",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "1c2550f1-3fc0-45d8-8bc4-4c06d720283b"
+    },
+    {
+        "fields": {
+            "currenttask": "09f73737-f7ca-4ea2-9676-d369f390e650",
+            "defaultexitmessage": "2",
+            "defaultnextchainlink": "307edcde-ad10-401c-92c4-652917c993ed",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "1cb7e228-6e94-4c93-bf70-430af99b9264"
+    },
+    {
+        "fields": {
+            "currenttask": "5a3d244e-c7a1-4cd9-b1a8-2890bf1f254c",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "67b44f8f-bc97-4cb3-b6dd-09dba3c99d30",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "1cd3b36a-5252-4a69-9b1c-3b36829288ab"
+    },
+    {
+        "fields": {
+            "currenttask": "28e8e81c-3380-47f6-a973-e48f94104692",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "33d7ac55-291c-43ae-bb42-f599ef428325",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Process submission documentation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "1dce8e21-7263-4cc4-aa59-968d9793b5f2"
+    },
+    {
+        "fields": {
+            "currenttask": "eb14ba91-20cb-4b0e-ab5d-c30bfea4dbc8",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-12-06T18:58:24Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "20129b22-8f28-429b-a3f2-0648090fa305"
+    },
+    {
+        "fields": {
+            "currenttask": "bf71562c-bc87-4fd0-baa6-1d85ff751ea2",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Store AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "20515483-25ed-4133-b23e-5bb14cab8e22"
+    },
+    {
+        "fields": {
+            "currenttask": "e82c3c69-3799-46fd-afc1-f479f960a362",
+            "defaultexitmessage": "2",
+            "defaultnextchainlink": "7d0616b2-afed-41a6-819a-495032e86291",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify SIP compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "208d441b-6938-44f9-b54a-bd73f05bc764"
+    },
+    {
+        "fields": {
+            "currenttask": "cfc7f6be-3984-4727-a71a-02ce27bef791",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Include default Transfer processingMCP.xml",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "209400c1-5619-4acc-b091-b9d9c8fbb1c0"
+    },
+    {
+        "fields": {
+            "currenttask": "f6fbbf4f-bf8d-49f2-a978-8d689380cafc",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-12-12T21:25:31Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "214f1004-2748-4bed-a38d-48fe500c41b9"
+    },
+    {
+        "fields": {
+            "currenttask": "9a0f8eac-6a9d-4b85-8049-74954fbd6594",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Scan for viruses",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "21d6d597-b876-4b3f-ab85-f97356f10507"
+    },
+    {
+        "fields": {
+            "currenttask": "a75ee667-3a1c-4950-9194-e07d0e6bf545",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "bd382151-afd0-41bf-bb7a-b39aef728a32",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "22ded604-6cc0-444b-b320-f96afb15d581"
+    },
+    {
+        "fields": {
+            "currenttask": "13aaa76e-41db-4bff-8519-1f9ba8ca794f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-12-04T20:13:09Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2483c25a-ade8-4566-a259-c6c37350d0d6"
+    },
+    {
+        "fields": {
+            "currenttask": "8558d885-d6c2-4d74-af46-20da45487ae7",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "cc16178b-b632-4624-9091-822dd802a2c6",
+            "lastmodified": "2013-11-07T22:51:42Z",
+            "microservicegroup": "Identify file format",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2522d680-c7d9-4d06-8b11-a28d8bd8a71f"
+    },
+    {
+        "fields": {
+            "currenttask": "9dd95035-e11b-4438-a6c6-a03df302933c",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Clean up names",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2584b25c-8d98-44b7-beca-2b3ea2ea2505"
+    },
+    {
+        "fields": {
+            "currenttask": "80ebef4c-0dd1-45eb-b993-1db56a077db8",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "f2a019ea-0601-419c-a475-1b96a927a2fb",
+            "lastmodified": "2012-11-06T01:03:43Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "26bf24c9-9139-4923-bf99-aa8648b1692b"
+    },
+    {
+        "fields": {
+            "currenttask": "bf5a1f0c-1b3e-4196-b51f-f6d509091346",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2714cd07-b99f-40e3-9ae8-c97281d0d429"
+    },
+    {
+        "fields": {
+            "currenttask": "b597753f-0b36-484f-ae78-4ae95951fd90",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "440ef381-8fe8-4b6e-9198-270ee5653454",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "286bbb36-6a38-41d5-bf7a-a8ba58aa71ce"
+    },
+    {
+        "fields": {
+            "currenttask": "dde51fc1-af7d-4923-ad6a-06e670447a2a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2872d007-6146-4359-b554-6e9fe7a8eca6"
+    },
+    {
+        "fields": {
+            "currenttask": "7c02a87b-7113-4851-97cd-2cf9d3fc0010",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "288b739d-40a1-4454-971b-812127a5e03d"
+    },
+    {
+        "fields": {
+            "currenttask": "1c7de28f-8f18-41c7-b03a-19f900d38f34",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "28a9f8a8-0006-4828-96d5-892e6e279f72"
+    },
+    {
+        "fields": {
+            "currenttask": "297e7ebd-71bb-41e9-b1b7-945b6a9f00c5",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "f574b2a0-6e0b-4c74-ac5b-a73ddb9593a0",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Transcribe SIP contents",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2900f6d8-b64c-4f2a-8f7f-bb60a57394f6"
+    },
+    {
+        "fields": {
+            "currenttask": "abeaa79e-668b-4de0-b8cb-70f8ab8056b6",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "11033dbd-e4d4-4dd6-8bcf-48c424e222e3",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Process submission documentation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2a62f025-83ec-4f23-adb4-11d5da7ad8c2"
+    },
+    {
+        "fields": {
+            "currenttask": "3ad0db9a-f57d-4664-ad34-947404dddd04",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2adf60a0-ecd7-441a-b82f-f77c6a3964c3"
+    },
+    {
+        "fields": {
+            "currenttask": "bec683fa-f006-48a4-b298-d33b3b681cb2",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Store AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2d32235c-02d4-4686-88a6-96f4d6c7b1c3"
+    },
+    {
+        "fields": {
+            "currenttask": "8558d885-d6c2-4d74-af46-20da45487ae7",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "83484326-7be7-4f9f-b252-94553cd42370",
+            "lastmodified": "2013-11-07T22:51:42Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2dd53959-8106-457d-a385-fee57fc93aa9"
+    },
+    {
+        "fields": {
+            "currenttask": "e485f0f4-7d44-45c6-a0d2-bba4b2abd0d0",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2017-08-18T10:07:07Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2e31580d-1678-474b-83e5-a53d97d150f6"
+    },
+    {
+        "fields": {
+            "currenttask": "3875546f-9137-4c8f-9fcc-ed112eaa6414",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Failed transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2e7f83f9-495a-44b3-b0cf-bff66f021a4d"
+    },
+    {
+        "fields": {
+            "currenttask": "0c1664f2-dfcb-46d9-bd9e-5b604baef788",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Identify DSpace files",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "2fd123ea-196f-4c9c-95c0-117aa65ed9c6"
+    },
+    {
+        "fields": {
+            "currenttask": "00041f5a-42cd-4b77-a6d4-6ef0f376a817",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "1b1a4565-b501-407b-b40f-2f20889423f1",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Characterize and extract metadata",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "303a65f6-a16f-4a06-807b-cb3425a30201"
+    },
+    {
+        "fields": {
+            "currenttask": "275b3640-68a6-4c4e-adc1-888ea3fdfba5",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2015-05-25T16:33:14Z",
+            "microservicegroup": "Update METS.xml document",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "307edcde-ad10-401c-92c4-652917c993ed"
+    },
+    {
+        "fields": {
+            "currenttask": "acd5e136-11ed-46fe-bf67-dc108f115d6b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "09b85517-e5f5-415b-a950-1a60ee285242",
+            "lastmodified": "2013-01-10T22:49:49Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "31abe664-745e-4fef-a669-ff41514e0083"
+    },
+    {
+        "fields": {
+            "currenttask": "135dd73d-845a-412b-b17e-23941a3d9f78",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "microservicegroup": "Reingest AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "31fc3f66-34e9-478f-8d1b-c29cd0012360"
+    },
+    {
+        "fields": {
+            "currenttask": "64a859be-f362-45d1-b9b4-4e15091f686f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "3229e01f-adf3-4294-85f7-4acb01b3fbcf"
+    },
+    {
+        "fields": {
+            "currenttask": "e20ea90b-fa16-4576-8647-199ecde0d511",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Reject transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "333532b9-b7c2-4478-9415-28a3056d58df"
+    },
+    {
+        "fields": {
+            "currenttask": "507c13db-63c9-476b-9a16-0c3a05aff1cb",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2017-08-18T10:07:03Z",
+            "microservicegroup": "Reingest AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "33533fbb-1607-434f-a82b-cf938c05f60b"
+    },
+    {
+        "fields": {
+            "currenttask": "530b3b90-b97a-4aaf-836f-3a889ad1d7d2",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "576f1f43-a130-4c15-abeb-c272ec458d33",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Process submission documentation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "33d7ac55-291c-43ae-bb42-f599ef428325"
+    },
+    {
+        "fields": {
+            "currenttask": "3df5643c-2556-412f-a7ac-e2df95722dae",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Generate METS.xml document",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "3409b898-e532-49d3-98ff-a2a1f9d988fa"
+    },
+    {
+        "fields": {
+            "currenttask": "be4e3ee6-9be3-465f-93f0-77a4ccdfd1db",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Reject SIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "3467d003-1603-49e3-b085-e58aa693afed"
+    },
+    {
+        "fields": {
+            "currenttask": "f452a117-a992-4447-9774-6a8130f05b30",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "180ae3d0-aa6c-4ed4-ab94-d0a2121e7f21",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "35c8763a-0430-46be-8198-9ecb23f895c8"
+    },
+    {
+        "fields": {
+            "currenttask": "4554c5f9-52f9-440c-bc69-0f7be3651949",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2013-04-19T22:39:27Z",
+            "microservicegroup": "Approve SIP creation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "36609513-6502-4aca-886a-6c4ae03a9f05"
+    },
+    {
+        "fields": {
+            "currenttask": "bd9769ba-4182-4dd4-ba85-cff24ea8733e",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "370aca94-65ab-4f2a-9d7d-294a62c8b7ba"
+    },
+    {
+        "fields": {
+            "currenttask": "99712faf-6cd0-48d1-9c66-35a2033057cf",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2013-01-08T02:12:00Z",
+            "microservicegroup": "Failed transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "377f8ebb-7989-4a68-9361-658079ff8138"
+    },
+    {
+        "fields": {
+            "currenttask": "90e0993d-23d4-4d0c-8b7d-73717b58f20e",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Prepare DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "378ae4fc-7b62-40af-b448-a1ab47ac2c0c"
+    },
+    {
+        "fields": {
+            "currenttask": "62ba16c8-4a3f-4199-a48e-d557a90728e2",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "1c2550f1-3fc0-45d8-8bc4-4c06d720283b",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "38c591d4-b7ee-4bc0-b993-c592bf15d97d"
+    },
+    {
+        "fields": {
+            "currenttask": "73ad6c9d-8ea1-4667-ae7d-229656a49237",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Create SIP from Transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "39a128e3-c35d-40b7-9363-87f75091e1ff"
+    },
+    {
+        "fields": {
+            "currenttask": "f872b932-90dd-4501-98c4-9fc5bac9d19a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "39e58573-2dbc-4939-bce0-96b2f55dae28"
+    },
+    {
+        "fields": {
+            "currenttask": "17aa7180-ded8-45c7-96d0-5ecebfd1a5cf",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "c2e6600d-cd26-42ed-bed5-95d41c06e37b",
+            "lastmodified": "2017-08-18T10:07:08Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "3a70bc05-fa82-4067-a069-a56b6006be0a"
+    },
+    {
+        "fields": {
+            "currenttask": "4a8d87e2-4a9a-4ad7-9b4c-d433c9281539",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "153c5f41-3cfb-47ba-9150-2dd44ebc27df",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "microservicegroup": "Policy checks for derivatives",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "3bbfbd27-ba41-4e36-8b7f-b4f02676bda3"
+    },
+    {
+        "fields": {
+            "currenttask": "feac0c04-3511-4e91-9403-5c569cff7bcc",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "3c526a07-c3b8-4e53-801b-7f3d0c4857a5"
+    },
+    {
+        "fields": {
+            "currenttask": "c075014f-4051-441a-b16b-3083d5c264c5",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Prepare AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "3e25bda6-5314-4bb4-aa1e-90900dce887d"
+    },
+    {
+        "fields": {
+            "currenttask": "39ac9ff8-d312-4033-a2c6-44219471abda",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Create SIP from Transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5"
+    },
+    {
+        "fields": {
+            "currenttask": "b57b3564-e271-4226-a5f9-2c7cf1661a83",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "microservicegroup": "Store AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "3f543585-fa4f-4099-9153-dd6d53572f5c"
+    },
+    {
+        "fields": {
+            "currenttask": "ea463bfd-5fa2-4936-b8c3-1ce3b74303cf",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "092b47db-6f77-4072-aed3-eb248ab69e9c",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "4103a5b0-e473-4198-8ff7-aaa6fec34749"
+    },
+    {
+        "fields": {
+            "currenttask": "74146fe4-365d-4f14-9aae-21eafa7d8393",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "424ee8f1-6cdd-4960-8641-ed82361d3ad7"
+    },
+    {
+        "fields": {
+            "currenttask": "fbaadb5d-63f9-440c-a607-a4ebfb973a78",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "2e7f83f9-495a-44b3-b0cf-bff66f021a4d",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "438dc1cf-9813-44b5-a0a3-58e09ae73b8a"
+    },
+    {
+        "fields": {
+            "currenttask": "102cd6b0-5d30-4e04-9b62-4e9f12d74549",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Prepare DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "43c72f8b-3cea-4b4c-b99d-cfdefdfcc270"
+    },
+    {
+        "fields": {
+            "currenttask": "51e31d21-3e92-4c9f-8fec-740f559285f2",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "dba3028d-2029-4a87-9992-f6335d890528",
+            "lastmodified": "2013-11-15T00:31:31Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "440ef381-8fe8-4b6e-9198-270ee5653454"
+    },
+    {
+        "fields": {
+            "currenttask": "0bb3f551-1418-4b99-8094-05a43fcd9537",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "fdfac6e5-86c0-4c81-895c-19a9edadedef",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Rename with transfer UUID",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "4417b129-fab3-4503-82dd-740f8e774bff"
+    },
+    {
+        "fields": {
+            "currenttask": "3c04068f-20b8-4cbc-8166-c61faacb6628",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "4430077a-92c5-4d86-b0f8-0d31bdb731fb"
+    },
+    {
+        "fields": {
+            "currenttask": "b3875772-0f3b-4b03-b602-5304ded86397",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61af079f-46a2-48ff-9b8a-0c78ba3a456d",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "45063ad6-f374-4215-a2c4-ac47be4ce2cd"
+    },
+    {
+        "fields": {
+            "currenttask": "2e3c3f0f-069e-4ca1-b71b-93f4880a39b5",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "46dcf7b1-3750-4f49-a9be-a4bf076e304f"
+    },
+    {
+        "fields": {
+            "currenttask": "a71f40ec-77b2-4f13-91b6-da3d4a67a284",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "46e19522-9a71-48f1-9ccd-09cabfba3f38"
+    },
+    {
+        "fields": {
+            "currenttask": "c310a18a-1659-45d0-845e-06eb3321512f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "4103a5b0-e473-4198-8ff7-aaa6fec34749",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "47c83e01-7556-4c13-881f-282c6d9c7d6a"
+    },
+    {
+        "fields": {
+            "currenttask": "f908bcd9-2fba-48c3-b04b-459f6ad1a4de",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Process submission documentation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "47dd6ea6-1ee7-4462-8b84-3fc4c1eeeb7f"
+    },
+    {
+        "fields": {
+            "currenttask": "134a1a94-22f0-4e67-be17-23a4c7178105",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "microservicegroup": "Store AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "48703fad-dc44-4c8e-8f47-933df3ef6179"
+    },
+    {
+        "fields": {
+            "currenttask": "75e00332-24a3-4076-aed1-e3dc44379227",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "2d32235c-02d4-4686-88a6-96f4d6c7b1c3",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "microservicegroup": "Store AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "49cbcc4d-067b-4cd5-b52e-faf50857b35a"
+    },
+    {
+        "fields": {
+            "currenttask": "674e21f3-1c50-4185-8e5d-70b1ed4a7f3a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Process submission documentation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "4edfe7e4-82ff-4c0a-ba5f-29f1ee14e17a"
+    },
+    {
+        "fields": {
+            "currenttask": "ede67763-2a12-4e8f-8c36-e266d3f05c6b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "2584b25c-8d98-44b7-beca-2b3ea2ea2505",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Generate transfer structure report",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "4efe00da-6ed0-45dd-89ca-421b78c4b6be"
+    },
+    {
+        "fields": {
+            "currenttask": "549181ed-febe-487a-a036-ed6fdfa10a86",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "5d780c7d-39d0-4f4a-922b-9d1b0d217bca",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "50b67418-cb8d-434d-acc9-4a8324e7fdd2"
+    },
+    {
+        "fields": {
+            "currenttask": "dee46f53-8afb-4aec-820e-d495bcbeaf20",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "f09847c2-ee51-429a-9478-a860477f6b8d",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5158c618-6160-41d6-bbbe-ddf34b5b06bc"
+    },
+    {
+        "fields": {
+            "currenttask": "e601b1e3-a957-487f-8cbe-54160070574d",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "52269473-5325-4a11-b38a-c4aafcbd8f54"
+    },
+    {
+        "fields": {
+            "currenttask": "5bf6bc93-fa3d-4c3e-9ae0-8e714e8fedba",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "f1e286f9-4ec7-4e19-820c-dae7b8ea7d09",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "microservicegroup": "Add README file",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "523c97cc-b267-4cfb-8209-d99e523bf4b3"
+    },
+    {
+        "fields": {
+            "currenttask": "8ea17652-a136-4251-b460-d50b0c7090eb",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Generate AIP METS",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "53e14112-21bb-46f0-aed3-4e8c2de6678f"
+    },
+    {
+        "fields": {
+            "currenttask": "388a277b-2463-4d11-b203-fc5b80a08f69",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "3409b898-e532-49d3-98ff-a2a1f9d988fa",
+            "lastmodified": "2018-05-16T18:06:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5415c813-3637-49ab-afec-9b435c2e4d2c"
+    },
+    {
+        "fields": {
+            "currenttask": "1cf09019-56a1-47eb-8fe0-9bbff158892d",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Add final metadata",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "54b73077-a062-41cc-882c-4df1eba447d9"
+    },
+    {
+        "fields": {
+            "currenttask": "48416179-7ae4-47cc-a0aa-f9847da08c63",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Generate transfer structure report",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "559d9b14-05bf-4136-918a-de74a821b759"
+    },
+    {
+        "fields": {
+            "currenttask": "07f6f419-d51f-4c69-bca6-a395adecbee0",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "55de1490-f3a0-4e1e-a25b-38b75f4f05e3"
+    },
+    {
+        "fields": {
+            "currenttask": "9649186d-e5bd-4765-b285-3b0d8e83b105",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2013-04-19T22:39:27Z",
+            "microservicegroup": "Create SIP from Transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "561bbb52-d95c-4004-b0d3-739c0a65f406"
+    },
+    {
+        "fields": {
+            "currenttask": "547f95f6-3fcd-45e1-98b6-a8a7d9097373",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "8ce130d4-3f7e-46ec-868a-505cf9033d96",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "56da7758-913a-4cd2-a815-be140ed09357"
+    },
+    {
+        "fields": {
+            "currenttask": "f1ebd62a-fbf3-4790-88e8-4a3abec4ba00",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Generate transfer structure report",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "56eebd45-5600-4768-a8c2-ec0114555a3d"
+    },
+    {
+        "fields": {
+            "currenttask": "5e0ac12e-6ce7-4d11-bd75-e14167210df4",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2017-08-18T10:07:07Z",
+            "microservicegroup": "Prepare DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5749c11f-ed08-4965-8d8e-1473b1016073"
+    },
+    {
+        "fields": {
+            "currenttask": "1e02e82a-2055-4f37-af3a-7dc606f9fd97",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Process submission documentation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "576f1f43-a130-4c15-abeb-c272ec458d33"
+    },
+    {
+        "fields": {
+            "currenttask": "b6479474-159d-47aa-a10f-40495cb0e273",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "dba3028d-2029-4a87-9992-f6335d890528",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5b0042a2-2244-475c-85d5-41e4b11e65d6"
+    },
+    {
+        "fields": {
+            "currenttask": "246c34b0-b785-485f-971b-0ed9f82e1ae3",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "dba3028d-2029-4a87-9992-f6335d890528",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5c0d8661-1c49-4023-8a67-4991365d70fb"
+    },
+    {
+        "fields": {
+            "currenttask": "108f7f4c-72f2-4ddb-910a-24f173d64fa7",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Failed transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5c459c1a-f998-404d-a0dd-808709510b72"
+    },
+    {
+        "fields": {
+            "currenttask": "7c02a87b-7113-4851-97cd-2cf9d3fc0010",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Failed transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5cf308fd-a6dc-4033-bda1-61689bb55ce2"
+    },
+    {
+        "fields": {
+            "currenttask": "4745d0bb-910c-4c0d-8b81-82d7bfca7819",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "74665638-5d8f-43f3-b7c9-98c4c8889766",
+            "lastmodified": "2012-10-24T00:40:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5d6a103c-9a5d-4010-83a8-6f4c61eb1478"
+    },
+    {
+        "fields": {
+            "currenttask": "85308c8b-b299-4453-bf40-9ac61d134015",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "ea0e8838-ad3a-4bdd-be14-e5dba5a4ae0c",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5d780c7d-39d0-4f4a-922b-9d1b0d217bca"
+    },
+    {
+        "fields": {
+            "currenttask": "528c8fe3-265f-45dd-b5c0-1a4ac0e15954",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer checksum",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5e4bd4e8-d158-4c2a-be89-51e3e9bd4a06"
+    },
+    {
+        "fields": {
+            "currenttask": "abf861ee-2125-4e7e-8d85-9e1dcd020b4b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2017-08-18T10:07:07Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5e58066d-e113-4383-b20b-f301ed4d751c"
+    },
+    {
+        "fields": {
+            "currenttask": "74146fe4-365d-4f14-9aae-21eafa7d8393",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "3f543585-fa4f-4099-9153-dd6d53572f5c",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Store AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5f213529-ced4-49b0-9e30-be4e0c9b81d5"
+    },
+    {
+        "fields": {
+            "currenttask": "feb27f44-3575-4d17-8e00-43aa5dc5c3dc",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Prepare AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "5fbc344c-19c8-48be-a753-02dac987428c"
+    },
+    {
+        "fields": {
+            "currenttask": "cd53e17c-1dd1-4e78-9086-e6e013a64536",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "microservicegroup": "Reingest AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "60b0e812-ebbe-487e-810f-56b1b6fdd819"
+    },
+    {
+        "fields": {
+            "currenttask": "9a70cc32-2b0e-4763-a168-b81485fac366",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Prepare DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "61a8de9c-7b25-4f0f-b218-ad4dde261eed"
+    },
+    {
+        "fields": {
+            "currenttask": "54a05ec3-a34f-4404-96ec-36b527445da9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Include default Transfer processingMCP.xml",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "61af079f-46a2-48ff-9b8a-0c78ba3a456d"
+    },
+    {
+        "fields": {
+            "currenttask": "32b2600c-6907-4cb2-b18a-3986f0842219",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "377f8ebb-7989-4a68-9361-658079ff8138",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Failed transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd"
+    },
+    {
+        "fields": {
+            "currenttask": "74146fe4-365d-4f14-9aae-21eafa7d8393",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "6327fdf9-9673-42a8-ace5-cccad005818b"
+    },
+    {
+        "fields": {
+            "currenttask": "83755035-1dfd-4e25-9031-e1178be4bb84",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7c44c454-e3cc-43d4-abe0-885f93d693c6",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Prepare AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "63f35161-ba76-4a43-8cfa-c38c6a2d5b2f"
+    },
+    {
+        "fields": {
+            "currenttask": "81f2a21b-a7a0-44e4-a2f6-9a6cf742b052",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Approve AIC",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "6404ce13-8619-48ba-b12f-aa7a034153ac"
+    },
+    {
+        "fields": {
+            "currenttask": "388a277b-2463-4d11-b203-fc5b80a08f69",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "dc144ff4-ad74-4a6e-ac15-b0beedcaf662",
+            "lastmodified": "2018-05-16T18:06:03Z",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "6441980c-b64b-447e-abc7-9351a2547f6a"
+    },
+    {
+        "fields": {
+            "currenttask": "7058a655-82f3-455c-9245-ad8e87e77a4f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "2e31580d-1678-474b-83e5-a53d97d150f6",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "651236d2-d77f-4ca7-bfe9-6332e96608ff"
+    },
+    {
+        "fields": {
+            "currenttask": "2dd14de8-62c7-49a5-bfa1-dd025e7a426b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2017-08-18T10:07:07Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "653b134f-4a37-4578-a286-7f2072e89f9e"
+    },
+    {
+        "fields": {
+            "currenttask": "450794b5-db3e-4557-8ab8-1abd77786429",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "66c9c178-2224-41c6-9c0b-dcb60ff57b1a"
+    },
+    {
+        "fields": {
+            "currenttask": "9ecf18d4-652b-4bd2-a3f5-bfb5794299f8",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "db99ab43-04d7-44ab-89ec-e09d7bbdc39d",
+            "lastmodified": "2017-08-18T10:07:10Z",
+            "microservicegroup": "Complete transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "675acd22-828d-4949-adc7-1888240f5e3d"
+    },
+    {
+        "fields": {
+            "currenttask": "f661aae0-05bf-4f55-a2f6-ef0f157231bd",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "67a91b4b-a5af-4b54-a836-705e6cf4eeb9"
+    },
+    {
+        "fields": {
+            "currenttask": "143b4734-9c33-4f6e-9af0-2dc09cf9017a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "67b44f8f-bc97-4cb3-b6dd-09dba3c99d30"
+    },
+    {
+        "fields": {
+            "currenttask": "74146fe4-365d-4f14-9aae-21eafa7d8393",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "6b39088b-683e-48bd-ab89-9dab47f4e9e0"
+    },
+    {
+        "fields": {
+            "currenttask": "b3b86729-470f-4301-8861-d62574966747",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "0a6558cf-cf5f-4646-977e-7d6b4fde47e8",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "6b931965-d5f6-4611-a536-39d5901f8f70"
+    },
+    {
+        "fields": {
+            "currenttask": "13aaa76e-41db-4bff-8519-1f9ba8ca794f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Include default Transfer processingMCP.xml",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "6bd4d385-c490-4c42-a195-dace8697891c"
+    },
+    {
+        "fields": {
+            "currenttask": "0f9f9634-275f-4460-aceb-09dcf37049c4",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "dae3c416-a8c2-4515-9081-6dbd7b265388",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "microservicegroup": "Validation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "6c147aeb-20c5-47ce-9f40-7f22683cea1f"
+    },
+    {
+        "fields": {
+            "currenttask": "9f7029af-739d-4ec1-840d-b92d1d30f0c7",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2015-05-25T16:33:13Z",
+            "microservicegroup": "Generate transfer structure report",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "6eca2676-b4ed-48d9-adb0-374e1d5c6e71"
+    },
+    {
+        "fields": {
+            "currenttask": "74146fe4-365d-4f14-9aae-21eafa7d8393",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify SIP compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "70669a5b-01e4-4ea0-ac70-10292f87da05"
+    },
+    {
+        "fields": {
+            "currenttask": "4c64875e-9f31-4596-96d9-f99bc886bb24",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Transcribe SIP contents",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7079be6d-3a25-41e6-a481-cee5f352fe6e"
+    },
+    {
+        "fields": {
+            "currenttask": "74146fe4-365d-4f14-9aae-21eafa7d8393",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "70f41678-baa5-46e6-a71c-4b6b4d99f4a6"
+    },
+    {
+        "fields": {
+            "currenttask": "3aaabae1-c329-4bbd-a25d-b07e0f7a6d08",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": null,
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "microservicegroup": "Validation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "70fc7040-d4fb-4d19-a0e6-792387ca1006"
+    },
+    {
+        "fields": {
+            "currenttask": "235c3727-b138-4e62-9265-c8f07761a5fa",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "74665638-5d8f-43f3-b7c9-98c4c8889766"
+    },
+    {
+        "fields": {
+            "currenttask": "55f0e6fa-834c-44f1-89f3-c912e79cea7d",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7c44c454-e3cc-43d4-abe0-885f93d693c6",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Prepare AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "746b1f47-2dad-427b-8915-8b0cb7acccd8"
+    },
+    {
+        "fields": {
+            "currenttask": "2bfd7cef-dcf8-4587-8043-2c69c612a6e3",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7509e7dc-1e1b-4dce-8d21-e130515fce73"
+    },
+    {
+        "fields": {
+            "currenttask": "de195451-989e-48fe-ad0c-3ff2265b3410",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "755b4177-c587-41a7-8c52-015277568302"
+    },
+    {
+        "fields": {
+            "currenttask": "33c0dea0-da6c-4b8f-8038-6e95844eea95",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "88807d68-062e-4d1a-a2d5-2d198c88d8ca",
+            "lastmodified": "2013-02-08T22:18:49Z",
+            "microservicegroup": "Process metadata directory",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "75fb5d67-5efa-4232-b00b-d85236de0d3f"
+    },
+    {
+        "fields": {
+            "currenttask": "88d8d473-6948-4f5d-abcb-12fb392df17a",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "ccf8ec5c-3a9a-404a-a7e7-8f567d3b36a0",
+            "lastmodified": "2018-05-16T18:06:04Z",
+            "microservicegroup": "Bind PIDs",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7677d1cd-2211-4969-8c10-5ec2a93d5c2f"
+    },
+    {
+        "fields": {
+            "currenttask": "ce57ffbc-abd9-43dc-a09b-e888397488f2",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-01-03T02:10:39Z",
+            "microservicegroup": "Process manually normalized files",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "78b7adff-861d-4450-b6dd-3fabe96a849e"
+    },
+    {
+        "fields": {
+            "currenttask": "f8d0b7df-68e8-4214-a49d-60a91ed27029",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "2dd53959-8106-457d-a385-fee57fc93aa9",
+            "lastmodified": "2013-11-07T22:51:42Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7a024896-c4f7-4808-a240-44c87c762bc5"
+    },
+    {
+        "fields": {
+            "currenttask": "5c831a10-5d75-44ca-9741-06fdfc72052a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "56da7758-913a-4cd2-a815-be140ed09357",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7a134af0-b285-4a9f-8acf-f6947b7ed072"
+    },
+    {
+        "fields": {
+            "currenttask": "c3e3f03d-c104-48c3-8c64-4290459965f4",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "f3a39155-d655-4336-8227-f8c88e4b7669",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7b146689-1a04-4f58-ba86-3caf2b76ddbc"
+    },
+    {
+        "fields": {
+            "currenttask": "4d56a90c-8d9f-498c-8331-cf469fcb3147",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "bb1f1ed8-6c92-46b9-bab6-3a37ffb665f1",
+            "lastmodified": "2012-10-02T14:25:06Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7b1f1ed8-6c92-46b9-bab6-3a37ffb665f1"
+    },
+    {
+        "fields": {
+            "currenttask": "502a8bc4-88b1-41b0-8821-f8afd984036e",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Store AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7c44c454-e3cc-43d4-abe0-885f93d693c6"
+    },
+    {
+        "fields": {
+            "currenttask": "52d646df-fd66-4157-b8aa-32786fef9481",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer checksums",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7c6a0b72-f37b-4512-87f3-267644de6f80"
+    },
+    {
+        "fields": {
+            "currenttask": "6ed7ec07-5df1-470b-9a2e-a934cba8af26",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Rename with transfer UUID",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7c95b242-1ce5-4210-b7d4-fdbb6c0aa5dd"
+    },
+    {
+        "fields": {
+            "currenttask": "8e06349b-d4a3-420a-9a64-69553bd9a183",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "f025f58c-d48c-4ba1-8904-a56d2a67b42f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Verify SIP compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7d0616b2-afed-41a6-819a-495032e86291"
+    },
+    {
+        "fields": {
+            "currenttask": "5370a0cb-da97-4983-868a-1376d7737af5",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7d33f228-0fa8-4f4c-a66b-24f8e264c214"
+    },
+    {
+        "fields": {
+            "currenttask": "32b2600c-6907-4cb2-b18a-3986f0842219",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "b2ef06b9-bca4-49da-bc5c-866d7b3c4bb1",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Failed SIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7d728c39-395f-4892-8193-92f086c0546f"
+    },
+    {
+        "fields": {
+            "currenttask": "f5ca3e51-35ba-4cdd-acf5-7d4fec955e76",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7e65c627-c11d-4aad-beed-65ceb7053fe8"
+    },
+    {
+        "fields": {
+            "currenttask": "a987e8d6-e633-4551-a082-2334a300fa72",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "651236d2-d77f-4ca7-bfe9-6332e96608ff",
+            "lastmodified": "2018-05-16T18:05:58Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "7f975ba6-2185-434c-b507-2911f3c77213"
+    },
+    {
+        "fields": {
+            "currenttask": "99324102-ebe8-415d-b5d8-b299ab2f4703",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Rename SIP directory with SIP UUID",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "823b0d76-9f3c-410d-83ab-f3c2cdd9ab22"
+    },
+    {
+        "fields": {
+            "currenttask": "59ebdcec-eacc-4daf-978a-1b0d8652cd0c",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2013-01-08T02:12:00Z",
+            "microservicegroup": "Failed SIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "828528c2-2eb9-4514-b5ca-dfd1f7cb5b8c"
+    },
+    {
+        "fields": {
+            "currenttask": "26ec68d5-8d33-4fe2-bc11-f06d80fb23e0",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-23T19:41:22Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "83484326-7be7-4f9f-b252-94553cd42370"
+    },
+    {
+        "fields": {
+            "currenttask": "032347f1-c0fb-4c6c-96ba-886ac8ac636c",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "microservicegroup": "Reingest AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "83d5e887-6f7c-48b0-bd81-e3f00a9da772"
+    },
+    {
+        "fields": {
+            "currenttask": "5044f7ec-96f9-4bf1-8540-671e543c2411",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61af079f-46a2-48ff-9b8a-0c78ba3a456d",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "87e7659c-d5de-4541-a09c-6deec966a0c0"
+    },
+    {
+        "fields": {
+            "currenttask": "9c9e75e9-04b0-4a04-83ad-07ddf2ff9a17",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "7677d1cd-2211-4969-8c10-5ec2a93d5c2f",
+            "lastmodified": "2018-05-16T18:06:04Z",
+            "microservicegroup": "Bind PIDs",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "87e93d08-36e4-4c81-99a8-beea00b18400"
+    },
+    {
+        "fields": {
+            "currenttask": "ef024cf9-1737-4161-b48a-13b4a8abddcd",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify checksums",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "88807d68-062e-4d1a-a2d5-2d198c88d8ca"
+    },
+    {
+        "fields": {
+            "currenttask": "f0c4abd3-1947-4d11-b78b-a55078460100",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "5415c813-3637-49ab-afec-9b435c2e4d2c",
+            "lastmodified": "2018-05-16T18:06:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "8882bad4-561c-4126-89c9-f7f0c083d5d7"
+    },
+    {
+        "fields": {
+            "currenttask": "6f5d5518-1ed4-49b8-9cd5-497d112c97e4",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-11-30T19:55:47Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "888a5bdc-9928-44f0-9fb7-91bc5f1e155b"
+    },
+    {
+        "fields": {
+            "currenttask": "3ae4931e-886e-4e0a-9a85-9b047c9983ac",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "89071669-3bb6-4e03-90a3-3c8b20c7f6fe",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Failed transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "88d2120a-4d19-4b47-922f-7438be1f52a2"
+    },
+    {
+        "fields": {
+            "currenttask": "0ae50158-a6e2-4663-a684-61d9a8384789",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Failed transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "89071669-3bb6-4e03-90a3-3c8b20c7f6fe"
+    },
+    {
+        "fields": {
+            "currenttask": "fe354b27-dbb2-4454-9c1c-340d85e67b78",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "5d6a103c-9a5d-4010-83a8-6f4c61eb1478",
+            "lastmodified": "2012-10-24T00:40:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "8ba83807-2832-4e41-843c-2e55ad10ea0b"
+    },
+    {
+        "fields": {
+            "currenttask": "8850aeff-8553-4ff1-ab31-99b5392a458b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-02-13T22:03:39Z",
+            "microservicegroup": "Process metadata directory",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "8bc92801-4308-4e3b-885b-1a89fdcd3014"
+    },
+    {
+        "fields": {
+            "currenttask": "f0e49772-3e2b-480d-8c06-023efc670dcd",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Reformat metadata files",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "8c8bac29-4102-4fd2-9d0a-a3bd2e607566"
+    },
+    {
+        "fields": {
+            "currenttask": "a91ad9f6-1027-409c-8e66-4c8769ff9f06",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": null,
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "microservicegroup": "Policy checks for derivatives",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "8ce07e94-6130-4987-96f0-2399ad45c5c2"
+    },
+    {
+        "fields": {
+            "currenttask": "a8489361-b731-4d4a-861d-f4da1767665f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "ef8bd3f3-22f5-4283-bfd6-d458a2d18f22",
+            "lastmodified": "2013-11-15T00:31:31Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "8ce130d4-3f7e-46ec-868a-505cf9033d96"
+    },
+    {
+        "fields": {
+            "currenttask": "51e31d21-3e92-4c9f-8fec-740f559285f2",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "dba3028d-2029-4a87-9992-f6335d890528",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "8ce378a5-1418-4184-bf02-328a06e1d3be"
+    },
+    {
+        "fields": {
+            "currenttask": "07bf7432-fd9b-456e-9d17-5b387087723a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "f7488721-c936-42af-a767-2f0b39564a86",
+            "lastmodified": "2012-11-30T19:55:48Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "8db10a7b-924f-4561-87b4-cb6078c65aab"
+    },
+    {
+        "fields": {
+            "currenttask": "bacb088a-66ef-4590-b855-69f21dfdf87a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "9e3dd445-551d-42d1-89ba-fe6dff7c6ee6",
+            "lastmodified": "2012-10-24T00:40:07Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "8de9fe10-932f-4151-88b0-b50cf271e156"
+    },
+    {
+        "fields": {
+            "currenttask": "81d64862-a4f6-4e3f-b32e-47268d9eb9a3",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "675acd22-828d-4949-adc7-1888240f5e3d",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Identify DSpace files",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "8ec0b0c1-79ad-4d22-abcd-8e95fcceabbc"
+    },
+    {
+        "fields": {
+            "currenttask": "7c02a87b-7113-4851-97cd-2cf9d3fc0010",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Create SIP from Transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "8f639582-8881-4a8b-8574-d2f86dc4db3d"
+    },
+    {
+        "fields": {
+            "currenttask": "a2e93146-a3ff-4e6c-ae3d-76ce49ca5e1b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "9071c352-aed5-444c-ac3f-b6c52dfb65ac"
+    },
+    {
+        "fields": {
+            "currenttask": "0a521e24-b376-4a9c-9cd6-ce41e187179a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-01-03T02:10:38Z",
+            "microservicegroup": "Process manually normalized files",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "91ca6f1f-feb5-485d-99d2-25eed195e330"
+    },
+    {
+        "fields": {
+            "currenttask": "ee00a5c7-a69c-46cf-a5e0-a9e2f18e563e",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Prepare AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "91dc1ab1-487e-4121-a6c5-d8441da7a422"
+    },
+    {
+        "fields": {
+            "currenttask": "16b8cc42-68b6-4751-b497-3e3a64101bbb",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "92879a29-45bf-4f0b-ac43-e64474f0f2f9"
+    },
+    {
+        "fields": {
+            "currenttask": "c450501a-251f-4de7-acde-91c47cf62e36",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "c103b2fb-9a6b-4b68-8112-b70597a6cd14",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "microservicegroup": "Reingest AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "9520386f-bb6d-4fb9-a6b6-5845ef39375f"
+    },
+    {
+        "fields": {
+            "currenttask": "09f73737-f7ca-4ea2-9676-d369f390e650",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "bd382151-afd0-41bf-bb7a-b39aef728a32",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "95616c10-a79f-48ca-a352-234cc91eaf08"
+    },
+    {
+        "fields": {
+            "currenttask": "388a277b-2463-4d11-b203-fc5b80a08f69",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "66c9c178-2224-41c6-9c0b-dcb60ff57b1a",
+            "lastmodified": "2018-05-16T18:06:06Z",
+            "microservicegroup": "Include default Transfer processingMCP.xml",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "960f6db0-5b41-417c-bedc-a0eb75a82227"
+    },
+    {
+        "fields": {
+            "currenttask": "efb7bf8e-4624-4b52-bf90-e3d389099fd9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Clean up names",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "970b7d17-7a6b-4d51-808b-c94b78c0d97f"
+    },
+    {
+        "fields": {
+            "currenttask": "acf7bd62-1587-4bff-b640-5b34b7196386",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "998044bb-6260-452f-a742-cfb19e80125b"
+    },
+    {
+        "fields": {
+            "currenttask": "97cc7629-c580-44db-8a41-68b6b2f23be4",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "e219ed78-2eda-4263-8c0f-0c7f6a86c33e",
+            "lastmodified": "2012-10-24T00:40:07Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "9e3dd445-551d-42d1-89ba-fe6dff7c6ee6"
+    },
+    {
+        "fields": {
+            "currenttask": "ea463bfd-5fa2-4936-b8c3-1ce3b74303cf",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Prepare AIC",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "9e810686-d747-4da1-9908-876fb89ac78e"
+    },
+    {
+        "fields": {
+            "currenttask": "ff8f70b9-e345-4163-a784-29b432b12558",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-01-03T02:10:39Z",
+            "microservicegroup": "Process manually normalized files",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "9e9b522a-77ab-4c17-ab08-5a4256f49d59"
+    },
+    {
+        "fields": {
+            "currenttask": "5ded9d05-dd24-484a-a8b2-73ec5d35aa63",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "ff89a530-0540-4625-8884-5a2198dea05a",
+            "lastmodified": "2017-08-18T10:06:58Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "a0db8294-f02a-4f49-a557-b1310a715ffc"
+    },
+    {
+        "fields": {
+            "currenttask": "c307d6bd-cb81-46a1-89f1-bb02a43e0a3a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-01-03T02:10:39Z",
+            "microservicegroup": "Process manually normalized files",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "a1b65fe3-9358-479b-93b9-68f2b5e71b2b"
+    },
+    {
+        "fields": {
+            "currenttask": "8b846431-5da9-4743-906d-2cdc4e777f8f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "a2173b55-abff-4d8f-97b9-79cc2e0a64fa"
+    },
+    {
+        "fields": {
+            "currenttask": "16eaacad-e180-4be1-a13c-35ab070808a7",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Clean up names",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "a329d39b-4711-4231-b54e-b5958934dccb"
+    },
+    {
+        "fields": {
+            "currenttask": "04c7e0fb-ec4e-4637-a7b7-41601d5523bd",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Clean up names",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "a46e95fe-4a11-4d3c-9b76-c5d8ea0b094d"
+    },
+    {
+        "fields": {
+            "currenttask": "530a3999-422f-4abb-a6be-bd29cbed04a4",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "dae3c416-a8c2-4515-9081-6dbd7b265388",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Validation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "a536828c-be65-4088-80bd-eb511a0a063d"
+    },
+    {
+        "fields": {
+            "currenttask": "7872599e-ebfc-472b-bb11-524ff728679f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "a6e97805-a420-41af-b708-2a56de5b47a6"
+    },
+    {
+        "fields": {
+            "currenttask": "b597753f-0b36-484f-ae78-4ae95951fd90",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "dba3028d-2029-4a87-9992-f6335d890528",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "a7c18fee-c8c1-4713-ba74-9705c45efbce"
+    },
+    {
+        "fields": {
+            "currenttask": "8fa944df-1baf-4f89-8106-af013b5078f4",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Failed transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "a98ba456-3dcd-4f45-804c-a40220ddc6cb"
+    },
+    {
+        "fields": {
+            "currenttask": "dde8c13d-330e-458b-9d53-0937370695fa",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "45063ad6-f374-4215-a2c4-ac47be4ce2cd",
+            "lastmodified": "2012-11-06T00:59:43Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "aa9ba088-0b1e-4962-a9d7-79d7a0cbea2d"
+    },
+    {
+        "fields": {
+            "currenttask": "8558d885-d6c2-4d74-af46-20da45487ae7",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "bd792750-a55b-42e9-903a-8c898bb77df1",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "aaa929e4-5c35-447e-816a-033a66b9b90b"
+    },
+    {
+        "fields": {
+            "currenttask": "c409f2b0-bcb7-49ad-a048-a217811ca9b6",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve SIP creation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "ab69c494-23b7-4f50-acff-2e00cf7bffda"
+    },
+    {
+        "fields": {
+            "currenttask": "f1586bd7-f550-4588-9f45-07a212db7994",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2013-04-05T23:08:30Z",
+            "microservicegroup": "Create SIP from Transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "abd6d60c-d50f-4660-a189-ac1b34fafe85"
+    },
+    {
+        "fields": {
+            "currenttask": "a0aecc16-3f78-4579-b6d4-a10df1f89a41",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "ac85a1dc-272b-46ac-bb3e-5bf3f8e56348"
+    },
+    {
+        "fields": {
+            "currenttask": "7569eff6-401f-11e3-ae52-1c6f65d9668b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Examine contents",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "accea2bf-ba74-4a3a-bb97-614775c74459"
+    },
+    {
+        "fields": {
+            "currenttask": "d49684b1-badd-4802-b54e-06eb6b329140",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Prepare DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "ad011cc2-b0eb-4f51-96bb-400149a2ea11"
+    },
+    {
+        "fields": {
+            "currenttask": "1fea5138-981f-4fef-9d74-4d6328fb9248",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "333532b9-b7c2-4478-9415-28a3056d58df",
+            "lastmodified": "2017-08-18T10:07:10Z",
+            "microservicegroup": "Reject transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "ae5cdd0d-2f81-4935-a380-d5c6f1337d93"
+    },
+    {
+        "fields": {
+            "currenttask": "bf9b2fb7-43bd-4c3e-9dd0-7b6f43e6cb48",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-12-06T17:59:43Z",
+            "microservicegroup": "Create SIP from Transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b04e9232-2aea-49fc-9560-27349c8eba4e"
+    },
+    {
+        "fields": {
+            "currenttask": "388a277b-2463-4d11-b203-fc5b80a08f69",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "52269473-5325-4a11-b38a-c4aafcbd8f54",
+            "lastmodified": "2018-05-16T18:06:06Z",
+            "microservicegroup": "Include default Transfer processingMCP.xml",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b08ad32b-f94f-4c2a-9fb0-9ef9328718dd"
+    },
+    {
+        "fields": {
+            "currenttask": "38b99e0c-7066-49c4-82ed-d77bd7f019a1",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "e4b0c713-988a-4606-82ea-4b565936d9a7",
+            "lastmodified": "2015-05-25T16:33:14Z",
+            "microservicegroup": "Process metadata directory",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b0ffcd90-eb26-4caf-8fab-58572d205f04"
+    },
+    {
+        "fields": {
+            "currenttask": "ce52ace2-68fc-4bfb-8444-f32ec8c01783",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-24T17:04:11Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b15c0ba6-e247-4512-8b56-860fd2b6299d"
+    },
+    {
+        "fields": {
+            "currenttask": "74146fe4-365d-4f14-9aae-21eafa7d8393",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b20ff203-1472-40db-b879-0e59d17de867"
+    },
+    {
+        "fields": {
+            "currenttask": "7b07859b-015e-4a17-8bbf-0d46f910d687",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-02-13T22:03:39Z",
+            "microservicegroup": "Process metadata directory",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b21018df-f67d-469a-9ceb-ac92ac68654e"
+    },
+    {
+        "fields": {
+            "currenttask": "d1f630dc-1082-4ad6-95b7-af36d2e2cf46",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "04493ab2-6cad-400d-8832-06941f121a96",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Process metadata directory",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b2444a6e-c626-4487-9abc-1556dd89a8ae"
+    },
+    {
+        "fields": {
+            "currenttask": "c74dfa47-9a6d-4a12-bffe-bf610ab75db9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "21d6d597-b876-4b3f-ab85-f97356f10507",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Extract attachments",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b2552a90-e674-4a40-a482-687c046407d3"
+    },
+    {
+        "fields": {
+            "currenttask": "7d5cb258-1ce2-4510-bd04-3517abbe8fbc",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "828528c2-2eb9-4514-b5ca-dfd1f7cb5b8c",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Failed SIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b2ef06b9-bca4-49da-bc5c-866d7b3c4bb1"
+    },
+    {
+        "fields": {
+            "currenttask": "fb64af31-8f8a-4fe5-a20d-27ee26c9dda2",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Store AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b320ce81-9982-408a-9502-097d0daa48fa"
+    },
+    {
+        "fields": {
+            "currenttask": "9413e636-1209-40b0-a735-74ec785ea14a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b3c5e343-5940-4aad-8a9f-fb0eccbfb3a3"
+    },
+    {
+        "fields": {
+            "currenttask": "3f3ab7ae-766e-4405-a05a-5ee9aea5042f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Rename SIP directory with SIP UUID",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b3d11842-0090-420a-8919-52d7039d50e6"
+    },
+    {
+        "fields": {
+            "currenttask": "7c02a87b-7113-4851-97cd-2cf9d3fc0010",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b4567e89-9fea-4256-99f5-a88987026488"
+    },
+    {
+        "fields": {
+            "currenttask": "5bd51fcb-6a68-4c5f-b99e-4fc36f51c40c",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "b21018df-f67d-469a-9ceb-ac92ac68654e",
+            "lastmodified": "2013-02-13T22:03:40Z",
+            "microservicegroup": "Process metadata directory",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b6b0fe37-aa26-40bd-8be8-d3acebf3ccf8"
+    },
+    {
+        "fields": {
+            "currenttask": "23ad16a5-49fe-409d-98d9-f5a8de333f81",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Generate METS.xml",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b6c9de5a-4a9f-41e1-a524-360bdca39893"
+    },
+    {
+        "fields": {
+            "currenttask": "f09c1aa1-8a5d-49d1-ba60-2866e026eed9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "d5a2ef60-a757-483c-a71a-ccbffe6b80da",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Store AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b7cf0d9a-504f-4f4e-9930-befa817d67ff"
+    },
+    {
+        "fields": {
+            "currenttask": "d9ce0690-a8f9-40dc-a8b5-b021f578f8ff",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b944ec7f-7f99-491f-986d-58914c9bb4fa"
+    },
+    {
+        "fields": {
+            "currenttask": "fa3e0099-b891-43f6-a4bc-390d544fa3e9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "b963a646-0569-43c4-89a2-e3b814c5c08e"
+    },
+    {
+        "fields": {
+            "currenttask": "f1f0409b-d4f8-419a-b625-218dc1abd335",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Create SIP from Transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "bb194013-597c-4e4a-8493-b36d190f8717"
+    },
+    {
+        "fields": {
+            "currenttask": "bcff2873-f006-442e-9628-5eadbb8d0db7",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "2e31580d-1678-474b-83e5-a53d97d150f6",
+            "lastmodified": "2012-10-02T14:25:06Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "bb1f1ed8-6c92-46b9-bab6-3a37ffb665f1"
+    },
+    {
+        "fields": {
+            "currenttask": "d1004e1d-f938-4c68-ba70-0e0ae508cbbe",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Failed transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "bbfbecde-370c-4e26-8087-cfa751e72e6a"
+    },
+    {
+        "fields": {
+            "currenttask": "2d9483ef-7dbb-4e7e-a9c6-76ed4de52da9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "440ef381-8fe8-4b6e-9198-270ee5653454",
+            "lastmodified": "2013-11-15T00:31:31Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "bcabd5e2-c93e-4aaa-af6a-9a74d54e8bf0"
+    },
+    {
+        "fields": {
+            "currenttask": "445d6579-ee40-47d0-af6c-e2f6799f450d",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Characterize and extract metadata",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "bd382151-afd0-41bf-bb7a-b39aef728a32"
+    },
+    {
+        "fields": {
+            "currenttask": "cadd5e12-82b2-43ec-813e-85cd42b2d511",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "307edcde-ad10-401c-92c4-652917c993ed",
+            "lastmodified": "2015-05-25T16:33:14Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "bd792750-a55b-42e9-903a-8c898bb77df1"
+    },
+    {
+        "fields": {
+            "currenttask": "f0c4abd3-1947-4d11-b78b-a55078460100",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "6441980c-b64b-447e-abc7-9351a2547f6a",
+            "lastmodified": "2018-05-16T18:06:03Z",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "bd899573-694e-4d33-8c9b-df0af802437d"
+    },
+    {
+        "fields": {
+            "currenttask": "d9ebceed-2cfb-462b-b130-48fecdf55bbf",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2015-05-25T16:33:14Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "bda96b35-48c7-44fc-9c9e-d7c5a05016c1"
+    },
+    {
+        "fields": {
+            "currenttask": "ef0bb0cf-28d5-4687-a13d-2377341371b5",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d33f228-0fa8-4f4c-a66b-24f8e264c214",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "bdce640d-6e94-49fe-9300-3192a7e5edac"
+    },
+    {
+        "fields": {
+            "currenttask": "fa2307df-e42a-4553-aaf5-b08879b0cbf4",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "823b0d76-9f3c-410d-83ab-f3c2cdd9ab22",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Rename SIP directory with SIP UUID",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "bdfecadc-8219-4109-885c-cfb9ef53ebc3"
+    },
+    {
+        "fields": {
+            "currenttask": "74146fe4-365d-4f14-9aae-21eafa7d8393",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "microservicegroup": "Reingest AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "c103b2fb-9a6b-4b68-8112-b70597a6cd14"
+    },
+    {
+        "fields": {
+            "currenttask": "2d0b36bb-5c82-4ee5-b54c-f3e146ce370b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "c2e6600d-cd26-42ed-bed5-95d41c06e37b"
+    },
+    {
+        "fields": {
+            "currenttask": "7a96f085-924b-483e-bc63-440323bce587",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Identify file format",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "c3269a0a-91db-44e8-96d0-9c748cf80177"
+    },
+    {
+        "fields": {
+            "currenttask": "57bd2747-181e-4f06-b969-dc012c592982",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "bdce640d-6e94-49fe-9300-3192a7e5edac",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "c5ecb5a9-d697-4188-844f-9a756d8734fa"
+    },
+    {
+        "fields": {
+            "currenttask": "6405c283-9eed-410d-92b1-ce7d938ef080",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "c77fee8c-7c4e-4871-a72e-94d499994869"
+    },
+    {
+        "fields": {
+            "currenttask": "da756a4e-9d8b-4992-a219-2a7fd1edf2bb",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Clean up names",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "c8f7bf7b-d903-42ec-bfdf-74d357ac4230"
+    },
+    {
+        "fields": {
+            "currenttask": "6a930177-66db-49d3-b95d-10c28ee47562",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-11-30T19:55:48Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "cb48ef2a-3394-4936-af1f-557b39620efa"
+    },
+    {
+        "fields": {
+            "currenttask": "58a83299-c854-49bb-9b16-bf97813edd8e",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "cb8e5706-e73f-472f-ad9b-d1236af8095f"
+    },
+    {
+        "fields": {
+            "currenttask": "a68d7873-86cf-42d3-a95e-68b62f92f0f9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "cc16178b-b632-4624-9091-822dd802a2c6"
+    },
+    {
+        "fields": {
+            "currenttask": "c52736fa-2bc5-4142-a111-8b13751ed067",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Generate AIP METS",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "ccf8ec5c-3a9a-404a-a7e7-8f567d3b36a0"
+    },
+    {
+        "fields": {
+            "currenttask": "55123c46-78c9-4b5d-ad92-2b1f3eb658af",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2017-08-18T10:07:07Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "cd844b6e-ab3c-4bc6-b34f-7103f88715de"
+    },
+    {
+        "fields": {
+            "currenttask": "74146fe4-365d-4f14-9aae-21eafa7d8393",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "cddde867-4cf9-4248-ac31-f7052fae053f"
+    },
+    {
+        "fields": {
+            "currenttask": "851d679e-44db-485a-9b0e-2dfbdf80c791",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "cf71e6ff-7740-4bdb-a6a9-f392d678c6e1"
+    },
+    {
+        "fields": {
+            "currenttask": "21292501-0c12-4376-8fb1-413286060dc2",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2017-08-18T10:07:07Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d026e5a4-96cf-4e4c-938d-a74b0d211da0"
+    },
+    {
+        "fields": {
+            "currenttask": "757b5f8b-0fdf-4c5c-9cff-569d63a2d209",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "2e7f83f9-495a-44b3-b0cf-bff66f021a4d",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d0c463c2-da4c-4a70-accb-c4ce96ac5194"
+    },
+    {
+        "fields": {
+            "currenttask": "b9613953-9f2d-474b-b8b4-2e17f0b0239d",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": null,
+            "lastmodified": "2018-05-16T18:06:06Z",
+            "microservicegroup": "Generate AIP METS",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d0dfa5fc-e3c2-4638-9eda-f96eea1070e0"
+    },
+    {
+        "fields": {
+            "currenttask": "e6591da1-abfa-4bf2-abeb-cc0791ba5284",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "8ec0b0c1-79ad-4d22-abcd-8e95fcceabbc",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Identify DSpace files",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d0dfbd93-d2d0-44db-9945-94fd8de8a1d4"
+    },
+    {
+        "fields": {
+            "currenttask": "92a7b76c-7c5c-41b3-8657-ba4cdd9a8176",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "f025f58c-d48c-4ba1-8904-a56d2a67b42f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d1018160-aaab-4d92-adce-d518880d7c7d"
+    },
+    {
+        "fields": {
+            "currenttask": "38cea9c4-d75c-48f9-ba88-8052e9d3aa61",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2013-11-07T22:51:42Z",
+            "microservicegroup": "Identify file format",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d1b27e9e-73c8-4954-832c-36bd1e00c802"
+    },
+    {
+        "fields": {
+            "currenttask": "6405c283-9eed-410d-92b1-ce7d938ef080",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-11-30T19:55:48Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d2035da2-dfe1-4a56-8524-84d5732fd3a3"
+    },
+    {
+        "fields": {
+            "currenttask": "39ac9ff8-d312-4033-a2c6-44219471abda",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Complete transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d27fd07e-d3ed-4767-96a5-44a2251c6d0a"
+    },
+    {
+        "fields": {
+            "currenttask": "f89b9e0f-8789-4292-b5d0-4a330c0205e1",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "142d0a36-2b88-4b98-8a33-d809f667ecef",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Prepare AIC",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d29105f0-161d-449d-9c34-5a5ea3263f8e"
+    },
+    {
+        "fields": {
+            "currenttask": "7c02a87b-7113-4851-97cd-2cf9d3fc0010",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Rename with transfer UUID",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d3c75c96-f8c7-4674-af46-5bcce7b05f87"
+    },
+    {
+        "fields": {
+            "currenttask": "d6a0dec1-63e7-4c7c-b4c0-e68f0afcedd3",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2013-04-05T23:08:30Z",
+            "microservicegroup": "Create SIP from Transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d46f6af8-bc4e-4369-a808-c0fedb439fef"
+    },
+    {
+        "fields": {
+            "currenttask": "bafe0ba3-420a-44f2-bb15-7509ef5c498c",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Prepare AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d55b42c8-c7c5-4a40-b626-d248d2bd883f"
+    },
+    {
+        "fields": {
+            "currenttask": "525db1a2-d494-4764-a900-7ff89d67c384",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Store AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d5a2ef60-a757-483c-a71a-ccbffe6b80da"
+    },
+    {
+        "fields": {
+            "currenttask": "f0c4abd3-1947-4d11-b78b-a55078460100",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "b08ad32b-f94f-4c2a-9fb0-9ef9328718dd",
+            "lastmodified": "2018-05-16T18:06:06Z",
+            "microservicegroup": "Include default Transfer processingMCP.xml",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d6f6f5db-4cc2-4652-9283-9ec6a6d181e5"
+    },
+    {
+        "fields": {
+            "currenttask": "7c02a87b-7113-4851-97cd-2cf9d3fc0010",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Scan for viruses",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "d7e6404a-a186-4806-a130-7e6d27179a15"
+    },
+    {
+        "fields": {
+            "currenttask": "966f5720-3081-4697-9691-c19b86ffa569",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "4417b129-fab3-4503-82dd-740f8e774bff",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Rename with transfer UUID",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "da2d650e-8ce3-4b9a-ac97-8ca4744b019f"
+    },
+    {
+        "fields": {
+            "currenttask": "08fc82e7-bc15-4608-8171-50475e8071e2",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Examine contents",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "dae3c416-a8c2-4515-9081-6dbd7b265388"
+    },
+    {
+        "fields": {
+            "currenttask": "24fb04f6-95c1-4244-8f3d-65061418b188",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "db9177f5-41d2-4894-be1a-a7547ed6b63a"
+    },
+    {
+        "fields": {
+            "currenttask": "81304470-37ef-4abb-99d9-ca075a9f440e",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Complete transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "db99ab43-04d7-44ab-89ec-e09d7bbdc39d"
+    },
+    {
+        "fields": {
+            "currenttask": "d7a2bfbe-3f4d-45f7-87c6-f5c3c98961cd",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "dba3028d-2029-4a87-9992-f6335d890528"
+    },
+    {
+        "fields": {
+            "currenttask": "71d4f810-8fb6-45f7-9da2-f2dc07217076",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Assign file UUIDs and checksums",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "dc144ff4-ad74-4a6e-ac15-b0beedcaf662"
+    },
+    {
+        "fields": {
+            "currenttask": "dc2994f2-6de6-4c46-81f7-54676c5054aa",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-02-13T22:03:40Z",
+            "microservicegroup": "Process metadata directory",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "dc9d4991-aefa-4d7e-b7b5-84e3c4336e74"
+    },
+    {
+        "fields": {
+            "currenttask": "2002fd7c-e238-4cca-a393-3c1c63a04915",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T07:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "de909a42-c5b5-46e1-9985-c031b50e9d30"
+    },
+    {
+        "fields": {
+            "currenttask": "a4a4679f-72b8-48da-a202-e0a25fbc41bf",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "dec97e3c-5598-4b99-b26e-f87a435a6b7f"
+    },
+    {
+        "fields": {
+            "currenttask": "f89b9e0f-8789-4292-b5d0-4a330c0205e1",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Include default SIP processingMCP.xml",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "df02cac1-f582-4a86-b7cf-da98a58e279e"
+    },
+    {
+        "fields": {
+            "currenttask": "accc69f9-5b99-4565-92b5-114c7727d9e9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "cf71e6ff-7740-4bdb-a6a9-f392d678c6e1",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "df1cc271-ff77-4f86-b4f3-afc01856db1f"
+    },
+    {
+        "fields": {
+            "currenttask": "4b7e128d-193d-4b7a-8c46-b37842bac047",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Generate METS.xml document",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "df957421-6bba-4ad7-8580-0fc04a54efd4"
+    },
+    {
+        "fields": {
+            "currenttask": "f0c4abd3-1947-4d11-b78b-a55078460100",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "f954326a-250b-4666-b2f2-1e54d36958a1",
+            "lastmodified": "2018-05-16T18:06:06Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "e10a31c3-56df-4986-af7e-2794ddfe8686"
+    },
+    {
+        "fields": {
+            "currenttask": "ef0bb0cf-28d5-4687-a13d-2377341371b5",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "22ded604-6cc0-444b-b320-f96afb15d581",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "e19f8eed-faf9-4e04-bf1f-e9418f2b2b11"
+    },
+    {
+        "fields": {
+            "currenttask": "63866950-cb04-4fe2-9b1d-9d5f1d22fc86",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "e219ed78-2eda-4263-8c0f-0c7f6a86c33e"
+    },
+    {
+        "fields": {
+            "currenttask": "cac32b11-820c-4d17-8c7f-4e71fc0be68a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7e65c627-c11d-4aad-beed-65ceb7053fe8",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "e2c0dae9-3295-4a98-b3ff-664ab2dc0cda"
+    },
+    {
+        "fields": {
+            "currenttask": "a73b3690-ac75-4030-bb03-0c07576b649b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-12-04T00:47:58Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "e399bd60-202d-42df-9760-bd14497b5034"
+    },
+    {
+        "fields": {
+            "currenttask": "d61bb906-feff-4d6f-9e6c-a3f077f46b21",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Rename SIP directory with SIP UUID",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "e3a6d178-fa65-4086-a4aa-6533e8f12d51"
+    },
+    {
+        "fields": {
+            "currenttask": "ba0d0244-1526-4a99-ab65-43bfcd704e70",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-02-13T22:03:40Z",
+            "microservicegroup": "Process metadata directory",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "e4b0c713-988a-4606-82ea-4b565936d9a7"
+    },
+    {
+        "fields": {
+            "currenttask": "09fae382-37ac-45bb-9b53-d1608a44742c",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "microservicegroup": "Reingest AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "e4e19c32-16cc-4a7f-a64d-a1f180bdb164"
+    },
+    {
+        "fields": {
+            "currenttask": "feac0c04-3511-4e91-9403-5c569cff7bcc",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-11-30T19:55:48Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "e64d26f4-3330-4d0b-bffe-81edb0dbe93d"
+    },
+    {
+        "fields": {
+            "currenttask": "ded09ddd-2deb-4d62-bfe3-84703f60c522",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-01-03T02:10:38Z",
+            "microservicegroup": "Process manually normalized files",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "e76aec15-5dfa-4b14-9405-735863e3a6fa"
+    },
+    {
+        "fields": {
+            "currenttask": "6b2a7301-df99-4157-b09f-76e87e08f6d9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "377f8ebb-7989-4a68-9361-658079ff8138",
+            "lastmodified": "2017-08-18T10:07:10Z",
+            "microservicegroup": "Failed transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "e780473a-0c10-431f-bab6-5d7238b2b70b"
+    },
+    {
+        "fields": {
+            "currenttask": "7fd4e564-bed2-42c7-a186-7ae615381516",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "5c0d8661-1c49-4023-8a67-4991365d70fb",
+            "lastmodified": "2013-11-15T00:31:31Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "e950cd98-574b-4e57-9ef8-c2231e1ce451"
+    },
+    {
+        "fields": {
+            "currenttask": "dde8c13d-330e-458b-9d53-0937370695fa",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "438dc1cf-9813-44b5-a0a3-58e09ae73b8a",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "ea0e8838-ad3a-4bdd-be14-e5dba5a4ae0c"
+    },
+    {
+        "fields": {
+            "currenttask": "aa2e26b3-539e-4071-b54c-bcb89650d2d2",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "db99ab43-04d7-44ab-89ec-e09d7bbdc39d",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Complete transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "eb52299b-9ae6-4a1f-831e-c7eee0de829f"
+    },
+    {
+        "fields": {
+            "currenttask": "c1bd4921-c446-4ff9-bb34-fcd155b8132a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "b0ffcd90-eb26-4caf-8fab-58572d205f04",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Process metadata directory",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "ee438694-815f-4b74-97e1-8e7dde2cc6d5"
+    },
+    {
+        "fields": {
+            "currenttask": "9f0388ae-155c-4cbf-9e15-525ff03e025f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Add final metadata",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "eeb23509-57e2-4529-8857-9d62525db048"
+    },
+    {
+        "fields": {
+            "currenttask": "4b07d97a-04c1-45ce-9d9b-36bc29054223",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Rename with transfer UUID",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "ef6332ee-a890-4e1b-88de-986efc4269fb"
+    },
+    {
+        "fields": {
+            "currenttask": "2d9483ef-7dbb-4e7e-a9c6-76ed4de52da9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "dba3028d-2029-4a87-9992-f6335d890528",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "ef8bd3f3-22f5-4283-bfd6-d458a2d18f22"
+    },
+    {
+        "fields": {
+            "currenttask": "74146fe4-365d-4f14-9aae-21eafa7d8393",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Prepare AIC",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "efd15406-fd6c-425b-8772-d460e1e79009"
+    },
+    {
+        "fields": {
+            "currenttask": "e18e0c3a-dffb-42d2-9bfa-ea6c61328e28",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Failed compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f025f58c-d48c-4ba1-8904-a56d2a67b42f"
+    },
+    {
+        "fields": {
+            "currenttask": "97545cb5-3397-4934-9bc5-143b774e4fa7",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2013-11-07T22:51:42Z",
+            "microservicegroup": "Identify file format",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f09847c2-ee51-429a-9478-a860477f6b8d"
+    },
+    {
+        "fields": {
+            "currenttask": "b5970cbb-1af7-4f8c-b41d-a0febd482da4",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f0f64c7e-30fa-47c1-9877-43955680c0d0"
+    },
+    {
+        "fields": {
+            "currenttask": "d7f13903-55a0-4a1c-87fa-9b75b14dccb4",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "2e31580d-1678-474b-83e5-a53d97d150f6",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f12ece2c-fb7e-44de-ba87-7e3c5b6feb74"
+    },
+    {
+        "fields": {
+            "currenttask": "86a832aa-bd37-44e2-ba02-418fb82e34f1",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Extract packages",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f19926dd-8fb5-4c79-8ade-c83f61f55b40"
+    },
+    {
+        "fields": {
+            "currenttask": "57ef1f9f-3a1a-4cdc-90fd-39b024524618",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Verify transfer checksums",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f1bfce12-b637-443f-85f8-b6450ca01a13"
+    },
+    {
+        "fields": {
+            "currenttask": "a493f430-d905-4f68-a742-f4393a43e694",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2013-02-13T22:03:37Z",
+            "microservicegroup": "Prepare AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f1e286f9-4ec7-4e19-820c-dae7b8ea7d09"
+    },
+    {
+        "fields": {
+            "currenttask": "06b45b5d-d06b-49a8-8f15-e9458fbae842",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "microservicegroup": "Verify transfer compliance",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f2a019ea-0601-419c-a475-1b96a927a2fb"
+    },
+    {
+        "fields": {
+            "currenttask": "2d8f4aa1-76ad-4c88-af81-f7f494780628",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "0d7f5dc2-b9af-43bf-b698-10fdcc5b014d",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Reject AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f2e784a0-356b-4b92-9a5a-11887aa3cf48"
+    },
+    {
+        "fields": {
+            "currenttask": "e5789749-00df-4b6c-af12-47eeabc8926a",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "39a128e3-c35d-40b7-9363-87f75091e1ff",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "microservicegroup": "Create SIP from Transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f378ec85-adcc-4ee6-ada2-bc90cfe20efb"
+    },
+    {
+        "fields": {
+            "currenttask": "41e84764-e3a0-4aac-94e9-adbe996b087f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "e950cd98-574b-4e57-9ef8-c2231e1ce451",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f3a39155-d655-4336-8227-f8c88e4b7669"
+    },
+    {
+        "fields": {
+            "currenttask": "bf0835be-4c76-4508-a5a7-cdc4c9dae217",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f3a58cbb-20a8-4c6d-9ae4-1a5f02c1a28e"
+    },
+    {
+        "fields": {
+            "currenttask": "ef0bb0cf-28d5-4687-a13d-2377341371b5",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "a46e95fe-4a11-4d3c-9b76-c5d8ea0b094d",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Remove cache files",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f3be1ee1-8881-465d-80a6-a6f093d40ec2"
+    },
+    {
+        "fields": {
+            "currenttask": "b24525cd-e68d-4afd-b6ec-46192bbc117b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "47dd6ea6-1ee7-4462-8b84-3fc4c1eeeb7f",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Process submission documentation",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f574b2a0-6e0b-4c74-ac5b-a73ddb9593a0"
+    },
+    {
+        "fields": {
+            "currenttask": "df1c53e4-1b69-441e-bdc9-6d08c3b47c9b",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Approve transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f6bcc82a-d629-4a78-8643-bf6e3cb39fe6"
+    },
+    {
+        "fields": {
+            "currenttask": "21f8f2b6-d285-490a-9276-bfa87a0a4fb9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "db9177f5-41d2-4894-be1a-a7547ed6b63a",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Normalize",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f6fdd1a7-f0c5-4631-b5d3-19421155bd7a"
+    },
+    {
+        "fields": {
+            "currenttask": "7c02a87b-7113-4851-97cd-2cf9d3fc0010",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-11-30T19:55:48Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f7488721-c936-42af-a767-2f0b39564a86"
+    },
+    {
+        "fields": {
+            "currenttask": "df51d25b-6a63-4e7a-b164-77b929dd2f31",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Include default Transfer processingMCP.xml",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f8319d49-f1e3-45dd-a404-66165c59dec7"
+    },
+    {
+        "fields": {
+            "currenttask": "7c02a87b-7113-4851-97cd-2cf9d3fc0010",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f8be53cd-6ca2-4770-8619-8a8101a809b9"
+    },
+    {
+        "fields": {
+            "currenttask": "79ba8ce2-d01a-4723-83b7-5ac2b9ab2ae9",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": null,
+            "lastmodified": "2017-08-18T10:07:07Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f8ee488b-5667-4417-ae15-bed9e42ee97d"
+    },
+    {
+        "fields": {
+            "currenttask": "fc64dc4c-e245-402b-b572-2dc027b414d1",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "microservicegroup": "Characterize and extract metadata",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f8ef02c4-f585-4b0d-9b6f-3cef6fbe527f"
+    },
+    {
+        "fields": {
+            "currenttask": "388a277b-2463-4d11-b203-fc5b80a08f69",
+            "defaultexitmessage": "Failed",
+            "defaultnextchainlink": "3409b898-e532-49d3-98ff-a2a1f9d988fa",
+            "lastmodified": "2018-05-16T18:06:06Z",
+            "microservicegroup": "TRIM transfer",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "f954326a-250b-4666-b2f2-1e54d36958a1"
+    },
+    {
+        "fields": {
+            "currenttask": "93e01ed2-8d69-4a56-b686-3cf507931885",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Quarantine",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "fbc3857b-bb02-425b-89ce-2d6a39eaa542"
+    },
+    {
+        "fields": {
+            "currenttask": "a3c27d23-dbdf-47af-bf66-4238aa1a508f",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7c95b242-1ce5-4210-b7d4-fdbb6c0aa5dd",
+            "lastmodified": "2012-10-02T00:25:06Z",
+            "microservicegroup": "Rename with transfer UUID",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "fdfac6e5-86c0-4c81-895c-19a9edadedef"
+    },
+    {
+        "fields": {
+            "currenttask": "f89b9e0f-8789-4292-b5d0-4a330c0205e1",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "7d728c39-395f-4892-8193-92f086c0546f",
+            "lastmodified": "2017-08-18T10:07:03Z",
+            "microservicegroup": "Reingest AIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "ff516d0b-2bba-414c-88d4-f3575ebf050a"
+    },
+    {
+        "fields": {
+            "currenttask": "71eaef05-264d-453e-b8c4-7b7e2c7ac889",
+            "defaultexitmessage": "4",
+            "defaultnextchainlink": "2e31580d-1678-474b-83e5-a53d97d150f6",
+            "lastmodified": "2017-08-18T10:06:58Z",
+            "microservicegroup": "Upload DIP",
+            "reloadfilelist": true,
+            "replaces": null
+        },
+        "model": "main.microservicechainlink",
+        "pk": "ff89a530-0540-4625-8884-5a2198dea05a"
+    }
+]

--- a/src/dashboard/tests/fixtures/am17-sip.json
+++ b/src/dashboard/tests/fixtures/am17-sip.json
@@ -1,0 +1,15 @@
+[
+    {
+        "fields": {
+            "aip_filename": "KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4.7z",
+            "createdtime": "2018-10-17T20:19:40Z",
+            "currentpath": "%sharedPath%currentlyProcessing/KSTest-535b4469-221b-41bb-aeaa-a78c5791c1c4/",
+            "diruuids": false,
+            "hidden": false,
+            "identifiers": [],
+            "sip_type": "SIP"
+        },
+        "model": "main.sip",
+        "pk": "535b4469-221b-41bb-aeaa-a78c5791c1c4"
+    }
+]

--- a/src/dashboard/tests/fixtures/am17-taskconfig.json
+++ b/src/dashboard/tests/fixtures/am17-taskconfig.json
@@ -1,0 +1,3698 @@
+[
+    {
+        "fields": {
+            "description": "Characterize and extract metadata",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "d6307888-f5ef-4828-80d6-fb6f707ae023"
+        },
+        "model": "main.taskconfig",
+        "pk": "00041f5a-42cd-4b77-a6d4-6ef0f376a817"
+    },
+    {
+        "fields": {
+            "description": "Set SIP to normalize with MediaInfo file identification.",
+            "lastmodified": "2012-10-23T19:41:24Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "be6dda53-ef28-42dd-8452-e11734d57a91"
+        },
+        "model": "main.taskconfig",
+        "pk": "008e5b38-b19c-48af-896f-349aaf5eba9f"
+    },
+    {
+        "fields": {
+            "description": "Bind PIDs?",
+            "lastmodified": "2018-05-16T18:06:04Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "02b44c99-f499-42d4-8742-3576c0d52804"
+    },
+    {
+        "fields": {
+            "description": "Set file group use and fileIDs for maildir AIP",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ec688528-d492-4de3-a176-b777734153b1"
+        },
+        "model": "main.taskconfig",
+        "pk": "032347f1-c0fb-4c6c-96ba-886ac8ac636c"
+    },
+    {
+        "fields": {
+            "description": "Sanitize SIP name",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "0c6990d8-ce1f-4093-803b-5ca6256119ca"
+        },
+        "model": "main.taskconfig",
+        "pk": "04c7e0fb-ec4e-4637-a7b7-41601d5523bd"
+    },
+    {
+        "fields": {
+            "description": "Select upload type (Project Client or direct upload)",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "06334a2c-82ed-477b-af0b-9c9f3dcade99"
+    },
+    {
+        "fields": {
+            "description": "Set specialized processing link",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "ed98984f-69c5-45de-8a32-2c9ecf65e83f"
+        },
+        "model": "main.taskconfig",
+        "pk": "06b45b5d-d06b-49a8-8f15-e9458fbae842"
+    },
+    {
+        "fields": {
+            "description": "Set SIP to normalize with FITS-file utility file identification.",
+            "lastmodified": "2012-10-23T19:41:23Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "9329d1d8-03f9-4c5e-81ec-7010552d0a3e"
+        },
+        "model": "main.taskconfig",
+        "pk": "0732af8f-d60b-43e0-8f75-8e89039a05a8"
+    },
+    {
+        "fields": {
+            "description": "Approve TRIM transfer",
+            "lastmodified": "2012-11-30T19:55:48Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "07bf7432-fd9b-456e-9d17-5b387087723a"
+    },
+    {
+        "fields": {
+            "description": "Find type to process as",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "6fe259c2-459d-4d4b-81a4-1b9daf7ee2e9",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "07f6f419-d51f-4c69-bca6-a395adecbee0"
+    },
+    {
+        "fields": {
+            "description": "Move to examine contents",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "f62e7309-61b3-4318-a770-ab40595bc7b8"
+        },
+        "model": "main.taskconfig",
+        "pk": "08fc82e7-bc15-4608-8171-50475e8071e2"
+    },
+    {
+        "fields": {
+            "description": "Extract contents from compressed archives",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "8fad772e-7d2e-4cdd-89e6-7976152b6696"
+        },
+        "model": "main.taskconfig",
+        "pk": "09f73737-f7ca-4ea2-9676-d369f390e650"
+    },
+    {
+        "fields": {
+            "description": "Is maildir AIP",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "c0ae5130-0c17-4fc1-91c7-aa36265a21d5"
+        },
+        "model": "main.taskconfig",
+        "pk": "09fae382-37ac-45bb-9b53-d1608a44742c"
+    },
+    {
+        "fields": {
+            "description": "Relate manual normalized preservation files to the original files",
+            "lastmodified": "2013-01-03T02:10:38Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "adde688c-eb79-4036-a3b8-49aacc6a1b36"
+        },
+        "model": "main.taskconfig",
+        "pk": "0a521e24-b376-4a9c-9cd6-ce41e187179a"
+    },
+    {
+        "fields": {
+            "description": "Move transfer back to activeTransfers directory.",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "4306315c-1f75-4eaf-8752-f08f67f9ada4"
+        },
+        "model": "main.taskconfig",
+        "pk": "0ae50158-a6e2-4663-a684-61d9a8384789"
+    },
+    {
+        "fields": {
+            "description": "Restructure TRIM for compliance",
+            "lastmodified": "2012-11-30T19:55:47Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "e3c09c46-6d05-4369-8c12-b5af6657c8f7"
+        },
+        "model": "main.taskconfig",
+        "pk": "0b90715c-50bc-4cb7-a390-771a7cc8180f"
+    },
+    {
+        "fields": {
+            "description": "Set files to identify",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "65263ec0-f3ff-4fd5-9cd3-cf6f51ef92c7"
+        },
+        "model": "main.taskconfig",
+        "pk": "0bb3f551-1418-4b99-8094-05a43fcd9537"
+    },
+    {
+        "fields": {
+            "description": "Verify checksums in fileSec of DSpace METS files",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "a5bb8df6-a8f0-4279-ac6d-873ec5cf37cd"
+        },
+        "model": "main.taskconfig",
+        "pk": "0c1664f2-dfcb-46d9-bd9e-5b604baef788"
+    },
+    {
+        "fields": {
+            "description": "Select file format identification command",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "0c95f944-837f-4ada-a396-2c7a818806c6"
+    },
+    {
+        "fields": {
+            "description": "Set resume link after processing metadata directory",
+            "lastmodified": "2013-02-13T22:03:40Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "6b4600f2-6df6-42cb-b611-32938b46a9cf"
+        },
+        "model": "main.taskconfig",
+        "pk": "0cbfd02e-94bc-4f0d-8e56-f7af6379c3ca"
+    },
+    {
+        "fields": {
+            "description": "Policy checks for originals",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "cd5c8bbe-3699-4caf-a134-0e77c8ccc84a"
+        },
+        "model": "main.taskconfig",
+        "pk": "0f9f9634-275f-4460-aceb-09dcf37049c4"
+    },
+    {
+        "fields": {
+            "description": "Copy OCR data to DIP directory",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "5c4f877f-b352-4977-b51b-53ebc437b08c"
+        },
+        "model": "main.taskconfig",
+        "pk": "102cd6b0-5d30-4e04-9b62-4e9f12d74549"
+    },
+    {
+        "fields": {
+            "description": "Attempt restructure for compliance?",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "108f7f4c-72f2-4ddb-910a-24f173d64fa7"
+    },
+    {
+        "fields": {
+            "description": "Index AIP",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "81f36881-9e54-4c75-a5b2-838cfb2ca228"
+        },
+        "model": "main.taskconfig",
+        "pk": "134a1a94-22f0-4e67-be17-23a4c7178105"
+    },
+    {
+        "fields": {
+            "description": "Restructure from bag AIP to SIP directory format",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "2808a160-82df-40a8-a6ca-330151584968"
+        },
+        "model": "main.taskconfig",
+        "pk": "135dd73d-845a-412b-b17e-23941a3d9f78"
+    },
+    {
+        "fields": {
+            "description": "Rename with transfer UUID",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "0b1177e8-8541-4293-a238-1783c793a7b1"
+        },
+        "model": "main.taskconfig",
+        "pk": "13aaa76e-41db-4bff-8519-1f9ba8ca794f"
+    },
+    {
+        "fields": {
+            "description": "Workflow decision - create transfer backup",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "1423da1c-e9f8-479c-9949-4238c59899ac"
+    },
+    {
+        "fields": {
+            "description": "Check for Access directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "8c50f6ab-7fa4-449e-bea8-483999568d85"
+        },
+        "model": "main.taskconfig",
+        "pk": "143b4734-9c33-4f6e-9af0-2dc09cf9017a"
+    },
+    {
+        "fields": {
+            "description": "Upload DIP",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "16b8cc42-68b6-4751-b497-3e3a64101bbb"
+    },
+    {
+        "fields": {
+            "description": "Sanitize Transfer name",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "f8af7e00-0ae4-47ab-9d22-92395ff053fc"
+        },
+        "model": "main.taskconfig",
+        "pk": "16eaacad-e180-4be1-a13c-35ab070808a7"
+    },
+    {
+        "fields": {
+            "description": "Normalization report",
+            "lastmodified": "2017-08-18T10:07:08Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "59531c29-59d3-468d-897c-9800c4525f81"
+        },
+        "model": "main.taskconfig",
+        "pk": "17aa7180-ded8-45c7-96d0-5ecebfd1a5cf"
+    },
+    {
+        "fields": {
+            "description": "Move to compressionAIPDecisions directory",
+            "lastmodified": "2013-11-07T22:51:34Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ae090b70-0234-40ea-bc11-4be27370515f"
+        },
+        "model": "main.taskconfig",
+        "pk": "18dceb0a-dfb1-4b18-81a7-c6c5c578c5f1"
+    },
+    {
+        "fields": {
+            "description": "Approve standard transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "1b8b596f-b6ee-440f-b59c-5e8b39a2b46d"
+    },
+    {
+        "fields": {
+            "description": "Assign checksums and file sizes to objects",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "ec54a7cb-690f-4dd6-ad2b-979ae9f8d25a"
+        },
+        "model": "main.taskconfig",
+        "pk": "1c7de28f-8f18-41c7-b03a-19f900d38f34"
+    },
+    {
+        "fields": {
+            "description": "Select format identification tool",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "1cd60a70-f78e-4625-9381-3863ff819f33"
+    },
+    {
+        "fields": {
+            "description": "Move to metadata reminder",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "b6b39093-297e-4180-ad61-274bc9c5b451"
+        },
+        "model": "main.taskconfig",
+        "pk": "1cf09019-56a1-47eb-8fe0-9bbff158892d"
+    },
+    {
+        "fields": {
+            "description": "Policy checks for preservation derivatives",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "0dc703b8-780a-4643-a427-bb60bd5879a8"
+        },
+        "model": "main.taskconfig",
+        "pk": "1dd8e61f-0579-4a87-bfec-60bedb355048"
+    },
+    {
+        "fields": {
+            "description": "Remove files without linking information (failed normalization artifacts etc.)",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "a32fc538-efd1-4be0-95a9-5ee40cbc70fd"
+        },
+        "model": "main.taskconfig",
+        "pk": "1e02e82a-2055-4f37-af3a-7dc606f9fd97"
+    },
+    {
+        "fields": {
+            "description": "Cleanup rejected transfer",
+            "lastmodified": "2017-08-18T10:07:10Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "72f11e68-7350-42a7-9bdc-60001d0505a2"
+        },
+        "model": "main.taskconfig",
+        "pk": "1fea5138-981f-4fef-9d74-4d6328fb9248"
+    },
+    {
+        "fields": {
+            "description": "Approve normalization",
+            "lastmodified": "2012-10-02T07:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "2002fd7c-e238-4cca-a393-3c1c63a04915"
+    },
+    {
+        "fields": {
+            "description": "Retrieve DIP Storage Locations",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "a19bfd9f-9989-4648-9351-013a10b382ed",
+            "tasktypepkreference": "5a6d1a88-1c2f-40b5-adec-ad7e533340ff"
+        },
+        "model": "main.taskconfig",
+        "pk": "21292501-0c12-4376-8fb1-413286060dc2"
+    },
+    {
+        "fields": {
+            "description": "Normalize for thumbnails",
+            "lastmodified": "2013-11-15T00:31:31Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "26309e7d-6435-4700-9171-131005f29cbb"
+        },
+        "model": "main.taskconfig",
+        "pk": "21f8f2b6-d285-490a-9276-bfa87a0a4fb9"
+    },
+    {
+        "fields": {
+            "description": "Grant normalization options for no pre-existing DIP",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "f85bbe03-8aca-4211-99b7-ddb7dfb24da1"
+        },
+        "model": "main.taskconfig",
+        "pk": "235c3727-b138-4e62-9265-c8f07761a5fa"
+    },
+    {
+        "fields": {
+            "description": "Generate METS.xml document",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "73b71a30-1a26-4a07-8aa8-4dfb6e66a321"
+        },
+        "model": "main.taskconfig",
+        "pk": "23ad16a5-49fe-409d-98d9-f5a8de333f81"
+    },
+    {
+        "fields": {
+            "description": "Approve zipped bagit transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "243b67e9-4d0b-4c38-8fa4-0fa3df8a5b86"
+    },
+    {
+        "fields": {
+            "description": "Normalize service files for access",
+            "lastmodified": "2013-11-15T00:31:31Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "339f300d-62d1-4a46-97c2-57244f54d32e"
+        },
+        "model": "main.taskconfig",
+        "pk": "246c34b0-b785-485f-971b-0ed9f82e1ae3"
+    },
+    {
+        "fields": {
+            "description": "Set resume link - postApproveNormalizationLink",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "95fb93a5-ef63-4ceb-8572-c0ddf88ef3ea"
+        },
+        "model": "main.taskconfig",
+        "pk": "24deba11-c719-4c64-a53c-e08c85663c40"
+    },
+    {
+        "fields": {
+            "description": "Select destination collection",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "01b748fe-2e9d-44e4-ae5d-113f74c9a0ba",
+            "tasktypepkreference": "e8fb137c-d499-45a8-a4aa-a884d81b9f3d"
+        },
+        "model": "main.taskconfig",
+        "pk": "24f82c1a-5de7-4b2a-8ac2-68a48edf252f"
+    },
+    {
+        "fields": {
+            "description": "Remove files without linking information (failed normalization artifacts etc.)",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "a32fc538-efd1-4be0-95a9-5ee40cbc70fd"
+        },
+        "model": "main.taskconfig",
+        "pk": "24fb04f6-95c1-4244-8f3d-65061418b188"
+    },
+    {
+        "fields": {
+            "description": "Set transfer type: TRIM",
+            "lastmodified": "2012-11-30T19:55:48Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "353f326a-c599-4e66-8e1c-6262316e3729"
+        },
+        "model": "main.taskconfig",
+        "pk": "256e18ca-1bcd-4b14-b3d5-4efbad5663fc"
+    },
+    {
+        "fields": {
+            "description": "Resume after normalization file identification tool selected.",
+            "lastmodified": "2012-10-23T19:41:22Z",
+            "replaces": null,
+            "tasktype": "c42184a3-1a7f-4c4d-b380-15d8d97fdd11",
+            "tasktypepkreference": "003b52a6-f80a-409c-95f9-82dd770aa132"
+        },
+        "model": "main.taskconfig",
+        "pk": "26ec68d5-8d33-4fe2-bc11-f06d80fb23e0"
+    },
+    {
+        "fields": {
+            "description": "Add processed structMap to METS.xml document",
+            "lastmodified": "2015-05-25T16:33:14Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "fefd486c-e6ce-4229-ac3d-cf53e66f46cc"
+        },
+        "model": "main.taskconfig",
+        "pk": "275b3640-68a6-4c4e-adc1-888ea3fdfba5"
+    },
+    {
+        "fields": {
+            "description": "Copy submission documentation",
+            "lastmodified": "2015-05-25T16:33:14Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "919dfbcd-b328-4a7e-9340-569a9d8859df"
+        },
+        "model": "main.taskconfig",
+        "pk": "2894f4ea-0d11-431f-a7de-c2f765bd55a6"
+    },
+    {
+        "fields": {
+            "description": "Identify file format",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "82b08f3a-ca8f-4259-bd92-2fc1ab4f9974"
+        },
+        "model": "main.taskconfig",
+        "pk": "28e8e81c-3380-47f6-a973-e48f94104692"
+    },
+    {
+        "fields": {
+            "description": "Transcribe",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "657bdd72-8f18-4477-8018-1f6c8df7ad85"
+        },
+        "model": "main.taskconfig",
+        "pk": "297e7ebd-71bb-41e9-b1b7-945b6a9f00c5"
+    },
+    {
+        "fields": {
+            "description": "Set resume link - returnFromManualNormalized",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "ba7bafe6-7241-4ffe-a0b8-97ca3c68eac1"
+        },
+        "model": "main.taskconfig",
+        "pk": "29937fd7-b482-4180-8037-1b57d71e903c"
+    },
+    {
+        "fields": {
+            "description": "Normalize",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "2bfd7cef-dcf8-4587-8043-2c69c612a6e3"
+    },
+    {
+        "fields": {
+            "description": "Move to approve normalization directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "87fb2e00-03b9-4890-a4d4-0e28f27e32c2"
+        },
+        "model": "main.taskconfig",
+        "pk": "2d0b36bb-5c82-4ee5-b54c-f3e146ce370b"
+    },
+    {
+        "fields": {
+            "description": "Cleanup rejected SIP",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "44758789-e1b5-4cfe-8011-442612da2d3b"
+        },
+        "model": "main.taskconfig",
+        "pk": "2d8f4aa1-76ad-4c88-af81-f7f494780628"
+    },
+    {
+        "fields": {
+            "description": "Normalize for access",
+            "lastmodified": "2013-11-15T00:31:31Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "3c256437-6435-4307-9757-fbac5c07541c"
+        },
+        "model": "main.taskconfig",
+        "pk": "2d9483ef-7dbb-4e7e-a9c6-76ed4de52da9"
+    },
+    {
+        "fields": {
+            "description": "Store DIP",
+            "lastmodified": "2017-08-18T10:07:07Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "1e4ccd56-a076-4aa2-9642-1ed8944b306a"
+        },
+        "model": "main.taskconfig",
+        "pk": "2dd14de8-62c7-49a5-bfa1-dd025e7a426b"
+    },
+    {
+        "fields": {
+            "description": "Set quarantine permissions on transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "0b17b446-11d4-45a8-9d0c-4297b8c8887c"
+        },
+        "model": "main.taskconfig",
+        "pk": "2e3c3f0f-069e-4ca1-b71b-93f4880a39b5"
+    },
+    {
+        "fields": {
+            "description": "Select compression level",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "2f6947ee-5d92-416a-bade-b1079767e641"
+    },
+    {
+        "fields": {
+            "description": "Set resume link after handling any manual normalized files",
+            "lastmodified": "2013-01-03T02:10:40Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "fc9f30bf-7f6e-4e62-9f99-689c8dc2e4ec"
+        },
+        "model": "main.taskconfig",
+        "pk": "31707047-5d61-4b9f-ba58-1353d6c38e0c"
+    },
+    {
+        "fields": {
+            "description": "Email fail report",
+            "lastmodified": "2013-01-08T02:11:59Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "807603e2-9914-46e0-9be4-73d4c073d2e8"
+        },
+        "model": "main.taskconfig",
+        "pk": "32b2600c-6907-4cb2-b18a-3986f0842219"
+    },
+    {
+        "fields": {
+            "description": "Remove empty manual normalization directories",
+            "lastmodified": "2013-01-11T00:50:39Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "8971383b-5c38-4818-975f-e539bd993eb8"
+        },
+        "model": "main.taskconfig",
+        "pk": "33c0dea0-da6c-4b8f-8038-6e95844eea95"
+    },
+    {
+        "fields": {
+            "description": "Check for specialized processing",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "replaces": null,
+            "tasktype": "c42184a3-1a7f-4c4d-b380-15d8d97fdd11",
+            "tasktypepkreference": "49d853a9-646d-4e9f-b825-d1bcc3ba77f0"
+        },
+        "model": "main.taskconfig",
+        "pk": "3649f0f4-2174-44af-aef9-31ebeddeb73b"
+    },
+    {
+        "fields": {
+            "description": "Find options to normalize as",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "6fe259c2-459d-4d4b-81a4-1b9daf7ee2e9",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "38324d67-8358-4679-902d-c20dcdfd548b"
+    },
+    {
+        "fields": {
+            "description": "Designate to process as a standard transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "3590f73d-5eb0-44a0-91a6-5b2db6655889",
+            "tasktypepkreference": "c691548f-0131-4bd5-864c-364b1f7feb7f"
+        },
+        "model": "main.taskconfig",
+        "pk": "3875546f-9137-4c8f-9fcc-ed112eaa6414"
+    },
+    {
+        "fields": {
+            "description": "Assign UUIDs to directories",
+            "lastmodified": "2018-05-16T18:06:03Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "91096265-d582-46be-b606-4769fc27c7a7"
+        },
+        "model": "main.taskconfig",
+        "pk": "388a277b-2463-4d11-b203-fc5b80a08f69"
+    },
+    {
+        "fields": {
+            "description": "Process JSON metadata",
+            "lastmodified": "2015-05-25T16:33:14Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "44d3789b-10ad-4a9c-9984-c2fe503c8720"
+        },
+        "model": "main.taskconfig",
+        "pk": "38b99e0c-7066-49c4-82ed-d77bd7f019a1"
+    },
+    {
+        "fields": {
+            "description": "Move to select file ID tool",
+            "lastmodified": "2013-11-07T22:51:42Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "3e8f5b9e-b3a6-4782-a944-749de6ae234d"
+        },
+        "model": "main.taskconfig",
+        "pk": "38cea9c4-d75c-48f9-ba88-8052e9d3aa61"
+    },
+    {
+        "fields": {
+            "description": "Move to SIP creation directory for completed transfers",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ac562701-7672-4e1d-a318-b986b7c9007c"
+        },
+        "model": "main.taskconfig",
+        "pk": "39ac9ff8-d312-4033-a2c6-44219471abda"
+    },
+    {
+        "fields": {
+            "description": "Perform policy checks on originals?",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "3aaabae1-c329-4bbd-a25d-b07e0f7a6d08"
+    },
+    {
+        "fields": {
+            "description": "Move to quarantine",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "94d0c52f-7594-4f59-9de5-b827d8d2a7f3"
+        },
+        "model": "main.taskconfig",
+        "pk": "3ad0db9a-f57d-4664-ad34-947404dddd04"
+    },
+    {
+        "fields": {
+            "description": "Attempt restructure for compliance",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "862c0ce2-82e3-4336-bd20-d8bcb2d0fa6c"
+        },
+        "model": "main.taskconfig",
+        "pk": "3ae4931e-886e-4e0a-9a85-9b047c9983ac"
+    },
+    {
+        "fields": {
+            "description": "Scan for viruses",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "de58249f-9594-439d-8bea-536ce59d70a3"
+        },
+        "model": "main.taskconfig",
+        "pk": "3c002fb6-a511-461e-ad16-0d2c46649374"
+    },
+    {
+        "fields": {
+            "description": "Set unquarantined file permissions on Transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "329fd50d-42fd-44e3-940e-7dc45d1a7727"
+        },
+        "model": "main.taskconfig",
+        "pk": "3c04068f-20b8-4cbc-8166-c61faacb6628"
+    },
+    {
+        "fields": {
+            "description": "Generate METS.xml document",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "761f00af-3d9a-4cb4-b7f1-259fccedb802"
+        },
+        "model": "main.taskconfig",
+        "pk": "3df5643c-2556-412f-a7ac-e2df95722dae"
+    },
+    {
+        "fields": {
+            "description": "Move to workFlowDecisions-quarantineSIP directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "e7d2a9ac-b5c5-4b5c-9e57-a3c4e98035e6"
+        },
+        "model": "main.taskconfig",
+        "pk": "3e70f50d-5056-413e-a3d1-7b4b13d2b821"
+    },
+    {
+        "fields": {
+            "description": "Check if SIP is from Maildir Transfer",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "c0ae5130-0c17-4fc1-91c7-aa36265a21d5"
+        },
+        "model": "main.taskconfig",
+        "pk": "3f3ab7ae-766e-4405-a05a-5ee9aea5042f"
+    },
+    {
+        "fields": {
+            "description": "Create thumbnails directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "9c94b1d7-0563-4be9-9d64-058d0d1a03f4"
+        },
+        "model": "main.taskconfig",
+        "pk": "41e84764-e3a0-4aac-94e9-adbe996b087f"
+    },
+    {
+        "fields": {
+            "description": "Characterize and extract metadata for attachments",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "2936f695-190e-49e9-b7c6-6d1610f6b6de"
+        },
+        "model": "main.taskconfig",
+        "pk": "445d6579-ee40-47d0-af6c-e2f6799f450d"
+    },
+    {
+        "fields": {
+            "description": "Set resume link after processing metadata directory",
+            "lastmodified": "2013-02-13T22:03:40Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "771dd17a-02d1-403b-a761-c70cc9cc1d1a"
+        },
+        "model": "main.taskconfig",
+        "pk": "449530ec-cd94-4d8c-aae0-3b7cd2e2d5f9"
+    },
+    {
+        "fields": {
+            "description": "Assign file UUIDs to objects",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "57d42245-79e2-4c2d-8ed3-b596cce416db"
+        },
+        "model": "main.taskconfig",
+        "pk": "450794b5-db3e-4557-8ab8-1abd77786429"
+    },
+    {
+        "fields": {
+            "description": "Create removal from backlog PREMIS events",
+            "lastmodified": "2013-04-19T22:39:27Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "463e5d1c-d680-47fa-a27a-7efd4f702355"
+        },
+        "model": "main.taskconfig",
+        "pk": "4554c5f9-52f9-440c-bc69-0f7be3651949"
+    },
+    {
+        "fields": {
+            "description": "Set remove preservation and access normalized files to renormalize link.",
+            "lastmodified": "2012-10-24T00:40:06Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "76eaa4d2-fd4f-4741-b68c-df5b96ba81d1"
+        },
+        "model": "main.taskconfig",
+        "pk": "4745d0bb-910c-4c0d-8b81-82d7bfca7819"
+    },
+    {
+        "fields": {
+            "description": "Move to approve normalization directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "3565ac77-780e-43d8-87c8-8a6bf04aab40"
+        },
+        "model": "main.taskconfig",
+        "pk": "4773c7e4-df8b-4928-acdd-1e9a3235b4b1"
+    },
+    {
+        "fields": {
+            "description": "Remove files without linking information (failed normalization artifacts etc.)",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "a32fc538-efd1-4be0-95a9-5ee40cbc70fd"
+        },
+        "model": "main.taskconfig",
+        "pk": "483d0fc9-8f89-4699-b90b-7be250bab743"
+    },
+    {
+        "fields": {
+            "description": "Move to generate transfer tree",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "760a9654-de3e-4ea7-bb76-eeff06acdf95"
+        },
+        "model": "main.taskconfig",
+        "pk": "48416179-7ae4-47cc-a0aa-f9847da08c63"
+    },
+    {
+        "fields": {
+            "description": "Set transfer type: Standard",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "36ad6300-5a2c-491b-867b-c202541749e8"
+        },
+        "model": "main.taskconfig",
+        "pk": "48929c19-c0c7-41b2-8bd0-552b22e2d86f"
+    },
+    {
+        "fields": {
+            "description": "Policy checks for access derivatives",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "0872e8ff-5b1b-4c00-a5ea-72efc498fcbf"
+        },
+        "model": "main.taskconfig",
+        "pk": "4a8d87e2-4a9a-4ad7-9b4c-d433c9281539"
+    },
+    {
+        "fields": {
+            "description": "Load finished with manual normalized link",
+            "lastmodified": "2013-01-03T02:10:38Z",
+            "replaces": null,
+            "tasktype": "c42184a3-1a7f-4c4d-b380-15d8d97fdd11",
+            "tasktypepkreference": "65af383e-2153-4117-a2f9-bbe83358e54b"
+        },
+        "model": "main.taskconfig",
+        "pk": "4ad0eecf-aa6e-4e3c-afe4-7e230cc671b2"
+    },
+    {
+        "fields": {
+            "description": "Rename with transfer UUID",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "0b1177e8-8541-4293-a238-1783c793a7b1"
+        },
+        "model": "main.taskconfig",
+        "pk": "4b07d97a-04c1-45ce-9d9b-36bc29054223"
+    },
+    {
+        "fields": {
+            "description": "Generate METS.xml document",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "bc7d263a-3798-4e5e-8098-8e273fd5890b"
+        },
+        "model": "main.taskconfig",
+        "pk": "4b7e128d-193d-4b7a-8c46-b37842bac047"
+    },
+    {
+        "fields": {
+            "description": "Transcribe SIP contents",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "4c64875e-9f31-4596-96d9-f99bc886bb24"
+    },
+    {
+        "fields": {
+            "description": "Rename DIP files with original UUIDs",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "5f5ca409-8009-4732-a47c-1a35c72abefc"
+        },
+        "model": "main.taskconfig",
+        "pk": "4d2ed238-1b35-43fb-9753-fcac0ede8da4"
+    },
+    {
+        "fields": {
+            "description": "Choose Config for Archivists Toolkit DIP Upload",
+            "lastmodified": "2013-03-26T03:25:01Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": ""
+        },
+        "model": "main.taskconfig",
+        "pk": "4d56a90c-8d9f-498c-8331-cf469fcb3147"
+    },
+    {
+        "fields": {
+            "description": "Move to the store AIP approval directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "867f326b-66d1-498d-87e9-b6bcacf45abd"
+        },
+        "model": "main.taskconfig",
+        "pk": "502a8bc4-88b1-41b0-8821-f8afd984036e"
+    },
+    {
+        "fields": {
+            "description": "Verify mets_structmap.xml compliance",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "fa903131-1d84-4d2b-b498-67a48bc44fc8"
+        },
+        "model": "main.taskconfig",
+        "pk": "5044f7ec-96f9-4bf1-8540-671e543c2411"
+    },
+    {
+        "fields": {
+            "description": "Populate database with reingested AIP data",
+            "lastmodified": "2017-08-18T10:07:03Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "12fcbb37-499b-4e1c-8164-3beb1657b6dd"
+        },
+        "model": "main.taskconfig",
+        "pk": "507c13db-63c9-476b-9a16-0c3a05aff1cb"
+    },
+    {
+        "fields": {
+            "description": "Load post approve normalization link",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "c42184a3-1a7f-4c4d-b380-15d8d97fdd11",
+            "tasktypepkreference": "7477907c-79ec-4d48-93ae-9e0cbbfd2b65"
+        },
+        "model": "main.taskconfig",
+        "pk": "5092ff10-097b-4bac-a4d8-9b4766aaf40d"
+    },
+    {
+        "fields": {
+            "description": "Normalize for preservation",
+            "lastmodified": "2013-11-15T00:31:31Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "7478e34b-da4b-479b-ad2e-5a3d4473364f"
+        },
+        "model": "main.taskconfig",
+        "pk": "51e31d21-3e92-4c9f-8fec-740f559285f2"
+    },
+    {
+        "fields": {
+            "description": "Remove the processing directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "805d7c5d-5ca9-4e66-9223-767eef79e0bd"
+        },
+        "model": "main.taskconfig",
+        "pk": "525db1a2-d494-4764-a900-7ff89d67c384"
+    },
+    {
+        "fields": {
+            "description": "Verify metadata directory checksums",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "c64b1064-c856-4758-9891-152c7eabde7f"
+        },
+        "model": "main.taskconfig",
+        "pk": "528c8fe3-265f-45dd-b5c0-1a4ac0e15954"
+    },
+    {
+        "fields": {
+            "description": "Verify metadata directory checksums",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "df65573b-70b7-4cd4-b825-d5d5d8dd016d"
+        },
+        "model": "main.taskconfig",
+        "pk": "52d646df-fd66-4157-b8aa-32786fef9481"
+    },
+    {
+        "fields": {
+            "description": "Validate formats",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "1d3ef137-b060-4b33-b13f-25aa9346877b"
+        },
+        "model": "main.taskconfig",
+        "pk": "530a3999-422f-4abb-a6be-bd29cbed04a4"
+    },
+    {
+        "fields": {
+            "description": "Characterize and extract metadata on submission documentation",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "4b816807-10a7-447a-b42f-f34c8b8b3b76"
+        },
+        "model": "main.taskconfig",
+        "pk": "530b3b90-b97a-4aaf-836f-3a889ad1d7d2"
+    },
+    {
+        "fields": {
+            "description": "Scan for viruses on extracted files",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "51bce222-4157-427c-aca9-a670083db223"
+        },
+        "model": "main.taskconfig",
+        "pk": "5370a0cb-da97-4983-868a-1376d7737af5"
+    },
+    {
+        "fields": {
+            "description": "Create thumbnails directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "9c94b1d7-0563-4be9-9d64-058d0d1a03f4"
+        },
+        "model": "main.taskconfig",
+        "pk": "547f95f6-3fcd-45e1-98b6-a8a7d9097373"
+    },
+    {
+        "fields": {
+            "description": "Remove hidden files and directories",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "6c50d546-b0a4-4900-90ac-b4bcca802368"
+        },
+        "model": "main.taskconfig",
+        "pk": "549181ed-febe-487a-a036-ed6fdfa10a86"
+    },
+    {
+        "fields": {
+            "description": "Failed compliance. See output in dashboard. Transfer moved back to activeTransfers.",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "b0aa4fd2-a837-4cb8-964d-7f905326aa85"
+        },
+        "model": "main.taskconfig",
+        "pk": "54a05ec3-a34f-4404-96ec-36b527445da9"
+    },
+    {
+        "fields": {
+            "description": "Store DIP location",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "01b748fe-2e9d-44e4-ae5d-113f74c9a0ba",
+            "tasktypepkreference": "1fa7994d-9106-4d5a-892c-539af7e4ad8d"
+        },
+        "model": "main.taskconfig",
+        "pk": "55123c46-78c9-4b5d-ad92-2b1f3eb658af"
+    },
+    {
+        "fields": {
+            "description": "Removed bagged files",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "d12b6b59-1f1c-47c2-b1a3-2bf898740eae"
+        },
+        "model": "main.taskconfig",
+        "pk": "55f0e6fa-834c-44f1-89f3-c912e79cea7d"
+    },
+    {
+        "fields": {
+            "description": "Sanitize extracted objects' file and directory names",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "f368a36d-2b27-4f08-b662-2828a96d189a"
+        },
+        "model": "main.taskconfig",
+        "pk": "57bd2747-181e-4f06-b969-dc012c592982"
+    },
+    {
+        "fields": {
+            "description": "Verify metadata directory checksums",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "7e47b56f-f9bc-4a10-9f63-1b165354d5f4"
+        },
+        "model": "main.taskconfig",
+        "pk": "57ef1f9f-3a1a-4cdc-90fd-39b024524618"
+    },
+    {
+        "fields": {
+            "description": "Normalize",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "58a83299-c854-49bb-9b16-bf97813edd8e"
+    },
+    {
+        "fields": {
+            "description": "Move to select normalization path.",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "55eec242-68fa-4a1b-a3cd-458c087a017b"
+        },
+        "model": "main.taskconfig",
+        "pk": "596a7fd5-a86b-489c-a9c0-3aa64b836cec"
+    },
+    {
+        "fields": {
+            "description": "Move to the failed directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "5401961e-773d-41fe-8d62-8c1262f6156b"
+        },
+        "model": "main.taskconfig",
+        "pk": "59ebdcec-eacc-4daf-978a-1b0d8652cd0c"
+    },
+    {
+        "fields": {
+            "description": "Check for Service directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "290b358c-cfff-488c-a0b7-fffce037b2c5"
+        },
+        "model": "main.taskconfig",
+        "pk": "5a3d244e-c7a1-4cd9-b1a8-2890bf1f254c"
+    },
+    {
+        "fields": {
+            "description": "Assign file UUIDs",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "4c25f856-6639-42b5-9120-3ac166dce932"
+        },
+        "model": "main.taskconfig",
+        "pk": "5a9fbb03-2434-4034-b20f-bcc6f971a8e5"
+    },
+    {
+        "fields": {
+            "description": "Generate METS.xml document",
+            "lastmodified": "2018-05-16T18:06:06Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "07d6dff8-20ee-4346-88da-6dfe549eddb1"
+        },
+        "model": "main.taskconfig",
+        "pk": "5ba69f6a-1605-42a5-a53a-4d5179613e12"
+    },
+    {
+        "fields": {
+            "description": "Assign checksums and file sizes to metadata ",
+            "lastmodified": "2013-02-13T22:03:40Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "e377b543-d9b8-47a9-8297-4f95ca7600b3"
+        },
+        "model": "main.taskconfig",
+        "pk": "5bd51fcb-6a68-4c5f-b99e-4fc36f51c40c"
+    },
+    {
+        "fields": {
+            "description": "Add README file",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "acb6b747-54b5-4d53-920d-85746cb453a4"
+        },
+        "model": "main.taskconfig",
+        "pk": "5bf6bc93-fa3d-4c3e-9ae0-8e714e8fedba"
+    },
+    {
+        "fields": {
+            "description": "Create DIP directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "5341d647-dc75-4f00-8e02-cef59c9862e5"
+        },
+        "model": "main.taskconfig",
+        "pk": "5c831a10-5d75-44ca-9741-06fdfc72052a"
+    },
+    {
+        "fields": {
+            "description": "Choose Config for ArchivesSpace DIP Upload",
+            "lastmodified": "2017-08-18T10:06:58Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": ""
+        },
+        "model": "main.taskconfig",
+        "pk": "5ded9d05-dd24-484a-a8b2-73ec5d35aa63"
+    },
+    {
+        "fields": {
+            "description": "Pre-processing for DIP generation",
+            "lastmodified": "2017-08-18T10:07:07Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "cbe200ab-a634-4902-a0e6-8ed1858538d4"
+        },
+        "model": "main.taskconfig",
+        "pk": "5e0ac12e-6ce7-4d11-bd75-e14167210df4"
+    },
+    {
+        "fields": {
+            "description": "Identify manually normalized files",
+            "lastmodified": "2013-02-19T00:52:52Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "2843eba9-a9cf-462a-9cfc-f24ff35a22c0"
+        },
+        "model": "main.taskconfig",
+        "pk": "602e9b26-5839-4940-b230-0264bb873fe7"
+    },
+    {
+        "fields": {
+            "description": "Create unquarantine PREMIS events",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "27dfc012-7cf4-449c-b0f0-bdd252c6f6e9"
+        },
+        "model": "main.taskconfig",
+        "pk": "62ba16c8-4a3f-4199-a48e-d557a90728e2"
+    },
+    {
+        "fields": {
+            "description": "Load rights",
+            "lastmodified": "2017-08-18T10:07:10Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "82579891-1cb7-486e-a0a6-b4cdf99c282f"
+        },
+        "model": "main.taskconfig",
+        "pk": "637cc23a-c5f5-4df5-a352-5d47014be63b"
+    },
+    {
+        "fields": {
+            "description": "Grant normalization options for pre-existing DIP",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "1871a1a5-1937-4c4d-ab05-3b0c04a0bca1"
+        },
+        "model": "main.taskconfig",
+        "pk": "63866950-cb04-4fe2-9b1d-9d5f1d22fc86"
+    },
+    {
+        "fields": {
+            "description": "Assign checksums and file sizes to objects",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "c06ecc19-8f75-4ccf-a549-22fde3972f28"
+        },
+        "model": "main.taskconfig",
+        "pk": "6405c283-9eed-410d-92b1-ce7d938ef080"
+    },
+    {
+        "fields": {
+            "description": "Extract zipped bag transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "9e6d6445-ccc6-427a-9407-a126699f98b4"
+        },
+        "model": "main.taskconfig",
+        "pk": "64a859be-f362-45d1-b9b4-4e15091f686f"
+    },
+    {
+        "fields": {
+            "description": "Characterize and extract metadata on metadata files",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "e1e813dd-87ce-4468-a6de-35b787a02c7a"
+        },
+        "model": "main.taskconfig",
+        "pk": "6511ac58-d68e-4381-9cf3-01f2637acb4c"
+    },
+    {
+        "fields": {
+            "description": "Assign file UUIDs to submission documentation",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "614b1d56-9078-4cb0-80cc-1ea87b9fbbe8"
+        },
+        "model": "main.taskconfig",
+        "pk": "674e21f3-1c50-4185-8e5d-70b1ed4a7f3a"
+    },
+    {
+        "fields": {
+            "description": "Run FITS on manual normalized preservation files",
+            "lastmodified": "2013-01-03T02:10:38Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "79f3c95a-c1f1-463b-ab23-972ad859e136"
+        },
+        "model": "main.taskconfig",
+        "pk": "68920df3-66aa-44fc-b221-710dbe97680a"
+    },
+    {
+        "fields": {
+            "description": "Verify TRIM manifest",
+            "lastmodified": "2012-11-30T19:55:47Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "748eef17-84d3-4b84-9439-6756f0fc697d"
+        },
+        "model": "main.taskconfig",
+        "pk": "6a930177-66db-49d3-b95d-10c28ee47562"
+    },
+    {
+        "fields": {
+            "description": "Create transfer backup (sharedDirectory/transferBackups)",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "9e302b2b-e28d-4a61-9be7-b94e16929560"
+        },
+        "model": "main.taskconfig",
+        "pk": "6af5d804-de90-4c5b-bdba-e15a89e1a3db"
+    },
+    {
+        "fields": {
+            "description": "Cleanup failed Transfer",
+            "lastmodified": "2017-08-18T10:07:10Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "3362ef11-b4f1-4862-b91d-496665d15cce"
+        },
+        "model": "main.taskconfig",
+        "pk": "6b2a7301-df99-4157-b09f-76e87e08f6d9"
+    },
+    {
+        "fields": {
+            "description": "Rename with transfer UUID",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "b3fed349-54c4-4142-8d86-925b3a9f4365"
+        },
+        "model": "main.taskconfig",
+        "pk": "6ed7ec07-5df1-470b-9a2e-a934cba8af26"
+    },
+    {
+        "fields": {
+            "description": "Verify TRIM checksums",
+            "lastmodified": "2012-11-30T19:55:47Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "3b889d1d-bfe1-467f-8373-2c9366127093"
+        },
+        "model": "main.taskconfig",
+        "pk": "6f5d5518-1ed4-49b8-9cd5-497d112c97e4"
+    },
+    {
+        "fields": {
+            "description": "Upload DIP",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ee80b69b-6128-4e31-9db4-ef90aa677c87"
+        },
+        "model": "main.taskconfig",
+        "pk": "7058a655-82f3-455c-9245-ad8e87e77a4f"
+    },
+    {
+        "fields": {
+            "description": "Assign file UUIDs to objects",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "2ad612bc-1993-407e-9d66-a8ab9c1ebbd5"
+        },
+        "model": "main.taskconfig",
+        "pk": "71d4f810-8fb6-45f7-9da2-f2dc07217076"
+    },
+    {
+        "fields": {
+            "description": "Upload to ArchivesSpace",
+            "lastmodified": "2017-08-18T10:06:58Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "10a0f352-aeb7-4c13-8e9e-e81bda9bca29"
+        },
+        "model": "main.taskconfig",
+        "pk": "71eaef05-264d-453e-b8c4-7b7e2c7ac889"
+    },
+    {
+        "fields": {
+            "description": "Create thumbnails directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "d079b090-bc81-4fc6-a9c5-a267ad5f69a9"
+        },
+        "model": "main.taskconfig",
+        "pk": "72dce7bc-054c-4d2d-8971-a480cb894bdc"
+    },
+    {
+        "fields": {
+            "description": "Create SIP from transfer objects",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "744000f8-8688-4080-9225-5547cd3f77cc"
+        },
+        "model": "main.taskconfig",
+        "pk": "73ad6c9d-8ea1-4667-ae7d-229656a49237"
+    },
+    {
+        "fields": {
+            "description": "Move submission documentation into objects directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "2f2a9b2b-bcdb-406b-a842-898d4bed02be"
+        },
+        "model": "main.taskconfig",
+        "pk": "73e12d44-ec3d-41a9-b138-80ec7e31ede5"
+    },
+    {
+        "fields": {
+            "description": "Move to processing directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "464a0a66-571b-4e6d-ba3a-4d182551a20f"
+        },
+        "model": "main.taskconfig",
+        "pk": "74146fe4-365d-4f14-9aae-21eafa7d8393"
+    },
+    {
+        "fields": {
+            "description": "Create AIC METS file",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "77e6b5ec-acf7-44d0-b250-32cbe014499d"
+        },
+        "model": "main.taskconfig",
+        "pk": "741a09ee-8143-4216-8919-1046571af3e9"
+    },
+    {
+        "fields": {
+            "description": "Examine contents?",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "7569eff6-401f-11e3-ae52-1c6f65d9668b"
+    },
+    {
+        "fields": {
+            "description": "Verify mets_structmap.xml compliance",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "fa903131-1d84-4d2b-b498-67a48bc44fc8"
+        },
+        "model": "main.taskconfig",
+        "pk": "757b5f8b-0fdf-4c5c-9cff-569d63a2d209"
+    },
+    {
+        "fields": {
+            "description": "Retrieve AIP Storage Locations",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "a19bfd9f-9989-4648-9351-013a10b382ed",
+            "tasktypepkreference": "857fb861-8aa1-45c0-95f5-c5af66764142"
+        },
+        "model": "main.taskconfig",
+        "pk": "75e00332-24a3-4076-aed1-e3dc44379227"
+    },
+    {
+        "fields": {
+            "description": "Set SIP to normalize with FITS-JHOVE file identification.",
+            "lastmodified": "2012-10-23T19:41:23Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "face6ee9-42d5-46ff-be1b-a645594b2da8"
+        },
+        "model": "main.taskconfig",
+        "pk": "76135f22-6dba-417f-9833-89ecbe9a3d99"
+    },
+    {
+        "fields": {
+            "description": "Rename with transfer UUID",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "0b1177e8-8541-4293-a238-1783c793a7b1"
+        },
+        "model": "main.taskconfig",
+        "pk": "76729a40-dfa1-4c1a-adbf-01fb362324f5"
+    },
+    {
+        "fields": {
+            "description": "Designate to process as a DSpace transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "3590f73d-5eb0-44a0-91a6-5b2db6655889",
+            "tasktypepkreference": "f1357379-0118-4f51-aa49-37aeb702b760"
+        },
+        "model": "main.taskconfig",
+        "pk": "7872599e-ebfc-472b-bb11-524ff728679f"
+    },
+    {
+        "fields": {
+            "description": "Handle unstored DIP",
+            "lastmodified": "2018-05-16T18:06:03Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "888281a1-9678-46ed-a1a0-be9f0c6d02b0"
+        },
+        "model": "main.taskconfig",
+        "pk": "79ba8ce2-d01a-4723-83b7-5ac2b9ab2ae9"
+    },
+    {
+        "fields": {
+            "description": "Determine which files to identify",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "replaces": null,
+            "tasktype": "c42184a3-1a7f-4c4d-b380-15d8d97fdd11",
+            "tasktypepkreference": "97ddf0be-7b07-48b1-82f6-6a3b49edde2b"
+        },
+        "model": "main.taskconfig",
+        "pk": "7a96f085-924b-483e-bc63-440323bce587"
+    },
+    {
+        "fields": {
+            "description": "Sanitize file and directory names in metadata",
+            "lastmodified": "2013-02-13T22:03:39Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "58b192eb-0507-4a83-ae5a-f5e260634c2a"
+        },
+        "model": "main.taskconfig",
+        "pk": "7b07859b-015e-4a17-8bbf-0d46f910d687"
+    },
+    {
+        "fields": {
+            "description": "Load labels from metadata/file_labels.csv",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "2f851d03-722f-4c49-8369-64f11542af89"
+        },
+        "model": "main.taskconfig",
+        "pk": "7beb3689-02a7-4f56-a6d1-9c9399f06842"
+    },
+    {
+        "fields": {
+            "description": "Move to processing directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "037feb3c-f4d1-44dd-842e-c681793094df"
+        },
+        "model": "main.taskconfig",
+        "pk": "7c02a87b-7113-4851-97cd-2cf9d3fc0010"
+    },
+    {
+        "fields": {
+            "description": "Cleanup failed SIP",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "bad1aea1-404c-4a0a-8f0a-83f09bf99fd5"
+        },
+        "model": "main.taskconfig",
+        "pk": "7d5cb258-1ce2-4510-bd04-3517abbe8fbc"
+    },
+    {
+        "fields": {
+            "description": "Normalize service files for thumbnails",
+            "lastmodified": "2013-11-15T00:31:31Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "62f21582-3925-47f6-b17e-90f46323b0d1"
+        },
+        "model": "main.taskconfig",
+        "pk": "7fd4e564-bed2-42c7-a186-7ae615381516"
+    },
+    {
+        "fields": {
+            "description": "Set transfer type: DSpace",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "6c261f8f-17ce-4b58-86c2-ac3bfb0d2850"
+        },
+        "model": "main.taskconfig",
+        "pk": "80ebef4c-0dd1-45eb-b993-1db56a077db8"
+    },
+    {
+        "fields": {
+            "description": "Create transfer metadata XML",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "290c1989-4d8a-4b6e-80bd-9ff43439aeca"
+        },
+        "model": "main.taskconfig",
+        "pk": "81304470-37ef-4abb-99d9-ca075a9f440e"
+    },
+    {
+        "fields": {
+            "description": "Identify DSpace mets files",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "f798426b-fbe9-4fd3-9180-8df776384b14"
+        },
+        "model": "main.taskconfig",
+        "pk": "81d64862-a4f6-4e3f-b32e-47268d9eb9a3"
+    },
+    {
+        "fields": {
+            "description": "Approve AIC",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "81f2a21b-a7a0-44e4-a2f6-9a6cf742b052"
+    },
+    {
+        "fields": {
+            "description": "Remove bagged files",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "d17b25c7-f83c-4862-904b-8074150b1395"
+        },
+        "model": "main.taskconfig",
+        "pk": "83755035-1dfd-4e25-9031-e1178be4bb84"
+    },
+    {
+        "fields": {
+            "description": "Designate to process as a standard transfer when unquarantined",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "3590f73d-5eb0-44a0-91a6-5b2db6655889",
+            "tasktypepkreference": "1c460578-e696-4378-a5d1-63ee77dd18bc"
+        },
+        "model": "main.taskconfig",
+        "pk": "851d679e-44db-485a-9b0e-2dfbdf80c791"
+    },
+    {
+        "fields": {
+            "description": "Remove unneeded files",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "66aa823d-3b72-4d13-9ad6-c5e6580857b8"
+        },
+        "model": "main.taskconfig",
+        "pk": "85308c8b-b299-4453-bf40-9ac61d134015"
+    },
+    {
+        "fields": {
+            "description": "Identify file format",
+            "lastmodified": "2013-11-07T22:51:42Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "9c3680a5-91cb-413f-af4e-d39c3346f8db"
+        },
+        "model": "main.taskconfig",
+        "pk": "8558d885-d6c2-4d74-af46-20da45487ae7"
+    },
+    {
+        "fields": {
+            "description": "Select format identification tool",
+            "lastmodified": "2012-10-24T00:45:13Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "85a2ec9b-5a80-497b-af60-04926c0bf183"
+    },
+    {
+        "fields": {
+            "description": "Store DIP",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "1f6f0cd1-acaf-40fb-bb2a-047383b8c977"
+        },
+        "model": "main.taskconfig",
+        "pk": "85ce72dd-627a-4d0d-b118-fdaedf8ed8e6"
+    },
+    {
+        "fields": {
+            "description": "Examine contents",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "3a17cc3f-eabc-4b58-90e8-1df2a96cf182"
+        },
+        "model": "main.taskconfig",
+        "pk": "869c4c44-6e7d-4473-934d-80c7b95a8310"
+    },
+    {
+        "fields": {
+            "description": "Delete package after extraction?",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "86a832aa-bd37-44e2-ba02-418fb82e34f1"
+    },
+    {
+        "fields": {
+            "description": "Scan for viruses in metadata",
+            "lastmodified": "2013-02-13T22:03:39Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "7316e6ed-1c1a-4bf6-a570-aead6b544e41"
+        },
+        "model": "main.taskconfig",
+        "pk": "8850aeff-8553-4ff1-ab31-99b5392a458b"
+    },
+    {
+        "fields": {
+            "description": "Bind PIDs",
+            "lastmodified": "2018-05-16T18:06:04Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "0bd2524d-573a-4c8e-86b4-8fa54a5acfad"
+        },
+        "model": "main.taskconfig",
+        "pk": "88d8d473-6948-4f5d-abcb-12fb392df17a"
+    },
+    {
+        "fields": {
+            "description": "Select compression algorithm",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "8a291152-729c-42f2-ab2e-c53b9f357799"
+    },
+    {
+        "fields": {
+            "description": "Move to select file ID tool",
+            "lastmodified": "2013-11-07T22:51:42Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "179373e8-a6b4-4274-a245-ca3f4b105396"
+        },
+        "model": "main.taskconfig",
+        "pk": "8b846431-5da9-4743-906d-2cdc4e777f8f"
+    },
+    {
+        "fields": {
+            "description": "Check transfer directory for objects",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "77ea8809-bc90-4e9d-a144-ad6d5ec59de9"
+        },
+        "model": "main.taskconfig",
+        "pk": "8cda5b7a-fb44-4a61-a865-6ad01af5a150"
+    },
+    {
+        "fields": {
+            "description": "Attempt restructure for compliance",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "285a7b4d-155b-4f5b-ab35-daa6414303f9"
+        },
+        "model": "main.taskconfig",
+        "pk": "8e06349b-d4a3-420a-9a64-69553bd9a183"
+    },
+    {
+        "fields": {
+            "description": "Generate METS.xml document",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "1f3f4e3b-2f5a-47a2-8d1c-27a6f1b94b95"
+        },
+        "model": "main.taskconfig",
+        "pk": "8ea17652-a136-4251-b460-d50b0c7090eb"
+    },
+    {
+        "fields": {
+            "description": "Copy preconfigured choice XML to DIP directory",
+            "lastmodified": "2015-05-25T16:33:14Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "67a7341c-276e-46bf-9021-0dcd5123687f"
+        },
+        "model": "main.taskconfig",
+        "pk": "8ed6f0e4-cd5c-4c4b-bce0-e8949ea696cd"
+    },
+    {
+        "fields": {
+            "description": "Find branch to continue processing",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "6fe259c2-459d-4d4b-81a4-1b9daf7ee2e9",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "8fa944df-1baf-4f89-8106-af013b5078f4"
+    },
+    {
+        "fields": {
+            "description": "Copy thumbnails to DIP directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "6abefa8d-387d-4f23-9978-bea7e6657a57"
+        },
+        "model": "main.taskconfig",
+        "pk": "90e0993d-23d4-4d0c-8b7d-73717b58f20e"
+    },
+    {
+        "fields": {
+            "description": "Verify mets_structmap.xml compliance",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "fa903131-1d84-4d2b-b498-67a48bc44fc8"
+        },
+        "model": "main.taskconfig",
+        "pk": "92a7b76c-7c5c-41b3-8657-ba4cdd9a8176"
+    },
+    {
+        "fields": {
+            "description": "Create SIPs from TRIM transfer containers",
+            "lastmodified": "2012-12-04T21:29:48Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "4cfac870-24ec-4a80-8bcb-7a38fd02e048"
+        },
+        "model": "main.taskconfig",
+        "pk": "9371ba25-b600-485d-b2d8-cef2f39c35ed"
+    },
+    {
+        "fields": {
+            "description": "Find type to remove from quarantine as",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "6fe259c2-459d-4d4b-81a4-1b9daf7ee2e9",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "93e01ed2-8d69-4a56-b686-3cf507931885"
+    },
+    {
+        "fields": {
+            "description": "Normalize",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "9413e636-1209-40b0-a735-74ec785ea14a"
+    },
+    {
+        "fields": {
+            "description": "Select target CONTENTdm server",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "94942d82-8b87-4be3-a338-158f893573cd"
+    },
+    {
+        "fields": {
+            "description": "Generate DIP",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "a51af5c7-0ed4-41c2-9142-fc9e43e83960"
+        },
+        "model": "main.taskconfig",
+        "pk": "95d2ddff-a5e5-49cd-b4da-a5dd6fd3d2eb"
+    },
+    {
+        "fields": {
+            "description": "Create placement in backlog PREMIS events",
+            "lastmodified": "2013-04-19T22:39:27Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "6733ebdd-5c5f-4168-81a5-fe9a2fbc10c9"
+        },
+        "model": "main.taskconfig",
+        "pk": "9649186d-e5bd-4765-b285-3b0d8e83b105"
+    },
+    {
+        "fields": {
+            "description": "Set transfer type: Maildir",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "7b455fc5-b201-4233-ba1c-e05be059b279"
+        },
+        "model": "main.taskconfig",
+        "pk": "966f5720-3081-4697-9691-c19b86ffa569"
+    },
+    {
+        "fields": {
+            "description": "Select file format identification command",
+            "lastmodified": "2013-11-07T22:51:42Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "97545cb5-3397-4934-9bc5-143b774e4fa7"
+    },
+    {
+        "fields": {
+            "description": "Set remove preservation normalized files to renormalize link.",
+            "lastmodified": "2012-10-24T00:40:07Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "b5808a0f-e842-4820-837a-832d18398ebb"
+        },
+        "model": "main.taskconfig",
+        "pk": "97cc7629-c580-44db-8a41-68b6b2f23be4"
+    },
+    {
+        "fields": {
+            "description": "Set files to normalize",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "f226ecea-ae91-42d5-b039-39a1125b1c30"
+        },
+        "model": "main.taskconfig",
+        "pk": "99324102-ebe8-415d-b5d8-b299ab2f4703"
+    },
+    {
+        "fields": {
+            "description": "Move to the failed directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "c79f55f7-637c-4d32-a6fa-1d193e87c5fc"
+        },
+        "model": "main.taskconfig",
+        "pk": "99712faf-6cd0-48d1-9c66-35a2033057cf"
+    },
+    {
+        "fields": {
+            "description": "Scan for viruses",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "de58249f-9594-439d-8bea-536ce59d70a3"
+        },
+        "model": "main.taskconfig",
+        "pk": "9a0f8eac-6a9d-4b85-8049-74954fbd6594"
+    },
+    {
+        "fields": {
+            "description": "Generate DIP",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ed8c70b7-1456-461c-981b-6b9c84896263"
+        },
+        "model": "main.taskconfig",
+        "pk": "9a70cc32-2b0e-4763-a168-b81485fac366"
+    },
+    {
+        "fields": {
+            "description": "Bind PID",
+            "lastmodified": "2018-05-16T18:06:04Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "b055f0a4-75d7-4747-98fe-aab08d835403"
+        },
+        "model": "main.taskconfig",
+        "pk": "9c9e75e9-04b0-4a04-83ad-07ddf2ff9a17"
+    },
+    {
+        "fields": {
+            "description": "Sanitize object's file and directory names",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "80759ad1-c79a-4c3b-b255-735c28a50f9e"
+        },
+        "model": "main.taskconfig",
+        "pk": "9dd95035-e11b-4438-a6c6-a03df302933c"
+    },
+    {
+        "fields": {
+            "description": "Parse external METS",
+            "lastmodified": "2017-08-18T10:07:10Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "d9708512-ac5f-4211-b07a-e5a41c6825b6"
+        },
+        "model": "main.taskconfig",
+        "pk": "9ecf18d4-652b-4bd2-a3f5-bfb5794299f8"
+    },
+    {
+        "fields": {
+            "description": "Reminder: add metadata if desired",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": "5c149b3b-8fb3-431c-a577-11cf349cfb38"
+        },
+        "model": "main.taskconfig",
+        "pk": "9f0388ae-155c-4cbf-9e15-525ff03e025f"
+    },
+    {
+        "fields": {
+            "description": "Move to processing directory",
+            "lastmodified": "2015-05-25T16:33:13Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "cb6cd728-fe54-4a50-a6cc-1c5bd9fa1198"
+        },
+        "model": "main.taskconfig",
+        "pk": "9f7029af-739d-4ec1-840d-b92d1d30f0c7"
+    },
+    {
+        "fields": {
+            "description": "Set unquarantined file permissions on Transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "329fd50d-42fd-44e3-940e-7dc45d1a7727"
+        },
+        "model": "main.taskconfig",
+        "pk": "a0aecc16-3f78-4579-b6d4-a10df1f89a41"
+    },
+    {
+        "fields": {
+            "description": "Designate to process as a standard transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "3590f73d-5eb0-44a0-91a6-5b2db6655889",
+            "tasktypepkreference": "5dffcd9c-472d-44e0-ae4d-a30705cf80cd"
+        },
+        "model": "main.taskconfig",
+        "pk": "a2e93146-a3ff-4e6c-ae3d-76ce49ca5e1b"
+    },
+    {
+        "fields": {
+            "description": "Attempt restructure for compliance",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "db753cdd-c556-4f4b-aa09-e55eb637244d"
+        },
+        "model": "main.taskconfig",
+        "pk": "a3c27d23-dbdf-47af-bf66-4238aa1a508f"
+    },
+    {
+        "fields": {
+            "description": "Check if DIP should be generated",
+            "lastmodified": "2013-02-13T22:03:37Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "49c816cd-b443-498f-9369-9274d060ddd3"
+        },
+        "model": "main.taskconfig",
+        "pk": "a493f430-d905-4f68-a742-f4393a43e694"
+    },
+    {
+        "fields": {
+            "description": "Extract packages?",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "a4a4679f-72b8-48da-a202-e0a25fbc41bf"
+    },
+    {
+        "fields": {
+            "description": "Perform policy checks on preservation derivatives?",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "a4aad773-480a-422a-8e61-124fc7487572"
+    },
+    {
+        "fields": {
+            "description": "Move to extract packages",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "8daffda4-397c-4f56-85db-c4376bf6891e"
+        },
+        "model": "main.taskconfig",
+        "pk": "a68d7873-86cf-42d3-a95e-68b62f92f0f9"
+    },
+    {
+        "fields": {
+            "description": "Include default Transfer processingMCP.xml",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "a56a116c-167b-45c5-b634-253696270a12"
+        },
+        "model": "main.taskconfig",
+        "pk": "a71f40ec-77b2-4f13-91b6-da3d4a67a284"
+    },
+    {
+        "fields": {
+            "description": "Include default Transfer processingMCP.xml",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "a56a116c-167b-45c5-b634-253696270a12"
+        },
+        "model": "main.taskconfig",
+        "pk": "a73b3690-ac75-4030-bb03-0c07576b649b"
+    },
+    {
+        "fields": {
+            "description": "Identify file format of attachments",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "02fd0952-4c9c-4da6-9ea3-a1409c87963d"
+        },
+        "model": "main.taskconfig",
+        "pk": "a75ee667-3a1c-4950-9194-e07d0e6bf545"
+    },
+    {
+        "fields": {
+            "description": "Normalize for thumbnails",
+            "lastmodified": "2013-11-15T00:31:31Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "8fe4a2c3-d43c-41e4-aeb9-18e8f57c9ccf"
+        },
+        "model": "main.taskconfig",
+        "pk": "a8489361-b731-4d4a-861d-f4da1767665f"
+    },
+    {
+        "fields": {
+            "description": "Perform policy checks on access derivatives?",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "a91ad9f6-1027-409c-8e66-4c8769ff9f06"
+    },
+    {
+        "fields": {
+            "description": "Choose config for AtoM DIP upload",
+            "lastmodified": "2018-05-16T18:05:58Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": ""
+        },
+        "model": "main.taskconfig",
+        "pk": "a987e8d6-e633-4551-a082-2334a300fa72"
+    },
+    {
+        "fields": {
+            "description": "Index transfer contents",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "2c9fd8e4-a4f9-4aa6-b443-de8a9a49e396"
+        },
+        "model": "main.taskconfig",
+        "pk": "aa2e26b3-539e-4071-b54c-bcb89650d2d2"
+    },
+    {
+        "fields": {
+            "description": "Assign checksums and file sizes to submissionDocumentation",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "c8f93c3d-b078-428d-bd53-1b5789cde598"
+        },
+        "model": "main.taskconfig",
+        "pk": "abeaa79e-668b-4de0-b8cb-70f8ab8056b6"
+    },
+    {
+        "fields": {
+            "description": "Store DIP?",
+            "lastmodified": "2017-08-18T10:07:07Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "abf861ee-2125-4e7e-8d85-9e1dcd020b4b"
+    },
+    {
+        "fields": {
+            "description": "Create quarantine PREMIS events",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "30ea6854-cf7a-42d4-b1e8-3c4ca0b82b7d"
+        },
+        "model": "main.taskconfig",
+        "pk": "accc69f9-5b99-4565-92b5-114c7727d9e9"
+    },
+    {
+        "fields": {
+            "description": "Create thumbnails directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "9c94b1d7-0563-4be9-9d64-058d0d1a03f4"
+        },
+        "model": "main.taskconfig",
+        "pk": "acd5e136-11ed-46fe-bf67-dc108f115d6b"
+    },
+    {
+        "fields": {
+            "description": "Approve maildir transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "acf7bd62-1587-4bff-b640-5b34b7196386"
+    },
+    {
+        "fields": {
+            "description": "Remove from quarantine",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "ad1f1ae6-658f-4281-abc2-fe2f6c5d5e8e"
+    },
+    {
+        "fields": {
+            "description": "Copy transfer submission documentation",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "b3c14f6c-bc91-4349-9e8f-c02f7dac27b3"
+        },
+        "model": "main.taskconfig",
+        "pk": "b24525cd-e68d-4afd-b6ec-46192bbc117b"
+    },
+    {
+        "fields": {
+            "description": "Verify transfer compliance",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "cf23dd75-d273-4c4e-8394-17622adf9bd6"
+        },
+        "model": "main.taskconfig",
+        "pk": "b3875772-0f3b-4b03-b602-5304ded86397"
+    },
+    {
+        "fields": {
+            "description": "Create thumbnails directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "d079b090-bc81-4fc6-a9c5-a267ad5f69a9"
+        },
+        "model": "main.taskconfig",
+        "pk": "b3b86729-470f-4301-8861-d62574966747"
+    },
+    {
+        "fields": {
+            "description": "Verify AIP",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ae6b87d8-59c8-4ffa-b417-ce93ab472e74"
+        },
+        "model": "main.taskconfig",
+        "pk": "b57b3564-e271-4226-a5f9-2c7cf1661a83"
+    },
+    {
+        "fields": {
+            "description": "Verify bag, and restructure for compliance",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "e884b0db-8e51-4ea6-87f9-0420ee9ddf8f"
+        },
+        "model": "main.taskconfig",
+        "pk": "b5970cbb-1af7-4f8c-b41d-a0febd482da4"
+    },
+    {
+        "fields": {
+            "description": "Validate access derivatives",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "52e7912e-2ce9-4192-9ba4-19a75b2a2807"
+        },
+        "model": "main.taskconfig",
+        "pk": "b597753f-0b36-484f-ae78-4ae95951fd90"
+    },
+    {
+        "fields": {
+            "description": "Set SIP to normalize with FITS-ffident file identification.",
+            "lastmodified": "2012-10-23T19:41:23Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "6c02936d-552a-415e-b3c1-6d681b01d1c6"
+        },
+        "model": "main.taskconfig",
+        "pk": "b5e6340f-07f3-4ed1-aada-7a7f049b19b9"
+    },
+    {
+        "fields": {
+            "description": "Create transfer backup (sharedDirectory/transferBackups)",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "9e302b2b-e28d-4a61-9be7-b94e16929560"
+        },
+        "model": "main.taskconfig",
+        "pk": "b6167c79-1770-4519-829c-fa01718756f4"
+    },
+    {
+        "fields": {
+            "description": "Validate preservation derivatives",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "f8bc7b43-8bd4-4db8-88dc-d6f55732fb63"
+        },
+        "model": "main.taskconfig",
+        "pk": "b6479474-159d-47aa-a10f-40495cb0e273"
+    },
+    {
+        "fields": {
+            "description": "Characterize and extract metadata on objects",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "51eab45d-6a24-4080-a1be-1e5c9405ce25"
+        },
+        "model": "main.taskconfig",
+        "pk": "b8403044-12a3-4b63-8399-772b9adace15"
+    },
+    {
+        "fields": {
+            "description": "Set SIP to normalize with FITS-Droid file identification.",
+            "lastmodified": "2012-10-23T19:41:22Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "4093954b-5e44-4fe9-9a47-14c82158a00d"
+        },
+        "model": "main.taskconfig",
+        "pk": "b8c10f19-40c9-44c8-8b9f-6fab668513f5"
+    },
+    {
+        "fields": {
+            "description": "Document empty directories?",
+            "lastmodified": "2018-05-16T18:06:06Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "b9613953-9f2d-474b-b8b4-2e17f0b0239d"
+    },
+    {
+        "fields": {
+            "description": "Move metadata to objects directory",
+            "lastmodified": "2013-02-13T22:03:40Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ce13677c-8ad4-4af0-92c8-ae8763f5094d"
+        },
+        "model": "main.taskconfig",
+        "pk": "ba0d0244-1526-4a99-ab65-43bfcd704e70"
+    },
+    {
+        "fields": {
+            "description": "Remove preservation normalized files to renormalize.",
+            "lastmodified": "2012-10-24T00:40:07Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "352fc88d-4228-4bc8-9c15-508683dabc58"
+        },
+        "model": "main.taskconfig",
+        "pk": "bacb088a-66ef-4590-b855-69f21dfdf87a"
+    },
+    {
+        "fields": {
+            "description": "Compress AIP",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "4dc2b1d2-acbb-47e7-88ca-570281f3236f"
+        },
+        "model": "main.taskconfig",
+        "pk": "bafe0ba3-420a-44f2-bb15-7509ef5c498c"
+    },
+    {
+        "fields": {
+            "description": "Upload to Archivists Toolkit",
+            "lastmodified": "2013-03-26T03:25:01Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "a650921e-b754-4e61-9713-1457cf52e77d"
+        },
+        "model": "main.taskconfig",
+        "pk": "bcff2873-f006-442e-9628-5eadbb8d0db7"
+    },
+    {
+        "fields": {
+            "description": "Assign checksums and file sizes to objects",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "ec54a7cb-690f-4dd6-ad2b-979ae9f8d25a"
+        },
+        "model": "main.taskconfig",
+        "pk": "bd9769ba-4182-4dd4-ba85-cff24ea8733e"
+    },
+    {
+        "fields": {
+            "description": "Move to the rejected directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "11e6fcbe-3d7b-41cc-bfac-14dee9172b51"
+        },
+        "model": "main.taskconfig",
+        "pk": "be4e3ee6-9be3-465f-93f0-77a4ccdfd1db"
+    },
+    {
+        "fields": {
+            "description": "Store AIP",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "bec683fa-f006-48a4-b298-d33b3b681cb2"
+    },
+    {
+        "fields": {
+            "description": "Remove from quarantine",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "bf0835be-4c76-4508-a5a7-cdc4c9dae217"
+    },
+    {
+        "fields": {
+            "description": "Assign checksums and file sizes to objects",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "45df6fd4-9200-4ec7-bd31-ba0338c07806"
+        },
+        "model": "main.taskconfig",
+        "pk": "bf5a1f0c-1b3e-4196-b51f-f6d509091346"
+    },
+    {
+        "fields": {
+            "description": "Store the AIP",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "7df9e91b-282f-457f-b91a-ad6135f4337d"
+        },
+        "model": "main.taskconfig",
+        "pk": "bf71562c-bc87-4fd0-baa6-1d85ff751ea2"
+    },
+    {
+        "fields": {
+            "description": "Load options to create SIPs",
+            "lastmodified": "2012-12-06T17:43:25Z",
+            "replaces": null,
+            "tasktype": "c42184a3-1a7f-4c4d-b380-15d8d97fdd11",
+            "tasktypepkreference": "11aef684-f2c7-494e-9763-277344e139bf"
+        },
+        "model": "main.taskconfig",
+        "pk": "bf9b2fb7-43bd-4c3e-9dd0-7b6f43e6cb48"
+    },
+    {
+        "fields": {
+            "description": "Remove indexed AIP files",
+            "lastmodified": "2013-04-22T18:37:56Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "bfaf4e65-ab7b-11e2-bace-08002742f837"
+        },
+        "model": "main.taskconfig",
+        "pk": "bfb30b76-ab7b-11e2-bace-08002742f837"
+    },
+    {
+        "fields": {
+            "description": "Prepare AIP",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "045f84de-2669-4dbc-a31b-43a4954d0481"
+        },
+        "model": "main.taskconfig",
+        "pk": "c075014f-4051-441a-b16b-3083d5c264c5"
+    },
+    {
+        "fields": {
+            "description": "Copy transfers metadata and logs",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "2e9fb50f-2275-4253-87e5-47d2faf1031e"
+        },
+        "model": "main.taskconfig",
+        "pk": "c1bd4921-c446-4ff9-bb34-fcd155b8132a"
+    },
+    {
+        "fields": {
+            "description": "Sanitize extracted objects' file and directory names",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "89b4d447-1cfc-4bbf-beaa-fb6477b00f70"
+        },
+        "model": "main.taskconfig",
+        "pk": "c2c7edcc-0e65-4df7-812f-a2ee5b5d52b6"
+    },
+    {
+        "fields": {
+            "description": "Move access files to DIP",
+            "lastmodified": "2013-01-03T02:10:39Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "68b1456e-9a59-48d8-96ef-92bc20fd7cab"
+        },
+        "model": "main.taskconfig",
+        "pk": "c307d6bd-cb81-46a1-89f1-bb02a43e0a3a"
+    },
+    {
+        "fields": {
+            "description": "Create DIP directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "1fb68647-9db0-49ef-b6b7-3f775646ffbe"
+        },
+        "model": "main.taskconfig",
+        "pk": "c310a18a-1659-45d0-845e-06eb3321512f"
+    },
+    {
+        "fields": {
+            "description": "Create DIP directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "a540bd68-27fa-47c3-9fc3-bd297999478d"
+        },
+        "model": "main.taskconfig",
+        "pk": "c3e3f03d-c104-48c3-8c64-4290459965f4"
+    },
+    {
+        "fields": {
+            "description": "Approve SIP Creation",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "c409f2b0-bcb7-49ad-a048-a217811ca9b6"
+    },
+    {
+        "fields": {
+            "description": "Approve AIP reingest",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "c450501a-251f-4de7-acde-91c47cf62e36"
+    },
+    {
+        "fields": {
+            "description": "Load post approve normalization link",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "c42184a3-1a7f-4c4d-b380-15d8d97fdd11",
+            "tasktypepkreference": "e076e08f-5f14-4fc3-93d0-1e80ca727f34"
+        },
+        "model": "main.taskconfig",
+        "pk": "c4b2e8ce-fe02-45d4-9b0f-b163bffcc05f"
+    },
+    {
+        "fields": {
+            "description": "Generate METS.xml document",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "0aec05d4-7222-4c28-89f4-043d20a812cc"
+        },
+        "model": "main.taskconfig",
+        "pk": "c52736fa-2bc5-4142-a111-8b13751ed067"
+    },
+    {
+        "fields": {
+            "description": "Upload DIP to CONTENTdm",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "e469dc77-5712-4ef1-b053-06f3cd3c34be"
+        },
+        "model": "main.taskconfig",
+        "pk": "c5d7e646-01b1-4d4a-9e38-b89d97e77e33"
+    },
+    {
+        "fields": {
+            "description": "Move to workFlowDecisions-createDip directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "df526440-c08e-49f9-9b9e-c9aa3adedc72"
+        },
+        "model": "main.taskconfig",
+        "pk": "c5e80ef1-aa90-45b2-beb4-c42652acf3e7"
+    },
+    {
+        "fields": {
+            "description": "Designate to process as a standard transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "3590f73d-5eb0-44a0-91a6-5b2db6655889",
+            "tasktypepkreference": "5057b0ce-a7f9-48c4-a7e9-65a7d88bb4ca"
+        },
+        "model": "main.taskconfig",
+        "pk": "c6f9f99a-0b60-438f-9a8d-35d4989db2bb"
+    },
+    {
+        "fields": {
+            "description": "Extract attachments",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "24272436-39b0-44f1-a0d6-c4bdca93ce88"
+        },
+        "model": "main.taskconfig",
+        "pk": "c74dfa47-9a6d-4a12-bffe-bf610ab75db9"
+    },
+    {
+        "fields": {
+            "description": "Set SIP to normalize with FITS-FITS file identification.",
+            "lastmodified": "2012-10-23T19:41:24Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "471ff5ad-1fd3-4540-9245-360cc8c9b389"
+        },
+        "model": "main.taskconfig",
+        "pk": "c87ec738-b679-4d8e-8324-73038ccf0dfd"
+    },
+    {
+        "fields": {
+            "description": "Set resume link after handling any manual normalized files",
+            "lastmodified": "2013-01-03T02:10:39Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "5035632e-7879-4ece-bf43-2fc253026ff5"
+        },
+        "model": "main.taskconfig",
+        "pk": "caaa29bc-a2b6-487b-abff-c3031a0e147a"
+    },
+    {
+        "fields": {
+            "description": "Create quarantine PREMIS events",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "30ea6854-cf7a-42d4-b1e8-3c4ca0b82b7d"
+        },
+        "model": "main.taskconfig",
+        "pk": "cac32b11-820c-4d17-8c7f-4e71fc0be68a"
+    },
+    {
+        "fields": {
+            "description": "Determine if transfer still contains packages",
+            "lastmodified": "2015-05-25T16:33:14Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "93039c6d-5ef7-4a95-bf07-5f89c8886808"
+        },
+        "model": "main.taskconfig",
+        "pk": "cadd5e12-82b2-43ec-813e-85cd42b2d511"
+    },
+    {
+        "fields": {
+            "description": "Determine processing path for this AIP version",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "feec6329-c21a-48b6-b142-cd3c810e846f"
+        },
+        "model": "main.taskconfig",
+        "pk": "cd53e17c-1dd1-4e78-9086-e6e013a64536"
+    },
+    {
+        "fields": {
+            "description": "Set re-normalize link",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "c26b2859-7a96-462f-880a-0cd8d1b0ac32"
+        },
+        "model": "main.taskconfig",
+        "pk": "ce48a9f5-4513-49e2-83db-52b01234705b"
+    },
+    {
+        "fields": {
+            "description": "Determine what to remove to re-normalize.",
+            "lastmodified": "2012-10-24T17:04:11Z",
+            "replaces": null,
+            "tasktype": "c42184a3-1a7f-4c4d-b380-15d8d97fdd11",
+            "tasktypepkreference": "e56e168e-d339-45b4-bc2a-a3eb24390f0f"
+        },
+        "model": "main.taskconfig",
+        "pk": "ce52ace2-68fc-4bfb-8444-f32ec8c01783"
+    },
+    {
+        "fields": {
+            "description": "Check for manual normalized files",
+            "lastmodified": "2013-01-03T02:10:39Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "e8fc5fd0-fd55-4eb6-9170-92615fc9c344"
+        },
+        "model": "main.taskconfig",
+        "pk": "ce57ffbc-abd9-43dc-a09b-e888397488f2"
+    },
+    {
+        "fields": {
+            "description": "Include default Transfer processingMCP.xml",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "a56a116c-167b-45c5-b634-253696270a12"
+        },
+        "model": "main.taskconfig",
+        "pk": "cfc7f6be-3984-4727-a71a-02ce27bef791"
+    },
+    {
+        "fields": {
+            "description": "Failed compliance.",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "1e5e8ee2-8b93-4e8c-bb9c-0cb40d2728dd"
+        },
+        "model": "main.taskconfig",
+        "pk": "d1004e1d-f938-4c68-ba70-0e0ae508cbbe"
+    },
+    {
+        "fields": {
+            "description": "Identify file format of metadata files",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "866037a3-d99e-4b9c-afb5-6de527a26e35"
+        },
+        "model": "main.taskconfig",
+        "pk": "d1f630dc-1082-4ad6-95b7-af36d2e2cf46"
+    },
+    {
+        "fields": {
+            "description": "Copy METS to DIP directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "20915fc5-594f-46d8-aa23-bfa45b622d17"
+        },
+        "model": "main.taskconfig",
+        "pk": "d49684b1-badd-4802-b54e-06eb6b329140"
+    },
+    {
+        "fields": {
+            "description": "Rename SIP directory with SIP UUID",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "9f473616-9094-45b0-aa3c-41d81a204d3b"
+        },
+        "model": "main.taskconfig",
+        "pk": "d61bb906-feff-4d6f-9e6c-a3f077f46b21"
+    },
+    {
+        "fields": {
+            "description": "Index transfer contents",
+            "lastmodified": "2013-04-05T23:08:30Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "16ce41d9-7bfa-4167-bca8-49fe358f53ba"
+        },
+        "model": "main.taskconfig",
+        "pk": "d6a0dec1-63e7-4c7c-b4c0-e68f0afcedd3"
+    },
+    {
+        "fields": {
+            "description": "Index AIP contents",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "40bf5b85-7cfd-47b0-9fbc-aed6c2cde8be"
+        },
+        "model": "main.taskconfig",
+        "pk": "d7542890-281f-4cdb-a64c-4b6bdd88c4b8"
+    },
+    {
+        "fields": {
+            "description": "Remove files without linking information (failed normalization artifacts etc.)",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "a32fc538-efd1-4be0-95a9-5ee40cbc70fd"
+        },
+        "model": "main.taskconfig",
+        "pk": "d7a2bfbe-3f4d-45f7-87c6-f5c3c98961cd"
+    },
+    {
+        "fields": {
+            "description": "Restructure DIP for CONTENTdm upload",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "f9f7793c-5a70-4ffd-9727-159c1070e4f5"
+        },
+        "model": "main.taskconfig",
+        "pk": "d7f13903-55a0-4a1c-87fa-9b75b14dccb4"
+    },
+    {
+        "fields": {
+            "description": "Determine if transfer contains packages",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "93039c6d-5ef7-4a95-bf07-5f89c8886808"
+        },
+        "model": "main.taskconfig",
+        "pk": "d9ce0690-a8f9-40dc-a8b5-b021f578f8ff"
+    },
+    {
+        "fields": {
+            "description": "Check if file or folder",
+            "lastmodified": "2015-05-25T16:33:14Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "21f89353-30ba-4601-8690-7c235630736f"
+        },
+        "model": "main.taskconfig",
+        "pk": "d9ebceed-2cfb-462b-b130-48fecdf55bbf"
+    },
+    {
+        "fields": {
+            "description": "Sanitize object's file and directory names",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "89b4d447-1cfc-4bbf-beaa-fb6477b00f70"
+        },
+        "model": "main.taskconfig",
+        "pk": "da756a4e-9d8b-4992-a219-2a7fd1edf2bb"
+    },
+    {
+        "fields": {
+            "description": "Assign file UUIDs to metadata",
+            "lastmodified": "2013-02-13T22:03:40Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "34966164-9800-4ae1-91eb-0a0c608d72d5"
+        },
+        "model": "main.taskconfig",
+        "pk": "dc2994f2-6de6-4c46-81f7-54676c5054aa"
+    },
+    {
+        "fields": {
+            "description": "Set quarantine permissions on transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "0b17b446-11d4-45a8-9d0c-4297b8c8887c"
+        },
+        "model": "main.taskconfig",
+        "pk": "dde51fc1-af7d-4923-ad6a-06e670447a2a"
+    },
+    {
+        "fields": {
+            "description": "Attempt restructure for compliance",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "c3625e5b-2c8d-47d9-9f66-c37111d39a07"
+        },
+        "model": "main.taskconfig",
+        "pk": "dde8c13d-330e-458b-9d53-0937370695fa"
+    },
+    {
+        "fields": {
+            "description": "Workflow decision - send transfer to quarantine",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "de195451-989e-48fe-ad0c-3ff2265b3410"
+    },
+    {
+        "fields": {
+            "description": "Assign checksums to manual normalized preservation files",
+            "lastmodified": "2013-01-03T02:10:38Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "0bdecdc8-f5ef-48dd-8a89-f937d2b3f2f9"
+        },
+        "model": "main.taskconfig",
+        "pk": "ded09ddd-2deb-4d62-bfe3-84703f60c522"
+    },
+    {
+        "fields": {
+            "description": "Create unquarantine PREMIS events",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "27dfc012-7cf4-449c-b0f0-bdd252c6f6e9"
+        },
+        "model": "main.taskconfig",
+        "pk": "dee46f53-8afb-4aec-820e-d495bcbeaf20"
+    },
+    {
+        "fields": {
+            "description": "Approve bagit transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "df1c53e4-1b69-441e-bdc9-6d08c3b47c9b"
+    },
+    {
+        "fields": {
+            "description": "Include default Transfer processingMCP.xml",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "35ef1f2d-0124-422f-a84a-5e1d756b6bf2"
+        },
+        "model": "main.taskconfig",
+        "pk": "df51d25b-6a63-4e7a-b164-77b929dd2f31"
+    },
+    {
+        "fields": {
+            "description": "Failed compliance. See output in dashboard. SIP moved back to SIPsUnderConstruction",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "3843f87a-12c4-4526-904a-d900572c6483"
+        },
+        "model": "main.taskconfig",
+        "pk": "e18e0c3a-dffb-42d2-9bfa-ea6c61328e28"
+    },
+    {
+        "fields": {
+            "description": "Move to the rejected directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "42aed4a4-8e2b-49f3-ba03-1a45c8baf52c"
+        },
+        "model": "main.taskconfig",
+        "pk": "e20ea90b-fa16-4576-8647-199ecde0d511"
+    },
+    {
+        "fields": {
+            "description": "Approve normalization",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "e211ae41-bf9d-4f34-8b58-9a0dcc0bebe2"
+    },
+    {
+        "fields": {
+            "description": "Set resume link after tool selected.",
+            "lastmodified": "2012-10-23T19:41:25Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "1871a1a5-1937-4c4d-ab05-3b0c04a0bca1"
+        },
+        "model": "main.taskconfig",
+        "pk": "e476ac7e-d3e8-43fa-bb51-5a9cf42b2713"
+    },
+    {
+        "fields": {
+            "description": "Move to the uploadedDIPs directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "302be9f9-af3f-45da-9305-02706d81b742"
+        },
+        "model": "main.taskconfig",
+        "pk": "e485f0f4-7d44-45c6-a0d2-bba4b2abd0d0"
+    },
+    {
+        "fields": {
+            "description": "Serialize Dublin Core metadata to disk",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ed6daadf-a594-4327-b85c-7219c5832369"
+        },
+        "model": "main.taskconfig",
+        "pk": "e5789749-00df-4b6c-af12-47eeabc8926a"
+    },
+    {
+        "fields": {
+            "description": "Assign file UUIDs to objects",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "2ad612bc-1993-407e-9d66-a8ab9c1ebbd5"
+        },
+        "model": "main.taskconfig",
+        "pk": "e601b1e3-a957-487f-8cbe-54160070574d"
+    },
+    {
+        "fields": {
+            "description": "Set resume link after tool selected.",
+            "lastmodified": "2012-10-23T19:41:25Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "f85bbe03-8aca-4211-99b7-ddb7dfb24da1"
+        },
+        "model": "main.taskconfig",
+        "pk": "e62e4b85-e3f1-4550-8e40-3939e6497e92"
+    },
+    {
+        "fields": {
+            "description": "Identify DSpace text files",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "9ea66f4e-150b-4911-b68d-29fd5d372d2c"
+        },
+        "model": "main.taskconfig",
+        "pk": "e6591da1-abfa-4bf2-abeb-cc0791ba5284"
+    },
+    {
+        "fields": {
+            "description": "Verify SIP compliance",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "80c4a6ed-abe4-4e02-8de8-55a50f559dab"
+        },
+        "model": "main.taskconfig",
+        "pk": "e82c3c69-3799-46fd-afc1-f479f960a362"
+    },
+    {
+        "fields": {
+            "description": "Move to workFlowDecisions-createTransferBackup directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "f46bbd28-d533-4933-9b5c-4a5d32927ff3"
+        },
+        "model": "main.taskconfig",
+        "pk": "e9f57845-4609-4e0a-a573-4b488d8a4aeb"
+    },
+    {
+        "fields": {
+            "description": "Create thumbnails directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "9c94b1d7-0563-4be9-9d64-058d0d1a03f4"
+        },
+        "model": "main.taskconfig",
+        "pk": "ea463bfd-5fa2-4936-b8c3-1ce3b74303cf"
+    },
+    {
+        "fields": {
+            "description": "Set TRIM options to create SIPs",
+            "lastmodified": "2012-12-06T19:01:04Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "6adccf2b-1c91-448b-bf0f-56414ee237ac"
+        },
+        "model": "main.taskconfig",
+        "pk": "eb14ba91-20cb-4b0e-ab5d-c30bfea4dbc8"
+    },
+    {
+        "fields": {
+            "description": "Set resume link",
+            "lastmodified": "2013-11-07T22:51:35Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "d8e2c7b2-5452-4c26-b57a-04caafe9f95c"
+        },
+        "model": "main.taskconfig",
+        "pk": "ec503c22-1f4d-442f-b546-f90c9a9e5c86"
+    },
+    {
+        "fields": {
+            "description": "Save directory tree",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "f1a272df-bb3f-463e-95c0-6d2062bddfb8"
+        },
+        "model": "main.taskconfig",
+        "pk": "ede67763-2a12-4e8f-8c36-e266d3f05c6b"
+    },
+    {
+        "fields": {
+            "description": "Check if AIP is a file or directory",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "8c96ba0c-44e5-4ff8-8c73-0c567d52e2d4"
+        },
+        "model": "main.taskconfig",
+        "pk": "ee00a5c7-a69c-46cf-a5e0-a9e2f18e563e"
+    },
+    {
+        "fields": {
+            "description": "Verify checksums generated on ingest",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "4f400b71-37be-49d0-8da3-125abac2bfd0"
+        },
+        "model": "main.taskconfig",
+        "pk": "ef024cf9-1737-4161-b48a-13b4a8abddcd"
+    },
+    {
+        "fields": {
+            "description": "Remove cache files",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "49b803e3-8342-4098-bb3f-434e1eb5cfa8"
+        },
+        "model": "main.taskconfig",
+        "pk": "ef0bb0cf-28d5-4687-a13d-2377341371b5"
+    },
+    {
+        "fields": {
+            "description": "Load Dublin Core metadata from disk",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "cc8a1a4f-ccc8-4639-947e-01d0a5fddbb7"
+        },
+        "model": "main.taskconfig",
+        "pk": "efb7bf8e-4624-4b52-bf90-e3d389099fd9"
+    },
+    {
+        "fields": {
+            "description": "Clean up after storing AIP",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ab404b46-9c54-4ca5-87f1-b69a8d2299a1"
+        },
+        "model": "main.taskconfig",
+        "pk": "f09c1aa1-8a5d-49d1-ba60-2866e026eed9"
+    },
+    {
+        "fields": {
+            "description": "Assign UUIDs to directories?",
+            "lastmodified": "2018-05-16T18:06:03Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "f0c4abd3-1947-4d11-b78b-a55078460100"
+    },
+    {
+        "fields": {
+            "description": "Process transfer JSON metadata",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "44d3789b-10ad-4a9c-9984-c2fe503c8720"
+        },
+        "model": "main.taskconfig",
+        "pk": "f0e49772-3e2b-480d-8c06-023efc670dcd"
+    },
+    {
+        "fields": {
+            "description": "Move transfer to backlog",
+            "lastmodified": "2013-04-05T23:08:30Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "9f25a366-f7a4-4b59-b219-2d5f259a1be9"
+        },
+        "model": "main.taskconfig",
+        "pk": "f1586bd7-f550-4588-9f45-07a212db7994"
+    },
+    {
+        "fields": {
+            "description": "Generate transfer structure report",
+            "lastmodified": "2014-09-11T16:09:53Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "f1ebd62a-fbf3-4790-88e8-4a3abec4ba00"
+    },
+    {
+        "fields": {
+            "description": "Create SIP(s)",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "f1f0409b-d4f8-419a-b625-218dc1abd335"
+    },
+    {
+        "fields": {
+            "description": "Sanitize file and directory names in submission documentation",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ad65bf76-3491-4c3d-afb0-acc94ff28bee"
+        },
+        "model": "main.taskconfig",
+        "pk": "f23a22b8-a3b0-440b-bf4e-fb6e8e6e6b14"
+    },
+    {
+        "fields": {
+            "description": "Workflow decision - send transfer to quarantine",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "f3567a6d-8a45-4174-b302-a629cdbfbe92"
+    },
+    {
+        "fields": {
+            "description": "Create thumbnails directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "9c94b1d7-0563-4be9-9d64-058d0d1a03f4"
+        },
+        "model": "main.taskconfig",
+        "pk": "f452a117-a992-4447-9774-6a8130f05b30"
+    },
+    {
+        "fields": {
+            "description": "Designate to process as a DSpace transfer when unquarantined",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "3590f73d-5eb0-44a0-91a6-5b2db6655889",
+            "tasktypepkreference": "5975a5df-41af-4e3e-8e4e-ec7aff3ae085"
+        },
+        "model": "main.taskconfig",
+        "pk": "f5ca3e51-35ba-4cdd-acf5-7d4fec955e76"
+    },
+    {
+        "fields": {
+            "description": "Move to quarantined",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "39f8d4bf-2078-4415-b600-ce2865585aca"
+        },
+        "model": "main.taskconfig",
+        "pk": "f661aae0-05bf-4f55-a2f6-ef0f157231bd"
+    },
+    {
+        "fields": {
+            "description": "Create rights to flag closed AIPS.",
+            "lastmodified": "2012-12-12T21:37:10Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ccbaa53f-a486-4564-9b1a-a1b7bd5b1239"
+        },
+        "model": "main.taskconfig",
+        "pk": "f6fbbf4f-bf8d-49f2-a978-8d689380cafc"
+    },
+    {
+        "fields": {
+            "description": "Move to workFlowDecisions-quarantineSIP directory",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "f46bbd28-d533-4933-9b5c-4a5d32927ff3"
+        },
+        "model": "main.taskconfig",
+        "pk": "f872b932-90dd-4501-98c4-9fc5bac9d19a"
+    },
+    {
+        "fields": {
+            "description": "Include default SIP processingMCP.xml",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "e887c51e-afb9-48b1-b416-502a2357e621"
+        },
+        "model": "main.taskconfig",
+        "pk": "f89b9e0f-8789-4292-b5d0-4a330c0205e1"
+    },
+    {
+        "fields": {
+            "description": "Select pre-normalize file format identification command",
+            "lastmodified": "2013-11-07T22:51:42Z",
+            "replaces": null,
+            "tasktype": "9c84b047-9a6d-463f-9836-eafa49743b84",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "f8d0b7df-68e8-4214-a49d-60a91ed27029"
+    },
+    {
+        "fields": {
+            "description": "Check for submission documentation",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "1aaa6e10-7907-4dea-a92a-dd0931eff226"
+        },
+        "model": "main.taskconfig",
+        "pk": "f908bcd9-2fba-48c3-b04b-459f6ad1a4de"
+    },
+    {
+        "fields": {
+            "description": "Set files to identify",
+            "lastmodified": "2013-11-07T22:51:43Z",
+            "replaces": null,
+            "tasktype": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7",
+            "tasktypepkreference": "42454e81-e776-44cc-ae9f-b40e7e5c7738"
+        },
+        "model": "main.taskconfig",
+        "pk": "fa2307df-e42a-4553-aaf5-b08879b0cbf4"
+    },
+    {
+        "fields": {
+            "description": "Approve DSpace transfer",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c",
+            "tasktypepkreference": null
+        },
+        "model": "main.taskconfig",
+        "pk": "fa3e0099-b891-43f6-a4bc-390d544fa3e9"
+    },
+    {
+        "fields": {
+            "description": "Sanitize file and directory names in submission documentation",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ad65bf76-3491-4c3d-afb0-acc94ff28bee"
+        },
+        "model": "main.taskconfig",
+        "pk": "fb55b404-90f5-45b6-a47c-ccfbd0de2401"
+    },
+    {
+        "fields": {
+            "description": "Store AIP location",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "01b748fe-2e9d-44e4-ae5d-113f74c9a0ba",
+            "tasktypepkreference": "ebab9878-f42e-4451-a24a-ec709889a858"
+        },
+        "model": "main.taskconfig",
+        "pk": "fb64af31-8f8a-4fe5-a20d-27ee26c9dda2"
+    },
+    {
+        "fields": {
+            "description": "Verify transfer compliance",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "cf23dd75-d273-4c4e-8394-17622adf9bd6"
+        },
+        "model": "main.taskconfig",
+        "pk": "fbaadb5d-63f9-440c-a607-a4ebfb973a78"
+    },
+    {
+        "fields": {
+            "description": "Store file modification dates",
+            "lastmodified": "2018-05-16T18:06:02Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "102edcd9-3d0c-47d1-be1e-137875d73765"
+        },
+        "model": "main.taskconfig",
+        "pk": "fc64dc4c-e245-402b-b572-2dc027b414d1"
+    },
+    {
+        "fields": {
+            "description": "Remove preservation and access normalized files to renormalize.",
+            "lastmodified": "2012-10-24T00:40:06Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "c15de53e-a5b2-41a1-9eee-1a7b4dd5447a"
+        },
+        "model": "main.taskconfig",
+        "pk": "fe354b27-dbb2-4454-9c1c-340d85e67b78"
+    },
+    {
+        "fields": {
+            "description": "Assign file UUIDs to objects",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "179c8ce5-2b83-4ae2-9653-971e868fe183"
+        },
+        "model": "main.taskconfig",
+        "pk": "feac0c04-3511-4e91-9403-5c569cff7bcc"
+    },
+    {
+        "fields": {
+            "description": "Set bag file permissions",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "36b2e239-4a57-4aa5-8ebc-7a29139baca6",
+            "tasktypepkreference": "ba937c55-6148-4f45-a9ad-9697c0cf11ed"
+        },
+        "model": "main.taskconfig",
+        "pk": "feb27f44-3575-4d17-8e00-43aa5dc5c3dc"
+    },
+    {
+        "fields": {
+            "description": "Scan for viruses in submission documentation",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "2fdb8408-8bbb-45d1-846b-5e28bf220d5c"
+        },
+        "model": "main.taskconfig",
+        "pk": "fecb3fe4-5c5c-4796-b9dc-c7d7cf33a9f3"
+    },
+    {
+        "fields": {
+            "description": "Get list of collections on server",
+            "lastmodified": "2012-10-02T00:25:11Z",
+            "replaces": null,
+            "tasktype": "a19bfd9f-9989-4648-9351-013a10b382ed",
+            "tasktypepkreference": "13d2adfc-8cb8-4206-bf70-04f031436ca2"
+        },
+        "model": "main.taskconfig",
+        "pk": "fedffebc-7292-4b94-b402-84628c4254de"
+    },
+    {
+        "fields": {
+            "description": "Assign UUIDs to manual normalized preservation files",
+            "lastmodified": "2013-01-03T02:10:39Z",
+            "replaces": null,
+            "tasktype": "a6b1c323-7d36-428e-846a-e7e819423577",
+            "tasktypepkreference": "4f47371b-a69b-4a8a-87b5-01e7eb1628c3"
+        },
+        "model": "main.taskconfig",
+        "pk": "ff8f70b9-e345-4163-a784-29b432b12558"
+    }
+]

--- a/src/dashboard/tests/fixtures/am17-tasktype.json
+++ b/src/dashboard/tests/fixtures/am17-tasktype.json
@@ -1,0 +1,92 @@
+[
+    {
+        "fields": {
+            "description": "Get user choice from microservice generated list",
+            "lastmodified": "2012-10-02T00:25:10Z",
+            "replaces": null
+        },
+        "model": "main.tasktype",
+        "pk": "01b748fe-2e9d-44e4-ae5d-113f74c9a0ba"
+    },
+    {
+        "fields": {
+            "description": "assign magic link",
+            "lastmodified": "2012-10-02T00:25:10Z",
+            "replaces": null
+        },
+        "model": "main.tasktype",
+        "pk": "3590f73d-5eb0-44a0-91a6-5b2db6655889"
+    },
+    {
+        "fields": {
+            "description": "one instance",
+            "lastmodified": "2012-10-02T00:25:10Z",
+            "replaces": null
+        },
+        "model": "main.tasktype",
+        "pk": "36b2e239-4a57-4aa5-8ebc-7a29139baca6"
+    },
+    {
+        "fields": {
+            "description": "get user choice to proceed with",
+            "lastmodified": "2012-10-02T00:25:10Z",
+            "replaces": null
+        },
+        "model": "main.tasktype",
+        "pk": "61fb3874-8ef6-49d3-8a2d-3cb66e86a30c"
+    },
+    {
+        "fields": {
+            "description": "linkTaskManagerSetUnitVariable",
+            "lastmodified": "2012-10-22T17:05:07Z",
+            "replaces": null
+        },
+        "model": "main.tasktype",
+        "pk": "6f0b612c-867f-4dfd-8e43-5b35b7f882d7"
+    },
+    {
+        "fields": {
+            "description": "goto magic link",
+            "lastmodified": "2012-10-02T00:25:10Z",
+            "replaces": null
+        },
+        "model": "main.tasktype",
+        "pk": "6fe259c2-459d-4d4b-81a4-1b9daf7ee2e9"
+    },
+    {
+        "fields": {
+            "description": "get replacement dic from user choice",
+            "lastmodified": "2012-10-02T00:25:10Z",
+            "replaces": null
+        },
+        "model": "main.tasktype",
+        "pk": "9c84b047-9a6d-463f-9836-eafa49743b84"
+    },
+    {
+        "fields": {
+            "description": "Get microservice generated list in stdOut",
+            "lastmodified": "2012-10-02T00:25:10Z",
+            "replaces": null
+        },
+        "model": "main.tasktype",
+        "pk": "a19bfd9f-9989-4648-9351-013a10b382ed"
+    },
+    {
+        "fields": {
+            "description": "for each file",
+            "lastmodified": "2012-10-02T00:25:10Z",
+            "replaces": null
+        },
+        "model": "main.tasktype",
+        "pk": "a6b1c323-7d36-428e-846a-e7e819423577"
+    },
+    {
+        "fields": {
+            "description": "linkTaskManagerUnitVariableLinkPull",
+            "lastmodified": "2012-10-22T17:03:13Z",
+            "replaces": null
+        },
+        "model": "main.tasktype",
+        "pk": "c42184a3-1a7f-4c4d-b380-15d8d97fdd11"
+    }
+]

--- a/src/dashboard/tests/fixtures/am17-transfer.json
+++ b/src/dashboard/tests/fixtures/am17-transfer.json
@@ -1,0 +1,18 @@
+[
+    {
+        "fields": {
+            "accessionid": "",
+            "currentlocation": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/KSTest-cea636e5-0e6f-4f9e-80ac-06039fec247d/",
+            "description": "",
+            "diruuids": false,
+            "hidden": false,
+            "notes": "",
+            "sourceofacquisition": "",
+            "transfermetadatasetrow": null,
+            "type": "Standard",
+            "typeoftransfer": ""
+        },
+        "model": "main.transfer",
+        "pk": "cea636e5-0e6f-4f9e-80ac-06039fec247d"
+    }
+]

--- a/src/dashboard/tests/test_api.py
+++ b/src/dashboard/tests/test_api.py
@@ -105,19 +105,6 @@ class TestAPI(TestCase):
         assert status['sip_uuid'] == 'BACKLOG'
         assert len(completed) == 1
 
-    def test_get_unit_status_completed_sip(self):
-        """It should return COMPLETE."""
-        # Setup fixtures
-        load_fixture(['jobs-processing.json', 'jobs-transfer-complete.json', 'jobs-sip-complete.json'])
-        # Test
-        status = views.get_unit_status('4060ee97-9c3f-4822-afaf-ebdf838284c3', 'unitSIP')
-        completed = helpers.completed_units_efficient(unit_type='transfer', include_failed=True)
-        # Verify
-        assert len(status) == 2
-        assert 'microservice' in status
-        assert status['status'] == 'COMPLETE'
-        assert len(completed) == 1
-
 
 class TestProcessingConfigurationAPI(TestCase):
     fixture_files = ['test_user.json']
@@ -196,3 +183,39 @@ class TestAPI2(TestCase):
         assert '85216028-1150-4321-abb3-31ea570a341b' in completed
         assert '5d0ab97f-a45b-4e0f-9cb6-90ee3a404549' in completed
         assert 'b949773d-7cf7-4c1e-aea5-ccbf65b70ccd' in completed
+
+
+class TestAPI3(TestCase):
+    """Test API endpoints (use AM1.7 fixtures)."""
+    fixture_files = ['am17-transfer.json', 'am17-sip.json']
+    fixtures = [os.path.join(THIS_DIR, 'fixtures', p) for p in fixture_files]
+
+    def test_get_unit_status_completed_sip(self):
+        """It should return COMPLETE."""
+        # Setup fixtures
+        load_fixture(['am17-microservicechainlink.json', 'am17-taskconfig.json', 'am17-tasktype.json', 'am17-jobs-sip-complete.json'])
+        # Test
+        status = views.get_unit_status('535b4469-221b-41bb-aeaa-a78c5791c1c4', 'unitSIP')
+        completed = helpers.completed_units_efficient(unit_type='transfer', include_failed=True)
+        # Verify
+        assert len(status) == 2
+        assert 'microservice' in status
+        assert status['status'] == 'COMPLETE'
+        assert len(completed) == 1
+
+    def test_get_unit_status_completed_sip_chainlink_fix(self):
+        """Test get unit status for a completed SIP when the job with the latest
+        created time is not the last according to the microservicechainlink
+        (i.e, job with jobtype 'Remove the processing directory' is not the one with
+        latest created time)
+        It should return COMPLETE."""
+        # Setup fixtures
+        load_fixture(['am17-microservicechainlink.json', 'am17-taskconfig.json', 'am17-tasktype.json', 'am17-jobs-sip-complete-clean-up-last.json'])
+        # Test
+        status = views.get_unit_status('535b4469-221b-41bb-aeaa-a78c5791c1c4', 'unitSIP')
+        completed = helpers.completed_units_efficient(unit_type='transfer', include_failed=True)
+        # Verify
+        assert len(status) == 2
+        assert 'microservice' in status
+        assert status['status'] == 'COMPLETE'
+        assert len(completed) == 1


### PR DESCRIPTION
Fix get_unit_status for SIPs, to use the job that is the last in the
microservice chain, not the one with the latest created time.

Unit tests fixed/added

Connected to https://github.com/archivematica/Issues/issues/262