### PR TITLE
Point validate formats job to correct variable link pull

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -8868,7 +8868,7 @@
                 }
             },
             "fallback_job_status": "Failed",
-            "fallback_link_id": "dae3c416-a8c2-4515-9081-6dbd7b265388",
+            "fallback_link_id": "ec3c965c-c056-47e3-a551-ad1966e00824",
             "group": {
                 "en": "Validation",
                 "es": "Validación",


### PR DESCRIPTION
This commit sees the validate formats job point to the correct
microservice job to 'Determine if Dataverse METS XML needs to be
parsed' if the job fails. Previously it would skip this step if
validation failed which caused errors in the ingest workflow
related to indexing the right components of the AIP.

Connected to https://github.com/archivematica/Issues/issues/513

**NB.** For @sromkey or @evelynPM if you want to test this, then we'll get the purest result where JHOVE is expected to fail on RPM or CentOS for this transfer. 

For others, you can simulate the issue by changing the `if name main` entry point in the FPR script for JHOVE to:
```python
if __name__ == '__main__':
    target = sys.argv[1]
    sys.exit(1)
```
Where `sys.exit(1)` indicates a failure. 

This is the result in my docker-compose environment, where you can see the `parse external files` microservice run, under either a pass or fail condition:

![image](https://user-images.githubusercontent.com/1880412/53305371-225d7e80-3881-11e9-8d9e-694da751dbcd.png)
