### PR TITLE
Update agentarchives to v0.5.0

### DIFF
--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 import argparse
 import sys
-
 import requests
 
 import django
@@ -17,11 +16,22 @@ from custom_handlers import get_script_logger
 import elasticSearchFunctions
 import storageService as storage_service
 
+from agentarchives.archivesspace import ArchivesSpaceClient
+
 logger = get_script_logger("archivematica.mcp.client.post_store_aip_hook")
 
 COMPLETED = 0
 NO_ACTION = 1
 ERROR = 2
+
+
+def _build_base_url(host, port):
+    """Parse ``host`` and ``port`` to build ``base_url``.
+
+    ``ArchivesSpaceClient`` is not entirely used in this script but it's a
+    change expected to happen in future releases.
+    """
+    return ArchivesSpaceClient.__dict__['_build_base_url'](None, host, port)
 
 
 def dspace_handle_to_archivesspace(sip_uuid):
@@ -48,7 +58,7 @@ def dspace_handle_to_archivesspace(sip_uuid):
     # POST Dspace handle to ArchivesSpace
     # Get ArchivesSpace config
     config = models.DashboardSetting.objects.get_dict('upload-archivesspace_v0.0')
-    archivesspace_url = 'http://' + config['host'] + ':' + str(config['port'])
+    archivesspace_url = _build_base_url(config['host'], config['port'])
 
     # Log in
     url = archivesspace_url + '/users/' + config['user'] + '/login'

--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -1,4 +1,4 @@
-agentarchives==0.4.0
+agentarchives==0.5.0
 bagit==1.5.2
 Django>=1.8,<1.9
 elasticsearch>=1.0.0,<2.0.0

--- a/src/dashboard/src/components/administration/forms_dip_upload.py
+++ b/src/dashboard/src/components/administration/forms_dip_upload.py
@@ -25,8 +25,8 @@ EAD_SHOW_CHOICES = [
 
 
 class ArchivesSpaceConfigForm(forms.Form):
-    host = forms.CharField(label=_('ArchivesSpace host'), help_text=_('Do not include http:// or www. Example: aspace.test.org'))
-    port = forms.IntegerField(label=_('ArchivesSpace backend port'), help_text=_('Example: 8089'), initial=8089)
+    host = forms.CharField(label=_('ArchivesSpace host or base URL'), help_text=_('Examples: "http://space.test.org:8089", "space.test.org"'))
+    port = forms.IntegerField(label=_('ArchivesSpace backend port'), help_text=_('Ignored when the host value is a valid URL. Example: 8089'), initial=8089)
     user = forms.CharField(label=_('ArchivesSpace administrative user'), help_text=_('Example: admin'))
     passwd = forms.CharField(required=False, label=_('ArchivesSpace administrative user password'), help_text=_('Password for user set above. Re-enter this password every time changes are made.'))
     restrictions = forms.ChoiceField(choices=PREMIS_CHOICES, label=_('Restrictions apply'), initial='yes')

--- a/src/dashboard/src/components/archival_storage/forms.py
+++ b/src/dashboard/src/components/archival_storage/forms.py
@@ -36,7 +36,7 @@ class UploadMetadataOnlyAtomForm(forms.Form):
         client = get_atom_client()
         try:
             client.find_parent_id_for_component(slug)
-        except (Timeout, ConnectionError) as e:
+        except (Timeout, ConnectionError):
             raise forms.ValidationError(_('Connection establishment failed: AtoM server cannot be reached.'))
         except CommunicationError as e:
             if '404' in e.message:

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -1,5 +1,5 @@
 # Base requirements - for all installations
-agentarchives==0.4.0
+agentarchives==0.5.0
 brotli==0.5.2  # Better compression library for WhiteNoise
 Django>=1.8,<1.9
 django-braces==1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands = flake8 .
 [flake8]
 exclude = .tox, .git, __pycache__, .cache, build, dist, *.pyc, *.egg-info, .eggs
 application-import-names = flake8
-ignore = E402, E501, E722, E741
+ignore = E402, E501, E722, E741, W504, W605
 max-line-length = 160
 
 ; Report: $ .tox/flake8/bin/flake8 --isolated -qq --statistics --count --max-line-length=160


### PR DESCRIPTION
This is a port of https://github.com/artefactual/archivematica/pull/1328 for `stable/1.7.x`. It brings more flexibility for the user to determine the connection details used in the ArchivesSpace client.

This is connected to https://github.com/archivematica/Issues/issues/409.