### PR TITLE
Add import support for self-describing backlog transfers

### DIFF
--- a/src/MCPClient/lib/clientScripts/copy_transfer_submission_documentation.py
+++ b/src/MCPClient/lib/clientScripts/copy_transfer_submission_documentation.py
@@ -28,7 +28,8 @@ import shutil
 import django
 
 django.setup()
-# dashboard
+
+from bag import is_bag
 from main.models import File, SIP
 
 
@@ -87,5 +88,12 @@ def call(jobs):
                             job.pyprint(item_path, " -> ", dst)
                             shutil.copytree(item_path, dst)
                 else:
+                    if is_bag(transferLocation):
+                        src = os.path.join(
+                            transferLocation,
+                            "data",
+                            "metadata",
+                            "submissionDocumentation",
+                        )
                     job.pyprint(src, " -> ", dst)
                     shutil.copytree(src, dst)

--- a/src/MCPClient/lib/clientScripts/copy_transfers_metadata_and_logs.py
+++ b/src/MCPClient/lib/clientScripts/copy_transfers_metadata_and_logs.py
@@ -30,7 +30,8 @@ import traceback
 import django
 
 django.setup()
-# dashboard
+
+from bag import is_bag
 from main.models import File, SIP
 
 
@@ -55,6 +56,14 @@ def main(
         try:
             if sharedPath != "":
                 transferPath = transferPath.replace("%sharedPath%", sharedPath, 1)
+
+            if is_bag(transferPath):
+                transfer_logs_dir = os.path.join(transferPath, "data", "logs")
+                transfer_md_dir = os.path.join(transferPath, "data", "metadata")
+            else:
+                transfer_logs_dir = os.path.join(transferPath, "logs")
+                transfer_md_dir = os.path.join(transferPath, "metadata")
+
             transferBasename = os.path.basename(os.path.abspath(transferPath))
 
             # Copy transfer metadata
@@ -69,7 +78,7 @@ def main(
                     transfersMetadataDirectory, transferBasename
                 )
                 os.makedirs(transferMetaDestDir)
-                transferMetadataDirectory = os.path.join(transferPath, "metadata")
+                transferMetadataDirectory = transfer_md_dir
             if not os.path.exists(transferMetadataDirectory):
                 continue
             for met in os.listdir(transferMetadataDirectory):
@@ -88,7 +97,7 @@ def main(
                 transfersLogsDirectory, transferBasename
             )
             os.makedirs(transfersLogsDestDir)
-            src = os.path.join(transferPath, "logs")
+            src = transfer_logs_dir
             dst = os.path.join(transfersLogsDestDir, "logs")
             shutil.copytree(src, dst)
             job.pyprint("copied: ", src, " -> ", dst)

--- a/src/MCPClient/lib/clientScripts/create_transfer_mets.py
+++ b/src/MCPClient/lib/clientScripts/create_transfer_mets.py
@@ -636,9 +636,8 @@ def rights_to_premis(rights, file_uuid):
     else:
         rights_basis = "Other"
 
-    premis_data = (
+    rights_statement = (
         "rights_statement",
-        PREMIS_META,
         (
             "rights_statement_identifier",
             ("rights_statement_identifier_type", id_type),
@@ -651,31 +650,33 @@ def rights_to_premis(rights, file_uuid):
     if basis_type == "copyright":
         copyright_info = get_premis_copyright_information(rights)
         if copyright_info:
-            premis_data += (copyright_info,)
+            rights_statement += (copyright_info,)
     elif basis_type == "license":
         license_info = get_premis_license_information(rights)
         if license_info:
-            premis_data += (license_info,)
+            rights_statement += (license_info,)
     elif basis_type == "statute":
         statute_info = get_premis_statute_information(rights)
         if statute_info:
-            premis_data += (statute_info,)
+            rights_statement += (statute_info,)
     elif basis_type == "other":
         other_info = get_premis_other_rights_information(rights)
         if other_info:
-            premis_data += (other_info,)
+            rights_statement += (other_info,)
 
     rights_info = get_premis_rights_granted(rights)
     if rights_info:
-        premis_data += (rights_info,)
+        rights_statement += (rights_info,)
 
-    premis_data += (
+    rights_statement += (
         (
             "linking_object_identifier",
             ("linking_object_identifier_type", "UUID"),
             ("linking_object_identifier_value", file_uuid),
         ),
     )
+
+    premis_data = ("rights", PREMIS_META, rights_statement)
 
     return metsrw.plugins.premisrw.data_to_premis(
         premis_data, premis_version=PREMIS_META["version"]

--- a/src/MCPClient/lib/clientScripts/create_transfer_mets.py
+++ b/src/MCPClient/lib/clientScripts/create_transfer_mets.py
@@ -320,7 +320,7 @@ def get_premis_object_characteristics_extension(documents):
         # This only covers the UTF-8 and ASCII cases.
         xml_element = etree.fromstring(document.content.encode("utf-8"))
 
-        extensions += ("object_characteristics_extension", xml_element)
+        extensions += (("object_characteristics_extension", xml_element),)
 
     return extensions
 
@@ -548,8 +548,9 @@ def file_obj_to_premis(file_obj):
             ),
         ),
     )
+
     if object_characteristics_extensions:
-        object_characteristics += (object_characteristics_extensions,)
+        object_characteristics += object_characteristics_extensions
 
     # Add mandatory ``xsi:type`` attribute to instance.
     premis_meta = PREMIS_META.copy()

--- a/src/MCPClient/lib/clientScripts/create_transfer_mets.py
+++ b/src/MCPClient/lib/clientScripts/create_transfer_mets.py
@@ -551,9 +551,13 @@ def file_obj_to_premis(file_obj):
     if object_characteristics_extensions:
         object_characteristics += (object_characteristics_extensions,)
 
+    # Add mandatory ``xsi:type`` attribute to instance.
+    premis_meta = PREMIS_META.copy()
+    premis_meta["xsi:type"] = "premis:file"
+
     premis_data = (
         "object",
-        PREMIS_META,
+        premis_meta,
         (
             "object_identifier",
             ("object_identifier_type", "UUID"),

--- a/src/MCPClient/lib/clientScripts/create_transfer_mets.py
+++ b/src/MCPClient/lib/clientScripts/create_transfer_mets.py
@@ -590,7 +590,7 @@ def event_to_premis(event):
         ),
         ("event_type", event.event_type),
         ("event_date_time", event.event_datetime),
-        ("event_detail", event.event_detail),
+        ("event_detail_information", ("event_detail", event.event_detail)),
         (
             "event_outcome_information",
             ("event_outcome", event.event_outcome),

--- a/src/MCPClient/lib/clientScripts/move_to_backlog.py
+++ b/src/MCPClient/lib/clientScripts/move_to_backlog.py
@@ -9,7 +9,6 @@ The local copy is removed.
 PREMIS events are created after this job runs as part of the workflow.
 """
 
-from copy import deepcopy
 import multiprocessing
 import os
 import pprint
@@ -150,7 +149,6 @@ def _record_backlog_event(transfer_id, transfer_path, created_at):
         transfer_path, "metadata", "submissionDocumentation", "METS.xml"
     )
     mets = metsrw.METSDocument().fromfile(mets_path)
-    hdr = deepcopy(mets.tree.find("mets:metsHdr", namespaces=metsrw.NAMESPACES))
 
     # Run all_files once, convert into a dict for faster lookups.
     fsentries = {entry.file_uuid: entry for entry in mets.all_files()}
@@ -175,15 +173,7 @@ def _record_backlog_event(transfer_id, transfer_path, created_at):
             agents=agents,
         )
 
-    # Ideally we would be doing something like the following::
-    #
-    #     >>> mets.write(mets_path, pretty_print=True)
-    #
-    # In practice, this is still not possible because metsrw is not performing
-    # roundtripping of ``metsHdr``. TODO: this needs to be fixed!
-    root = mets.serialize(fully_qualified=True)
-    root[0] = hdr  # metsHdr is the first element in the ``metsType`` sequence.
-    root.getroottree().write(mets_path, xml_declaration=True, pretty_print=True)
+    mets.write(mets_path, pretty_print=True)
 
 
 def main(job, transfer_id, transfer_path, created_at):

--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -6,7 +6,7 @@ django-extensions==1.1.1
 mysqlclient==1.3.9
 gearman==2.0.2
 lxml==3.5.0
-metsrw==0.3.4
+metsrw==0.3.7
 requests==2.21.0
 unidecode==0.04.19
 opf-fido==1.3.10

--- a/src/MCPClient/tests/test_create_transfer_mets.py
+++ b/src/MCPClient/tests/test_create_transfer_mets.py
@@ -329,6 +329,22 @@ def test_transfer_mets_objid(tmp_path, transfer):
 
 
 @pytest.mark.django_db
+def test_transfer_mets_accession_id(tmp_path, transfer):
+    transfer.accessionid = "12345"
+    transfer.save()
+    mets_path = tmp_path / "METS.xml"
+    write_mets(str(mets_path), str(tmp_path), "transferDirectory", transfer.uuid)
+    mets_doc = metsrw.METSDocument.fromfile(str(mets_path))
+    mets_xml = mets_doc.serialize()
+    alt_record_id = mets_xml.xpath(
+        ".//mets:metsHdr/mets:altRecordID", namespaces=mets_xml.nsmap
+    )[0]
+
+    assert alt_record_id.get("TYPE") == "Accession ID"
+    assert alt_record_id.text == "12345"
+
+
+@pytest.mark.django_db
 def test_transfer_mets_header(tmp_path, transfer, file_obj, dashboard_uuid):
     mets_path = tmp_path / "METS.xml"
     write_mets(str(mets_path), str(tmp_path), "transferDirectory", transfer.uuid)

--- a/src/MCPClient/tests/test_create_transfer_mets.py
+++ b/src/MCPClient/tests/test_create_transfer_mets.py
@@ -364,6 +364,22 @@ def test_transfer_mets_header(tmp_path, transfer, file_obj, dashboard_uuid):
 
 
 @pytest.mark.django_db
+def test_transfer_mets_premis_object_includes_type(
+    tmp_path, transfer, file_obj, fpcommand_output
+):
+    mets_path = tmp_path / "METS.xml"
+    write_mets(str(mets_path), str(tmp_path), "transferDirectory", transfer.uuid)
+    mets_doc = metsrw.METSDocument.fromfile(str(mets_path))
+    mets_xml = mets_doc.serialize()
+    premis_objects = mets_xml.xpath(".//premis:object", namespaces=PREMIS_NAMESPACES)
+
+    assert len(premis_objects) == 1
+
+    attr = "{%s}type" % PREMIS_NAMESPACES["xsi"]
+    assert premis_objects[0].get(attr) == "premis:file"
+
+
+@pytest.mark.django_db
 def test_transfer_mets_includes_fpcommand_output(
     tmp_path, transfer, file_obj, fpcommand_output
 ):

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -421,7 +421,7 @@
                 "pt_BR": "Enviar para o backlog",
                 "sv": "Skicka till backlogg"
             },
-            "link_id": "abd6d60c-d50f-4660-a189-ac1b34fafe85"
+            "link_id": "e6e553cf-85f5-4e2f-abf4-d276acd66f5a"
         },
         "76befd52-14c3-44f9-838f-15a4e01624b0": {
             "description": {
@@ -11799,6 +11799,40 @@
                 "en": "TRIM transfer",
                 "fr": "Transfert TRIM",
                 "pt_BR": "Transferência do TRIM "
+            }
+        },
+        "e6e553cf-85f5-4e2f-abf4-d276acd66f5a": {
+            "config": {
+                "@manager": "linkTaskManagerDirectories",
+                "@model": "StandardTaskConfig",
+                "arguments": "\"%SIPUUID%\" \"%relativeLocation%metadata/dc.json\"",
+                "execute": "saveDublinCore_v0.0",
+                "filter_file_end": null,
+                "filter_file_start": null,
+                "filter_subdir": null,
+                "stderr_file": null,
+                "stdout_file": null
+            },
+            "description": {
+                "en": "Serialize Dublin Core metadata to disk",
+                "pt_BR": "Seriar os metadados Dublin Core para o disco",
+                "sv": "Sänd Dublin Core metadata till disk som serie"
+            },
+            "exit_codes": {
+                "0": {
+                    "job_status": "Completed successfully",
+                    "link_id": "abd6d60c-d50f-4660-a189-ac1b34fafe85"
+                }
+            },
+            "fallback_job_status": "Failed",
+            "fallback_link_id": "abd6d60c-d50f-4660-a189-ac1b34fafe85",
+            "group": {
+                "en": "Create SIP from Transfer",
+                "es": "Crear SIP a partir de la transferencia",
+                "fr": "Créer un SIP à partir du Transfert",
+                "ja": "転送からSIPを作成する",
+                "pt_BR": "Crie SIP a partir da transferência",
+                "sv": "Skapa SIP från överföringspaket"
             }
         },
         "e76aec15-5dfa-4b14-9405-735863e3a6fa": {

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -125,7 +125,7 @@ def insertIntoFiles(
             sipUUID + "-" + transferUUID,
         )
 
-    File.objects.create(**kwargs)
+    return File.objects.create(**kwargs)
 
 
 def getAMAgentsForFile(fileUUID):

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -38,7 +38,6 @@ from main.models import (
     File,
     FPCommandOutput,
     SIP,
-    Transfer,
     UnitVariable,
 )
 
@@ -314,22 +313,6 @@ def createSIP(path, UUID=None, sip_type="SIP", diruuids=False, printfn=print):
     sip.save()
 
     return UUID
-
-
-def getAccessionNumberFromTransfer(UUID):
-    """
-    Fetches the accession number from a transfer, given its UUID.
-
-    :param str UUID: The UUID of the transfer, as a string.
-
-    :returns str: The accession number, as a string.
-    :raises ValueError: if the requested Transfer cannot be found.
-    """
-
-    try:
-        return Transfer.objects.get(uuid=UUID).accessionid
-    except Transfer.DoesNotExist:
-        raise ValueError("No Transfer found for UUID: {}".format(UUID))
 
 
 def deUnicode(unicode_string):

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -875,8 +875,8 @@ def _get_file_formats(f):
         "format_version__description",
         "format_version__format__group__description",
     ]
-    for puid, format, group in f.fileformatversion_set.all().values_list(*fields):
-        formats.append({"puid": puid, "format": format, "group": group})
+    for puid, fmt, group in f.fileformatversion_set.all().values_list(*fields):
+        formats.append({"puid": puid, "format": fmt, "group": group})
 
     return formats
 

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -86,7 +86,7 @@ def addFileToTransfer(
 ):
     if not originalLocation:
         originalLocation = filePathRelativeToSIP
-    insertIntoFiles(
+    file_obj = insertIntoFiles(
         fileUUID,
         filePathRelativeToSIP,
         date,
@@ -103,6 +103,7 @@ def addFileToTransfer(
         eventOutcomeDetailNote="",
     )
     addAccessionEvent(fileUUID, transferUUID, date)
+    return file_obj
 
 
 def addAccessionEvent(fileUUID, transferUUID, date):

--- a/src/archivematicaCommon/tests/test_database_functions.py
+++ b/src/archivematicaCommon/tests/test_database_functions.py
@@ -138,16 +138,3 @@ class TestDatabaseFunctions(TestCase):
         assert agents.get(id=1)
         assert agents.get(id=2)
         assert agents.get(id=5)
-
-    # getAccessionNumberFromTransfer
-
-    def test_get_accession_number_from_transfer(self):
-        accession_id = databaseFunctions.getAccessionNumberFromTransfer(
-            "5a8d0539-8e5a-4aa9-98d8-5e5053140398"
-        )
-        assert accession_id == "Accession ID"
-
-    def test_get_acession_number_from_transfer_raises(self):
-        with pytest.raises(ValueError) as excinfo:
-            databaseFunctions.getAccessionNumberFromTransfer("no such transfer")
-        assert "No Transfer found" in str(excinfo.value)

--- a/src/dashboard/src/components/rights/load.py
+++ b/src/dashboard/src/components/rights/load.py
@@ -5,18 +5,6 @@ module, we load a ``premisrw.PREMISRights`` object into the database.
 
 This module does not use the ``__`` notation for accessors offered by
 ``premisrw``.
-
-TODO:
-  * !! premisrw - fix start_date/end_date issue
-  * !! premisrw - lack of support for "role" attribute in premisrw (doc identifiers)
-
-Nice to have:
-  * (rights_granted)   termOfRestriction is not supported in the model.
-  * (rights_granted)   premisrw - support many rights_granted.restriction
-  * (rights_granted)   premisrw - support many rights_granted.rights_granted_note
-  * (rights_statement) linkingObjectIdentifier (minOccurs="0" maxOccurs="unbounded")
-  * (rights_statement) linkingAgentIdentifier (minOccurs="0" maxOccurs="unbounded")
-  * (rights_statement) support many statute objects
 """
 
 from __future__ import unicode_literals
@@ -37,9 +25,9 @@ from main.models import (
 )
 
 
-def load_rights(obj, rights_statement):
+def load_rights(obj, rights):
     """Populate ``PREMISRights`` into the database."""
-    return _create_rights_statement(_mdtype(obj), obj.uuid, rights_statement)
+    return _create_rights_statement(_mdtype(obj), obj.uuid, rights.rights_statement[0])
 
 
 def _create_rights_statement(md_type, obj_id, rights_statement):

--- a/src/dashboard/src/components/rights/load.py
+++ b/src/dashboard/src/components/rights/load.py
@@ -1,0 +1,418 @@
+"""Import ``PREMISRights``.
+
+Similar to ``rights_from_csv`` in that it imports rights statements. In this
+module, we load a ``premisrw.PREMISRights`` object into the database.
+
+This module does not use the ``__`` notation for accessors offered by
+``premisrw``.
+
+TODO:
+  * !! premisrw - fix start_date/end_date issue
+  * !! premisrw - lack of support for "role" attribute in premisrw (doc identifiers)
+
+Nice to have:
+  * (rights_granted)   termOfRestriction is not supported in the model.
+  * (rights_granted)   premisrw - support many rights_granted.restriction
+  * (rights_granted)   premisrw - support many rights_granted.rights_granted_note
+  * (rights_statement) linkingObjectIdentifier (minOccurs="0" maxOccurs="unbounded")
+  * (rights_statement) linkingAgentIdentifier (minOccurs="0" maxOccurs="unbounded")
+  * (rights_statement) support many statute objects
+"""
+
+from __future__ import unicode_literals
+
+import six
+
+from components.helpers import get_metadata_type_id_by_description
+from main.models import (
+    File,
+    Transfer,
+    SIP,
+    RightsStatement,
+    RightsStatementCopyright,
+    RightsStatementLicense,
+    RightsStatementRightsGranted,
+    RightsStatementStatuteInformation,
+    RightsStatementOtherRightsInformation,
+)
+
+
+def load_rights(obj, rights_statement):
+    """Populate ``PREMISRights`` into the database."""
+    return _create_rights_statement(_mdtype(obj), obj.uuid, rights_statement)
+
+
+def _create_rights_statement(md_type, obj_id, rights_statement):
+    """Populate ``RightsStatement`` from a ``PREMISRights`` object."""
+    db_stmt = RightsStatement.objects.create(
+        metadataappliestotype=md_type,
+        metadataappliestoidentifier=obj_id,
+        status="ORIGINAL",
+        rightsstatementidentifiertype=rights_statement.rights_statement_identifier_type,
+        rightsstatementidentifiervalue=rights_statement.rights_statement_identifier_value,
+        rightsbasis=rights_statement.rights_basis,
+    )
+
+    if db_stmt.rightsbasis == "Copyright":
+        copyright_information = rights_statement.copyright_information[0]
+        _create_rights_basis_copyright(db_stmt, copyright_information)
+    elif db_stmt.rightsbasis == "License":
+        license_information = rights_statement.license_information[0]
+        _create_rights_basis_license(db_stmt, license_information)
+    elif db_stmt.rightsbasis == "Statute":
+        statute_information = rights_statement.statute_information[0]
+        _create_rights_basis_statute(db_stmt, statute_information)
+    elif db_stmt.rightsbasis in ("Donor", "Policy", "Other"):
+        other_rights_information = rights_statement.other_rights_information[0]
+        _create_rights_basis_other(db_stmt, other_rights_information)
+    else:
+        raise ValueError("Unsupported basis: {}".format(db_stmt.rightsbasis))
+
+    for item in rights_statement.rights_granted:
+        _create_rights_granted(db_stmt, item)
+
+    return db_stmt
+
+
+def _create_rights_basis_copyright(db_stmt, copyright_information):
+    """Persist ``copyrightInformation``.
+
+    <xs:complexType name="copyrightInformationComplexType">
+        <xs:sequence>
+            <xs:element ref="copyrightStatus"/>
+            <xs:element ref="copyrightJurisdiction"/>
+            <xs:element ref="copyrightStatusDeterminationDate" minOccurs="0"/>
+            <xs:element ref="copyrightNote" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="copyrightDocumentationIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="copyrightApplicableDates" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    """
+    create_kwargs = {
+        "rightsstatement": db_stmt,
+        "copyrightstatus": copyright_information.copyright_status.lower(),
+        "copyrightjurisdiction": copyright_information.copyright_jurisdiction,
+    }
+    create_kwargs.update(
+        _get_dates(
+            copyright_information,
+            "copyright_applicable_dates",
+            prefix="copyrightapplicable",
+        )
+    )
+    create_kwargs.update(
+        _get_simple_attr(
+            copyright_information,
+            "copyright_status_determination_date",
+            "copyrightstatusdeterminationdate",
+            modifier=_parse_edtf_datetime,
+        )
+    )
+
+    ret = RightsStatementCopyright.objects.create(**create_kwargs)
+
+    _set_list(
+        copyright_information,
+        "copyright_note",
+        ret.rightsstatementcopyrightnote_set,
+        "copyrightnote",
+    )
+    _set_list(
+        copyright_information,
+        "copyright_documentation_identifier",
+        ret.rightsstatementcopyrightdocumentationidentifier_set,
+        (
+            (
+                "copyrightdocumentationidentifiertype",
+                "copyright_documentation_identifier_type",
+            ),
+            (
+                "copyrightdocumentationidentifiervalue",
+                "copyright_documentation_identifier_value",
+            ),
+        ),
+    )
+
+    return ret
+
+
+def _create_rights_basis_license(db_stmt, license_information):
+    """Persist ``licenseInformation``.
+
+    <xs:complexType name="licenseInformationComplexType">
+        <xs:choice>
+            <xs:sequence>
+                <xs:element ref="licenseDocumentationIdentifier" maxOccurs="unbounded"/>
+                <xs:element ref="licenseTerms" minOccurs="0"/>
+                <xs:element ref="licenseNote" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="licenseApplicableDates" minOccurs="0"/>
+            </xs:sequence>
+            <xs:sequence>
+                <xs:element ref="licenseTerms"/>
+                <xs:element ref="licenseNote" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="licenseApplicableDates" minOccurs="0"/>
+            </xs:sequence>
+            <xs:sequence>
+                <xs:element ref="licenseNote" maxOccurs="unbounded"/>
+                <xs:element ref="licenseApplicableDates" minOccurs="0"/>
+            </xs:sequence>
+            <xs:element ref="licenseApplicableDates"/>
+        </xs:choice>
+    </xs:complexType>
+    """
+    create_kwargs = {"rightsstatement": db_stmt}
+    create_kwargs.update(
+        _get_dates(
+            license_information, "license_applicable_dates", prefix="licenseapplicable"
+        )
+    )
+    create_kwargs.update(
+        _get_simple_attr(license_information, "license_terms", "licenseterms")
+    )
+
+    ret = RightsStatementLicense.objects.create(**create_kwargs)
+
+    _set_list(
+        license_information,
+        "license_note",
+        ret.rightsstatementlicensenote_set,
+        "licensenote",
+    )
+    _set_list(
+        license_information,
+        "license_documentation_identifier",
+        ret.rightsstatementlicensedocumentationidentifier_set,
+        (
+            (
+                "licensedocumentationidentifiertype",
+                "license_documentation_identifier_type",
+            ),
+            (
+                "licensedocumentationidentifiervalue",
+                "license_documentation_identifier_value",
+            ),
+        ),
+    )
+
+    return ret
+
+
+def _create_rights_basis_statute(db_stmt, statute_information):
+    """Persist ``statuteInformation``.
+
+    <xs:complexType name="statuteInformationComplexType">
+        <xs:sequence>
+            <xs:element ref="statuteJurisdiction"/>
+            <xs:element ref="statuteCitation"/>
+            <xs:element ref="statuteInformationDeterminationDate" minOccurs="0"/>
+            <xs:element ref="statuteNote" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="statuteDocumentationIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="statuteApplicableDates" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    """
+    create_kwargs = {
+        "rightsstatement": db_stmt,
+        "statutejurisdiction": statute_information.statute_jurisdiction,
+        "statutecitation": statute_information.statute_citation,
+    }
+    create_kwargs.update(
+        _get_dates(
+            statute_information, "statute_applicable_dates", prefix="statuteapplicable"
+        )
+    )
+    create_kwargs.update(
+        _get_simple_attr(
+            statute_information,
+            "statute_determination_date",
+            "statutedeterminationdate",
+            modifier=_parse_edtf_datetime,
+        )
+    )
+
+    ret = RightsStatementStatuteInformation.objects.create(**create_kwargs)
+
+    _set_list(
+        statute_information,
+        "statute_note",
+        ret.rightsstatementstatuteinformationnote_set,
+        "statutenote",
+    )
+    _set_list(
+        statute_information,
+        "statute_information_documentation_identifier",
+        ret.rightsstatementstatutedocumentationidentifier_set,
+        (
+            (
+                "statutedocumentationidentifiertype",
+                "statute_information_documentation_identifier_type",
+            ),
+            (
+                "statutedocumentationidentifiervalue",
+                "statute_information_documentation_identifier_value",
+            ),
+        ),
+    )
+
+    return ret
+
+
+def _create_rights_basis_other(db_stmt, other_rights):
+    """Persist ``otherRightsInformation``.
+
+    <xs:complexType name="otherRightsInformationComplexType">
+        <xs:sequence>
+            <xs:element ref="otherRightsDocumentationIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="otherRightsBasis"/>
+            <xs:element ref="otherRightsApplicableDates" minOccurs="0"/>
+            <xs:element ref="otherRightsNote" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    """
+    create_kwargs = {
+        "rightsstatement": db_stmt,
+        "otherrightsbasis": other_rights.other_rights_basis,
+    }
+    create_kwargs.update(
+        _get_dates(
+            other_rights,
+            "other_rights_applicable_dates",
+            prefix="otherrightsapplicable",
+        )
+    )
+
+    ret = RightsStatementOtherRightsInformation.objects.create(**create_kwargs)
+
+    _set_list(
+        other_rights,
+        "other_rights_note",
+        ret.rightsstatementotherrightsinformationnote_set,
+        "otherrightsnote",
+    )
+    _set_list(
+        other_rights,
+        "other_rights_documentation_identifier",
+        ret.rightsstatementotherrightsdocumentationidentifier_set,
+        (
+            (
+                "otherrightsdocumentationidentifiertype",
+                "other_rights_documentation_identifier_type",
+            ),
+            (
+                "otherrightsdocumentationidentifiervalue",
+                "other_rights_documentation_identifier_value",
+            ),
+        ),
+    )
+
+    return ret
+
+
+def _create_rights_granted(db_stmt, rights_granted):
+    """Persist ``rightsGranted``.
+
+    <xs:complexType name="rightsGrantedComplexType">
+        <xs:sequence>
+            <xs:element ref="act"/>
+            <xs:element ref="restriction" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="termOfGrant" minOccurs="0"/>
+            <xs:element ref="termOfRestriction" minOccurs="0"/>
+            <xs:element ref="rightsGrantedNote" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    """
+    create_kwargs = {"rightsstatement": db_stmt, "act": rights_granted.act}
+    create_kwargs.update(_get_dates(rights_granted, "term_of_grant"))
+
+    ret = RightsStatementRightsGranted.objects.create(**create_kwargs)
+
+    _set_list(rights_granted, "restriction", ret.restrictions, "restriction")
+    _set_list(rights_granted, "rights_granted_note", ret.notes, "rightsgrantednote")
+
+    return ret
+
+
+_ALLOWED_METADATA_TYPES = (File, Transfer, SIP)
+
+
+def _mdtype(obj):
+    """Return the ``MetadataAppliesToType`` that corresponds to ``obj.``."""
+    if obj.__class__ not in _ALLOWED_METADATA_TYPES:
+        raise TypeError(
+            "Types supported: %s"
+            % ", ".join([item.__name__ for item in _ALLOWED_METADATA_TYPES])
+        )
+    return get_metadata_type_id_by_description(obj.__class__.__name__)
+
+
+def _parse_edtf_datetime(date_string):
+    if not date_string:
+        return None
+    return date_string.replace("-", "/")
+
+
+def _get_dates(abctuple, attr, prefix=""):
+    """Return dict with start-end-date attributes."""
+    try:
+        dates = getattr(abctuple, attr)[0]
+    except (AttributeError, IndexError, TypeError):
+        return {}
+
+    startdate_key = "{}startdate".format(prefix)
+    enddate_key = "{}enddate".format(prefix)
+
+    suffix = "applicable"
+    if prefix.endswith(suffix):
+        prefix = prefix[: -len(suffix)]
+    enddateopen_key = "{}enddateopen".format(prefix)
+
+    ret = {}
+
+    # Tuple when undefined, weird!
+    if isinstance(dates.start_date, tuple) or not dates.start_date:
+        return ret
+
+    ret = {startdate_key: _parse_edtf_datetime(dates.start_date)}
+    if dates.end_date == "OPEN":
+        ret[enddateopen_key] = True
+    elif dates.end_date:
+        ret[enddate_key] = _parse_edtf_datetime(dates.end_date)
+
+    return ret
+
+
+def _set_list(abctuple, attr, relmanager, fkprops):
+    """Create a related model given its ``RelatedManager`` (``relmanager``).
+
+    - ``abctuple`` is the data source (``PREMISElement`` tuple)
+    - ``attr`` is the list property that we are writing.
+    - ``relmanager`` e.g. ``granted.restrictions``.
+    - ``fkprops`` association of model properties and PREMIS properties
+      e.g. "copyrightnote" or (("modelprop1", "tupleprop1",), ...)
+    """
+    try:
+        values = getattr(abctuple, attr)
+    except AttributeError:
+        return
+    if not isinstance(values, tuple):
+        values = (values,)
+    for item in values:
+        if isinstance(fkprops, six.string_types):
+            create_kwargs = {fkprops: item}
+        else:
+            create_kwargs = {k: getattr(item, v) for k, v in fkprops}
+        relmanager.create(**create_kwargs)
+
+
+def _get_simple_attr(abctuple, attr, prop, modifier=None):
+    try:
+        value = getattr(abctuple, attr)
+    except AttributeError:
+        return {}
+    if not isinstance(value, six.string_types):
+        raise TypeError("Expected string type")
+    if modifier is not None:
+        value = modifier(value)
+    if not value:
+        return {}
+    return {prop: value}

--- a/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
+++ b/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
@@ -14,21 +14,41 @@ location is stored.
 Copied from https://git.io/vN6v6.
 """
 
+from __future__ import unicode_literals
+
+import multiprocessing
 import logging
 import os
 import sys
+import traceback
 import time
+
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 
 from django.conf import settings as django_settings
 from django.core.management.base import CommandError
+from django.utils import six
 
+from fileOperations import addFileToTransfer
 import elasticSearchFunctions
+import metsrw
 import storageService
-from main.management.commands import boolean_input, DashboardCommand
-from main.models import Transfer
 
+from fpr.models import FormatVersion
+from components.rights.load import load_rights
+from main.management.commands import boolean_input, DashboardCommand
+from main.models import Agent, Transfer, FileFormatVersion, FileID
+
+import bagit
 
 logger = logging.getLogger("archivematica.dashboard")
+
+
+def _elasticsearch_noop_printfn(*args, **kwargs):
+    pass
 
 
 class Command(DashboardCommand):
@@ -65,12 +85,14 @@ class Command(DashboardCommand):
         if not self.confirm(options["no_prompt"]):
             sys.exit(0)
 
+        # Ignore elasticsearch-py logging events unless they're errors.
+        logging.getLogger("elasticsearch").setLevel(logging.ERROR)
+        logging.getLogger("archivematica.common").setLevel(logging.ERROR)
+
         transfer_backlog_dir = self.prepdir(options["transfer_backlog_dir"])
         if not os.path.exists(transfer_backlog_dir):
             raise CommandError("Directory does not exist: %s", transfer_backlog_dir)
-        self.success(
-            'Rebuilding "transfers" index from {}.'.format(transfer_backlog_dir)
-        )
+        self.info('Rebuilding "transfers" index from {}.'.format(transfer_backlog_dir))
 
         # Connect to Elasticsearch.
         elasticSearchFunctions.setup_reading_from_conf(django_settings)
@@ -80,7 +102,7 @@ class Command(DashboardCommand):
         except Exception as err:
             raise CommandError("Unable to connect to Elasticsearch: %s" % err)
         else:
-            self.success(
+            self.info(
                 "Connected to Elasticsearch node {} (v{}).".format(
                     es_info["name"], es_info["version"]["number"]
                 )
@@ -89,8 +111,8 @@ class Command(DashboardCommand):
         indexes = ["transfers", "transferfiles"]
         self.delete_indexes(es_client, indexes)
         self.create_indexes(es_client, indexes)
-        self.populate_indexes(es_client, transfer_backlog_dir)
-        self.success("Indexing complete!")
+
+        self.populate_data(es_client, transfer_backlog_dir)
 
     def confirm(self, no_prompt):
         """Ask user to confirm the operation."""
@@ -124,34 +146,242 @@ class Command(DashboardCommand):
         self.stdout.write("Creating indexes ...")
         elasticSearchFunctions.create_indexes_if_needed(es_client, indexes)
 
-    def populate_indexes(self, es_client, transfer_backlog_dir):
-        """Populate search indexes."""
-        for directory in os.listdir(transfer_backlog_dir):
-            if directory == ".gitignore":
+    def populate_data(self, es_client, transfer_backlog_dir):
+        """Populate data in search indices and/or the database."""
+        transfer_backlog_dir = Path(transfer_backlog_dir)
+        processed = 0
+        for transfer_dir in transfer_backlog_dir.glob("*"):
+            if transfer_dir.name == ".gitignore" or transfer_dir.is_file():
                 continue
-
-            transfer_uuid = directory[-36:]
-            transfer_dir = os.path.basename(directory)
-
             try:
-                Transfer.objects.get(uuid=transfer_uuid)
-            except Transfer.DoesNotExist:
-                self.warning("Skipping transfer {}: not found!".format(transfer_uuid))
-                continue
-
-            self.stdout.write("Indexing {} ({})".format(transfer_uuid, transfer_dir))
-
-            elasticSearchFunctions.index_transfer_and_files(
-                es_client,
-                transfer_uuid,
-                os.path.join(transfer_backlog_dir, directory, ""),
-                status="backlog",
-            )
-
-            try:
-                storageService.reindex_file(transfer_uuid)
-            except Exception:
-                self.warning(
-                    "Could not reindex Transfer in the Storage Service, "
-                    "UUID: %s" % transfer_uuid
+                bag = bagit.Bag(str(transfer_dir))
+                bag.validate(
+                    processes=multiprocessing.cpu_count(), completeness_only=True
                 )
+            except bagit.BagError:
+                self.warning(
+                    "Skipping transfer {} - not a valid bag!".format(transfer_dir)
+                )
+            transfer_uuid = transfer_dir.name[-36:]
+            if "External-Identifier" in bag.info:
+                self.info(
+                    "Importing self-describing transfer {}.".format(transfer_uuid)
+                )
+                _import_self_describing_transfer(
+                    self, es_client, self.stdout, transfer_dir, transfer_uuid
+                )
+            else:
+                self.info("Rebuilding known transfer {}.".format(transfer_uuid))
+                _import_pipeline_dependant_transfer(
+                    self, es_client, self.stdout, transfer_dir, transfer_uuid
+                )
+            processed += 1
+        self.success("{} transfers indexed!".format(processed))
+
+
+def _import_dir_from_fsentry(cmd, fsentry, transfer_uuid):
+    pass
+    """
+    Directory.objects.create(
+        uuid=uuid.uuid4(),  # TODO: what goes here?
+        transfer_id=transfer_uuid,
+        originallocation="TODO",
+        currentlocation="TODO")
+    """
+
+
+def _import_file_from_fsentry(cmd, fsentry, transfer_uuid):
+    premis_events = fsentry.get_premis_events()
+
+    ingestion_date = None
+    for evt in fsentry.get_premis_events():
+        if evt.event_type == "ingestion":
+            ingestion_date = evt.event_date_time
+            break
+
+    file_obj = addFileToTransfer(
+        "%transferDirectory%{}".format(fsentry.path),
+        fsentry.file_uuid,
+        transfer_uuid,
+        None,
+        ingestion_date,
+        sourceType="ingestion",
+        use="original",
+    )
+
+    for rights_statement in fsentry.get_premis_rights():
+        load_rights(file_obj, rights_statement)
+
+    for event in premis_events:
+        _load_event(file_obj, event)
+
+    try:
+        premis_object = fsentry.get_premis_objects()[0]
+    except IndexError:
+        return
+
+    # Populate extra attributes in the File object.
+    file_obj.checksum = premis_object.message_digest
+    file_obj.checksumtype = _convert_checksum_algo(
+        premis_object.message_digest_algorithm
+    )
+    file_obj.size = premis_object.size
+    file_obj.save()
+
+    # Populate format details of the File object.
+    if premis_object.format_registry_name != "PRONOM":
+        return
+    try:
+        format_version = FormatVersion.active.get(
+            pronom_id=premis_object.format_registry_key
+        )
+    except FormatVersion.DoesNotExist:
+        return
+    FileFormatVersion.objects.create(file_uuid=file_obj, format_version=format_version)
+    FileID.objects.create(
+        file=file_obj,
+        format_name=format_version.format.description,
+        format_version=format_version.version or "",
+        format_registry_name=premis_object.format_registry_name,
+        format_registry_key=premis_object.format_registry_key,
+    )
+
+
+def _load_event(file_obj, event):
+    create_kwargs = {
+        "event_id": event.event_identifier_value,
+        "event_type": event.event_type,
+        "event_datetime": event.event_date_time,
+    }
+
+    event_detail = None
+    if event.premis_version == "3.0":
+        # It should be: ``event_detail_information__event_detail``
+        # TODO: update this once the tranfser METS is fixed
+        event_detail_attr = "event_detail"
+    else:
+        event_detail_attr = "event_detail"
+    try:
+        event_detail = getattr(event, event_detail_attr)
+    except AttributeError:
+        raise
+    if isinstance(event_detail, six.text_type):
+        create_kwargs["event_detail"] = event.event_detail
+
+    try:
+        event_outcome_information = event.event_outcome_information[0]
+    except (AttributeError, IndexError):
+        pass
+    else:
+        event_outcome = event_outcome_information.event_outcome
+        if isinstance(event_outcome, six.text_type):
+            create_kwargs["event_outcome"] = event_outcome
+        event_outcome_note = event_outcome_information.event_outcome_detail_note
+        if isinstance(event_outcome_note, six.text_type):
+            create_kwargs["event_outcome_detail"] = event_outcome_note
+
+    event_obj = file_obj.event_set.create(**create_kwargs)
+
+    try:
+        identifiers = event.linking_agent_identifier
+    except AttributeError:
+        return
+    for item in identifiers:
+        try:
+            # Is this cached?
+            agent = Agent.objects.get(
+                identifiertype=item.linking_agent_identifier_type,
+                identifiervalue=item.linking_agent_identifier_value,
+            )
+        except Agent.DoesNotExist:
+            continue
+        event_obj.agents.add(agent)
+
+
+def _convert_checksum_algo(algo):
+    """Convert hash function names to the internal form expected.
+
+    This may be good enough at least for the vocab at:
+    http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions.
+    """
+    return algo.replace("-", "").lower()
+
+
+def _import_self_describing_transfer(
+    cmd, es_client, stdout, transfer_dir, transfer_uuid
+):
+    """Import a self-describing transfer.
+
+    Knowledge of this transfer is not required in the transfer. If missing,
+    this function will populate the necessary state so arrangement and ingest
+    work as expected.
+    """
+    transfer, created = Transfer.objects.get_or_create(
+        uuid=transfer_uuid,
+        defaults=dict(
+            type="Standard",
+            diruuids=False,
+            currentlocation="%sharedPath%www/AIPsStore/transferBacklog/originals/"
+            + str(transfer_dir.name)
+            + "/",
+        ),
+    )
+
+    # The transfer did not exist, we need to populate everything else.
+    if created:
+        mets = metsrw.METSDocument.fromfile(
+            str(transfer_dir / "data/metadata/submissionDocumentation/METS.xml")
+        )
+        for fsentry in mets.all_files():
+            try:
+                if fsentry.type == "Directory":
+                    _import_dir_from_fsentry(cmd, fsentry, transfer_uuid)
+                else:
+                    _import_file_from_fsentry(cmd, fsentry, transfer_uuid)
+            except Exception as err:
+                cmd.warning(
+                    "There was an error processing file {} (transfer {}): {}".format(
+                        fsentry.file_uuid, transfer_uuid, err
+                    )
+                )
+                if django_settings.DEBUG:
+                    traceback.print_exc()
+
+    elasticSearchFunctions.index_transfer_and_files(
+        es_client,
+        transfer_uuid,
+        str(transfer_dir) + "/",
+        printfn=_elasticsearch_noop_printfn,
+    )
+
+
+def _import_pipeline_dependant_transfer(
+    cmd, es_client, stdout, transfer_dir, transfer_uuid
+):
+    """Import a pipeline-dependant transfer.
+
+    We can only import pipeline-dependant transfers from backlog if the
+    pipeline has records of it, e.g. the Transfer object exists in the
+    database.
+    """
+    try:
+        Transfer.objects.get(uuid=transfer_uuid)
+    except Transfer.DoesNotExist:
+        cmd.warning(
+            "Skipping transfer {} - not found in the database!".format(transfer_uuid)
+        )
+        return
+    cmd.info("Indexing {} ({})".format(transfer_uuid, transfer_dir))
+    elasticSearchFunctions.index_transfer_and_files(
+        es_client,
+        transfer_uuid,
+        str(transfer_dir) + "/",
+        printfn=_elasticsearch_noop_printfn,
+    )
+    try:
+        storageService.reindex_file(transfer_uuid)
+    except Exception as err:
+        cmd.warning(
+            "Could not reindex Transfer in the Storage Service, UUID: %s (%s)"
+            % (transfer_uuid, err)
+        )

--- a/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
+++ b/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
@@ -256,9 +256,7 @@ def _load_event(file_obj, event):
 
     event_detail = None
     if event.premis_version == "3.0":
-        # It should be: ``event_detail_information__event_detail``
-        # TODO: update this once the tranfser METS is fixed
-        event_detail_attr = "event_detail"
+        event_detail_attr = "event_detail_information__event_detail"
     else:
         event_detail_attr = "event_detail"
     try:

--- a/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
+++ b/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
@@ -332,6 +332,16 @@ def _import_self_describing_transfer(
         mets = metsrw.METSDocument.fromfile(
             str(transfer_dir / "data/metadata/submissionDocumentation/METS.xml")
         )
+
+        try:
+            alt_id = mets.alternate_ids[0]
+        except IndexError:
+            pass
+        else:
+            if alt_id.type == "Accession ID":
+                transfer.accessionid = alt_id.text
+            transfer.save()
+
         for fsentry in mets.all_files():
             try:
                 if fsentry.type == "Directory":

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -17,7 +17,7 @@ gunicorn==19.9.0
 futures==3.2.0  # used by gunicorn's async workers
 lazy-paged-sequence
 lxml==3.5.0
-metsrw==0.3.4
+metsrw==0.3.7
 mysqlclient==1.3.7
 pytz
 pyopenssl

--- a/src/dashboard/tests/test_rights.py
+++ b/src/dashboard/tests/test_rights.py
@@ -12,17 +12,13 @@ from components.rights import load
 from main.models import File, Transfer, SIP, MetadataAppliesToType
 
 
-_RIGHTS_STATEMENT_BASE = (
-    "rights_statement",
-    premisrw.PREMIS_META,
-    (
-        "rights_statement_identifier",
-        ("rights_statement_identifier_type", "UUID"),
-        ("rights_statement_identifier_value", "3a9838ac-ebe9-4ecb-ba46-c31ee1d6e7c2"),
-    ),
+RIGHTS_STATEMENT_IDENTIFIER = (
+    "rights_statement_identifier",
+    ("rights_statement_identifier_type", "UUID"),
+    ("rights_statement_identifier_value", "3a9838ac-ebe9-4ecb-ba46-c31ee1d6e7c2"),
 )
 
-_RIGHTS_STATEMENT_COPYRIGHT = (
+RIGHTS_STATEMENT_COPYRIGHT = (
     ("rights_basis", "Copyright"),
     (
         "copyright_information",
@@ -42,7 +38,7 @@ _RIGHTS_STATEMENT_COPYRIGHT = (
     ),
 )
 
-_RIGHTS_STATEMENT_LICENSE = (
+RIGHTS_STATEMENT_LICENSE = (
     ("rights_basis", "License"),
     (
         "license_information",
@@ -60,7 +56,7 @@ _RIGHTS_STATEMENT_LICENSE = (
     ),
 )
 
-_RIGHTS_STATEMENT_STATUTE = (
+RIGHTS_STATEMENT_STATUTE = (
     ("rights_basis", "Statute"),
     (
         "statute_information",
@@ -80,7 +76,7 @@ _RIGHTS_STATEMENT_STATUTE = (
     ),
 )
 
-_RIGHTS_STATEMENT_OTHER = (
+RIGHTS_STATEMENT_OTHER = (
     ("rights_basis", "Other"),
     (
         "other_rights_information",
@@ -98,81 +94,91 @@ _RIGHTS_STATEMENT_OTHER = (
     ),
 )
 
-_RIGHTS_STATEMENT_GRANTED_1 = (
-    (
-        "rights_granted",
-        ("act", "Disseminate"),
-        ("restriction", "Allow"),
-        ("term_of_grant", ("start_date", "2000"), ("end_date", "OPEN")),
-        ("rights_granted_note", "Attribution required"),
-    ),
+RIGHTS_STATEMENT_GRANTED_1 = (
+    "rights_granted",
+    ("act", "Disseminate"),
+    ("restriction", "Allow"),
+    ("term_of_grant", ("start_date", "2000"), ("end_date", "OPEN")),
+    ("rights_granted_note", "Attribution required"),
 )
 
-_RIGHTS_STATEMENT_GRANTED_2 = (
-    (
-        "rights_granted",
-        ("act", "Access"),
-        ("restriction", "Allow"),
-        ("term_of_grant", ("start_date", "1999"), ("end_date", "OPEN")),
-        ("rights_granted_note", "Access one year before dissemination"),
-    ),
+RIGHTS_STATEMENT_GRANTED_2 = (
+    "rights_granted",
+    ("act", "Access"),
+    ("restriction", "Allow"),
+    ("term_of_grant", ("start_date", "1999"), ("end_date", "OPEN")),
+    ("rights_granted_note", "Access one year before dissemination"),
 )
 
-_RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER = (
-    (
-        "linking_object_identifier",
-        ("linking_object_identifier_type", "UUID"),
-        ("linking_object_identifier_value", "c09903c4-bc29-4db4-92da-47355eec752f"),
-    ),
+RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER = (
+    "linking_object_identifier",
+    ("linking_object_identifier_type", "UUID"),
+    ("linking_object_identifier_value", "c09903c4-bc29-4db4-92da-47355eec752f"),
 )
 
 
 @pytest.fixture()
 def rights_statement_with_basis_copyright():
-    data = (
-        _RIGHTS_STATEMENT_BASE
-        + _RIGHTS_STATEMENT_COPYRIGHT
-        + _RIGHTS_STATEMENT_GRANTED_1
-        + _RIGHTS_STATEMENT_GRANTED_2
-        + _RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER
+    rights_statement = (
+        "rights_statement",
+        RIGHTS_STATEMENT_IDENTIFIER,
+        RIGHTS_STATEMENT_COPYRIGHT[0],
+        RIGHTS_STATEMENT_COPYRIGHT[1],
+        RIGHTS_STATEMENT_GRANTED_1,
+        RIGHTS_STATEMENT_GRANTED_2,
+        RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER,
     )
-    return premisrw.PREMISRights(data=data)
+    return premisrw.PREMISRights(
+        data=("rights", premisrw.PREMIS_META, rights_statement)
+    )
 
 
 @pytest.fixture()
 def rights_statement_with_basis_license():
-    data = (
-        _RIGHTS_STATEMENT_BASE
-        + _RIGHTS_STATEMENT_LICENSE
-        + _RIGHTS_STATEMENT_GRANTED_1
-        + _RIGHTS_STATEMENT_GRANTED_2
-        + _RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER
+    rights_statement = (
+        "rights_statement",
+        RIGHTS_STATEMENT_IDENTIFIER,
+        RIGHTS_STATEMENT_LICENSE[0],
+        RIGHTS_STATEMENT_LICENSE[1],
+        RIGHTS_STATEMENT_GRANTED_1,
+        RIGHTS_STATEMENT_GRANTED_2,
+        RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER,
     )
-    return premisrw.PREMISRights(data=data)
+    return premisrw.PREMISRights(
+        data=("rights", premisrw.PREMIS_META, rights_statement)
+    )
 
 
 @pytest.fixture()
 def rights_statement_with_basis_statute():
-    data = (
-        _RIGHTS_STATEMENT_BASE
-        + _RIGHTS_STATEMENT_STATUTE
-        + _RIGHTS_STATEMENT_GRANTED_1
-        + _RIGHTS_STATEMENT_GRANTED_2
-        + _RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER
+    rights_statement = (
+        "rights_statement",
+        RIGHTS_STATEMENT_IDENTIFIER,
+        RIGHTS_STATEMENT_STATUTE[0],
+        RIGHTS_STATEMENT_STATUTE[1],
+        RIGHTS_STATEMENT_GRANTED_1,
+        RIGHTS_STATEMENT_GRANTED_2,
+        RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER,
     )
-    return premisrw.PREMISRights(data=data)
+    return premisrw.PREMISRights(
+        data=("rights", premisrw.PREMIS_META, rights_statement)
+    )
 
 
 @pytest.fixture()
 def rights_statement_with_basis_other():
-    data = (
-        _RIGHTS_STATEMENT_BASE
-        + _RIGHTS_STATEMENT_OTHER
-        + _RIGHTS_STATEMENT_GRANTED_1
-        + _RIGHTS_STATEMENT_GRANTED_2
-        + _RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER
+    rights_statement = (
+        "rights_statement",
+        RIGHTS_STATEMENT_IDENTIFIER,
+        RIGHTS_STATEMENT_OTHER[0],
+        RIGHTS_STATEMENT_OTHER[1],
+        RIGHTS_STATEMENT_GRANTED_1,
+        RIGHTS_STATEMENT_GRANTED_2,
+        RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER,
     )
-    return premisrw.PREMISRights(data=data)
+    return premisrw.PREMISRights(
+        data=("rights", premisrw.PREMIS_META, rights_statement)
+    )
 
 
 @pytest.fixture()

--- a/src/dashboard/tests/test_rights.py
+++ b/src/dashboard/tests/test_rights.py
@@ -1,0 +1,330 @@
+# from components.rights.load import load_rights
+#
+# for premis_rights in fsentry.get_premis_rights():
+#     load_rights(premis_rights)
+#
+
+from metsrw.plugins import premisrw
+import pytest
+import uuid
+
+from components.rights import load
+from main.models import File, Transfer, SIP, MetadataAppliesToType
+
+
+_RIGHTS_STATEMENT_BASE = (
+    "rights_statement",
+    premisrw.PREMIS_META,
+    (
+        "rights_statement_identifier",
+        ("rights_statement_identifier_type", "UUID"),
+        ("rights_statement_identifier_value", "3a9838ac-ebe9-4ecb-ba46-c31ee1d6e7c2"),
+    ),
+)
+
+_RIGHTS_STATEMENT_COPYRIGHT = (
+    ("rights_basis", "Copyright"),
+    (
+        "copyright_information",
+        ("copyright_status", "Under copyright"),
+        ("copyright_jurisdiction", "CA"),
+        ("copyright_status_determination_date", "2015"),
+        ("copyright_note", "Dummy note 1"),
+        (
+            "copyright_documentation_identifier",
+            ("copyright_documentation_identifier_type", "UUID"),
+            (
+                "copyright_documentation_identifier_value",
+                "a59b5006-23c4-4195-bc1e-7d1855d555cc",
+            ),
+        ),
+        ("copyright_applicable_dates", ("start_date", "1999"), ("end_date", "OPEN")),
+    ),
+)
+
+_RIGHTS_STATEMENT_LICENSE = (
+    ("rights_basis", "License"),
+    (
+        "license_information",
+        (
+            "license_documentation_identifier",
+            ("license_documentation_identifier_type", "UUID"),
+            (
+                "license_documentation_identifier_value",
+                "a59b5006-23c4-4195-bc1e-7d1855d555cc",
+            ),
+        ),
+        ("license_terms", "Dummy license terms"),
+        ("license_note", "Dummy note 1"),
+        ("license_applicable_dates", ("start_date", "1999"), ("end_date", "OPEN")),
+    ),
+)
+
+_RIGHTS_STATEMENT_STATUTE = (
+    ("rights_basis", "Statute"),
+    (
+        "statute_information",
+        ("statute_jurisdiction", "Jurisdiction"),
+        ("statute_citation", "Citation"),
+        ("statute_determination_date", "2015"),
+        ("statute_note", "Dummy note 1"),
+        (
+            "statute_information_documentation_identifier",
+            ("statute_information_documentation_identifier_type", "UUID"),
+            (
+                "statute_information_documentation_identifier_value",
+                "a59b5006-23c4-4195-bc1e-7d1855d555cc",
+            ),
+        ),
+        ("statute_applicable_dates", ("start_date", "1999"), ("end_date", "OPEN")),
+    ),
+)
+
+_RIGHTS_STATEMENT_OTHER = (
+    ("rights_basis", "Other"),
+    (
+        "other_rights_information",
+        (
+            "other_rights_documentation_identifier",
+            ("other_rights_documentation_identifier_type", "UUID"),
+            (
+                "other_rights_documentation_identifier_value",
+                "a59b5006-23c4-4195-bc1e-7d1855d555cc",
+            ),
+        ),
+        ("other_rights_basis", "Foobar"),
+        ("other_rights_applicable_dates", ("start_date", "1999"), ("end_date", "OPEN")),
+        ("other_rights_note", "Dummy note 1"),
+    ),
+)
+
+_RIGHTS_STATEMENT_GRANTED_1 = (
+    (
+        "rights_granted",
+        ("act", "Disseminate"),
+        ("restriction", "Allow"),
+        ("term_of_grant", ("start_date", "2000"), ("end_date", "OPEN")),
+        ("rights_granted_note", "Attribution required"),
+    ),
+)
+
+_RIGHTS_STATEMENT_GRANTED_2 = (
+    (
+        "rights_granted",
+        ("act", "Access"),
+        ("restriction", "Allow"),
+        ("term_of_grant", ("start_date", "1999"), ("end_date", "OPEN")),
+        ("rights_granted_note", "Access one year before dissemination"),
+    ),
+)
+
+_RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER = (
+    (
+        "linking_object_identifier",
+        ("linking_object_identifier_type", "UUID"),
+        ("linking_object_identifier_value", "c09903c4-bc29-4db4-92da-47355eec752f"),
+    ),
+)
+
+
+@pytest.fixture()
+def rights_statement_with_basis_copyright():
+    data = (
+        _RIGHTS_STATEMENT_BASE
+        + _RIGHTS_STATEMENT_COPYRIGHT
+        + _RIGHTS_STATEMENT_GRANTED_1
+        + _RIGHTS_STATEMENT_GRANTED_2
+        + _RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER
+    )
+    return premisrw.PREMISRights(data=data)
+
+
+@pytest.fixture()
+def rights_statement_with_basis_license():
+    data = (
+        _RIGHTS_STATEMENT_BASE
+        + _RIGHTS_STATEMENT_LICENSE
+        + _RIGHTS_STATEMENT_GRANTED_1
+        + _RIGHTS_STATEMENT_GRANTED_2
+        + _RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER
+    )
+    return premisrw.PREMISRights(data=data)
+
+
+@pytest.fixture()
+def rights_statement_with_basis_statute():
+    data = (
+        _RIGHTS_STATEMENT_BASE
+        + _RIGHTS_STATEMENT_STATUTE
+        + _RIGHTS_STATEMENT_GRANTED_1
+        + _RIGHTS_STATEMENT_GRANTED_2
+        + _RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER
+    )
+    return premisrw.PREMISRights(data=data)
+
+
+@pytest.fixture()
+def rights_statement_with_basis_other():
+    data = (
+        _RIGHTS_STATEMENT_BASE
+        + _RIGHTS_STATEMENT_OTHER
+        + _RIGHTS_STATEMENT_GRANTED_1
+        + _RIGHTS_STATEMENT_GRANTED_2
+        + _RIGHTS_STATEMENT_LINKING_OBJECT_IDENTIFIER
+    )
+    return premisrw.PREMISRights(data=data)
+
+
+@pytest.fixture()
+def file(db):
+    return File.objects.create(uuid=uuid.uuid4())
+
+
+@pytest.mark.django_db
+def test_mdtype():
+    assert isinstance(load._mdtype(File()), MetadataAppliesToType)
+    assert isinstance(load._mdtype(Transfer()), MetadataAppliesToType)
+    assert isinstance(load._mdtype(SIP()), MetadataAppliesToType)
+
+    class UnknownClass(object):
+        pass
+
+    with pytest.raises(TypeError) as excinfo:
+        load._mdtype(UnknownClass())
+    assert "Types supported: File, Transfer, SIP" in str(excinfo.value)
+
+
+@pytest.mark.django_db
+def test_load_rights(file, rights_statement_with_basis_copyright):
+    stmt = load.load_rights(file, rights_statement_with_basis_copyright)
+    assert stmt.metadataappliestotype.description == "File"
+    assert stmt.metadataappliestoidentifier == file.uuid
+    assert stmt.rightsstatementidentifiertype == "UUID"
+    assert stmt.rightsstatementidentifiervalue == "3a9838ac-ebe9-4ecb-ba46-c31ee1d6e7c2"
+
+    rights_granted = stmt.rightsstatementrightsgranted_set.all()
+    assert len(rights_granted) == 2
+    assert rights_granted[0].act == "Disseminate"
+    assert rights_granted[0].restrictions.all()[0].restriction == "Allow"
+    assert rights_granted[0].notes.all()[0].rightsgrantednote == "Attribution required"
+    assert rights_granted[0].startdate == "2000"
+    assert rights_granted[0].enddate is None
+    assert rights_granted[0].enddateopen is True
+    assert rights_granted[1].act == "Access"
+    assert rights_granted[1].restrictions.all()[0].restriction == "Allow"
+    assert (
+        rights_granted[1].notes.all()[0].rightsgrantednote
+        == "Access one year before dissemination"
+    )
+    assert rights_granted[1].startdate == "1999"
+    assert rights_granted[1].enddate is None
+    assert rights_granted[1].enddateopen is True
+
+
+@pytest.mark.django_db
+def test_load_rights_with_basis_copyright(file, rights_statement_with_basis_copyright):
+    stmt = load.load_rights(file, rights_statement_with_basis_copyright)
+
+    assert stmt.rightsbasis == "Copyright"
+    copyrights = stmt.rightsstatementcopyright_set.all()
+    assert len(copyrights) == 1
+    assert copyrights[0].copyrightstatus == "under copyright"
+    assert copyrights[0].copyrightjurisdiction == "CA"
+    assert copyrights[0].copyrightstatusdeterminationdate == "2015"
+    assert (
+        copyrights[0].rightsstatementcopyrightnote_set.all()[0].copyrightnote
+        == "Dummy note 1"
+    )
+    assert (
+        copyrights[0]
+        .rightsstatementcopyrightdocumentationidentifier_set.all()[0]
+        .copyrightdocumentationidentifiertype
+        == "UUID"
+    )
+    assert (
+        copyrights[0]
+        .rightsstatementcopyrightdocumentationidentifier_set.all()[0]
+        .copyrightdocumentationidentifiervalue
+        == "a59b5006-23c4-4195-bc1e-7d1855d555cc"
+    )
+
+
+@pytest.mark.django_db
+def test_load_rights_with_basis_license(file, rights_statement_with_basis_license):
+    stmt = load.load_rights(file, rights_statement_with_basis_license)
+
+    assert stmt.rightsbasis == "License"
+    license = stmt.rightsstatementlicense_set.all()
+    assert len(license) == 1
+    assert license[0].licenseterms == "Dummy license terms"
+    assert (
+        license[0].rightsstatementlicensenote_set.all()[0].licensenote == "Dummy note 1"
+    )
+    assert (
+        license[0]
+        .rightsstatementlicensedocumentationidentifier_set.all()[0]
+        .licensedocumentationidentifiertype
+        == "UUID"
+    )
+    assert (
+        license[0]
+        .rightsstatementlicensedocumentationidentifier_set.all()[0]
+        .licensedocumentationidentifiervalue
+        == "a59b5006-23c4-4195-bc1e-7d1855d555cc"
+    )
+
+
+@pytest.mark.django_db
+def test_load_rights_with_basis_statute(file, rights_statement_with_basis_statute):
+    stmt = load.load_rights(file, rights_statement_with_basis_statute)
+
+    assert stmt.rightsbasis == "Statute"
+    statute = stmt.rightsstatementstatuteinformation_set.all()
+    assert len(statute) == 1
+    assert statute[0].statutejurisdiction == "Jurisdiction"
+    assert statute[0].statutecitation == "Citation"
+    assert statute[0].statutedeterminationdate == "2015"
+    assert (
+        statute[0].rightsstatementstatuteinformationnote_set.all()[0].statutenote
+        == "Dummy note 1"
+    )
+    assert (
+        statute[0]
+        .rightsstatementstatutedocumentationidentifier_set.all()[0]
+        .statutedocumentationidentifiertype
+        == "UUID"
+    )
+    assert (
+        statute[0]
+        .rightsstatementstatutedocumentationidentifier_set.all()[0]
+        .statutedocumentationidentifiervalue
+        == "a59b5006-23c4-4195-bc1e-7d1855d555cc"
+    )
+
+
+@pytest.mark.django_db
+def test_load_rights_with_basis_other(file, rights_statement_with_basis_other):
+    stmt = load.load_rights(file, rights_statement_with_basis_other)
+
+    assert stmt.rightsbasis == "Other"
+    otherrights = stmt.rightsstatementotherrightsinformation_set.all()
+    assert len(otherrights) == 1
+    assert otherrights[0].otherrightsbasis == "Foobar"
+    assert (
+        otherrights[0]
+        .rightsstatementotherrightsinformationnote_set.all()[0]
+        .otherrightsnote
+        == "Dummy note 1"
+    )
+    assert (
+        otherrights[0]
+        .rightsstatementotherrightsdocumentationidentifier_set.all()[0]
+        .otherrightsdocumentationidentifiertype
+        == "UUID"
+    )
+    assert (
+        otherrights[0]
+        .rightsstatementotherrightsdocumentationidentifier_set.all()[0]
+        .otherrightsdocumentationidentifiervalue
+        == "a59b5006-23c4-4195-bc1e-7d1855d555cc"
+    )


### PR DESCRIPTION
This pull requests updates the `rebuild_transfer_backlog` management command to support restoring the new self-describing transfer packages. The biggest change is that it can be done over any pipeline even when it's freshly installed.

Directories are not populated yet - this work and other improvements may be completed in following pull requests.

Connects to https://github.com/archivematica/Issues/issues/446.
Connects to https://github.com/archivematica/Issues/issues/586.