### PR TITLE
Dashboard: enhance SS locations and usage pages

### DIFF
--- a/src/dashboard/src/components/administration/tests/test_storage.py
+++ b/src/dashboard/src/components/administration/tests/test_storage.py
@@ -1,0 +1,147 @@
+import mock
+
+from django.test import TestCase
+
+from components import helpers
+
+
+class TestStorage(TestCase):
+    fixtures = ["test_user"]
+
+    def setUp(self):
+        self.client.login(username="test", password="test")
+        self.url = "/administration/storage/"
+        helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    @mock.patch(
+        "components.administration.views.storage_service.get_location",
+        side_effect=Exception(),
+    )
+    def test_ss_connection_fail(self, mock_get_location):
+        response = self.client.get(self.url)
+        self.assertIn("Error retrieving locations", response.content)
+
+    @mock.patch("components.administration.views.storage_service.get_location")
+    def test_success(self, mock_get_location):
+        mock_get_location.return_value = [
+            {
+                "uuid": "821d8b48-8b19-42ae-9956-df1d749c21a2",
+                "pipeline": ["/api/v2/pipeline/fe263021-f1d7-4a25-b691-df80da5ee048/"],
+                "used": "0",
+                "description": None,
+                "space": "/api/v2/space/85a6a5af-8b99-4e04-83da-4d1d712f1115/",
+                "enabled": True,
+                "quota": None,
+                "relative_path": "var/archivematica/sharedDirectory/",
+                "purpose": "CP",
+                "path": "/var/archivematica/sharedDirectory",
+                "resource_uri": "/api/v2/location/821d8b48-8b19-42ae-9956-df1d749c21a2/",
+            },
+            {
+                "uuid": "bad1cfd5-a67a-4791-b4a9-43590727d25f",
+                "pipeline": ["/api/v2/pipeline/fe263021-f1d7-4a25-b691-df80da5ee048/"],
+                "used": "0",
+                "description": "",
+                "space": "/api/v2/space/85a6a5af-8b99-4e04-83da-4d1d712f1115/",
+                "enabled": True,
+                "quota": None,
+                "relative_path": "home",
+                "purpose": "TS",
+                "path": "/home",
+                "resource_uri": "/api/v2/location/bad1cfd5-a67a-4791-b4a9-43590727d25f/",
+            },
+            {
+                "uuid": "1232e1d5-a67a-4791-b4a9-4359072747bf",
+                "pipeline": ["/api/v2/pipeline/fe263021-f1d7-4a25-b691-df80da5ee048/"],
+                "used": "0",
+                "description": "",
+                "space": "/api/v2/space/85a6a5af-8b99-4e04-83da-4d1d712f1115/",
+                "enabled": False,
+                "quota": None,
+                "relative_path": "home",
+                "purpose": "TS",
+                "path": "/home",
+                "resource_uri": "/api/v2/location/1232e1d5-a67a-4791-b4a9-4359072747bf/",
+            },
+            {
+                "uuid": "817f9ef7-dcf7-450d-bfeb-7dba00abedd5",
+                "pipeline": ["/api/v2/pipeline/fe263021-f1d7-4a25-b691-df80da5ee048/"],
+                "used": "5368709120",
+                "description": "Store AIP in standard Archivematica Directory",
+                "space": "/api/v2/space/85a6a5af-8b99-4e04-83da-4d1d712f1115/",
+                "enabled": True,
+                "quota": "10737418240",
+                "relative_path": "var/archivematica/sharedDirectory/www/AIPsStore",
+                "purpose": "AS",
+                "path": "/var/archivematica/sharedDirectory/www/AIPsStore",
+                "resource_uri": "/api/v2/location/817f9ef7-dcf7-450d-bfeb-7dba00abedd5/",
+            },
+            {
+                "uuid": "6e4cf229-e614-436d-9055-839dfe3145a6",
+                "pipeline": ["/api/v2/pipeline/fe263021-f1d7-4a25-b691-df80da5ee048/"],
+                "used": "0",
+                "description": "Store DIP in standard Archivematica Directory",
+                "space": "/api/v2/space/85a6a5af-8b99-4e04-83da-4d1d712f1115/",
+                "enabled": True,
+                "quota": None,
+                "relative_path": "var/archivematica/sharedDirectory/www/DIPsStore",
+                "purpose": "DS",
+                "path": "/var/archivematica/sharedDirectory/www/DIPsStore",
+                "resource_uri": "/api/v2/location/6e4cf229-e614-436d-9055-839dfe3145a6/",
+            },
+            {
+                "uuid": "8ace39fe-d52e-4b84-a8ab-3c68fdfea829",
+                "pipeline": ["/api/v2/pipeline/fe263021-f1d7-4a25-b691-df80da5ee048/"],
+                "used": "0",
+                "description": "Default transfer backlog",
+                "space": "/api/v2/space/85a6a5af-8b99-4e04-83da-4d1d712f1115/",
+                "enabled": True,
+                "quota": None,
+                "relative_path": "var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog",
+                "purpose": "BL",
+                "path": "/var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog",
+                "resource_uri": "/api/v2/location/8ace39fe-d52e-4b84-a8ab-3c68fdfea829/",
+            },
+            {
+                "uuid": "b3333b2a-5f3d-4c32-86b4-d334ff80c111",
+                "pipeline": ["/api/v2/pipeline/fe263021-f1d7-4a25-b691-df80da5ee048/"],
+                "used": "0",
+                "description": "Default AIP recovery",
+                "space": "/api/v2/space/85a6a5af-8b99-4e04-83da-4d1d712f1115/",
+                "enabled": True,
+                "quota": None,
+                "relative_path": "var/archivematica/storage_service/recover",
+                "purpose": "AR",
+                "path": "/var/archivematica/storage_service/recover",
+                "resource_uri": "/api/v2/location/b3333b2a-5f3d-4c32-86b4-d334ff80c111/",
+            },
+        ]
+        response = self.client.get(self.url)
+        locations = response.context["locations"]
+        # The currently processing and AIP recovery locations are removed
+        self.assertFalse([loc for loc in locations if loc["purpose"] == "CP"])
+        self.assertFalse([loc for loc in locations if loc["purpose"] == "AR"])
+        # Disabled location is removed
+        self.assertFalse(
+            [
+                loc
+                for loc in locations
+                if loc["uuid"] == "1232e1d5-a67a-4791-b4a9-4359072747bf"
+            ]
+        )
+        # Only two locations show usage
+        self.assertEqual(len([loc for loc in locations if loc["show_usage"]]), 2)
+        # One of them has an unlimited quota set
+        self.assertEqual(
+            len([loc for loc in locations if loc["quota"] == "unlimited"]), 1
+        )
+        # The other, 5 of 10 GB used (formated and in unicode)
+        used_loc = [
+            loc
+            for loc in locations
+            if loc["uuid"] == "817f9ef7-dcf7-450d-bfeb-7dba00abedd5"
+        ]
+        self.assertEqual(used_loc[0]["quota"], u"10.0\xa0GB")
+        self.assertEqual(used_loc[0]["used"], u"5.0\xa0GB")
+        # Purpose is formatted
+        self.assertEqual(used_loc[0]["purpose"], "AIP Storage")

--- a/src/dashboard/src/components/administration/tests/test_usage.py
+++ b/src/dashboard/src/components/administration/tests/test_usage.py
@@ -1,0 +1,50 @@
+import mock
+
+from django.conf import settings
+from django.test import TestCase
+
+from components import helpers
+
+
+class TestUsage(TestCase):
+    fixtures = ["test_user"]
+
+    def setUp(self):
+        self.client.login(username="test", password="test")
+        helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    def test_no_calculation(self):
+        for calculate in [None, "False", "false", "no", "0", "random"]:
+            if calculate is None:
+                response = self.client.get("/administration/usage/")
+            else:
+                response = self.client.get(
+                    "/administration/usage/?calculate=%s" % calculate
+                )
+            self.assertFalse(response.context["calculate_usage"])
+            self.assertIn('<a href="?calculate=true"', response.content)
+            self.assertIn("Calculate disk usage", response.content)
+
+    @mock.patch(
+        "components.administration.views._usage_get_directory_used_bytes",
+        return_value=5368709120,
+    )
+    @mock.patch(
+        "components.administration.views._usage_check_directory_volume_size",
+        return_value=10737418240,
+    )
+    @mock.patch(
+        "components.administration.views._get_mount_point_path", return_value="/"
+    )
+    def test_calculation(self, mock_mount_path, mock_dir_size, mock_dir_used):
+        for calculate in ["true", "True", "ON", "yes", "1"]:
+            response = self.client.get(
+                "/administration/usage/?calculate=%s" % calculate
+            )
+            self.assertTrue(response.context["calculate_usage"])
+
+        mock_mount_path.assert_called_with(settings.SHARED_DIRECTORY)
+        mock_dir_size.assert_called_with("/")
+        self.assertEqual(mock_mount_path.call_count, 5)
+        self.assertEqual(mock_dir_size.call_count, 5)
+        self.assertEqual(mock_dir_used.call_count, 45)

--- a/src/dashboard/src/components/administration/urls.py
+++ b/src/dashboard/src/components/administration/urls.py
@@ -36,7 +36,6 @@ urlpatterns = [
         TemplateView.as_view(template_name="administration/language.html"),
         name="admin_set_language",
     ),
-    url(r"sources/$", views.sources),
     url(r"storage/$", views.storage),
     url(r"usage/$", views.usage),
     url(r"usage/clear/(?P<dir_id>\w+)/$", views.usage_clear),

--- a/src/dashboard/src/templates/administration/locations.html
+++ b/src/dashboard/src/templates/administration/locations.html
@@ -16,7 +16,9 @@
 
     <div class="col-md-10">
 
-      <h3>{{ system_directory_description }}</h3>
+      <h3>{% trans "Available storage locations" %}</h3>
+
+      <p>{% trans "Storage locations are configured by an administrative user in the Archivematica Storage Service." %}</p>
 
       <div id="directories"></div>
 
@@ -24,14 +26,24 @@
         <table class="table">
         <thead>
           <tr>
+            <th>{% trans "Purpose" %}</th>
             <th>{% trans "Description" %}</th>
+            <th>{% trans "Used / available" %}</th>
             <th>{% trans "Path" %}</th>
           </tr>
         </thead>
         <tbody>
         {% for location in locations %}
           <tr>
+            <td>{{ location.purpose }}</td>
             <td>{{ location.description }}</td>
+            <td>
+              {% if location.show_usage %}
+                {{ location.used }} / {{ location.quota }}
+              {% else %}
+                {% trans "N/A" %}
+              {% endif %}
+            </td>
             <td>{{ location.path }}</td>
           </tr>
         {% endfor %}

--- a/src/dashboard/src/templates/administration/sidebar.html
+++ b/src/dashboard/src/templates/administration/sidebar.html
@@ -8,7 +8,6 @@
   {% url 'components.administration.views.failure_report' as failure_report %}
   {% url 'components.administration.views_dip_upload.admin_atom' as url_atom_dip %}
   {% url 'components.administration.views_dip_upload.admin_as' as url_as_dips %}
-  {% url 'components.administration.views.sources' as url_sources %}
   {% url 'components.administration.views.storage' as url_storage %}
   {% url 'components.administration.views.usage' as url_usage %}
   {% url 'components.administration.views.premis_agent' as url_premis %}
@@ -25,9 +24,7 @@
 
     <li class="{% active request failure_report %}"><a href="{{ failure_report }}">{% trans "Failures" %}</a></li>
 
-    <li class="{% active request url_sources %}"><a href="{{ url_sources }}">{% trans "Transfer source locations" %}</a></li>
-
-    <li class="{% active request url_storage %}"><a href="{{ url_storage }}">{% trans "AIP storage locations" %}</a></li>
+    <li class="{% active request url_storage %}"><a href="{{ url_storage }}">{% trans "Storage locations" %}</a></li>
 
     <li class="{% active request url_usage %}"><a href="{{ url_usage }}">{% trans "Processing storage usage" %}</a></li>
 

--- a/src/dashboard/src/templates/administration/usage.html
+++ b/src/dashboard/src/templates/administration/usage.html
@@ -18,32 +18,96 @@
 
       <h3>{% trans "Processing storage usage" %}</h3>
 
-      <table class="table">
-        <tr>
-          <th>{% trans "Purpose" %}</th>
-          <th>{% trans "Path" %}</th>
-          <th>{% trans "Usage" %}</th>
-          <th>{% trans "Size" %}</th>
-          <th></th>
-        </tr>
-        {% for id, dir in usage_dirs.items %}
-        <tr>
-          <td>{{ dir.description }}</td>
-          <td>{{ dir.path }}</td>
-          <td>{{ dir.used|filesizeformat }}
-            ({% if dir.used %}{% widthratio dir.used dir.size 100 %}{% else %}0{% endif %}%)
-          </td>
-          <td>{{ dir.size|filesizeformat }}</td>
-          <td>
-            {% if dir.description %}
-            <form method='POST' action='{% url 'components.administration.views.usage_clear' id %}'>
-              <input type='submit' value='{% trans "Clear" %}' class='btn btn-default btn-sm'>
-            </form>
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </table>
+      <p>
+        {% blocktrans trimmed %}
+          The processing storage location is determined in the Archivematica
+          pipeline with the shared directory configuration path and in the
+          Storage Service with the currently processing location associated
+          with this pipeline.
+        {% endblocktrans %}
+      </p>
+
+      <br/>
+
+      {% if not calculate_usage %}
+        <p>
+          {% blocktrans trimmed %}
+            By clicking the button below, this page will be reloaded calculating the space and
+            usage of the entire disk where the shared directory is located. This process may
+            take a long time depending on the disk configuration and its usage.
+          {% endblocktrans %}
+        </p>
+
+        <a href="{{ url_usage }}?calculate=true" class="btn btn-default">
+          {% trans "Calculate disk usage" %}
+        </a>
+      {% else %}
+        <h4>{% trans "General information:" %}</h4>
+
+        <p>
+          {% blocktrans trimmed %}
+            This section displays the location where the disk is mounted on the system and its
+            current usage and space alongside the shared directory path and size.
+          {% endblocktrans %}
+        </p>
+
+        <ul>
+          <li>
+            <strong>{% trans "Disk location" %}:</strong>
+            {{ root.path }}
+          </li>
+          <li>
+            <strong>{% trans "Disk usage" %}:</strong>
+            {{ root.used|filesizeformat }} / {{ root.size|filesizeformat }}
+            ({% widthratio root.used root.size 100 %}%)
+          </li>
+          <li>
+            <strong>{% trans "Shared directory" %}:</strong>
+            {{ shared.path }}
+          </li>
+          <li>
+            <strong>{% trans "Shared directory size" %}:</strong>
+            {{ shared.used|filesizeformat }}
+            ({% widthratio shared.used root.size 100 %}%)
+          </li>
+        </ul>
+
+        <br/>
+
+        <h4>{% trans "Clearable directories:" %}</h4>
+
+        <p>
+          {% blocktrans trimmed %}
+            This table displays some directories within the shared directory that
+            can be cleared manually.
+          {% endblocktrans %}
+        </p>
+
+        <table class="table">
+          <thead>
+            <tr>
+              <th>{% trans "Purpose" %}</th>
+              <th>{% trans "Size" %}</th>
+              <th>{% trans "Path" %}</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for id, dir in usage_dirs.items %}
+              <tr>
+                <td>{{ dir.description }}</td>
+                <td>{{ dir.used|filesizeformat }}</td>
+                <td>{{ dir.path }}</td>
+                <td>
+                  <a target="_blank" href="{% url 'components.administration.views.usage_clear' id %}" class="btn btn-default btn-sm">
+                    {% trans "Clear" %} &#x2197;
+                  </a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
 
     </div>
 


### PR DESCRIPTION
Dashboard: unify SS locations administration pages

    - Remove transfer source locations URL, link and view.
    - Rename 'AIP storage locations' link to 'Storage locations'.
    - Change 'Storage locations' page title and add page description.
    - Show all related SS locations for this pipeline in this page, except
      currently processing, AIP recovery and SS internal purposes and
      disabled locations.
    - Sort locations by purpose and show it in human readable form.
    - Show formated used and quota values for AIP and DIP storage locations.
    - Add tests.

Dashboard: improve processing storage usage page

    To avoid timeouts on the first load of this page, the usage data is only
    calculated when the `calculate` get parameter is evaluated as `True`.
    When the usage data is not calculated, the page shows a description and
    a button to reload the page calculating the usage. When the usage is
    calculated, the page will display a general information section and a
    table of clearable directories from within the shared path.

    - Show the root of the filesystem where the shared directory is located.
    - Only show the size of the root path.
    - Rename `_usage_dirs`function to`_get_shared_dirs` and change default
     `calculate_usage` to`False`.
    - Simplify directory list generation and only include clearable dirs.
    - Add`--one-file-system` option to `du` calls.
    - Fix translations.
    - Cosmetic changes.
    - Add tests.

Connects to https://github.com/archivematica/Issues/issues/312.