### PR TITLE
Remove query/filters from elasticSearchFunctions

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -49,41 +49,6 @@ from elasticsearch import Elasticsearch, ImproperlyConfigured
 
 logger = logging.getLogger('archivematica.common')
 
-MATCH_ALL_QUERY = {
-    "query": {
-        "match_all": {}
-    }
-}
-
-# Returns files which are in the backlog; *omits* files without UUIDs,
-# e.g. administrative files (AM metadata and logs directories).
-BACKLOG_FILTER_NO_MD_LOGS = {
-    'bool': {
-        'must': {
-            'term': {
-                'status': 'backlog',
-            },
-        },
-        'must_not': {
-            'term': {
-                'fileuuid': '',
-            }
-        }
-    },
-}
-
-# Returns files which are in the backlog; *includes* files without UUIDs,
-# e.g. administrative files (AM metadata and logs directories).
-BACKLOG_FILTER = {
-    'bool': {
-        'must': {
-            'term': {
-                'status': 'backlog',
-            },
-        }
-    }
-}
-
 
 class ElasticsearchError(Exception):
     """ Not operational errors. """

--- a/src/dashboard/src/components/advanced_search.py
+++ b/src/dashboard/src/components/advanced_search.py
@@ -19,8 +19,6 @@ import logging
 
 import dateutil.parser
 
-import elasticSearchFunctions
-
 logger = logging.getLogger("archivematica.dashboard.advanced_search")
 
 OBJECT_FIELDS = (
@@ -129,7 +127,7 @@ def assemble_query(queries, ops, fields, types, filters=[]):
 
     # Return match all query if no clauses
     if len(must_haves + must_not_haves + should_haves + filters) == 0:
-        return elasticSearchFunctions.MATCH_ALL_QUERY
+        return {"query": {"match_all": {}}}
 
     # TODO: Fix boolean query build:
     # Should clauses will only influence the weight of the results if

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -16,7 +16,6 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 import ast
-import copy
 import httplib
 import json
 import logging
@@ -400,9 +399,7 @@ def elasticsearch_query_excluding_aips_pending_deletion(uuid_field_name):
             }
         }
     else:
-        # Return a deepcopy of MATCH_ALL_QUERY because it can be modified by the
-        # caller and we don't want those modifications to persist
-        query = copy.deepcopy(elasticSearchFunctions.MATCH_ALL_QUERY)
+        query = {"query": {"match_all": {}}}
 
     return query
 
@@ -485,7 +482,7 @@ def list_display(request):
         start = (page - 1) * page_size
         results = es_client.search(
             index='aips',
-            body=elasticSearchFunctions.MATCH_ALL_QUERY,
+            body={"query": {"match_all": {}}},
             _source='origin,uuid,filePath,created,name,size,encrypted',
             sort=sort_specification,
             size=page_size,
@@ -496,7 +493,7 @@ def list_display(request):
     items_per_page = 10
     count = es_client.count(
         index='aips',
-        body=elasticSearchFunctions.MATCH_ALL_QUERY,
+        body={"query": {"match_all": {}}},
     )['count']
     results = LazyPagedSequence(es_pager, page_size=items_per_page, length=count)
 


### PR DESCRIPTION
The match all query and backlog filters attributes are prone to be
modified externally causing issues when they're obtained after for other
queries.

Connects to https://github.com/archivematica/Issues/issues/452.