### PR TITLE
MCPServer: fix workflow lookup in ReplacementDicFromChoice

### DIFF
--- a/src/MCPServer/lib/linkTaskManagerReplacementDicFromChoice.py
+++ b/src/MCPServer/lib/linkTaskManagerReplacementDicFromChoice.py
@@ -108,7 +108,7 @@ class linkTaskManagerReplacementDicFromChoice(LinkTaskManager):
         """
         try:
             link = self.jobChainLink.workflow.get_link(
-                self.jobChainLink.link.config["fallback_link_id"])
+                self.jobChainLink.link["fallback_link_id"])
         except KeyError:
             return
         execute = link.config["execute"]


### PR DESCRIPTION
Access to `fallback_link_id` failed because it was using the wrong accessor.

This was introduced in https://github.com/artefactual/archivematica/pull/1251.

Connects to https://github.com/archivematica/Issues/issues/474.