### PR TITLE
Docker: use `python:2.7-stretch` images

### DIFF
--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-jessie
+FROM python:2.7-stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DJANGO_SETTINGS_MODULE settings.common
@@ -9,7 +9,7 @@ RUN set -ex \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		gettext \
-		libmysqlclient-dev \
+		default-libmysqlclient-dev \
 		libldap2-dev \
 		libsasl2-dev \
 		locales \

--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-jessie
+FROM python:2.7-stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DJANGO_SETTINGS_MODULE settings.production
@@ -12,7 +12,7 @@ RUN set -ex \
 	&& curl -sL https://deb.nodesource.com/setup_8.x | bash - \
 	&& apt-get install -y --no-install-recommends \
 		gettext \
-		libmysqlclient-dev \
+		default-libmysqlclient-dev \
 		libldap2-dev \
 		libsasl2-dev \
 		nodejs \


### PR DESCRIPTION
Connects to https://github.com/archivematica/Issues/issues/617.