### PR TITLE
MCPServer: link activeAgent to transfer

### DIFF
--- a/src/MCPServer/lib/RPCServer.py
+++ b/src/MCPServer/lib/RPCServer.py
@@ -241,6 +241,7 @@ class RPCServer(GearmanWorker):
             payload.get("access_system_id"),
             payload.get("path"),
             payload.get("metadata_set_id"),
+            payload.get("user_id"),
             self.workflow,
         )
         kwargs = {

--- a/src/MCPServer/lib/package.py
+++ b/src/MCPServer/lib/package.py
@@ -25,12 +25,13 @@ from tempfile import mkdtemp
 from uuid import uuid4
 
 from django.conf import settings as django_settings
+from django.utils import six
 
 from archivematicaFunctions import unicodeToStr
 from databaseFunctions import auto_close_db
 from executor import Executor
 from jobChain import jobChain
-from main.models import Transfer, TransferMetadataSet
+from main.models import Transfer, TransferMetadataSet, UnitVariable
 import storageService as storage_service
 from unitTransfer import unitTransfer
 
@@ -254,7 +255,7 @@ def _move_to_internal_shared_dir(filepath, dest, transfer):
 
 
 def create_package(name, type_, accession, access_system_id, path,
-                   metadata_set_id, workflow, auto_approve=True,
+                   metadata_set_id, user_id, workflow, auto_approve=True,
                    wait_until_complete=False, processing_config=None):
     """Launch transfer and return its object immediately.
 
@@ -274,6 +275,10 @@ def create_package(name, type_, accession, access_system_id, path,
         raise ValueError('No path provided.')
     if isinstance(auto_approve, bool) is False:
         raise ValueError('Unexpected value in auto_approve parameter')
+    try:
+        int(user_id)
+    except (TypeError, ValueError):
+        raise ValueError('Unexpected value in user_id parameter')
 
     # Create Transfer object.
     kwargs = {'uuid': str(uuid4())}
@@ -289,6 +294,9 @@ def create_package(name, type_, accession, access_system_id, path,
             pass
     transfer = Transfer.objects.create(**kwargs)
     logger.debug('Transfer object created: %s', transfer.pk)
+    UnitVariable.objects.create(
+        unittype="Transfer", unituuid=transfer.uuid,
+        variable="activeAgent", variablevalue=six.text_type(user_id))
 
     @auto_close_db
     def _start(transfer, name, type_, path):

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -253,7 +253,7 @@ class Event(models.Model):
 
     def __unicode__(self):
         return six.text_type(_('%(type)s event on %(file_uuid)s (%(detail)s)') % {
-            'type': self.even_type,
+            'type': self.event_type,
             'file_uuid': self.file_uuid,
             'detail': self.event_detail
         })


### PR DESCRIPTION
Ensure that a new transfer created by the new `package` module has a linked
"activeAgent".

This should be enough to have the logged-in user recorded as an
Agent for Events during transfer.

This is connected to https://github.com/archivematica/Issues/issues/529.