### PR TITLE
Verify AIP: avoid checksum check on deleted files

### DIFF
--- a/src/MCPClient/lib/clientScripts/verify_aip.py
+++ b/src/MCPClient/lib/clientScripts/verify_aip.py
@@ -165,6 +165,7 @@ def verify_checksums(job, bag, sip_uuid):
         for file_ in File.objects.filter(sip_id=sip_uuid):
             if (
                 os.path.basename(file_.originallocation) in removableFiles or
+                file_.removedtime or
                 not file_.currentlocation.startswith(
                     '%SIPDirectory%objects/') or
                 file_.filegrpuse == 'manualNormalization'


### PR DESCRIPTION
For example: `manualNormalization/normalization.csv` in a manual
normalization transfer. Check `removedtime` before `currentlocation`
as the later will be empty for removed files.

Connects to https://github.com/archivematica/Issues/issues/331