### PR TITLE
Fix: Problem while running the docker-compose up -d -build command

### DIFF
--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -5,7 +5,7 @@ ENV DJANGO_SETTINGS_MODULE settings.common
 ENV PYTHONPATH /src/MCPServer/lib/:/src/archivematicaCommon/lib/:/src/dashboard/src/
 ENV PYTHONUNBUFFERED 1
 
-RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list \
+RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list \
   && set -ex \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -5,7 +5,7 @@ ENV DJANGO_SETTINGS_MODULE settings.common
 ENV PYTHONPATH /src/MCPServer/lib/:/src/archivematicaCommon/lib/:/src/dashboard/src/
 ENV PYTHONUNBUFFERED 1
 
-RUN RUN RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list \
+RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list \
   && set -ex \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -5,7 +5,8 @@ ENV DJANGO_SETTINGS_MODULE settings.common
 ENV PYTHONPATH /src/MCPServer/lib/:/src/archivematicaCommon/lib/:/src/dashboard/src/
 ENV PYTHONUNBUFFERED 1
 
-RUN set -ex \
+RUN RUN RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list \
+  && set -ex \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		gettext \

--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -8,7 +8,7 @@ ENV AM_GUNICORN_BIND 0.0.0.0:8000
 ENV AM_GUNICORN_CHDIR /src/dashboard/src
 ENV FORWARDED_ALLOW_IPS *
 
-RUN RUN RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list \
+RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list \
   && set -ex \
 	&& curl -sL https://deb.nodesource.com/setup_8.x | bash - \
 	&& apt-get install -y --no-install-recommends \

--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -8,7 +8,8 @@ ENV AM_GUNICORN_BIND 0.0.0.0:8000
 ENV AM_GUNICORN_CHDIR /src/dashboard/src
 ENV FORWARDED_ALLOW_IPS *
 
-RUN set -ex \
+RUN RUN RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list \
+  && set -ex \
 	&& curl -sL https://deb.nodesource.com/setup_8.x | bash - \
 	&& apt-get install -y --no-install-recommends \
 		gettext \

--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -8,7 +8,7 @@ ENV AM_GUNICORN_BIND 0.0.0.0:8000
 ENV AM_GUNICORN_CHDIR /src/dashboard/src
 ENV FORWARDED_ALLOW_IPS *
 
-RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list \
+RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list \
   && set -ex \
 	&& curl -sL https://deb.nodesource.com/setup_8.x | bash - \
 	&& apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Problem while running the `docker-compose up -d -build` command:

> Err http://deb.debian.org jessie-updates/main amd64 Packages
>   404  Not Found
> Fetched 10.1 MB in 7s (1268 kB/s)
> W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/main/binary-amd64/Packages  404  Not Found

According to the IRC channel for Debian, Jessie is now not supported:

Debian Jessie, jessie-updates and jessie-backports REMOVED 2019-03-24

https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html