### PR TITLE
Ensure that there is some form of label for storage locations and they don't overwrite each other

### DIFF
--- a/src/MCPClient/lib/clientScripts/get_aip_storage_locations.py
+++ b/src/MCPClient/lib/clientScripts/get_aip_storage_locations.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python2
 
+import json
+
 # storageService requires Django to be set up
 import django
 django.setup()
@@ -15,12 +17,19 @@ logger = get_script_logger("archivematica.mcp.client.get_aip_storage_locations")
 def get_aip_storage_locations(purpose, job):
     """ Return a dict of AIP Storage Locations and their descriptions."""
     storage_directories = storage_service.get_location(purpose=purpose)
-    logger.debug("Storage Directories: {}".format(storage_directories))
+    logger.debug("Storage Directories: {}".format(
+        json.dumps(storage_directories, indent=4, sort_keys=True)))
     choices = {}
     for storage_dir in storage_directories:
-        choices[storage_dir['description']] = storage_dir['resource_uri']
-    choices['Default location'] = '/api/v2/location/default/{}/'.format(purpose)
-    job.pyprint(choices)
+        label = storage_dir['description']
+        if not label:
+            label = storage_dir['relative_path']
+        choices[storage_dir['uuid']] = {
+            "description": label, "uri": storage_dir['resource_uri']}
+    choices['default'] = {
+        "description": "Default Location",
+        "uri": "/api/v2/location/default/{}/".format(purpose)}
+    job.pyprint(json.dumps(choices, indent=4, sort_keys=True))
 
 
 def call(jobs):

--- a/src/MCPServer/lib/linkTaskManagerGetUserChoiceFromMicroserviceGeneratedList.py
+++ b/src/MCPServer/lib/linkTaskManagerGetUserChoiceFromMicroserviceGeneratedList.py
@@ -70,11 +70,14 @@ class linkTaskManagerGetUserChoiceFromMicroserviceGeneratedList(LinkTaskManager)
             if isinstance(item, ChoicesDict):
                 # For display, convert the ChoicesDict passVar into a list
                 # of tuples: (index, description, replacement dict string)
-                for description, value in item.items():
-                    description = TranslationLabel(description)
+                for _, value in item.items():
+                    description = TranslationLabel(value["description"])
                     self.choices.append(
-                        (index, description, str({key: value})))
+                        (index, description, str({key: value["uri"]})))
                     index += 1
+                # We don't need to maintain state, and we can't easily update
+                # or use the passVar list below in proceedWithChoice if we do.
+                self.jobChainLink.passVar.remove(item)
                 break
         else:
             errmsg = "ChoicesDict not found in passVar: {}".format(

--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -310,7 +310,10 @@ class ProcessingConfigurationForm(forms.Form):
                     _('Default location'))
                 )
                 for loc in get_storage_locations(purpose=field['purpose']):
-                    choices.append((loc['resource_uri'], loc['description']))
+                    label = loc['description']
+                    if not label:
+                        label = loc['relative_path']
+                    choices.append((loc['resource_uri'], label))
             self.fields[choice_uuid] = forms.ChoiceField(
                 widget=Select(attrs={'class': 'form-control'}), **opts)
 


### PR DESCRIPTION
In this PR I construct a new data structure to return from 'Job: Retrieve storage locations' this data structure is designed to avoid indexes being overwritten by empty values. The data structure looks as follows:

```
{
    "7f111c13-a54d-49bb-8b75-b3eae94c2a27": {
        "description": "/var/archivematica/AIPsStore/2", 
        "uri": "/api/v2/location/7f111c13-a54d-49bb-8b75-b3eae94c2a27/"
    }, 
    "b2113a69-ecb9-4a4c-b81d-9983de3657b7": {
        "description": "Store AIP in standard Archivematica Directory", 
        "uri": "/api/v2/location/b2113a69-ecb9-4a4c-b81d-9983de3657b7/"
    }, 
    "d13cc6f5-6d8c-4f4f-943e-73a68ad30335": {
        "description": "/var/archivematica/AIPsStore/3", 
        "uri": "/api/v2/location/d13cc6f5-6d8c-4f4f-943e-73a68ad30335/"
    }, 
    "default": {
        "description": "Default Location", 
        "uri": "/api/v2/location/default/AS/"
    }
}
```

Storage locations are required to be displayed, and used, by `Job: Store AIP location`. As described in archivematica/issues#456 if a storage location is blank, or is a duplicate to another description, then the storage locations list will be incomplete - duplicate values overwrite each other. 

In the example above, we would will now see:
```
Default Location
Store AIP in standard Archivematica Directory
/var/archivematica/AIPsStore/2
/var/archivematica/AIPsStore/3
```

Where previously their descriptions being blank would mean we see:
```
Default Location
Store AIP in standard Archivematica Directory

```

**NB.** The last field is simply blank, and to the end-user could be one of either `AIPsStore/2` or `AIPsStore/3`. 

As discussed in `#456` the module `linkTaskManagerGetUserChoiceFromMicroserviceGeneratedList.py` is used only by the Store AIP functionality in Archivematica. 

As such, the change to the way it queries the data structure that is now passed to it, should have very little impact other than to make it more robust than perhaps the dictionary sent to it. 

The structure once consumed is removed from the global `passVar` variable. There seems little reason maintaining it here. Once the user has made a choice a modified version of the structure is sent back and added to `passVar` in `proceedWithChoice(...)`. 

A more simple change has been made to `administration/forms.py` where there was a similar issue. In the processing configuration we use a list to store these values so we would see two blank values - none was overwritten by the other. Here we simply output the path in lieu of something more descriptive. 

Both changes have been tested and show to work well in concert with one-another. 

I ran out of time to develop unit tests for either change unfortunately.

Connected to archivematica/issues#456 
