### PR TITLE
Validation API

### DIFF
--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -61,5 +61,5 @@ urlpatterns = [
         name="processing_configuration",
     ),
     url(r"v2beta/package", views.package),
-    url(r"v2beta/validate", views.validate),
+    url(r"v2beta/validate/([-\w]+)", views.validate, name="validate"),
 ]

--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -61,4 +61,5 @@ urlpatterns = [
         name="processing_configuration",
     ),
     url(r"v2beta/package", views.package),
+    url(r"v2beta/validate", views.validate),
 ]

--- a/src/dashboard/src/components/api/validators.py
+++ b/src/dashboard/src/components/api/validators.py
@@ -1,0 +1,243 @@
+"""Validation of transfer documents."""
+
+from base64 import b64decode
+import collections
+import csv
+from io import BytesIO
+
+
+class ValidationError(Exception):
+    pass
+
+
+class BaseValidator(object):
+    def _decode(self, s):
+        try:
+            return b64decode(s)
+        except Exception as err:  # Py3: binascii.Error?
+            raise ValidationError("Base64 decoding failed: {}".format(err))
+
+    def validate(self, s):
+        """Implementors are expected to raise ``ValidationError`` if needed."""
+        raise NotImplementedError
+
+
+class AvalonValidator(BaseValidator):
+    @staticmethod
+    def _check_admin_data(row):
+        """Raise if the administrative data line in an Avalon CSV is missing."""
+        err = ValidationError(
+            "Administrative data must include reference name and author."
+        )
+        if len(row) < 2:
+            raise err
+        name = row[0]
+        author = row[1]
+        if not bool(name and author):
+            raise err
+
+    @staticmethod
+    def _check_header_data(row):
+        """Validate header data line in an Avalon CSV.
+
+        :param row: list: metadata fields
+        """
+        all_headers = [
+            "Bibliographic ID",
+            "Bibliographic ID Label",
+            "Other Identifier",
+            "Other Identifier Type",
+            "Title",
+            "Creator",
+            "Contributor",
+            "Genre",
+            "Publisher",
+            "Date Created",
+            "Date Issued",
+            "Abstract",
+            "Language",
+            "Physical Description",
+            "Related Item URL",
+            "Related Item Label",
+            "Topical Subject",
+            "Geographic Subject",
+            "Temporal Subject",
+            "Terms of Use",
+            "Table of Contents",
+            "Statement of Responsibility",
+            "Note",
+            "Note Type",
+            "Publish",
+            "Hidden",
+            "File",
+            "Label",
+            "Offset",
+            "Skip Transcoding",
+            "Absolute Location",
+            "Date Ingested",
+        ]
+        req_headers = ["Title", "Date Issued", "File"]
+        unique_headers = [
+            "Bibliographic ID",
+            "Bibliographic ID Label",
+            "Title",
+            "Date Created",
+            "Date Issued",
+            "Abstract",
+            "Physical Description",
+            "Terms of Use",
+        ]
+        collected_headers = collections.Counter(row).items()
+        repeated_headers = [k for k, v in collected_headers if v > 1]
+
+        for x in row:
+            while "" in row:
+                row.remove("")
+            if x[0] == " " or x[-1] == " ":
+                raise ValidationError(
+                    (
+                        "Header fields cannot have leading or trailing blanks. Invalid field: "
+                        + str(x)
+                    )
+                )
+
+        if not (set(row).issubset(set(all_headers))):
+            raise ValidationError(
+                "Manifest includes invalid metadata field(s). Invalid field(s): "
+                + ",".join(list(set(row) - set(all_headers)))
+            )
+
+        if any(x in repeated_headers for x in unique_headers):
+            raise ValidationError(
+                "A non-repeatable header field is repeated. Repeating field(s): "
+                + ",".join(repeated_headers)
+            )
+
+        if not (all(x in row for x in req_headers)):
+            if "Bibliographic ID" not in row:
+                raise ValidationError(
+                    (
+                        "One of the required headers is missing: Title, Date Issued, File."
+                    )
+                )
+        return True
+
+    @staticmethod
+    def _get_file_columns(row):
+        """Identify columns containing file data.
+
+        :param row: list: metadata fields
+        """
+        columns = []
+        for i, field in enumerate(row):
+            if field == "File":
+                columns.append(i)
+        return columns
+
+    @staticmethod
+    def _get_op_columns(row):
+        """Identify columns containing file data.
+
+        :param row: list: metadata fields
+        """
+        columns = []
+        for i, field in enumerate(row):
+            if field == "Publish" or field == "Hidden":
+                columns.append(i)
+        return columns
+
+    @staticmethod
+    def _check_field_pairs(row):
+        """Checks paired fields have associated pair.
+
+        :param row: list: metadata fields
+        """
+        for i, field in enumerate(row):
+            if field == "Other Identifier Type":
+                if not all(
+                    f in row for f in ["Other Identifier", "Other Identifier Type"]
+                ):
+                    raise ValidationError(
+                        ("Other Identifier Type field missing its required pair.")
+                    )
+            if field == "Related Item Label":
+                if not all(
+                    f in row for f in ["Related Item URL", "Related Item Label"]
+                ):
+                    raise ValidationError(
+                        ("Related Item Label field missing its required pair.")
+                    )
+            if field == "Note Type":
+                if not all(f in row for f in ["Note", "Note Type"]):
+                    raise ValidationError(
+                        ("Note Type field missing its required pair.")
+                    )
+
+    @staticmethod
+    def _check_file_exts(row, file_cols):
+        """Checks for only one period in filepath, unless specifying transcoded
+        video quality.
+
+        :param row: list: metadata fields
+        :param file_cols: list: columns holding file data
+        """
+        for c in file_cols:
+            if row[c].count(".") > 1 and not any(
+                q in row[c] for q in [".high.", ".medium.", ".low"]
+            ):
+                raise ValidationError(
+                    ("Filepath " + row[c] + " contains" " more than one period.")
+                )
+
+    @staticmethod
+    def _check_op_fields(row, op_cols):
+        """Checks that operational fields are marked only as "yes" or "no".
+
+        :param row: list: metadata fields
+        :param op_cols: list: columns holding operational field data
+        """
+        for c in op_cols:
+            if row[c]:
+                if not (row[c].lower() == "yes" or row[c].lower() == "no"):
+                    raise ValidationError(
+                        (
+                            "Publish/Hidden fields must have boolean value (yes or no). Value is "
+                            + str(row[c])
+                        )
+                    )
+
+    def validate(self, s):
+        csvr = csv.reader(BytesIO(super(AvalonValidator, self)._decode(s)))
+        for i, row in enumerate(csvr):
+            if i == 0:
+                self._check_admin_data(row)
+            if i == 1:
+                self._check_header_data(row)
+                file_cols = self._get_file_columns(row)
+                op_cols = self._get_op_columns(row)
+                self._check_field_pairs(row)
+            if i >= 2:
+                self._check_file_exts(row, file_cols)
+                self._check_op_fields(row, op_cols)
+
+
+_VALIDATORS = {"avalon": AvalonValidator}
+
+
+class ValidatorNotAvailableError(Exception):
+    default = "Unknown validator. Accepted values: {}".format(
+        ",".join(_VALIDATORS.keys())
+    )
+
+    def __init__(self, *args, **kwargs):
+        if not (args or kwargs):
+            args = (self.default,)
+        super(ValidatorNotAvailableError, self).__init__(*args, **kwargs)
+
+
+def validator(name):
+    try:
+        klass = _VALIDATORS[name]
+    except KeyError:
+        raise ValidatorNotAvailableError
+    return klass()

--- a/src/dashboard/src/components/api/validators.py
+++ b/src/dashboard/src/components/api/validators.py
@@ -216,9 +216,7 @@ class AvalonValidator(BaseValidator):
 
     def validate(self, string):
         csvr = csv.reader(BytesIO(string))
-        empty = True
         for i, row in enumerate(csvr):
-            empty = False
             if i == 0:
                 self._check_admin_data(row)
             if i == 1:
@@ -229,8 +227,13 @@ class AvalonValidator(BaseValidator):
             if i >= 2:
                 self._check_file_exts(row, file_cols)
                 self._check_op_fields(row, op_cols)
-        if empty:
+        try:
+            i
+        except NameError:
             raise ValidationError("The document is empty.")
+        else:
+            if i < 2:
+                raise ValidationError("The document is incomplete.")
         return True
 
 

--- a/src/dashboard/tests/test_api_v2beta.py
+++ b/src/dashboard/tests/test_api_v2beta.py
@@ -4,6 +4,7 @@ import base64
 import json
 import os
 
+from django.core.urlresolvers import reverse
 from django.test import TestCase, Client
 import mock
 
@@ -107,18 +108,36 @@ class TestValidate(TestCase):
     fixture_files = ["test_user.json"]
     fixtures = [os.path.join(THIS_DIR, "fixtures", p) for p in fixture_files]
 
+    VALID_AVALON_CSV = u"""Avalon Demo Batch,archivist1@example.com,,,,,,,,,,,,,,,,,,,,,,
+Bibliographic ID,Bibliographic ID Label,Title,Creator,Contributor,Contributor,Contributor,Contributor,Contributor,Publisher,Date Created,Date Issued,Abstract,Topical Subject,Topical Subject,Publish,File,Skip Transcoding,Label,File,Skip Transcoding,Label,Note Type,Note
+,,Symphony no. 3,"Mahler, Gustav, 1860-1911",,,,,,,,1996,,,,yes,assets/agz3068a.wav,no,CD 1,,,,local,This was batch ingested without skip transcoding
+,,Féte (Excerpt),"Langlais, Jean, 1907-1991","Young, Christopher C. (Christopher Clark)",,,,,William and Gayle Cook Music Library,,2010,"Recorded on May 2, 2010, Auer Concert Hall, Indiana University, Bloomington.",Organ music,,yes,assets/OrganClip.mp4,yes,,,,,local,This was batch ingested with multiple quality level skip transcoding
+,,Beginning Responsibility: Lunchroom Manners,Coronet Films,,,,,,Coronet Films,,1959,"The rude, clumsy puppet Mr. Bungle shows kids how to behave in the school cafeteria - the assumption being that kids actually want to behave during lunch. This film has a cult following since it appeared on a Pee Wee Herman HBO special.",Social engineering,Puppet theater,yes,assets/lunchroom_manners_512kb.high.mp4,yes,Lunchroom 1,assets/lunchroom_manners_512kb.mp4,yes,Lunchroom Again,local,This was batch ingested with skip transcoding and with structure
+"""
+
+    INVALID_AVALON_CSV = u"""Avalon Demo Batch,archivist1@example.com,,,,,,,,,,,,,,,,,,,,,,
+Bibliographic ID,Bibliographic ID Lbl,Title,Creator,Contributor,Contributor,Contributor,Contributor,Contributor,Publisher,Date Created,Date Issued,Abstract,Topical Subject,Topical Subject,Publish,File,Skip Transcoding,Label,File,Skip Transcoding,Label,Note Type,Note
+,,Symphony no. 3,"Mahler, Gustav, 1860-1911",,,,,,,,1996,,,,Yes,assets/agz3068a.wav,no,CD 1,,,,local,This was batch ingested without skip transcoding
+,,Féte (Excerpt),"Langlais, Jean, 1907-1991","Young, Christopher C. (Christopher Clark)",,,,,William and Gayle Cook Music Library,,2010,"Recorded on May 2, 2010, Auer Concert Hall, Indiana University, Bloomington.",Organ music,,Yes,assets/OrganClip.mp4,yes,,,,,local,This was batch ingested with multiple quality level skip transcoding
+,,Beginning Responsibility: Lunchroom Manners,Coronet Films,,,,,,Coronet Films,,1959,"The rude, clumsy puppet Mr. Bungle shows kids how to behave in the school cafeteria - the assumption being that kids actually want to behave during lunch. This film has a cult following since it appeared on a Pee Wee Herman HBO special.",Social engineering,Puppet theater,Yes,assets/lunchroom_manners_512kb.mp4,yes,Lunchroom 1,assets/lunchroom_manners_512kb.mp4,yes,Lunchroom Again,local,This was batch ingested with skip transcoding and with structure
+"""
+
     def setUp(self):
         self.client = Client()
         self.client.login(username="test", password="test")
         helpers.set_setting("dashboard_uuid", "test-uuid")
 
-    def test_validate_with_unknown_validator(self):
-        resp = self.client.post(
-            "/api/v2beta/validate/",
-            json.dumps({"validator": "!!unknown", "payload": "..."}),
-            content_type="application/json",
+    def _post(self, validator_name, payload, content_type="text/csv; charset=utf-8"):
+        return self.client.post(
+            reverse("validate", args=[validator_name]),
+            payload,
+            content_type=content_type,
         )
-        assert resp.status_code == 400
+
+    def test_unknown_validator(self):
+        resp = self._post("unknown-validator", b"...")
+
+        assert resp.status_code == 404
         assert resp.content == json.dumps(
             {
                 "message": "Unknown validator. Accepted values: {}".format(
@@ -128,84 +147,30 @@ class TestValidate(TestCase):
             }
         )
 
-    def test_validate_with_undecodable_base64(self):
-        resp = self.client.post(
-            "/api/v2beta/validate/",
-            json.dumps({"validator": "avalon", "payload": "badpadding="}),
-            content_type="application/json",
-        )
-        assert resp.status_code == 200
-        assert resp.content == json.dumps(
-            {"valid": False, "reason": "Base64 decoding failed: Incorrect padding"}
-        )
+    def test_unaccepted_content_type(self):
+        resp = self._post("avalon", b"...", content_type="text/plain")
 
-    @mock.patch(
-        "components.api.validators.AvalonValidator.validate",
-        side_effect=validators.ValidationError("Bad contents!"),
-    )
-    def test_validate_valid_err(self, validate_mock):
-        resp = self.client.post(
-            "/api/v2beta/validate/",
-            json.dumps({"validator": "avalon", "payload": "Rm9vYmFy"}),
-            content_type="application/json",
-        )
-        assert resp.status_code == 200
-        assert resp.content == json.dumps({"valid": False, "reason": "Bad contents!"})
-        validate_mock.assert_called_once_with("Rm9vYmFy")
-
-    @mock.patch("components.api.validators.AvalonValidator.validate")
-    def test_validate_valid_ok(self, validate_mock):
-        resp = self.client.post(
-            "/api/v2beta/validate/",
-            json.dumps({"validator": "avalon", "payload": "Rm9vYmFy"}),
-            content_type="application/json",
-        )
-        assert resp.status_code == 200
-        assert resp.content == json.dumps({"valid": True})
-        validate_mock.assert_called_once_with("Rm9vYmFy")
-
-    def test_validate_avalon_err(self):
-        SAMPLE = b"""Avalon Demo Batch,archivist1@example.com,,,,,,,,,,,,,,,,,,,,,,
-Bibliographic ID,Bibliographic ID Lbl,Title,Creator,Contributor,Contributor,Contributor,Contributor,Contributor,Publisher,Date Created,Date Issued,Abstract,Topical Subject,Topical Subject,Publish,File,Skip Transcoding,Label,File,Skip Transcoding,Label,Note Type,Note
-,,Symphony no. 3,"Mahler, Gustav, 1860-1911",,,,,,,,1996,,,,Yes,assets/agz3068a.wav,no,CD 1,,,,local,This was batch ingested without skip transcoding
-,,Fete (Excerpt),"Langlais, Jean, 1907-1991","Young, Christopher C. (Christopher Clark)",,,,,William and Gayle Cook Music Library,,2010,"Recorded on May 2, 2010, Auer Concert Hall, Indiana University, Bloomington.",Organ music,,Yes,assets/OrganClip.mp4,yes,,,,,local,This was batch ingested with multiple quality level skip transcoding
-,,Beginning Responsibility: Lunchroom Manners,Coronet Films,,,,,,Coronet Films,,1959,"The rude, clumsy puppet Mr. Bungle shows kids how to behave in the school cafeteria - the assumption being that kids actually want to behave during lunch. This film has a cult following since it appeared on a Pee Wee Herman HBO special.",Social engineering,Puppet theater,Yes,assets/lunchroom_manners_512kb.mp4,yes,Lunchroom 1,assets/lunchroom_manners_512kb.mp4,yes,Lunchroom Again,local,This was batch ingested with skip transcoding and with structure
-"""
-
-        resp = self.client.post(
-            "/api/v2beta/validate/",
-            json.dumps(
-                {
-                    "validator": "avalon",
-                    "payload": base64.b64encode(SAMPLE).decode("utf-8"),
-                }
-            ),
-            content_type="application/json",
-        )
-        assert resp.status_code == 200
+        assert resp.status_code == 400
         assert resp.content == json.dumps(
             {
-                "reason": "Manifest includes invalid metadata field(s). Invalid field(s): Bibliographic ID Lbl",
-                "valid": False,
+                "message": 'Content type should be "text/csv; charset=utf-8"',
+                "error": True,
             }
         )
 
-    def test_validate_avalon_ok(self):
-        SAMPLE = b"""Avalon Demo Batch,archivist1@example.com,,,,,,,,,,,,,,,,,,,,,,
-Bibliographic ID,Bibliographic ID Label,Title,Creator,Contributor,Contributor,Contributor,Contributor,Contributor,Publisher,Date Created,Date Issued,Abstract,Topical Subject,Topical Subject,Publish,File,Skip Transcoding,Label,File,Skip Transcoding,Label,Note Type,Note
-,,Symphony no. 3,"Mahler, Gustav, 1860-1911",,,,,,,,1996,,,,yes,assets/agz3068a.wav,no,CD 1,,,,local,This was batch ingested without skip transcoding
-,,Fete (Excerpt),"Langlais, Jean, 1907-1991","Young, Christopher C. (Christopher Clark)",,,,,William and Gayle Cook Music Library,,2010,"Recorded on May 2, 2010, Auer Concert Hall, Indiana University, Bloomington.",Organ music,,yes,assets/OrganClip.mp4,yes,,,,,local,This was batch ingested with multiple quality level skip transcoding
-,,Beginning Responsibility: Lunchroom Manners,Coronet Films,,,,,,Coronet Films,,1959,"The rude, clumsy puppet Mr. Bungle shows kids how to behave in the school cafeteria - the assumption being that kids actually want to behave during lunch. This film has a cult following since it appeared on a Pee Wee Herman HBO special.",Social engineering,Puppet theater,yes,assets/lunchroom_manners_512kb.high.mp4,yes,Lunchroom 1,assets/lunchroom_manners_512kb.mp4,yes,Lunchroom Again,local,This was batch ingested with skip transcoding and with structure
-"""
-        resp = self.client.post(
-            "/api/v2beta/validate/",
-            json.dumps(
-                {
-                    "validator": "avalon",
-                    "payload": base64.b64encode(SAMPLE).decode("utf-8"),
-                }
-            ),
-            content_type="application/json",
-        )
+    def test_avalon_pass(self):
+        resp = self._post("avalon", self.VALID_AVALON_CSV.encode("utf-8"))
+
         assert resp.status_code == 200
         assert resp.content == json.dumps({"valid": True})
+
+    def test_avalon_err(self):
+        resp = self._post("avalon", self.INVALID_AVALON_CSV.encode("utf-8"))
+
+        assert resp.status_code == 400
+        assert resp.content == json.dumps(
+            {
+                "valid": False,
+                "reason": "Manifest includes invalid metadata field(s). Invalid field(s): Bibliographic ID Lbl",
+            }
+        )

--- a/src/dashboard/tests/test_api_v2beta.py
+++ b/src/dashboard/tests/test_api_v2beta.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import base64
 import json
 import os
@@ -6,6 +8,7 @@ from django.test import TestCase, Client
 import mock
 
 from components import helpers
+from components.api import validators
 
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -98,3 +101,111 @@ class TestAPIv2(TestCase):
         payload = json.loads(resp.content)
         assert payload["error"] is True
         assert payload["message"] == "Package cannot be created"
+
+
+class TestValidate(TestCase):
+    fixture_files = ["test_user.json"]
+    fixtures = [os.path.join(THIS_DIR, "fixtures", p) for p in fixture_files]
+
+    def setUp(self):
+        self.client = Client()
+        self.client.login(username="test", password="test")
+        helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    def test_validate_with_unknown_validator(self):
+        resp = self.client.post(
+            "/api/v2beta/validate/",
+            json.dumps({"validator": "!!unknown", "payload": "..."}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert resp.content == json.dumps(
+            {
+                "message": "Unknown validator. Accepted values: {}".format(
+                    ",".join(validators._VALIDATORS.keys())
+                ),
+                "error": True,
+            }
+        )
+
+    def test_validate_with_undecodable_base64(self):
+        resp = self.client.post(
+            "/api/v2beta/validate/",
+            json.dumps({"validator": "avalon", "payload": "badpadding="}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        assert resp.content == json.dumps(
+            {"valid": False, "reason": "Base64 decoding failed: Incorrect padding"}
+        )
+
+    @mock.patch(
+        "components.api.validators.AvalonValidator.validate",
+        side_effect=validators.ValidationError("Bad contents!"),
+    )
+    def test_validate_valid_err(self, validate_mock):
+        resp = self.client.post(
+            "/api/v2beta/validate/",
+            json.dumps({"validator": "avalon", "payload": "Rm9vYmFy"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        assert resp.content == json.dumps({"valid": False, "reason": "Bad contents!"})
+        validate_mock.assert_called_once_with("Rm9vYmFy")
+
+    @mock.patch("components.api.validators.AvalonValidator.validate")
+    def test_validate_valid_ok(self, validate_mock):
+        resp = self.client.post(
+            "/api/v2beta/validate/",
+            json.dumps({"validator": "avalon", "payload": "Rm9vYmFy"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        assert resp.content == json.dumps({"valid": True})
+        validate_mock.assert_called_once_with("Rm9vYmFy")
+
+    def test_validate_avalon_err(self):
+        SAMPLE = b"""Avalon Demo Batch,archivist1@example.com,,,,,,,,,,,,,,,,,,,,,,
+Bibliographic ID,Bibliographic ID Lbl,Title,Creator,Contributor,Contributor,Contributor,Contributor,Contributor,Publisher,Date Created,Date Issued,Abstract,Topical Subject,Topical Subject,Publish,File,Skip Transcoding,Label,File,Skip Transcoding,Label,Note Type,Note
+,,Symphony no. 3,"Mahler, Gustav, 1860-1911",,,,,,,,1996,,,,Yes,assets/agz3068a.wav,no,CD 1,,,,local,This was batch ingested without skip transcoding
+,,Fete (Excerpt),"Langlais, Jean, 1907-1991","Young, Christopher C. (Christopher Clark)",,,,,William and Gayle Cook Music Library,,2010,"Recorded on May 2, 2010, Auer Concert Hall, Indiana University, Bloomington.",Organ music,,Yes,assets/OrganClip.mp4,yes,,,,,local,This was batch ingested with multiple quality level skip transcoding
+,,Beginning Responsibility: Lunchroom Manners,Coronet Films,,,,,,Coronet Films,,1959,"The rude, clumsy puppet Mr. Bungle shows kids how to behave in the school cafeteria - the assumption being that kids actually want to behave during lunch. This film has a cult following since it appeared on a Pee Wee Herman HBO special.",Social engineering,Puppet theater,Yes,assets/lunchroom_manners_512kb.mp4,yes,Lunchroom 1,assets/lunchroom_manners_512kb.mp4,yes,Lunchroom Again,local,This was batch ingested with skip transcoding and with structure
+"""
+
+        resp = self.client.post(
+            "/api/v2beta/validate/",
+            json.dumps(
+                {
+                    "validator": "avalon",
+                    "payload": base64.b64encode(SAMPLE).decode("utf-8"),
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        assert resp.content == json.dumps(
+            {
+                "reason": "Manifest includes invalid metadata field(s). Invalid field(s): Bibliographic ID Lbl",
+                "valid": False,
+            }
+        )
+
+    def test_validate_avalon_ok(self):
+        SAMPLE = b"""Avalon Demo Batch,archivist1@example.com,,,,,,,,,,,,,,,,,,,,,,
+Bibliographic ID,Bibliographic ID Label,Title,Creator,Contributor,Contributor,Contributor,Contributor,Contributor,Publisher,Date Created,Date Issued,Abstract,Topical Subject,Topical Subject,Publish,File,Skip Transcoding,Label,File,Skip Transcoding,Label,Note Type,Note
+,,Symphony no. 3,"Mahler, Gustav, 1860-1911",,,,,,,,1996,,,,yes,assets/agz3068a.wav,no,CD 1,,,,local,This was batch ingested without skip transcoding
+,,Fete (Excerpt),"Langlais, Jean, 1907-1991","Young, Christopher C. (Christopher Clark)",,,,,William and Gayle Cook Music Library,,2010,"Recorded on May 2, 2010, Auer Concert Hall, Indiana University, Bloomington.",Organ music,,yes,assets/OrganClip.mp4,yes,,,,,local,This was batch ingested with multiple quality level skip transcoding
+,,Beginning Responsibility: Lunchroom Manners,Coronet Films,,,,,,Coronet Films,,1959,"The rude, clumsy puppet Mr. Bungle shows kids how to behave in the school cafeteria - the assumption being that kids actually want to behave during lunch. This film has a cult following since it appeared on a Pee Wee Herman HBO special.",Social engineering,Puppet theater,yes,assets/lunchroom_manners_512kb.high.mp4,yes,Lunchroom 1,assets/lunchroom_manners_512kb.mp4,yes,Lunchroom Again,local,This was batch ingested with skip transcoding and with structure
+"""
+        resp = self.client.post(
+            "/api/v2beta/validate/",
+            json.dumps(
+                {
+                    "validator": "avalon",
+                    "payload": base64.b64encode(SAMPLE).decode("utf-8"),
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        assert resp.content == json.dumps({"valid": True})


### PR DESCRIPTION
This pull request adds the [proposed](https://adr.archivematica.org/0005-new-api-endpoint-for-csv-validation.html) validation API.

* URL: `/api/v2beta/validate/avalon`
* Content-Type: `text/csv; charset=utf-8`
* Body: `<document>`

Usage example: (assuming that `avalon.csv` exists)

```bash
curl http://127.0.0.1:62080/api/v2beta/validate/avalon \
  --data-binary "@avalon.csv" \
  --header "Authorization: ApiKey test:test" \
  --header "Content-Type: text/csv; charset=utf-8"
```

Note: do not use `--data`, use `--data-binary` instead.

Response examples:

- **200 OK**
  ```json
  {
    "valid": true
  }
  ```

- **400 Bad Request**
  (expect `reason` to include different validation errors)
  ```json
  {
    "valid": false,
    "reason": "Administrative data must include reference name and author."
  }
  ```

- **404 Not Found**
  ```json
  {
    "error": true,
    "message": "Unknown validator. Accepted values: avalon"
  }

See also: [ADR-0005](https://adr.archivematica.org/0005-new-api-endpoint-for-csv-validation.html).
Connects to https://github.com/archivematica/Issues/issues/618.