### PR TITLE
Dashboard: fix disk serializing of DC AIC field

### DIFF
--- a/src/MCPClient/lib/clientScripts/save_dublin_core.py
+++ b/src/MCPClient/lib/clientScripts/save_dublin_core.py
@@ -11,6 +11,7 @@ from main import models
 
 FIELDS = (
     'title',
+    'is_part_of',
     'creator',
     'subject',
     'description',

--- a/src/dashboard/src/components/ingest/forms.py
+++ b/src/dashboard/src/components/ingest/forms.py
@@ -70,7 +70,7 @@ class DublinCoreMetadataForm(forms.ModelForm):
 class AICDublinCoreMetadataForm(DublinCoreMetadataForm):
     class Meta:
         model = models.DublinCore
-        fields = ('title', 'identifier', 'creator', 'subject', 'description', 'publisher', 'contributor', 'date', 'format', 'source', 'relation', 'language', 'coverage', 'rights')  # Removed 'is_part_of'
+        fields = ('title', 'is_part_of', 'identifier', 'creator', 'subject', 'description', 'publisher', 'contributor', 'date', 'format', 'source', 'relation', 'language', 'coverage', 'rights')
         widgets = DublinCoreMetadataForm.Meta.widgets.copy()
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Connects to https://github.com/archivematica/Issues/issues/311

The DC field not being serialized after the transfer prevented it to be copied to the SIP causing a mismatch in the values of both metadata forms.