### PR TITLE
Reduce the need to access the disk in ES scripts

### DIFF
--- a/src/MCPClient/lib/clientScripts/index_aip.py
+++ b/src/MCPClient/lib/clientScripts/index_aip.py
@@ -19,6 +19,7 @@ django.setup()
 
 from django.conf import settings as mcpclient_settings
 
+
 logger = get_script_logger("archivematica.mcp.client.indexAIP")
 
 
@@ -42,28 +43,21 @@ def get_identifiers(job, sip_path):
 
 
 def index_aip(job):
-    """ Write AIP information to ElasticSearch. """
-    sip_uuid = job.args[1]  # %SIPUUID%
-    sip_name = job.args[2]  # %SIPName%
-    sip_path = job.args[3]  # %SIPDirectory%
-    sip_type = job.args[4]  # %SIPType%
-
+    """Write AIP information to ElasticSearch. """
+    sip_uuid = job.args[1]          # %SIPUUID%
+    sip_name = job.args[2]          # %SIPName%
+    sip_staging_path = job.args[3]  # %SIPDirectory%
+    sip_type = job.args[4]          # %SIPType%
     if 'aips' not in mcpclient_settings.SEARCH_ENABLED:
         logger.info('Skipping indexing: AIPs indexing is currently disabled.')
         return 0
-
     elasticSearchFunctions.setup_reading_from_conf(mcpclient_settings)
     client = elasticSearchFunctions.get_client()
-
     aip_info = storage_service.get_file_info(uuid=sip_uuid)
     job.pyprint('AIP info:', aip_info)
     aip_info = aip_info[0]
-
-    mets_name = 'METS.{}.xml'.format(sip_uuid)
-    mets_path = os.path.join(sip_path, mets_name)
-
-    identifiers = get_identifiers(job, sip_path)
-
+    mets_staging_path = os.path.join(sip_staging_path, 'METS.{}.xml'.format(sip_uuid))
+    identifiers = get_identifiers(job, sip_staging_path)
     # If this is an AIC, find the number of AIP stored in it and index that
     aips_in_aic = None
     if sip_type == "AIC":
@@ -74,13 +68,11 @@ def index_aip(job):
             aips_in_aic = uv.variablevalue
         except UnitVariable.DoesNotExist:
             pass
-
     # Delete ES index before creating new one if reingesting
     if 'REIN' in sip_type:
         job.pyprint('Deleting outdated entry for AIP and AIP files with UUID', sip_uuid, 'from archival storage')
         elasticSearchFunctions.delete_aip(client, sip_uuid)
         elasticSearchFunctions.delete_aip_files(client, sip_uuid)
-
     job.pyprint('Indexing AIP and AIP files')
     # Even though we treat MODS identifiers as SIP-level, we need to index them
     # here because the archival storage tab actually searches on the
@@ -88,19 +80,17 @@ def index_aip(job):
     ret = elasticSearchFunctions.index_aip_and_files(
         client=client,
         uuid=sip_uuid,
-        path=aip_info['current_full_path'],
-        mets_path=mets_path,
+        aip_stored_path=aip_info['current_full_path'],
+        mets_staging_path=mets_staging_path,
         name=sip_name,
-        size=aip_info['size'],
+        aip_size=aip_info['size'],
         aips_in_aic=aips_in_aic,
         identifiers=identifiers,
         encrypted=aip_info['encrypted'],
         printfn=job.pyprint,
     )
-
     if ret == 1:
         job.pyprint('Error indexing AIP and AIP files', file=sys.stderr)
-
     return ret
 
 

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -364,40 +364,35 @@ def _get_index_settings():
 # ---------------
 
 
-def index_aip_and_files(client, uuid, path, mets_path, name, size=None, aips_in_aic=None, identifiers=[], encrypted=False, printfn=print):
+def index_aip_and_files(
+        client, uuid, aip_stored_path, mets_staging_path, name, aip_size,
+        aips_in_aic=None, identifiers=[], encrypted=False, printfn=print):
     """Index AIP and AIP files with UUID `uuid` at path `path`.
 
     :param client: The ElasticSearch client.
     :param uuid: The UUID of the AIP we're indexing.
-    :param path: path on disk where the AIP is located.
-    :param path: path on disk where the AIP's METS file is located.
+    :param aip_stored_path: path on disk where the AIP is located.
+    :param mets_staging_path: path on disk where the AIP METS file is located.
     :param name: AIP name.
-    :param size: optional AIP size.
+    :param aip_size: AIP size.
     :param aips_in_aic: optional number of AIPs stored in AIC.
     :param identifiers: optional additional identifiers (MODS, Islandora, etc.).
     :param identifiers: optional AIP encrypted boolean (defaults to `False`).
     :param printfn: optional print funtion.
     :return: 0 is succeded, 1 otherwise.
     """
-    # Stop if AIP or METS file don't not exist
+    # Stop if AIP or METS file don't not exist.
     error_message = None
-    if not os.path.exists(path):
-        error_message = 'AIP does not exist at: ' + path
-    if not os.path.exists(mets_path):
-        error_message = 'METS file does not exist at: ' + mets_path
+    if not os.path.exists(mets_staging_path):
+        error_message = 'METS file does not exist at: ' + mets_staging_path
     if error_message:
         logger.error(error_message)
         printfn(error_message, file=sys.stderr)
         return 1
-
     printfn('AIP UUID: ' + uuid)
     printfn('Indexing AIP ...')
-
-    tree = ElementTree.parse(mets_path)
-
-    # TODO: Add a conditional to toggle this
+    tree = ElementTree.parse(mets_staging_path)
     _remove_tool_output_from_mets(tree)
-
     root = tree.getroot()
     # Extract AIC identifier, other specially-indexed information
     aic_identifier = None
@@ -408,28 +403,23 @@ def index_aip_and_files(client, uuid, path, mets_path, name, size=None, aips_in_
         if aip_type == 'Archival Information Collection':
             aic_identifier = dublincore.findtext('dc:identifier', namespaces=ns.NSMAP) or dublincore.findtext('dcterms:identifier', namespaces=ns.NSMAP)
         is_part_of = dublincore.findtext('dcterms:isPartOf', namespaces=ns.NSMAP)
-
     # Convert METS XML to dict
     xml = ElementTree.tostring(root)
     mets_data = _rename_dict_keys_with_child_dicts(_normalize_dict_values(xmltodict.parse(xml)))
-
     # Pull the create time from the METS header
     mets_hdr = root.find('mets:metsHdr', namespaces=ns.NSMAP)
     mets_created_attr = mets_hdr.get('CREATEDATE')
-
     created = time.time()
-
     if mets_created_attr:
         try:
             created = calendar.timegm(time.strptime(mets_created_attr, '%Y-%m-%dT%H:%M:%S'))
         except ValueError:
             printfn('Failed to parse METS CREATEDATE: %s' % (mets_created_attr))
-
     aip_data = {
         'uuid': uuid,
         'name': name,
-        'filePath': path,
-        'size': (size or os.path.getsize(path)) / 1024 / 1024,
+        'filePath': aip_stored_path,
+        'size': aip_size,
         'mets': mets_data,
         'origin': get_dashboard_uuid(),
         'created': created,
@@ -443,17 +433,15 @@ def index_aip_and_files(client, uuid, path, mets_path, name, size=None, aips_in_
     _wait_for_cluster_yellow_status(client)
     _try_to_index(client, aip_data, 'aips', printfn=printfn)
     printfn('Done.')
-
     printfn('Indexing AIP files ...')
     files_indexed = _index_aip_files(
         client=client,
         uuid=uuid,
-        mets_path=mets_path,
+        mets_path=mets_staging_path,
         name=name,
         identifiers=identifiers,
         printfn=printfn,
     )
-
     printfn('Files indexed: ' + str(files_indexed))
     return 0
 


### PR DESCRIPTION
This commit removes the need to test the existence of an AIP on disk
when being indexed by our elasticsearch scripts by sending the
statistics that we are already in possession of when that script is
called. Additionally variables are cleaned up to perhaps be a bit
more intuitive to future readers of this code.

Connected to archivematica/issues#559