### PR TITLE
Enable the deletion of packages in a Dataverse transfer

### DIFF
--- a/src/MCPClient/tests/fixtures/dataverse/metadata/METS.duplicate.xml
+++ b/src/MCPClient/tests/fixtures/dataverse/metadata/METS.duplicate.xml
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  METS with just two files. One of which when compared with the Dataverse
+  fixtures will show up as a duplicate object. This can happen in Dataverse
+  because this METS file in a transfer scenario is populated using metadata
+  only, not the files themselves, and so a certain number of assumptions are
+  made about what is and isn't there.
+-->
+<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mets="http://www.loc.gov/METS/" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version18/mets.xsd">
+  <mets:metsHdr CREATEDATE="2015-09-12T00:01:35"/>
+  <mets:fileSec>
+    <mets:fileGrp USE="original">
+      <mets:file ID="file-a001048d-4c3e-485d-af02-1d19584a93b1" GROUPID="Group-fb3b1250-5e45-499f-b0b1-0f6a20d77366">
+        <mets:FLocat xlink:href="Weather_data/Weather_data.RData" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+      <!-- The file below is the duplicate object in the mets fixtures -->
+      <mets:file ID="file-e5fde5cb-a5d7-4e67-ae66-20b73552eedf" GROUPID="Group-fb3b1250-5e45-499f-b0b1-0f6a20d77366">
+        <mets:FLocat xlink:href="Weather_data/i_am_a_duplicate.original" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap ID="structMap_1" LABEL="Archivematica default" TYPE="physical">
+    <mets:div LABEL="duplicated_object_example" TYPE="Directory">
+        <!-- The file below is the duplicate object in the mets fixtures -->
+        <mets:div LABEL="Weather_data.RData" TYPE="Item">
+          <mets:fptr FILEID="file-a001048d-4c3e-485d-af02-1d19584a93b1"/>
+        </mets:div>
+        <mets:div LABEL="i_am_a_duplicate.original" TYPE="Item">
+          <mets:fptr FILEID="file-e5fde5cb-a5d7-4e67-ae66-20b73552eedf"/>
+        </mets:div>
+    </mets:div>
+  </mets:structMap>
+</mets:mets>

--- a/src/MCPClient/tests/fixtures/dataverse/metadata/METS.missing.xml
+++ b/src/MCPClient/tests/fixtures/dataverse/metadata/METS.missing.xml
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  METS with just two files. One of which should not exist in the Dataverse
+  fixtures. This will help us in testing the behavior of the Dataverse scripts
+  when objects are missing. Missing objects happen in Dataverse because this
+  METS file in a transfer scenario is populated using metadata only, not the
+  files themselves, and so a certain number of assumptions are made about what
+  is and isn't there.
+-->
+<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mets="http://www.loc.gov/METS/" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version18/mets.xsd">
+  <mets:metsHdr CREATEDATE="2015-09-12T00:01:35"/>
+  <mets:fileSec>
+    <mets:fileGrp USE="original">
+      <mets:file ID="file-a001048d-4c3e-485d-af02-1d19584a93b1" GROUPID="Group-fb3b1250-5e45-499f-b0b1-0f6a20d77366">
+        <mets:FLocat xlink:href="Weather_data/Weather_data.RData" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+      <!-- The file below is the non-existent object in the mets fixtures -->
+      <mets:file ID="file-e5fde5cb-a5d7-4e67-ae66-20b73552eedf" GROUPID="Group-fb3b1250-5e45-499f-b0b1-0f6a20d77366">
+        <mets:FLocat xlink:href="Weather_data/i_am_not_here" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap ID="structMap_1" LABEL="Archivematica default" TYPE="physical">
+    <mets:div LABEL="missing_object_example" TYPE="Directory">
+        <mets:div LABEL="Weather_data/Weather_data.RData" TYPE="Item">
+          <mets:fptr FILEID="file-a001048d-4c3e-485d-af02-1d19584a93b1"/>
+        </mets:div>
+        <!-- The file below is the non-existent object in the mets fixtures -->
+        <mets:div LABEL="i_am_not_here" TYPE="Item">
+          <mets:fptr FILEID="file-e5fde5cb-a5d7-4e67-ae66-20b73552eedf"/>
+        </mets:div>
+    </mets:div>
+  </mets:structMap>
+</mets:mets>

--- a/src/MCPClient/tests/fixtures/dataverse/metadata/METS.removed.xml
+++ b/src/MCPClient/tests/fixtures/dataverse/metadata/METS.removed.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  METS with just two files. One of which should not exist in the Dataverse
+  fixtures. This will help us in testing the behavior of the Dataverse scripts
+  when objects that have been purposely removed, e.g. via extract packages.
+-->
+<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mets="http://www.loc.gov/METS/" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version18/mets.xsd">
+  <mets:metsHdr CREATEDATE="2015-09-12T00:01:35"/>
+  <mets:fileSec>
+    <mets:fileGrp USE="original">
+      <mets:file ID="file-a001048d-4c3e-485d-af02-1d19584a93b1" GROUPID="Group-fb3b1250-5e45-499f-b0b1-0f6a20d77366">
+        <mets:FLocat xlink:href="Weather_data/Weather_data.RData" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+      <!-- The file below is the non-existent object in the mets fixtures -->
+      <mets:file ID="file-d6e0cc66-0ecc-4b60-8e2e-ffcf47196355" GROUPID="Group-fb3b1250-5e45-499f-b0b1-0f6a20d77366">
+        <mets:FLocat xlink:href="Weather_data/i_have_been_removed" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap ID="structMap_1" LABEL="Archivematica default" TYPE="physical">
+    <mets:div LABEL="removed_object_example" TYPE="Directory">
+        <mets:div LABEL="Weather_data/Weather_data.RData" TYPE="Item">
+          <mets:fptr FILEID="file-a001048d-4c3e-485d-af02-1d19584a93b1"/>
+        </mets:div>
+        <!-- The file below is the duplicate object in the mets fixtures -->
+        <mets:div LABEL="i_have_been_removed" TYPE="Item">
+          <mets:fptr FILEID="file-d6e0cc66-0ecc-4b60-8e2e-ffcf47196355"/>
+        </mets:div>
+    </mets:div>
+  </mets:structMap>
+</mets:mets>

--- a/src/MCPClient/tests/fixtures/dataverse_sip.json
+++ b/src/MCPClient/tests/fixtures/dataverse_sip.json
@@ -166,5 +166,59 @@
     },
     "model": "main.file",
     "pk": "e2834eed-4178-469a-9a4e-c8f1490bb804"
+},
+{
+    "fields": {
+        "filegrpuuid": "",
+        "sip": null,
+        "originallocation": "%transferDirectory%objects/Weather_data/i_am_a_duplicate.original",
+        "transfer": "6741c782-f22b-47b3-8bcf-72fd0c94e195",
+        "filegrpuse": "original",
+        "removedtime": null,
+        "label": "",
+        "checksum": "c54c464c5efbdb4d6c903043c18d41b690653a38cbfcbc0cc31fabe6cda55a0e",
+        "enteredsystem": "2015-11-05T22:06:49",
+        "currentlocation": "%transferDirectory%objects/Weather_data/i_am_a_duplicate.original",
+        "size": 563285
+    },
+    "model": "main.file",
+    "pk": "3e91412f-cd37-4215-afbc-a7197868e794"
+},
+{
+    "fields": {
+        "filegrpuuid": "",
+        "sip": null,
+        "originallocation": "%transferDirectory%objects/Weather_data/i_am_a_duplicate.original",
+        "transfer": "6741c782-f22b-47b3-8bcf-72fd0c94e195",
+        "filegrpuse": "original",
+        "removedtime": null,
+        "label": "",
+        "checksum": "c54c464c5efbdb4d6c903043c18d41b690653a38cbfcbc0cc31fabe6cda55a0e",
+        "enteredsystem": "2015-11-05T22:06:49",
+        "currentlocation": "%transferDirectory%objects/Weather_data/i_am_a_duplicate.original",
+        "size": 563285
+    },
+    "model": "main.file",
+    "pk": "fa8496ab-a523-4493-a89d-026d91fc5311"
+},
+{
+    "fields": {
+        "filegrpuuid": "",
+        "sip": null,
+        "originallocation": "%transferDirectory%objects/Weather_data/i_have_been_removed",
+        "transfer": "6741c782-f22b-47b3-8bcf-72fd0c94e195",
+        "filegrpuse": "original",
+        "removedtime": "2019-01-15T23:13:00",
+        "label": "",
+        "checksum": "c54c464c5efbdb4d6c903043c18d41b690653a38cbfcbc0cc31fabe6cda55a0e",
+        "enteredsystem": "2015-11-05T22:06:49",
+        "currentlocation": null,
+        "size": 563285
+    },
+    "model": "main.file",
+    "pk": "d6e0cc66-0ecc-4b60-8e2e-ffcf47196355"
 }
 ]
+
+
+


### PR DESCRIPTION
This commit makes sure that when Archivematica is used with `Extract Packages: On` and `Remove extracted packages: On` a Dataverse transfer will not fail, e.g. if it contains an `RData` file. 

A modest number of tests have been added where there was less coverage before. 

Logging has been cleaned up somewhat too. If something goes wrong, users should be able to get a clearer view of what is going on. 

Connected to archivematica/issues#269