### PR TITLE
Verify AIP: fix checksum verification

### DIFF
--- a/src/MCPClient/lib/clientScripts/verify_aip.py
+++ b/src/MCPClient/lib/clientScripts/verify_aip.py
@@ -163,7 +163,12 @@ def verify_checksums(job, bag, sip_uuid):
         verification_count = 0
         verification_skipped_because_reingest = 0
         for file_ in File.objects.filter(sip_id=sip_uuid):
-            if (os.path.basename(file_.originallocation) in removableFiles) or (not file_.currentlocation.startswith('%SIPDirectory%objects/')):
+            if (
+                os.path.basename(file_.originallocation) in removableFiles or
+                not file_.currentlocation.startswith(
+                    '%SIPDirectory%objects/') or
+                file_.filegrpuse == 'manualNormalization'
+            ):
                 continue
             file_path = file_.currentlocation.replace('%SIPDirectory%', '', 1)
             assert_checksum_types_match(job, file_, sip_uuid, checksum_type)


### PR DESCRIPTION
When verifying checksums, omit files listed under the file group
`manualNormalization`.

This is connected to https://github.com/archivematica/Issues/issues/287.