### PR TITLE
Write external identifier to bag-info.txt

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -4527,7 +4527,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"create\" \"%SIPDirectory%%SIPName%-%SIPUUID%\" \"%SIPDirectory%\" \"logs/\" \"objects/\" \"METS.%SIPUUID%.xml\" \"README.html\" \"thumbnails/\" \"metadata/\" --writer \"filesystem\"",
+                "arguments": "\"create\" \"%SIPDirectory%%SIPName%-%SIPUUID%\" \"%SIPDirectory%\" \"logs/\" \"objects/\" \"METS.%SIPUUID%.xml\" \"README.html\" \"thumbnails/\" \"metadata/\" --writer \"filesystem\" --sipUUID \"%SIPUUID%\"",
                 "execute": "bagit_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,


### PR DESCRIPTION
Since the bag tool doesn't support specifying this field explicitly, it gets written to a `bag-info.txt` in a temporary directory which is passed in on the command line.

This connects to https://github.com/archivematica/Issues/issues/492.