### PR TITLE
README: fix prod installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See the [LICENSE](LICENSE) file for details.
 
 ## Installation
 
-* [Production installation](https://www.archivematica.org/docs/latest/admin-manual/installation/installation/)
+* [Production installation](https://www.archivematica.org/docs/latest/admin-manual/installation-setup/installation/installation/)
 * [Development installation](https://wiki.archivematica.org/Getting_started#Installation)
 
 


### PR DESCRIPTION
Connects to https://github.com/archivematica/Issues/issues/89.

---

Once 👍 I will cherry-pick into stable/1.8.x because that's the current landing page that users are seeing when opening our repo.