### PR TITLE
Update agent version string to Archivematica-1.8

### DIFF
--- a/src/dashboard/src/main/migrations/0064_version_number.py
+++ b/src/dashboard/src/main/migrations/0064_version_number.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Migrate the Archivematica agent version string to Archivematica-1.8."""
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def data_migration_down(apps, _):
+    """Undo the migration if requested."""
+    agent = apps.get_model('main', 'Agent')
+    agent.objects \
+        .filter(identifiertype='preservation system', name='Archivematica') \
+        .update(identifiervalue='Archivematica-1.7')
+
+
+def data_migration_up(apps, _):
+    """Update the application agent version in the database."""
+    agent = apps.get_model('main', 'Agent')
+    agent.objects \
+        .filter(identifiertype='preservation system', name='Archivematica') \
+        .update(identifiervalue='Archivematica-1.8')
+
+
+class Migration(migrations.Migration):
+    """Run the migration to update the Archivematica agent version string."""
+    dependencies = [
+        ('main', '0063_update_idtools'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration_up, data_migration_down)
+    ]


### PR DESCRIPTION
This is one approach to updating the agent version string as used for 1.6 and 1.7. It is my preferred option for the `1.8.1` release for which this is milestoned for. An future approach will be outlined in the original issue, and potentially a new feature request following that. 

Committed against `qa/1.x` I have confirmed that there are no migration conflicts between `qa` and `1.8.x` branches. The last migration in `stable/1.8.x` being `0063_update_idtools.py`

Testing on Docker-compose, devs can do the following to apply the migration:
```
make manage-dashboard ARG="migrate main 0064"
```

And the following to unapply (using the compose Makefile):
```
make manage-dashboard ARG="migrate main 0063"
```

The result should look as follows:
```
mysql> select * from Agents;
+----+-----------------------+----------------------+----------------------------------------------+--------------------+
| pk | agentIdentifierType   | agentIdentifierValue | agentName                                    | agentType          |
+----+-----------------------+----------------------+----------------------------------------------+--------------------+
|  1 | preservation system   | Archivematica-1.8    | Archivematica                                | software           |
|  2 | repository code       | ****                 | ****                                         | organization       |
|  3 | Archivematica user pk | 1                    | username="test", first_name="", last_name="" | Archivematica user |
+----+-----------------------+----------------------+----------------------------------------------+--------------------+
3 rows in set (0.00 sec)
```
And unapplying:
```
mysql> select * from Agents;
+----+-----------------------+----------------------+----------------------------------------------+--------------------+
| pk | agentIdentifierType   | agentIdentifierValue | agentName                                    | agentType          |
+----+-----------------------+----------------------+----------------------------------------------+--------------------+
|  1 | preservation system   | Archivematica-1.7    | Archivematica                                | software           |
|  2 | repository code       | ****                 | ****                                         | organization       |
|  3 | Archivematica user pk | 1                    | username="test", first_name="", last_name="" | Archivematica user |
+----+-----------------------+----------------------+----------------------------------------------+--------------------+
3 rows in set (0.00 sec)
```

Connected to https://github.com/archivematica/Issues/issues/353