### PR TITLE
Dashboard: fix view raw links in archival storage

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -125,20 +125,6 @@ def setup_reading_from_conf(settings):
     )
 
 
-def get_host():
-    """Return one of the Elasticsearch hosts configured in our client.
-
-    In the future this function could look it up in the Elasticsearch client
-    instead of using the module attribute _es_hosts, because in an Elasticsearch
-    cluster, nodes can be added or removed dynamically.
-    """
-    if not _es_hosts:
-        raise ImproperlyConfigured('The Elasticsearch client has not been set up yet, please call setup() first.')
-    if isinstance(_es_hosts, (list, tuple)):
-        return _es_hosts[0]
-    return _es_hosts
-
-
 def get_client():
     """Obtain the current Elasticsearch client.
 

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -16,7 +16,6 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 import ast
-import httplib
 import json
 import logging
 import os
@@ -561,22 +560,21 @@ def list_display(request):
                   )
 
 
-def document_json_response(document_id_modified, type):
+def document_json_response(document_id_modified, index):
     document_id = document_id_modified.replace('____', '-')
-    es_client = httplib.HTTPConnection(elasticSearchFunctions.get_host())
-    es_client.request("GET", "/aips/" + type + "/" + document_id)
-    response = es_client.getresponse()
-    data = response.read()
-    pretty_json = json.dumps(json.loads(data), sort_keys=True, indent=2)
+    es_client = elasticSearchFunctions.get_client()
+    data = es_client.get(
+        index=index, doc_type=elasticSearchFunctions.DOC_TYPE, id=document_id)
+    pretty_json = json.dumps(data, sort_keys=True, indent=2)
     return HttpResponse(pretty_json, content_type='application/json')
 
 
 def file_json(request, document_id_modified):
-    return document_json_response(document_id_modified, 'aipfile')
+    return document_json_response(document_id_modified, 'aipfiles')
 
 
 def aip_json(request, document_id_modified):
-    return document_json_response(document_id_modified, 'aip')
+    return document_json_response(document_id_modified, 'aips')
 
 
 def view_aip(request, uuid):


### PR DESCRIPTION
- Pass index to `document_json_response` and use the default doc. type.
- Use the Elasticsearch client directly instead of `httplib`.
- Remove (now) unused `get_host()` from `elasticsearchFunctions`.

Connects to #1171.
Connects to https://github.com/archivematica/Issues/issues/274.