### PR TITLE
Fix index_aip_and_files() call from mgmt cmd

### DIFF
--- a/src/dashboard/src/main/management/commands/rebuild_elasticsearch_aip_index_from_files.py
+++ b/src/dashboard/src/main/management/commands/rebuild_elasticsearch_aip_index_from_files.py
@@ -164,10 +164,10 @@ def processAIPThenDeleteMETSFile(path, temp_dir, es_client, delete_existing_data
     return elasticSearchFunctions.index_aip_and_files(
         client=es_client,
         uuid=aip_uuid,
-        path=path,
-        mets_path=path_to_mets,
+        aip_stored_path=path,
+        mets_staging_path=path_to_mets,
         name=aip_name,
-        size=aip_info[0]["size"],
+        aip_size=aip_info[0]["size"],
         aips_in_aic=aips_in_aic,
         identifiers=[],  # TODO get these
     )


### PR DESCRIPTION
Fix index_aip_and_files() invocation from
rebuild_elasticsearch_aip_index_from_files management command.

Connected to https://github.com/archivematica/Issues/issues/595