### PR TITLE
RPCServer: restore access_system_id property

### DIFF
--- a/src/MCPServer/lib/RPCServer.py
+++ b/src/MCPServer/lib/RPCServer.py
@@ -366,8 +366,11 @@ class RPCServer(GearmanWorker):
             jobs = Job.objects.filter(sipuuid=unit_id).order_by("-createdtime")
             if jobs:
                 item["directory"] = jobs[0].get_directory_name()
-            # Embed accession ID in status data (for DRMC customization)
-            if isinstance(model, Transfer):
+            # Embed "Access System ID" in status data (used in Upload DIP).
+            # `access_system_id` is a property of the Transfer model - the
+            # only way we have at the moment to look up the Transfer is by
+            # using the files in common.
+            if model is SIP:
                 try:
                     trfs = Transfer.objects.filter(
                         file__sip_id=item["uuid"]).distinct()


### PR DESCRIPTION
The status of ingest/transfer was moved to MCPServer and merged into a single
function. A branch in the code responsible for populating `access_system_id`
for SIP objects was not being executed because a condition was not adequate.
The behaviour expected in the frontend wasn't triggered because
`access_system_id` was not being included in the status data. This commit
restores the property.

Introduced by https://github.com/artefactual/archivematica/pull/1251.

This is connected to https://github.com/archivematica/Issues/issues/528.