### PR TITLE
WIP: Replace hashdeep with coreutils hash utilities

### DIFF
--- a/src/MCPClient-base.Dockerfile
+++ b/src/MCPClient-base.Dockerfile
@@ -37,7 +37,7 @@ RUN set -ex \
 		clamav \
 		ffmpeg \
 		ghostscript \
-		hashdeep \
+		coreutils \
 		libavcodec-extra \
 		fits \
 		imagemagick \
@@ -62,6 +62,7 @@ RUN set -ex \
 		ufraw \
 		unrar-free \
 		uuid \
+		ack \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Download ClamAV virus signatures

--- a/src/MCPClient/lib/clientScripts/verifyMD5.sh
+++ b/src/MCPClient/lib/clientScripts/verifyMD5.sh
@@ -1,72 +1,242 @@
 #!/bin/bash
 
-# This file is part of Archivematica.
+###############################################################################
+# TODO:
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Q. Do we need the log file output?
+# Q. Do we want to include SHA512 because we can? Blake2?
+# Q, Do we want additional failure states? FAIL, INVALID?
 #
-# Archivematica is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Remove: archivematicaCheckMD5NoGUI.sh script
 #
-# Archivematica is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# dateArgs previously used for log file output....
+# dateArgs="-u +%Y%m%dT%H%M%SZ"  # 20170605T220452Z (UTC ISO8601)
 #
-# You should have received a copy of the GNU General Public License
-# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+# Rename: script, and client module
+# Merge: After i18n work so that we don't have any additional migrations.
+#
+# Create: new mcp-client base image for Docker
+#
+# Delete: this TODO
+###############################################################################
 
-# @package Archivematica
-# @subpackage archivematicaClientScript
-# @author Joseph Perry <joseph@artefactual.com>
-# @version svn: $Id$
+# Script to run the various coreutils checksum utilities suite. Commands
+# include sha1sum, sha256sum etc. Easily extensible to the other algorithms in
+# the same suite, for example, b2sum for Blake2 hash comparison.
+#
+# The script can be run standalone outside of Archivematica using a transfer
+# style layout e.g.
+#
+#       transfer/
+#       ├── metadata
+#       │   ├── checksum.md5
+#       │   ├── checksum.sha1
+#       │   ├── checksum.sha256
+#       │   └── checksum.sha512
+#       └── objects
+#           ├── file1.dat
+#           ├── file1.dat
+#           ├── file3.dat
+#           └── file4.dat
+#
+# And the following commands:
+#
+# ./{script_name}.sh "absolute path to trnasfer" {date, e.g. 20170605T220452Z}\
+#       {uuid} {uuid}
+#
+# And the output will be send to stdout and stderr.
+#
+# For debugging users are recommended to use the `set -eux` flags following the
+# bash shebang. `set -u` is used by default.
+#
+# Dependencies (coreutils (sha1sum, sha256sum, head, etc.); ack)
 
-checkMD5NoGui="`dirname $0`/archivematicaCheckMD5NoGUI.sh"
-dateArgs="-u +%Y%m%dT%H%M%SZ"  # 20170605T220452Z (UTC ISO8601)
+set -u
 
-target="$1"
-date="$2"
-eventID="$3"
-transferUUID="$4"
+# Variables provided on execution by Archivematica.
+target="$1";
+date="$2";
+eventID="$3";
+transferUUID="$4";
 
+# Cumulative exit_code variable. Assumption being that we won't simply exit if
+# there is a comparison issue. We'll attempt to run a comparison for each
+# hash file a user provides. If three files have errors, exit_code will be '3'.
+# If no files have errors, the exit code will be '0'.
+exit_code=0;
 
-#       md5deep - Compute and compare MD5 message digests
-#       sha1deep - Compute and compare SHA-1 message digests
-#       sha256deep - Compute and compare SHA-256 message digests
-#       tigerdeep - Compute and compare Tiger message digests
-#       whirlpooldeep - Compute and compare Whirlpool message digests
+metadata_folder="${target}metadata/";
+objects_folder="${target}objects";
 
-ret=0
+# TOOLMAP for our hash files and command variables. Can be easily extended
+# for all algorithms provided with coreutils: https://perma.cc/BC92-PUX5
+declare -A TOOLMAP;
+TOOLMAP["${metadata_folder}checksum.md5"]="md5sum";
+TOOLMAP["${metadata_folder}checksum.sha1"]="sha1sum";
+TOOLMAP["${metadata_folder}checksum.sha256"]="sha256sum";
+TOOLMAP["${metadata_folder}checksum.sha512"]="sha512sum";
 
-MD5FILE="${target}metadata/checksum.md5"
-if [ -f "${MD5FILE}" ]; then
-    "${checkMD5NoGui}" "${target}objects/" "${MD5FILE}" "${target}logs/`basename "${MD5FILE}"`-Check-`date ${dateArgs}`" "md5deep" && \
-    "`dirname $0`/createEventsForGroup.py" --eventIdentifierUUID "${eventID}" --groupUUID "${transferUUID}" --groupType "transfer_id" --eventType "fixity check" --eventDateTime "$date" --eventOutcome "Pass" --eventDetail "`md5deep -v` md5deep ${target}"
-    ret+="$?"
-else
-    echo "File Does not exist:" "${MD5FILE}"
-fi
+echo "Transfer metadata folder:" "${metadata_folder}";
+echo "Transfer objects folder:" "${objects_folder}";
 
-SHA1FILE="${target}metadata/checksum.sha1"
-if [ -f "${SHA1FILE}" ]; then
-    "${checkMD5NoGui}" "${target}objects/" "${SHA1FILE}" "${target}logs/`basename "${SHA1FILE}"`-Check-`date ${dateArgs}`" "sha1deep" && \
-    "`dirname $0`/createEventsForGroup.py" --eventIdentifierUUID "${eventID}" --groupUUID "${transferUUID}" --groupType "transfer_id" --eventType "fixity check" --eventDateTime "$date" --eventOutcome "Pass" --eventDetail "`sha1deep -v` sha1deep ${target}"
-    ret+="$?"
-else
-    echo "File Does not exist:" "${SHA1FILE}"
-fi
+# Store current working directory to reset at the end of the script and then
+# change to the transfer directory.
+tmp_pwd=$(pwd);
+cd "${target}";
 
-SHA256FILE="${target}metadata/checksum.sha256"
-if [ -f "${SHA256FILE}" ]; then
-    "${checkMD5NoGui}" "${target}objects/" "${SHA256FILE}" "${target}logs/`basename "${SHA256FILE}"`-Check-`date ${dateArgs}`" "sha256deep" && \
-    "`dirname $0`/createEventsForGroup.py" --eventIdentifierUUID "${eventID}" --groupUUID "${transferUUID}" --groupType "transfer_id" --eventType "fixity check" --eventDateTime "$date" --eventOutcome "Pass" --eventDetail "`sha256deep -v` sha256deep ${target}"
-    ret+="$?"
-else
-    echo "File Does not exist:" "${SHA256FILE}"
-fi
+# Count the number of lines in the given hash file and the number of objects
+# in the objects/ folder.
+#
+# ARG1 ($1): Checksum file
+# ARG2 ARG ($2): Objects folder
+#
+# Return: True if the object count and checksum line count match.
+#         False if there is a discrepancy.
+#
+function count_and_compare_lines()
+{
+    local checksum_lines=$(cat "${1}" | wc -l);
+    local file_count=$(find "${2}" -type f | wc -l);
+    if [ "${checksum_lines}" -eq "${file_count}" ];
+    then
+        echo true;
+    else
+        msg="${3}"": Comparison failed with %d checksum lines and %d transfer files\n";
+        printf "${msg}" \
+            "${checksum_lines}" "${file_count}" >&2;
+        echo false;
+    fi
+}
 
+# Retrieve the file extension to prettify the output of the script. If the
+# second argument passed to the function is false, then don't output the
+# extension, output the filename on its own (minus its path structure).
+#
+# ARG1 ($1): File path
+# ARG2 ($2): true for ext, false for filename e.g. checksum.sha256
+#
+# Return: The file extension retrieved from the checksum.{ext} filename.
+#
+function get_file_extension()
+{
+    local filename=$(basename -- "${1}");
+    if [ "${2}" == false ];
+    then
+        echo "${filename}";
+    else
+        local extension="${filename##*.}";
+        echo $extension;
+    fi;
+}
 
-exit ${ret}
+# Output the version information from the hash command currently being called.
+# The version is the first line output from the command's --version flag.
+#
+# ARG1 ($1): Command name
+#
+# Return: First line of the --version information returned by the command.
+#
+function output_hashsum_version()
+{
+    # $(head -n 1) will close the pipe when it has read enough and the hash
+    # command will inconsistently interpret this as an error state resulting
+    # in: {command}: write error.
+    #
+    # Avoid the hash command's sensitivity to a closed pipe, or unwritable
+    # source e.g. $(sha1sum --version > /dev/full) by letting it write its
+    # entire output to a variable and then manipulating the variable instead.
+    version=$("${1}" --version);
+    echo "${version}" | head -n 1;
+}
 
+# Write out PREMIS information about the comparison happening here.
+function write_premis()
+{
+    >&2 echo "Writing PREMIS event for:" "${transferUUID}";
+    hashsum_version=$(output_hashsum_version "${1}");
+    "`dirname $0`/createEventsForGroup.py" \
+        --eventIdentifierUUID "${eventID}" \
+        --groupUUID "${transferUUID}" \
+        --groupType "transfer_id" \
+        --eventType "fixity check" \
+        --eventDateTime "$date" \
+        --eventOutcome "${2}" \
+        --eventDetail "${hashsum_version}";
+    >&2 echo "PREMIS written";
+}
 
+# Retrieve an error string from a given array and output information about what
+# we find to stderr.
+#
+# ARG1 ($1): Array: An array of strings output from the previous hash command.
+# ARG2 ($2): String: String, e.g. "FAILED" to search for.
+# ARG3 ($2): String: The hash algorithm currently being checked against.
+#
+# Return: The current globally scoped exit_code.
+#
+function retrieve_error()
+{
+    echo "${3}"":" "${1}" | >&2 ack -w "${2}";
+    local err=$?;
+    exit_code=$(increment_exit_code "${err}" 0);
+    echo $exit_code;
+}
+
+# Increment the exit code per error found running the hash commands.
+#
+# ARG1 ($1): Integer, ideally an $? value
+# ARG2 ($2): Integer, comparison value to increment counter if -eq true
+#
+# Return: The current or updated globally scoped exit_code.
+#
+function increment_exit_code()
+{
+    if [ "${1}" -eq "${2}" ];
+    then
+        local updated_exit_code=$(( "${exit_code}" + 1 ));
+        echo "${updated_exit_code}";
+    else
+        echo "${exit_code}";
+    fi
+}
+
+# Loop through keys and values the associative array TOOLMAP.
+for K in "${!TOOLMAP[@]}";
+do
+    ext=$(get_file_extension "${K}" true);
+    if [ -f "${K}" ];
+    then
+        >&2 printf "Comparing transfer checksums with the %s file\n" "${ext}";
+        ret=$(count_and_compare_lines "${K}" "${objects_folder}" "${ext}");
+        if [ "${ret}" == false ];
+        then
+            exit_code=$(increment_exit_code 0 0);
+        else
+            current_exit_code=$exit_code;
+            # Store our multi-line hash command results in an array.
+            declare out=$( "${TOOLMAP[$K]}" -c --strict "${K}" 2>&1);
+            exit_code=$(retrieve_error "${out}" "FAILED" "${ext}");
+            exit_code=$(retrieve_error "${out}" "improperly formatted" "${ext}");
+            exit_code=$(retrieve_error "${out}" "no properly formatted" "${ext}");
+            # Write 'Pass' to PREMIS. PREMIS only written to METS if this
+            # script doesn't fail.
+            write_premis "${TOOLMAP[$K]}" "Pass";
+            if [ ! $current_exit_code -lt $exit_code ];
+            then
+                echo "${ext} comparison was OK";
+            fi;
+        fi
+    else
+        printf "Nothing to do for %s: File '%s' not provided \n" \
+            "${ext}" $(get_file_extension "${K}" false);
+    fi;
+done
+
+# Reset to the original working directory and handle script exit.
+cd "${tmp_pwd}";
+>&2 printf "Exiting with code: %d\n" "${exit_code}";
+if [ "${exit_code}" -eq 0 ];
+then
+    echo "Script exiting without error. Any checksum comparisons made were OK";
+fi;
+exit "${exit_code}";

--- a/src/MCPClient/osdeps/CentOS-7.json
+++ b/src/MCPClient/osdeps/CentOS-7.json
@@ -42,7 +42,6 @@
   { "name": "libpst", "state": "latest"},
   { "name": "libraw1394", "state": "latest"},
   { "name": "libvpx", "state": "latest"},
-  { "name": "md5deep", "state": "latest"},
   { "name": "mediainfo", "state": "latest"},
   { "name": "mediaconch", "state": "latest"},
   { "name": "nfs-utils", "state": "latest"},
@@ -59,7 +58,9 @@
   { "name": "tesseract", "state": "latest"},
   { "name": "tree", "state": "latest"},
   { "name": "ufraw", "state": "latest"},
-  { "name": "uuid", "state": "latest"}
+  { "name": "uuid", "state": "latest"},
+  { "name": "coreutils", "state": "latest"},
+  { "name": "ack", "state": "latest"}
   ]
 }
 

--- a/src/MCPClient/osdeps/RedHat-7.json
+++ b/src/MCPClient/osdeps/RedHat-7.json
@@ -42,7 +42,6 @@
   { "name": "libpst", "state": "latest"},
   { "name": "libraw1394", "state": "latest"},
   { "name": "libvpx", "state": "latest"},
-  { "name": "md5deep", "state": "latest"},
   { "name": "mediainfo", "state": "latest"},
   { "name": "mediaconch", "state": "latest"},
   { "name": "nfs-utils", "state": "latest"},
@@ -59,7 +58,9 @@
   { "name": "tesseract", "state": "latest"},
   { "name": "tree", "state": "latest"},
   { "name": "ufraw", "state": "latest"},
-  { "name": "uuid", "state": "latest"}
+  { "name": "uuid", "state": "latest"},
+  { "name": "coreutils", "state": "latest"},
+  { "name": "ack", "state": "latest"}
   ]
 }
 

--- a/src/MCPClient/osdeps/Ubuntu-16.json
+++ b/src/MCPClient/osdeps/Ubuntu-16.json
@@ -23,14 +23,12 @@
   { "name": "fits", "state": "latest"},
   { "name": "gearman", "state": "latest"},
   { "name": "ghostscript", "state": "latest"},
-  { "name": "hashdeep", "state": "latest"},
   { "name": "imagemagick", "state": "latest"},
   { "name": "inkscape", "state": "latest"},
   { "name": "jhove", "state": "latest"},
   { "name": "libimage-exiftool-perl", "state": "latest"},
   { "name": "libxml2-utils", "state": "latest"},
   { "name": "logapp", "state": "latest"},
-  { "name": "md5deep", "state": "latest"},
   { "name": "mediainfo", "state": "latest"},
   { "name": "mediaconch", "state": "latest"},
   { "name": "nailgun", "state": "latest"},
@@ -48,6 +46,8 @@
   { "name": "tree", "state": "latest"},
   { "name": "ufraw", "state": "latest"},
   { "name": "unrar-free", "state": "latest"},
-  { "name": "uuid", "state": "latest"}
+  { "name": "uuid", "state": "latest"},
+  { "name": "coreutils", "state": "latest"},
+  { "name": "ack", "state": "latest"}
   ]
 }

--- a/src/MCPClient/osdeps/Ubuntu-18.json
+++ b/src/MCPClient/osdeps/Ubuntu-18.json
@@ -23,14 +23,12 @@
   { "name": "fits", "state": "latest"},
   { "name": "gearman", "state": "latest"},
   { "name": "ghostscript", "state": "latest"},
-  { "name": "hashdeep", "state": "latest"},
   { "name": "imagemagick", "state": "latest"},
   { "name": "inkscape", "state": "latest"},
   { "name": "jhove", "state": "latest"},
   { "name": "libimage-exiftool-perl", "state": "latest"},
   { "name": "libxml2-utils", "state": "latest"},
   { "name": "logapp", "state": "latest"},
-  { "name": "md5deep", "state": "latest"},
   { "name": "nailgun", "state": "latest"},
   { "name": "mediaconch", "state": "latest"},
   { "name": "mediainfo", "state": "latest"},
@@ -47,6 +45,8 @@
   { "name": "tree", "state": "latest"},
   { "name": "ufraw", "state": "latest"},
   { "name": "unrar-free", "state": "latest"},
-  { "name": "uuid", "state": "latest"}
+  { "name": "uuid", "state": "latest"},
+  { "name": "coreutils", "state": "latest"},
+  { "name": "ack", "state": "latest"}
   ]
 }

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -262,7 +262,7 @@ class Event(models.Model):
 
     def __unicode__(self):
         return six.text_type(_('%(type)s event on %(file_uuid)s (%(detail)s)') % {
-            'type': self.even_type,
+            'type': self.event_type,
             'file_uuid': self.file_uuid,
             'detail': self.event_detail
         })


### PR DESCRIPTION
:construction: :construction: :construction: :construction: :construction: :construction: 

Work to replace hashdeep in Archivematica. 

TODO:

* Push the docker-base image (currently a test one is on the server)
* Change the script name and module name (merge post i18n)
* Documentation about other hashes if we want them, e.g. including sha512
* Documentation that describes more specific requirements for the hash files supplied with Archivematica, i.e. current demo-transfer won't work with its current configuration.

Open questions:

* Do we still want the log output from the shell script ?
* It is easy  now to add other hashing algorithms, do we want to add sha512sum?
* What would automated testing look like?

Connected to archivematica/Issues#346
Connected to artefactual/archivematica#1061

Output currently looks as followss in the UI"

![image](https://user-images.githubusercontent.com/1880412/50549489-e1206800-0c5d-11e9-8420-2ca7996301db.png)

![image](https://user-images.githubusercontent.com/1880412/50549490-e67db280-0c5d-11e9-814e-53addfadb141.png)

And in the PREMIS:
```
<premis:event xmlns:premis="info:lc/xmlns/premis-v2" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd" version="2.2">
  <premis:eventIdentifier>
    <premis:eventIdentifierType>UUID</premis:eventIdentifierType>
    <premis:eventIdentifierValue>7be84e31-6f2c-41e6-966a-a7995a58470a</premis:eventIdentifierValue>
  </premis:eventIdentifier>
  <premis:eventType>fixity check</premis:eventType>
  <premis:eventDateTime>2018-12-30T17:04:06.276741+00:00</premis:eventDateTime>
  <premis:eventDetail>sha1sum (GNU coreutils) 8.28</premis:eventDetail>
  <premis:eventOutcomeInformation>
    <premis:eventOutcome>Pass</premis:eventOutcome>
    <premis:eventOutcomeDetail>
      <premis:eventOutcomeDetailNote></premis:eventOutcomeDetailNote>
    </premis:eventOutcomeDetail>
  </premis:eventOutcomeInformation>
  <premis:linkingAgentIdentifier>
    <premis:linkingAgentIdentifierType>preservation system</premis:linkingAgentIdentifierType>
    <premis:linkingAgentIdentifierValue>Archivematica-1.9</premis:linkingAgentIdentifierValue>
  </premis:linkingAgentIdentifier>
  <premis:linkingAgentIdentifier>
    <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>
    <premis:linkingAgentIdentifierValue>test</premis:linkingAgentIdentifierValue>
  </premis:linkingAgentIdentifier>
</premis:event>
```
```
<premis:event xmlns:premis="info:lc/xmlns/premis-v2" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd" version="2.2">
  <premis:eventIdentifier>
    <premis:eventIdentifierType>UUID</premis:eventIdentifierType>
    <premis:eventIdentifierValue>efebb151-33ad-430d-894c-e7d9851d6642</premis:eventIdentifierValue>
  </premis:eventIdentifier>
  <premis:eventType>fixity check</premis:eventType>
  <premis:eventDateTime>2018-12-30T17:04:05.205950+00:00</premis:eventDateTime>
  <premis:eventDetail>sha512sum (GNU coreutils) 8.28</premis:eventDetail>
  <premis:eventOutcomeInformation>
    <premis:eventOutcome>Pass</premis:eventOutcome>
    <premis:eventOutcomeDetail>
      <premis:eventOutcomeDetailNote></premis:eventOutcomeDetailNote>
    </premis:eventOutcomeDetail>
  </premis:eventOutcomeInformation>
  <premis:linkingAgentIdentifier>
    <premis:linkingAgentIdentifierType>preservation system</premis:linkingAgentIdentifierType>
    <premis:linkingAgentIdentifierValue>Archivematica-1.9</premis:linkingAgentIdentifierValue>
  </premis:linkingAgentIdentifier>
  <premis:linkingAgentIdentifier>
    <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>
    <premis:linkingAgentIdentifierValue>test</premis:linkingAgentIdentifierValue>
  </premis:linkingAgentIdentifier>
</premis:event>
```