### PR TITLE
Dashboard: fix save action in general settings

### DIFF
--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -461,7 +461,8 @@ def general(request):
 
     forms = (general_form, storage_form, checksum_form)
     if all(map(lambda form: form.is_valid(), forms)):
-        map(lambda form: form.save(), forms)
+        for item in forms:
+            item.save()
         messages.info(request, _('Saved.'))
 
     dashboard_uuid = helpers.get_setting('dashboard_uuid')


### PR DESCRIPTION
This commit ensures that the underlying forms are saved. Before, we were
using `map` to return an iterator but it was never being consumed.

Connects to https://github.com/archivematica/Issues/issues/307.