### PR TITLE
MCPClient: set activeAgent fallback in ingest

### DIFF
--- a/src/MCPServer/lib/package.py
+++ b/src/MCPServer/lib/package.py
@@ -25,13 +25,12 @@ from tempfile import mkdtemp
 from uuid import uuid4
 
 from django.conf import settings as django_settings
-from django.utils import six
 
 from archivematicaFunctions import unicodeToStr
 from databaseFunctions import auto_close_db
 from executor import Executor
 from jobChain import jobChain
-from main.models import Transfer, TransferMetadataSet, UnitVariable
+from main.models import Transfer, TransferMetadataSet
 import storageService as storage_service
 from unitTransfer import unitTransfer
 
@@ -293,10 +292,8 @@ def create_package(name, type_, accession, access_system_id, path,
         except TransferMetadataSet.DoesNotExist:
             pass
     transfer = Transfer.objects.create(**kwargs)
+    transfer.update_active_agent(user_id)
     logger.debug('Transfer object created: %s', transfer.pk)
-    UnitVariable.objects.create(
-        unittype="Transfer", unituuid=transfer.uuid,
-        variable="activeAgent", variablevalue=six.text_type(user_id))
 
     @auto_close_db
     def _start(transfer, name, type_, path):

--- a/src/MCPServer/lib/unit.py
+++ b/src/MCPServer/lib/unit.py
@@ -77,6 +77,8 @@ class unit:
         upsert `UnitVariable` rows for this unit. This is triggered by
         execution of a workflow chain link of type
         'linkTaskManagerSetUnitVariable'.
+
+        TODO: use Transfer/SIP model methods.
         """
         if not variableValue:
             variableValue = ""

--- a/src/dashboard/tests/test_models.py
+++ b/src/dashboard/tests/test_models.py
@@ -1,0 +1,46 @@
+import os
+
+from django.test import TestCase
+
+from main.models import SIP, Transfer, UnitVariable, User
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestActiveAgent(TestCase):
+    fixture_files = ['test_user.json']
+    fixtures = [os.path.join(THIS_DIR, 'fixtures', p) for p in fixture_files]
+
+    def test_transfer_update_active_agent(self):
+        user = User.objects.get(id=1)
+        transfer = Transfer.objects.create()
+        transfer.update_active_agent(user.id)
+        assert UnitVariable.objects.get(
+            unittype="Transfer", unituuid=transfer.uuid,
+            variable="activeAgent", variablevalue=user.userprofile.agent_id)
+
+    def test_sip_update_active_agent(self):
+        user = User.objects.get(id=1)
+        sip = SIP.objects.create()
+        sip.update_active_agent(user.id)
+        assert UnitVariable.objects.get(
+            unittype="SIP", unituuid=sip.uuid,
+            variable="activeAgent", variablevalue=user.userprofile.agent_id)
+
+    def test_unitvariable_update_variable(self):
+        obj, created = UnitVariable.objects.update_variable(
+            "UNIT_TYPE", "UNIT_ID", "VARIABLE", "VALUE", "LINK_ID")
+        assert created is True
+        assert isinstance(obj, UnitVariable)
+        UnitVariable.objects.get(
+            unittype="UNIT_TYPE", unituuid="UNIT_ID", variable="VARIABLE",
+            variablevalue="VALUE", microservicechainlink="LINK_ID")
+
+        obj, created = UnitVariable.objects.update_variable(
+            "UNIT_TYPE", "UNIT_ID", "VARIABLE", "NEW_VALUE", "NEW_LINK_ID")
+        assert created is False
+        assert isinstance(obj, UnitVariable)
+        UnitVariable.objects.get(
+            unittype="UNIT_TYPE", unituuid="UNIT_ID", variable="VARIABLE",
+            variablevalue="NEW_VALUE", microservicechainlink="NEW_LINK_ID")


### PR DESCRIPTION
Set `activeAgent` to the value used in Transfer to ensure the existence of the
user agent in PREMIS events. This value may change as soon as a different user
interacts with the user interface in processing, but this commit is useful when
interactions do not occur.

Follow-up for https://github.com/artefactual/archivematica/pull/1354.

Connects to https://github.com/archivematica/Issues/issues/529.