### PR TITLE
Dashboard: fix use of Return key in archival storage search

### DIFF
--- a/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
+++ b/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
@@ -122,8 +122,10 @@ $(document).ready(function() {
     return false;
   });
 
-  $('.aip-search-query-input').keypress(function (e) {
+  $('#search_form_container').on('keypress', '.aip-search-query-input', function (e) {
     if (e.which == 13) {  // Return key
+      // Remove focus from query input field to update its value
+      e.target.blur();
       aipSearchSubmit();
       return false;
     }


### PR DESCRIPTION
This PR fixes the search in the Archival Storage tab when the Return key is used to "submit" the form instead of clicking the `Search archival storage` button. The problem is caused by the query input not having its value set before the new redirect URL is calculated. Forcing the blur event on it fixes the problem.

There was a related problem when additional rows were added to the search but the event handler wasn't attached to them. Using `.on()` instead fixes the problem.

**Note**: I wasn't sure about the merge workflow so I based the PR against the `qa/1.x` branch.

Connected to https://github.com/artefactual/archivematica/issues/1044
Connected to archivematica/issues#271