### PR TITLE
ArchivesSpace: take base_url instead of host/port

### DIFF
--- a/src/MCPClient/lib/clientScripts/dip_generation_helper.py
+++ b/src/MCPClient/lib/clientScripts/dip_generation_helper.py
@@ -30,8 +30,7 @@ def create_archivesspace_client():
 
     try:
         client = archivesspace.ArchivesSpaceClient(
-            host=config['host'],
-            port=config['port'],
+            host=config['base_url'],
             user=config['user'],
             passwd=config['passwd'],
             repository=config['repository']

--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -47,7 +47,7 @@ def dspace_handle_to_archivesspace(job, sip_uuid):
     # POST Dspace handle to ArchivesSpace
     # Get ArchivesSpace config
     config = models.DashboardSetting.objects.get_dict('upload-archivesspace_v0.0')
-    archivesspace_url = 'http://' + config['host'] + ':' + str(config['port'])
+    archivesspace_url = config["base_url"]
 
     # Log in
     url = archivesspace_url + '/users/' + config['user'] + '/login'

--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -203,8 +203,7 @@ def call(jobs):
     INHERIT_NOTES_CHOICES = ['yes', 'y', 'true', '1']
 
     parser = argparse.ArgumentParser(description='A program to take digital objects from a DIP and upload them to an ArchivesSpace db')
-    parser.add_argument('--host', default='localhost', dest='host', metavar='host', help='Hostname of ArchivesSpace')
-    parser.add_argument('--port', type=int, default=8089, dest='port', metavar='port', help='Port used by ArchivesSpace backend API')
+    parser.add_argument('--base-url', default='http://localhost:8089', dest='base_url', metavar='base_url', help='Hostname of ArchivesSpace')
     parser.add_argument('--user', dest='user', help='Administrative user')
     parser.add_argument('--passwd', dest='passwd', help='Administrative user password')
     parser.add_argument('--dip_location', help='DIP location')
@@ -228,7 +227,7 @@ def call(jobs):
 
                 args.inherit_notes = args.inherit_notes.lower() in INHERIT_NOTES_CHOICES
 
-                client = ArchivesSpaceClient(host=args.host, port=args.port, user=args.user, passwd=args.passwd)
+                client = ArchivesSpaceClient(host=args.base_url, user=args.user, passwd=args.passwd)
 
                 try:
                     files = get_files_from_dip(args.dip_location, args.dip_name, args.dip_uuid)

--- a/src/MCPClient/tests/fixtures/archivesspaceconfig.json
+++ b/src/MCPClient/tests/fixtures/archivesspaceconfig.json
@@ -52,8 +52,8 @@
 {
     "fields": {
         "scope": "upload-archivesspace_v0.0",
-        "name": "host",
-        "value": "localhost",
+        "name": "base_url",
+        "value": "http://localhost:8089",
         "lastmodified": "2016-12-03T01:56:10Z"
     },
     "model": "main.dashboardsetting",
@@ -122,21 +122,11 @@
 {
     "fields": {
         "scope": "upload-archivesspace_v0.0",
-        "name": "port",
-        "value": "8089",
-        "lastmodified": "2016-12-03T01:56:10Z"
-    },
-    "model": "main.dashboardsetting",
-    "pk": 168
-},
-{
-    "fields": {
-        "scope": "upload-archivesspace_v0.0",
         "name": "xlink_show",
         "value": "embed",
         "lastmodified": "2016-12-03T01:56:10Z"
     },
     "model": "main.dashboardsetting",
-    "pk": 169
+    "pk": 168
 }
 ]

--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -1,4 +1,4 @@
-agentarchives==0.4.0
+agentarchives==0.5.0
 bagit==1.5.2
 Django>=1.8,<1.9
 elasticsearch>=1.0.0,<2.0.0

--- a/src/dashboard/src/components/administration/forms_dip_upload.py
+++ b/src/dashboard/src/components/administration/forms_dip_upload.py
@@ -25,8 +25,7 @@ EAD_SHOW_CHOICES = [
 
 
 class ArchivesSpaceConfigForm(forms.Form):
-    host = forms.CharField(label=_('ArchivesSpace host'), help_text=_('Do not include http:// or www. Example: aspace.test.org'))
-    port = forms.IntegerField(label=_('ArchivesSpace backend port'), help_text=_('Example: 8089'), initial=8089)
+    base_url = forms.CharField(label=_('ArchivesSpace base URL'), help_text=_('Example: http://aspace.test.org:8089'))
     user = forms.CharField(label=_('ArchivesSpace administrative user'), help_text=_('Example: admin'))
     passwd = forms.CharField(required=False, label=_('ArchivesSpace administrative user password'), help_text=_('Password for user set above. Re-enter this password every time changes are made.'))
     restrictions = forms.ChoiceField(choices=PREMIS_CHOICES, label=_('Restrictions apply'), initial='yes')

--- a/src/dashboard/src/components/ingest/views_as.py
+++ b/src/dashboard/src/components/ingest/views_as.py
@@ -26,8 +26,7 @@ def get_as_system_client():
         raise ArchivesSpaceError("ArchivesSpace host string has not been set")
 
     return ArchivesSpaceClient(
-        host=config['host'],
-        port=config['port'],
+        host=config['base_url'],
         user=config['user'],
         passwd=config['passwd'],
         repository=config['repository']

--- a/src/dashboard/src/main/migrations/0066_archivesspace_base_url.py
+++ b/src/dashboard/src/main/migrations/0066_archivesspace_base_url.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+"""Migrate the ArchivesSpace connection details.
+
+``host`` and `port`` are replaced by ``base_url``.
+"""
+from __future__ import unicode_literals
+
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
+
+from django.db import migrations
+
+
+_AS_DICTNAME = 'upload-archivesspace_v0.0'
+
+_AS_UPLOAD_STC = '10a0f352-aeb7-4c13-8e9e-e81bda9bca29'
+
+
+def _load_config(DashboardSetting):
+    """Load the ArchivesSpace configuration dictionary."""
+    return DashboardSetting.objects.get_dict(_AS_DICTNAME)
+
+
+def _save_config(DashboardSetting, params):
+    """Set the ArchivesSpace configuration dictionary."""
+    DashboardSetting.objects.set_dict(_AS_DICTNAME, params)
+
+
+def _get_base_url(host, port):
+    """Convert ``host`` and ``port`` to ``base_url``.
+
+    So the user does not need to tweak the settings during upgrades.
+    See ``test_migrations.py`` for to understand the behaviour.
+    """
+    try:
+        parsed = urlparse(host)
+    except AttributeError:
+        pass
+    else:
+        if parsed.scheme:
+            return parsed.geturl()
+    if not host:
+        return ""
+    parts = host.partition(":")
+    host = parts[0]
+    if parts[1] == ":":
+        return "http://{}:{}".format(host, parts[2])
+    try:
+        port = int(port)
+    except (ValueError, TypeError):
+        pass
+    else:
+        return "http://{}:{}".format(host, port)
+    return "http://{}".format(host)
+
+
+def _get_host_and_port(base_url):
+    """Convert ``base_url`` back to ``host`` and ``port``.
+
+    It is a losing game, only best effort.
+    See ``test_migrations.py`` for to understand the behaviour.
+    """
+    host, port = "", ""
+    try:
+        base_url = urlparse(base_url)
+    except AttributeError:
+        return host, port
+    host = base_url.netloc
+    if not host:
+        host = base_url.path
+    parts = host.partition(":")
+    if parts[1] == ":":
+        host, port = parts[0], parts[2]
+    return host, port
+
+
+def data_migration_up(apps, schema_editor):
+    """Restore `base_url`."""
+    DashboardSetting = apps.get_model('main', 'DashboardSetting')
+    StandardTaskConfig = apps.get_model('main', 'StandardTaskConfig')
+
+    config = _load_config(DashboardSetting)
+    host, port = config.pop("host", None), config.pop("port", None)
+    config["base_url"] = _get_base_url(host, port)
+    _save_config(DashboardSetting, config)
+
+    # Use new command-line arguments ``--base-url``.
+    StandardTaskConfig.objects.filter(
+        id=_AS_UPLOAD_STC, execute='upload-archivesspace_v0.0').update(
+            arguments='--base-url "%base_url%" '
+                      '--user "%user%" '
+                      '--passwd "%passwd%" '
+                      '--dip_location "%SIPDirectory%" '
+                      '--dip_name "%SIPName%" '
+                      '--dip_uuid "%SIPUUID%" '
+                      '--restrictions "%restrictions%" '
+                      '--object_type "%object_type%" '
+                      '--xlink_actuate "%xlink_actuate%" '
+                      '--xlink_show "%xlink_show%" '
+                      '--use_statement "%use_statement%" '
+                      '--uri_prefix "%uri_prefix%" '
+                      '--access_conditions "%access_conditions%" '
+                      '--use_conditions "%use_conditions%" '
+                      '--inherit_notes "%inherit_notes%"')
+
+
+def data_migration_down(apps, schema_editor):
+    """Restore `host` and `port`."""
+    DashboardSetting = apps.get_model('main', 'DashboardSetting')
+    StandardTaskConfig = apps.get_model('main', 'StandardTaskConfig')
+
+    config = _load_config(DashboardSetting)
+    base_url = config.pop("base_url", None)
+    config["host"], config["port"] = _get_host_and_port(base_url)
+    _save_config(DashboardSetting, config)
+
+    # Restore previous command-line arguments ``--host`` and ``--port``.
+    StandardTaskConfig.objects.filter(
+        id=_AS_UPLOAD_STC, execute='upload-archivesspace_v0.0').update(
+            arguments='--host "%host%" '
+                      '--port "%port%" '
+                      '--user "%user%" '
+                      '--passwd "%passwd%" '
+                      '--dip_location "%SIPDirectory%" '
+                      '--dip_name "%SIPName%" '
+                      '--dip_uuid "%SIPUUID%" '
+                      '--restrictions "%restrictions%" '
+                      '--object_type "%object_type%" '
+                      '--xlink_actuate "%xlink_actuate%" '
+                      '--xlink_show "%xlink_show%" '
+                      '--use_statement "%use_statement%" '
+                      '--uri_prefix "%uri_prefix%" '
+                      '--access_conditions "%access_conditions%" '
+                      '--use_conditions "%use_conditions%" '
+                      '--inherit_notes "%inherit_notes%"')
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('main', '0065_version_number'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration_up, data_migration_down)
+    ]

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -1,5 +1,5 @@
 # Base requirements - for all installations
-agentarchives==0.4.0
+agentarchives==0.5.0
 brotli==0.5.2  # Better compression library for WhiteNoise
 Django>=1.8,<1.9
 django-autoslug==1.9.3  # used by fpr

--- a/src/dashboard/tests/test_migrations.py
+++ b/src/dashboard/tests/test_migrations.py
@@ -1,0 +1,38 @@
+import importlib
+
+import pytest
+
+
+# Import package that starts with a number.
+mod = importlib.import_module("main.migrations.0066_archivesspace_base_url")
+
+
+@pytest.mark.parametrize("host_and_port, base_url", [
+    ((None, None), ""),
+    (("", ""), ""),
+    (("foobar", ""), "http://foobar"),
+    (("foobar.tld", ""), "http://foobar.tld"),
+    (("foobar.tld", None), "http://foobar.tld"),
+    (("foobar.tld", "12345"), "http://foobar.tld:12345"),
+    (("http://foobar.tld", "12345"), "http://foobar.tld"),
+    (("http://foobar.tld:789/asdf", "8089"), "http://foobar.tld:789/asdf"),
+])
+def test_0066_get_base_url(host_and_port, base_url):
+    """Test _get_baseurl."""
+    assert base_url == mod._get_base_url(*host_and_port), \
+        "Failed with args %s" % (host_and_port)
+
+
+@pytest.mark.parametrize("base_url, host_and_port", [
+    (None, ("", "")),
+    ("", ("", "")),
+    ("foobar.tld", ("foobar.tld", "")),
+    ("foobar.tld:12345", ("foobar.tld", "12345")),
+    ("http://foobar.tld", ("foobar.tld", "")),
+    ("http://foobar.tld:8089", ("foobar.tld", "8089")),
+    ("http://foobar.tld:8089/subpath", ("foobar.tld", "8089")),
+])
+def test_0066_get_host_and_port(base_url, host_and_port):
+    """Test _get_host_and_port."""
+    assert host_and_port == mod._get_host_and_port(base_url), \
+        "Failed with arg %s" % (base_url,)


### PR DESCRIPTION
Update the ArchivesSpace configuration page so it takes a URL instead of host/port.

The following changes have been made:

- agentarchives updated [v0.5.0](https://github.com/artefactual-labs/agentarchives/releases/tag/v0.5.0) (brings full support for URL values in `host` parameter)
- ArchivesSpace configuration form - showing new `ArchivesSpace base URL` field
- ArchivesSpace task CLI parameters (see migration 0066)
- ArchivesSpace config dictionary (see migration 0066)

See screenshot:

![image](https://user-images.githubusercontent.com/606459/50981996-0f4d4580-14b1-11e9-9070-92b280cbf539.png)

This is connected to https://github.com/archivematica/Issues/issues/409.