### PR TITLE
Search: store AIP size in MB

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -422,7 +422,7 @@ def index_aip_and_files(
         "uuid": uuid,
         "name": name,
         "filePath": aip_stored_path,
-        "size": aip_size,
+        "size": aip_size / (1024 * 1024),
         "mets": mets_data,
         "origin": get_dashboard_uuid(),
         "created": created,


### PR DESCRIPTION
This commit reverts a recent change where bytes were used - although I think
it's probably better to use bytes we have to keep using MB unless we update
consumers.

Found by @replaceafill.
Connects to https://github.com/archivematica/Issues/issues/559.
Once merged, it should also go to stable/1.9.x before the v1.9.1 release!