### PR TITLE
Bump version to 1.10.0

### DIFF
--- a/src/archivematicaCommon/lib/version.py
+++ b/src/archivematicaCommon/lib/version.py
@@ -1,4 +1,4 @@
-ARCHIVEMATICA_VERSION = (1, 9, 0)
+ARCHIVEMATICA_VERSION = (1, 10, 0)
 
 
 def get_version():

--- a/src/dashboard/src/main/migrations/0068_version_number.py
+++ b/src/dashboard/src/main/migrations/0068_version_number.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""Migrate the Archivematica agent version string to Archivematica-1.9."""
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def data_migration_down(apps, _):
+    """Undo the migration if requested."""
+    agent = apps.get_model("main", "Agent")
+    agent.objects.filter(
+        identifiertype="preservation system", name="Archivematica"
+    ).update(identifiervalue="Archivematica-1.9")
+
+
+def data_migration_up(apps, _):
+    """Update the application agent version in the database."""
+    agent = apps.get_model("main", "Agent")
+    agent.objects.filter(
+        identifiertype="preservation system", name="Archivematica"
+    ).update(identifiervalue="Archivematica-1.10")
+
+
+class Migration(migrations.Migration):
+    """Run the migration to update the Archivematica agent version string."""
+
+    dependencies = [("main", "0067_delete_workflow_models")]
+
+    operations = [migrations.RunPython(data_migration_up, data_migration_down)]


### PR DESCRIPTION
The "preservation system" agent is still a database object, this is the usual
migration that bumps its version (see #383).

Connects to https://github.com/archivematica/Issues/issues/582.