### PR TITLE
MCPClient: use instance attribute in rights_from_csv

### DIFF
--- a/src/MCPClient/lib/clientScripts/rights_from_csv.py
+++ b/src/MCPClient/lib/clientScripts/rights_from_csv.py
@@ -42,7 +42,6 @@ class RightCsvReader(object):
 
     metadata_applies_to_type = None
     current_row = None
-    object_basis_act_usage = {}
     rows_processed = 0
 
     required_column_names = [
@@ -77,6 +76,7 @@ class RightCsvReader(object):
         self.transfer_uuid = transfer_uuid
         self.rights_csv_filepath = rights_csv_filepath
         self.job = job
+        self.object_basis_act_usage = {}
 
     def parse(self):
         """Read and parse rights CSV file."""


### PR DESCRIPTION
`rights_from_csv` uses an internal data structure that was being stored
as an attribute of the class instead of as an attribute of the instance.
With the new MCPClient inline execution of client scripts, the data was
being shared causing the script to misbehave.

This is connected to https://github.com/archivematica/Issues/issues/305.