### PR TITLE
Fix pip dependency installation issue (brotli)

### DIFF
--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -1,6 +1,6 @@
 # Base requirements - for all installations
 agentarchives==0.5.0
-brotli==0.5.2  # Better compression library for WhiteNoise
+brotli==1.0.7  # Better compression library for WhiteNoise
 Django>=1.8,<1.9
 django-autoslug==1.9.3  # used by fpr
 django-braces==1.0.0


### PR DESCRIPTION
Recent versions of pip couldn't get brotli to build.
Updating brotli to the latest release fixed the problem.

This is connected to https://github.com/archivematica/Issues/issues/455.