### PR TITLE
Escape arguments fields consistently

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -2588,7 +2588,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "%SIPUUID%'' ''%SIPDirectory%metadata/rights.csv",
+                "arguments": "\"%SIPUUID%\" \"%SIPDirectory%metadata/rights.csv\"",
                 "execute": "rightsFromCSV_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -3874,7 +3874,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%SIPDirectory%\" \"%SIPUUID%\" \"%processingDirectory%\"  %sharedPath%",
+                "arguments": "\"%SIPDirectory%\" \"%SIPUUID%\" \"%processingDirectory%\" \"%sharedPath%\"",
                 "execute": "extractBagTransfer_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -3943,7 +3943,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "%SIPUUID% %SIPDirectory%",
+                "arguments": "\"%SIPUUID%\" \"%SIPDirectory%\"",
                 "execute": "parseMETStoDB_v1.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -4527,7 +4527,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "create \"%SIPDirectory%%SIPName%-%SIPUUID%\" \"%SIPDirectory%\" \"logs/\" \"objects/\" \"METS.%SIPUUID%.xml\" \"README.html\" \"thumbnails/\" \"metadata/\" --writer filesystem",
+                "arguments": "\"create\" \"%SIPDirectory%%SIPName%-%SIPUUID%\" \"%SIPDirectory%\" \"logs/\" \"objects/\" \"METS.%SIPUUID%.xml\" \"README.html\" \"thumbnails/\" \"metadata/\" --writer \"filesystem\"",
                 "execute": "bagit_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -5776,7 +5776,7 @@
             "config": {
                 "@manager": "linkTaskManagerFiles",
                 "@model": "StandardTaskConfig",
-                "arguments": "access \"%fileUUID%\" \"%relativeLocation%\" \"%SIPDirectory%\" \"%SIPUUID%\" \"%taskUUID%\" \"service\"",
+                "arguments": "\"access\" \"%fileUUID%\" \"%relativeLocation%\" \"%SIPDirectory%\" \"%SIPUUID%\" \"%taskUUID%\" \"service\"",
                 "execute": "normalize_v1.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -6358,7 +6358,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "--url=\"%url%\"  --email=\"%email%\" --password=\"%password%\" --uuid=\"%SIPUUID%\" --debug=\"%debug%\" --version=\"%version%\" --rsync-command=\"%rsync_command%\" --rsync-target=\"%rsync_target%\"",
+                "arguments": "--url=\"%url%\" --email=\"%email%\" --password=\"%password%\" --uuid=\"%SIPUUID%\" --debug=\"%debug%\" --version=\"%version%\" --rsync-command=\"%rsync_command%\" --rsync-target=\"%rsync_target%\"",
                 "execute": "upload-qubit_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -6469,7 +6469,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "%SIPUUID% \"%SIPDirectory%\"",
+                "arguments": "\"%SIPUUID%\" \"%SIPDirectory%\"",
                 "execute": "parseExternalMETS",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -8655,7 +8655,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "%SIPDirectory%",
+                "arguments": "\"%SIPDirectory%\"",
                 "execute": "convertDataverseStructure_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -9812,7 +9812,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "%SIPUUID%",
+                "arguments": "\"%SIPUUID%\"",
                 "execute": "hasPackages_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -10060,7 +10060,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "%SIPUUID%",
+                "arguments": "\"%SIPUUID%\"",
                 "execute": "hasPackages_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -11080,7 +11080,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "%AIPCompressionAlgorithm% %AIPCompressionLevel% %SIPDirectory% %SIPName% %SIPUUID%",
+                "arguments": "\"%AIPCompressionAlgorithm%\" \"%AIPCompressionLevel%\" \"%SIPDirectory%\" \"%SIPName%\" \"%SIPUUID%\"",
                 "execute": "compressAIP_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -12250,7 +12250,7 @@
             "config": {
                 "@manager": "linkTaskManagerFiles",
                 "@model": "StandardTaskConfig",
-                "arguments": "access \"%fileUUID%\" \"%relativeLocation%\" \"%SIPDirectory%\" \"%SIPUUID%\" \"%taskUUID%\" \"original\"",
+                "arguments": "\"access\" \"%fileUUID%\" \"%relativeLocation%\" \"%SIPDirectory%\" \"%SIPUUID%\" \"%taskUUID%\" \"original\"",
                 "execute": "normalize_v1.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -13101,7 +13101,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "%SIPDirectory% %SIPUUID%",
+                "arguments": "\"%SIPDirectory%\" \"%SIPUUID%\"",
                 "execute": "parseDataverse_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,


### PR DESCRIPTION
In this commit we escape all 'arguments' fields to be consistent
across the file. The main purpose of this is to ensure that
template values such as %SIPDirectory% do not get expanded and
then interpreted as multiple arguments via libraries such as shlex
because the directory name contains spaces.

Connected to archivematica/issues#511
Connected to archivematica/issues#503

**NB.** For those reviewing, the original entry for this line, https://github.com/artefactual/archivematica/pull/1350/files#diff-0943b1a41fef63182f0440965ba23499L2591 - I felt that was a bug so removed the single-quotes. I can't think of a functional reason for them being there? 