### PR TITLE
FPR: fix downgrade path in migration fpr.0029

### DIFF
--- a/src/dashboard/src/fpr/migrations/0029_update_inkscape_svg_command.py
+++ b/src/dashboard/src/fpr/migrations/0029_update_inkscape_svg_command.py
@@ -60,11 +60,14 @@ def data_migration_down(apps, schema_editor):
     FPCommand = apps.get_model('fpr', 'FPCommand')
     FPRule = apps.get_model('fpr', 'FPRule')
 
-    FPCommand.objects.filter(uuid=NEW_INKSCAPE_CMD_UUID).delete()
-
+    # The order matters. We make sure that the rules point to the previous
+    # command before the latter is deleted. Otherwise our rules would be
+    # deleted by Django's on cascade mechanism.
     FPRule.objects \
         .filter(uuid__in=INKSCAPE_SVG_RULES) \
         .update(command_id=OLD_INKSCAPE_CMD_UUID)
+
+    FPCommand.objects.filter(uuid=NEW_INKSCAPE_CMD_UUID).delete()
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
I had the data `data_migration_down` added but I didn't test it. It turned out to be broken.

---

This commit fixes the `data_migration_down` function in the migration
introduced by the previous commit to ensure that the order of the operations
is incorrect and the migration can be properly reverted.

Connects to https://github.com/archivematica/Issues/issues/537.