### PR TITLE
WIP Enable use of identifiers.json for PIDs in PREMIS

### DIFF
--- a/src/MCPClient/lib/clientScripts/bind_pid_helpers.py
+++ b/src/MCPClient/lib/clientScripts/bind_pid_helpers.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Archivematica.
+#
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Where third party PID values are provided to Archivematica in the
+``identifiers.json`` file update the ``Identifiers`` model to also include the
+values supplied in that file.
+"""
+import bindpid
+from main.models import Identifier
+
+
+class BindPIDsException(Exception):
+    """If I am raised, return 1."""
+    exit_code = 1
+
+
+class BindPIDsWarning(Exception):
+    """If I am raised, return 0."""
+    exit_code = 0
+
+
+def validate_handle_server_config(handle_config, logger=None):
+    """While the handle server form is configured with required fields, the
+    default form in Archivematica is blank which means the Bind PID service
+    can fail if a user has selected to Bind PIDs without entering configuration
+    values. Validate the configuration dictionary to handle this situation
+    gracefully.
+    """
+    for field in bindpid.REQ_PARAMS:
+        try:
+            handle_config[field]
+        except KeyError:
+            if logger:
+                logger.warning("Handle server configuration is incomplete")
+            return False
+    return True
+
+
+def _add_pid_to_mdl_identifiers(mdl, pid, purl):
+    """Add a newly minted handle/PID to the ``SIP`` or ``Directory`` model as
+    an identifier in its m2m ``identifiers`` attribute. Also add the PURL (URL
+    constructed out of the PID) as a URI-type identifier.
+    """
+    hdl_identifier = Identifier.objects.create(type='hdl', value=pid)
+    purl_identifier = Identifier.objects.create(type='URI', value=purl)
+    mdl.identifiers.add(hdl_identifier)
+    mdl.identifiers.add(purl_identifier)
+
+
+def _add_custom_pid_to_mdl_identifiers(mdl, scheme, value):
+    """Create an identifier with scheme:value and add the row to the
+    Identifiers table. Reference the new identifier in the given model (mdl)
+    table.
+    """
+    identifier = Identifier.objects.create(type=scheme, value=value)
+    mdl.identifiers.add(identifier)

--- a/src/MCPClient/lib/clientScripts/bind_third_party_pids.py
+++ b/src/MCPClient/lib/clientScripts/bind_third_party_pids.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Archivematica.
+#
+# Copyright 2010-2017 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Where third party PID values are provided to Archivematica in the
+``identifiers.json`` file update the ``Identifiers`` model to also include the
+values supplied in that file.
+"""
+import json
+from os import path, sep
+
+from bind_pid_helpers import BindPIDsException, \
+    _add_custom_pid_to_mdl_identifiers
+from main.models import Directory, File, SIP
+
+from django.core.exceptions import ObjectDoesNotExist
+
+
+IDENTIFIERS_JSON = "identifiers.json"
+SIPDIR = "%SIPDirectory%"
+
+ISSIP = "sip"
+ISDIR = "directory"
+ISFILE = "file"
+
+
+def create_absolute_objects_path(filepath, sip_loc):
+    """Return an absolute path for the objects in the SIP."""
+    return path.join(sip_loc, filepath)
+
+
+def create_sip_objects_path(filepath):
+    """Return a SIP path for the objects in the SIP."""
+    return "{}{}".format(SIPDIR, filepath)
+
+
+def context(filepath):
+    """Determine whether the filepath can be resolved to a physical path within
+    the SIP.
+    """
+    if filepath.endswith("objects") or filepath.endswith('objects/'):
+        return ISSIP
+    if path.isdir(filepath):
+        return ISDIR
+    if path.isfile(filepath):
+        return ISFILE
+
+
+def parse_identifiers_json(job, logger, json_data, sip_loc, sip_uuid):
+    """Parse ``identifiers.json`` and resolve its pointers with those in the
+    Archivematica database.
+    """
+    for path_ in json_data:
+        try:
+            object_path = path_['file']
+        except KeyError:
+            # Assume that other files in ``identifiers.json`` may still match.
+            continue
+        # Don't assume that there is an objects folder in the metadata supplied
+        # by the user.
+        obj_check = path.normpath(object_path).split(sep)[0]
+        if obj_check != "objects":
+            object_path = path.join("objects", object_path)
+        abs_object_path = create_absolute_objects_path(object_path, sip_loc)
+        sip_object_path = create_sip_objects_path(object_path)
+        logger.info("Looking for object: %s", sip_object_path)
+        try:
+            unit_type = context(abs_object_path)
+            if unit_type is ISSIP:
+                mdl = SIP.objects.get(uuid=sip_uuid)
+            elif unit_type is ISDIR:
+                mdl = Directory.objects.get(
+                    sip_id=sip_uuid,
+                    currentlocation=path.join(sip_object_path, ''))
+            elif unit_type is ISFILE:
+                mdl = File.objects.get(
+                    sip_id=sip_uuid, currentlocation=sip_object_path)
+            else:
+                logger.warning(
+                    "Object: %s not found on disk", abs_object_path)
+                continue
+        except ObjectDoesNotExist:
+            logger.warning(
+                "Cannot find unit type: %s in the db, path: %s",
+                unit_type, sip_object_path)
+            continue
+        job.pyprint("Found {}".format(mdl))
+        try:
+            pids = path_["identifiers"]
+        except KeyError:
+            logger.warning("Cannot find identifiers for: %s", sip_object_path)
+            continue
+        for ids in pids:
+            try:
+                identifier = ids["identifier"]
+                scheme = ids["identiferType"]
+            except KeyError:
+                logger.warning(
+                    "Cannot find identifier for unit type %s, path: %s",
+                    unit_type, sip_object_path)
+                continue
+            job.pyprint(
+                "Discovered identifier type: {} value: {} for: {}"
+                .format(scheme, identifier, sip_object_path))
+            _add_custom_pid_to_mdl_identifiers(mdl, scheme, identifier)
+
+
+def load_identifiers_json(job, logger, sip_uuid, identifiers_loc, shared_path):
+    """If ``identifiers.json`` is found to exist, load as JSON and then submit
+    to the parse function.
+    """
+    try:
+        sip_loc = SIP.objects.get(uuid=sip_uuid).currentpath\
+            .replace("%sharedPath%", shared_path)
+    except SIP.DoesNotExist:
+        cannot_find_sip = "Cannot find SIP {}".format(sip_uuid)
+        raise BindPIDsException(cannot_find_sip)
+    identifiers_loc = \
+        identifiers_loc.currentlocation.replace(
+            SIPDIR, sip_loc)
+    if path.exists(identifiers_loc):
+        job.pyprint("Loading PIDs from identifiers.json")
+        with open(identifiers_loc) as json_data_file:
+            try:
+                json_data = json.load(json_data_file)
+            except ValueError as err:
+                decode_error = "JSON decode error: {}".format(err)
+                raise BindPIDsException(decode_error)
+            parse_identifiers_json(job, logger, json_data, sip_loc, sip_uuid)

--- a/src/archivematicaCommon/lib/bindpid.py
+++ b/src/archivematicaCommon/lib/bindpid.py
@@ -200,7 +200,7 @@ ENTITY_TYPES = {
 
 
 class BindPIDException(Exception):
-    pass
+    """Exception to return to Job runner given a failure condition."""
 
 
 def _validate(argdict):
@@ -432,14 +432,14 @@ def _parse_config(args):
     ``args.config_file``, if there is such a reference. Return a dict of config
     attributes and values or an empty dict if there is no config.
     """
-    cf = args.config_file
-    if not cf:
+    config_file = args.config_file
+    if not config_file:
         return {}
-    if not os.path.isfile(cf):
-        print('Warning: there is no config file at {}'.format(cf))
+    if not os.path.isfile(config_file):
+        print('Warning: there is no config file at {}'.format(config_file))
         return {}
     config = configparser.SafeConfigParser()
-    with open(cf) as filei:
+    with open(config_file) as filei:
         try:
             config.read_file(filei)
         except AttributeError:
@@ -465,6 +465,7 @@ def _merge_args_config(args, config):
 
 
 def get_command_line_params():
+    """Read command line arguments."""
     parser = argparse.ArgumentParser(description='Request handle PIDs.')
     parser, args = _add_parser_args(parser)
     config = _parse_config(args)


### PR DESCRIPTION
:construction: :construction: :construction:

Where an identifiers.json file is found in a transfer metadata folder
and Bind PIDs is configured to 'Yes'; parse the identifiers.json file
and record the discovered PIDs in PREMIS.

If the Bind PIDs is configured to Yes and the handle server
configuration is missing or incorrect then the identifiers.json will
still be used.

Identifiers can be recorded for the SIP, directories, and files.

Some redundancy has been removed between Bind PID modules though some
may remain.

New steps have been taken to make sure services exit more gracefully
if there are issues around configuration, e.g. if the required fields
have not been populated for the handle server, the the suggestion is
that there is zero configuration. This should not result seemingly in
a failure for day-to-day users.

Flake8 and Pylint changes have been included in this commit to help
improve the robustness of the code.

Connected to archivematica/issues#133
Connected to archivematica/Issues#285
Connected to archivematica/Issues#284
Connected to IISH#1
Connected to IISH#3