### PR TITLE
Sanitize names faster

### DIFF
--- a/src/MCPClient/lib/clientScripts/create_mets_v2.py
+++ b/src/MCPClient/lib/clientScripts/create_mets_v2.py
@@ -73,7 +73,7 @@ from create_mets_dataverse_v2 import (
 )
 from custom_handlers import get_script_logger
 import namespaces as ns
-from sanitize_names import sanitizeName
+from sanitize_names import sanitize_name
 
 from bagit import Bag, BagError
 
@@ -877,9 +877,7 @@ def _fixup_path_input_by_user(job, path):
     """Fix-up paths submitted by a user, e.g. in custom structmap examples so
     that they don't have to anticipate the Archivematica normalization process.
     """
-    return os.path.join(
-        "", *[sanitizeName(name.encode("utf8")) for name in path.split(os.path.sep)]
-    )
+    return os.path.join("", *[sanitize_name(name) for name in path.split(os.path.sep)])
 
 
 def include_custom_structmap(

--- a/src/MCPClient/lib/clientScripts/pid_declaration.py
+++ b/src/MCPClient/lib/clientScripts/pid_declaration.py
@@ -20,7 +20,7 @@ django.setup()
 
 from main.models import Directory, File, SIP
 
-from sanitize_names import sanitizeName
+from sanitize_names import sanitize_name
 
 
 class DeclarePIDsException(Exception):
@@ -72,8 +72,7 @@ class DeclarePIDs(object):
         return "{}{}".format(
             self.SIP_DIRECTORY,
             os.path.join(
-                "",
-                *[sanitizeName(name.encode("utf8")) for name in path.split(os.path.sep)]
+                "", *[sanitize_name(name) for name in path.split(os.path.sep)]
             ),
         )
 

--- a/src/MCPClient/lib/clientScripts/sanitize_names.py
+++ b/src/MCPClient/lib/clientScripts/sanitize_names.py
@@ -38,10 +38,18 @@ REPLACEMENT_CHAR = "_"
 
 
 def sanitize_name(basename):
-    unicode_name = unidecode(strToUnicode(basename))
-    # Handle the case where '' is returned by unidecode
+    if basename == "":
+        raise ValueError("sanitize_name recieved an empty filename.")
+    unicode_basename = strToUnicode(basename)
+    unicode_name = unidecode(unicode_basename)
+    # We can't return  an empty string here because it will become the new filename.
+    # However, in some cases unidecode just strips out all chars (e.g.
+    # unidecode(u"🚀") == ""), so if that happens, we to replace the invalid chars with
+    # REPLACEMENT_CHAR. This will result in a filename of one or more underscores,
+    # which isn't great, but allows processing to continue.
     if unicode_name == "":
-        unicode_name = strToUnicode(basename)
+        unicode_name = unicode_basename
+
     return ALLOWED_CHARS.sub(REPLACEMENT_CHAR, unicode_name)
 
 

--- a/src/MCPClient/lib/clientScripts/sanitize_names.py
+++ b/src/MCPClient/lib/clientScripts/sanitize_names.py
@@ -81,9 +81,9 @@ def sanitize_tree(start_path, old_start_path):
     Recursive generator to sanitize all filesystem entries under the start
     path given.
 
-    Yields once for each file name sanitized, each dir sanitized, and
-    everything contained in each sanitized dir (e.g. if /foo/bår is
-    sanitized, /foo/bår/test will also be yielded.)
+    Yields a tuple of (old_path, sanitized_path, is_dir, was_sanitized) once
+    for each file or dir within the start_path, everything contained in each
+    dir.
     """
     start_path = os.path.abspath(start_path)
 
@@ -94,8 +94,8 @@ def sanitize_tree(start_path, old_start_path):
         sanitized_path = os.path.join(start_path, sanitized_name)
         old_path = os.path.join(old_start_path, dir_entry.name)
 
-        if sanitized_path != old_path:
-            yield old_path, sanitized_path, is_dir
+        was_sanitized = sanitized_path != old_path
+        yield old_path, sanitized_path, is_dir, was_sanitized
 
         if is_dir:
             for result in sanitize_tree(sanitized_path, old_path):

--- a/src/MCPClient/lib/clientScripts/sanitize_object_names.py
+++ b/src/MCPClient/lib/clientScripts/sanitize_object_names.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-
+# -*- coding: utf8
 # This file is part of Archivematica.
 #
 # Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
@@ -20,115 +20,226 @@
 # @package Archivematica
 # @subpackage archivematicaClientScript
 # @author Joseph Perry <joseph@artefactual.com>
-from itertools import chain
-import sys
 import os
 import unicodedata
 
 import django
+import six
 
 django.setup()
 from django.db import transaction
 
 # dashboard
-from main.models import File, Directory, Transfer
+from main.models import Event, File, Directory, Transfer, SIP
 
 # archivematicaCommon
 from custom_handlers import get_script_logger
-from fileOperations import updateFileLocation
-from archivematicaFunctions import unicodeToStr
 import sanitize_names
 
 logger = get_script_logger("archivematica.mcp.client.sanitizeObjectNames")
 
 
-def sanitize_object_names(
-    job, objectsDirectory, sipUUID, date, groupType, groupSQL, sipPath
-):
-    """Sanitize object names in a Transfer/SIP."""
-    relativeReplacement = objectsDirectory.replace(
-        sipPath, groupType, 1
-    )  # "%SIPDirectory%objects/"
+class NameSanitizer(object):
+    """
+    Class to track batch sanitizations of files and directories, both in the
+    filesystem and in the database.
+    """
 
-    # Get any ``Directory`` instances created for this transfer (if such exist)
-    directory_mdls = []
-    if groupSQL == "transfer_id":
-        transfer_mdl = Transfer.objects.get(uuid=sipUUID)
-        if transfer_mdl.diruuids:
-            directory_mdls = Directory.objects.filter(transfer=transfer_mdl).all()
+    BATCH_SIZE = 2000
+    EVENT_DETAIL = (
+        'prohibited characters removed: program="sanitize_names"; version="'
+        + sanitize_names.VERSION
+        + '"'
+    )
 
-    # Sanitize objects on disk
-    sanitizations = sanitize_names.sanitizeRecursively(job, objectsDirectory)
-    for oldfile, newfile in sanitizations.items():
-        logger.info("sanitizations: %s -> %s", oldfile, newfile)
+    def __init__(
+        self, job, objects_directory, sip_uuid, date, group_type, group_sql, sip_path
+    ):
+        if group_type not in ("%SIPDirectory%", "%transferDirectory%"):
+            raise ValueError("Unexpected group type: {}".format(group_type))
 
-    eventDetail = 'program="sanitize_names"; version="' + sanitize_names.VERSION + '"'
+        if isinstance(objects_directory, six.binary_type):
+            objects_directory = objects_directory.decode("utf-8")
 
-    # Update files in DB
-    kwargs = {groupSQL: sipUUID, "removedtime__isnull": True}
-    file_mdls = File.objects.filter(**kwargs)
-    # Iterate over ``File`` and ``Directory``
-    for model in chain(file_mdls, directory_mdls):
-        # Check all files to see if any parent directory had a sanitization event
-        current_location = unicodeToStr(
-            unicodedata.normalize("NFC", model.currentlocation)
-        ).replace(groupType, sipPath)
-        sanitized_location = unicodeToStr(current_location)
-        logger.info("Checking %s", current_location)
+        if isinstance(sip_path, six.binary_type):
+            sip_path = sip_path.decode("utf-8")
 
-        # Check parent directories
-        # Since directory keys are a mix of sanitized and unsanitized, this is
-        # a little complicated
-        # Directories keys are in the form sanitized/sanitized/unsanitized
-        # When a match is found (eg 'unsanitized' -> 'sanitized') reset the
-        # search.
-        # This will find 'sanitized/unsanitized2' -> 'sanitized/sanitized2' on
-        # the next pass
-        # TODO This should be checked for a more efficient solution
-        dirpath = sanitized_location
-        while objectsDirectory in dirpath:  # Stay within unit
-            if dirpath in sanitizations:  # Make replacement
-                sanitized_location = sanitized_location.replace(
-                    dirpath, sanitizations[dirpath]
-                )
-                dirpath = sanitized_location  # Reset search
-            else:  # Check next level up
-                dirpath = os.path.dirname(dirpath)
-
-        if current_location != sanitized_location:
-            old_location = current_location.replace(
-                objectsDirectory, relativeReplacement, 1
-            )
-            new_location = sanitized_location.replace(
-                objectsDirectory, relativeReplacement, 1
-            )
-            kwargs = {
-                "src": old_location,
-                "dst": new_location,
-                "eventType": "name cleanup",
-                "eventDateTime": date,
-                "eventDetail": "prohibited characters removed:" + eventDetail,
-                "fileUUID": None,
-            }
-            if groupType == "%SIPDirectory%":
-                kwargs["sipUUID"] = sipUUID
-            elif groupType == "%transferDirectory%":
-                kwargs["transferUUID"] = sipUUID
-            else:
-                job.pyprint("bad group type", groupType, file=sys.stderr)
-                return 3
-            logger.info("Sanitized name: %s -> %s", old_location, new_location)
-            job.pyprint("Sanitized name:", old_location, " -> ", new_location)
-            if isinstance(model, File):
-                updateFileLocation(**kwargs)
-            else:
-                model.currentlocation = new_location
-                model.save()
+        if group_sql == "transfer_id":
+            self.transfer = Transfer.objects.get(uuid=sip_uuid)
+            self.sip = None
+        elif group_sql == "sip_id":
+            self.transfer = None
+            self.sip = SIP.objects.get(uuid=sip_uuid)
         else:
-            logger.info("No sanitization for %s", current_location)
-            job.pyprint("No sanitization found for", current_location)
+            raise ValueError("Unexpected group sql: {}".format(group_sql))
 
-    return 0
+        self.job = job
+        self.objects_directory = objects_directory
+        self.date = date
+        self.group_type = group_type
+        self.sip_path = sip_path
+
+        self.files_index = {}  # old_path: new_path
+        self.dirs_index = {}  # old_path: new_path
+
+    @property
+    def directory_queryset(self):
+        """
+        Base queryset for Directory objects related to the SIP/Transfer.
+        """
+        if self.transfer is not None and self.transfer.diruuids:
+            return Directory.objects.filter(transfer=self.transfer)
+        elif self.sip is not None and self.sip.diruuids:
+            return Directory.objects.filter(sip=self.sip)
+
+        return None
+
+    @property
+    def file_queryset(self):
+        """
+        Base queryset for File objects related to the SIP/Transfer.
+        """
+        file_qs = File.objects.filter(removedtime__isnull=True)
+        if self.sip is not None:
+            return file_qs.filter(sip=self.sip)
+        else:
+            return file_qs.filter(transfer=self.transfer)
+
+    def normalize_path_for_db(self, path):
+        """
+        Returns a unicode normalized, relative paths (e.g.
+        %transferDirectory%objects/example.txt)
+        """
+        return unicodedata.normalize("NFC", path).replace(
+            self.sip_path, self.group_type, 1
+        )
+
+    def apply_file_updates(self):
+        """
+        Run a single batch of File updates.
+        """
+        if self.sip:
+            event_agents = self.sip.agents
+        else:
+            event_agents = self.transfer.agents
+
+        events = []
+
+        # We pass through _all_ objects here, as they may not be normalized in
+        # the db :(
+        for file_obj in self.file_queryset.iterator():
+            old_location = unicodedata.normalize("NFC", file_obj.currentlocation)
+            try:
+                sanitized_location = self.files_index[old_location]
+            except KeyError:
+                continue
+
+            file_obj.currentlocation = sanitized_location
+            file_obj.save()
+
+            sanitize_event = Event(
+                file_uuid=file_obj,
+                event_type="name cleanup",
+                event_datetime=self.date,
+                event_detail=self.EVENT_DETAIL,
+            )
+            events.append(sanitize_event)
+
+        Event.objects.bulk_create(events)
+
+        # Adding m2m fields with bulk create is awkward, we have to loop through again.
+        for event in Event.objects.filter(
+            file_uuid__in=[event.file_uuid for event in events]
+        ):
+            event.agents.add(*event_agents)
+
+        if len(self.files_index) > 0:
+            logger.info("Sanitized batch of %s files", len(self.files_index))
+
+            self.files_index = {}
+        else:
+            logger.info("No file sanitization required.")
+
+    def apply_dir_updates(self):
+        """
+        Run a single batch of Directory updates.
+        """
+        if self.directory_queryset is None:
+            logger.info("No directory sanitization required.")
+            return
+
+        # We pass through _all_ objects here, as they may not be normalized in
+        # the db :(
+        for dir_obj in self.directory_queryset.iterator():
+            old_location = unicodedata.normalize("NFC", dir_obj.currentlocation)
+            try:
+                sanitized_location = self.dirs_index[old_location]
+            except KeyError:
+                continue
+
+            dir_obj.currentlocation = sanitized_location
+            dir_obj.save()
+
+            # TODO: Dir sanitizations don't generate events?
+            # Is seems like they should.
+
+        if len(self.dirs_index) > 0:
+            logger.info("Sanitized batch of %s directories", len(self.dirs_index))
+            self.dirs_index = {}
+        else:
+            logger.info("No directory sanitization required.")
+
+    def add_file_to_batch(self, old_path, new_path):
+        """
+        Index a path change for later updating in the database.
+
+        If our index is over a certain size, then trigger application of the
+        batched changes.
+        """
+        old_path = self.normalize_path_for_db(old_path)
+        new_path = self.normalize_path_for_db(new_path)
+
+        self.files_index[old_path] = new_path
+
+        if len(self.files_index) >= self.BATCH_SIZE:
+            self.apply_file_updates()
+
+    def add_dir_to_batch(self, old_path, new_path):
+        """
+        Index a path change for later updating in the database.
+
+        If our index is over a certain size, then trigger application of the
+        batched changes.
+        """
+        old_path = self.normalize_path_for_db(old_path)
+        new_path = self.normalize_path_for_db(new_path)
+
+        # Add trailing slashes if necessary
+        old_path = os.path.join(old_path, "")
+        new_path = os.path.join(new_path, "")
+
+        self.dirs_index[old_path] = new_path
+
+        if len(self.dirs_index) >= self.BATCH_SIZE:
+            self.apply_dir_updates()
+
+    def sanitize_objects(self):
+        """
+        Iterate over the filesystem, sanitizing as we go. Updates made on disk
+        are batched and then applied to the database in chunks of BATCH_SIZE.
+        """
+        for old_path, new_path, is_dir in sanitize_names.sanitize_tree(
+            self.objects_directory, self.objects_directory
+        ):
+            logger.debug("Sanitized path on disk: %s -> %s", old_path, new_path)
+            if is_dir:
+                self.add_dir_to_batch(old_path, new_path)
+            else:
+                self.add_file_to_batch(old_path, new_path)
+
+        # Catch the remainder afer all batches
+        self.apply_file_updates()
+        self.apply_dir_updates()
 
 
 def call(jobs):
@@ -136,24 +247,24 @@ def call(jobs):
         for job in jobs:
             with job.JobContext(logger=logger):
                 # job.args[4] (taskUUID) is unused.
-                objectsDirectory = job.args[1]  # directory to run sanitization on.
-                sipUUID = job.args[2]  # %SIPUUID%
+                objects_directory = job.args[1]  # directory to run sanitization on.
+                sip_uuid = job.args[2]  # %sip_uuid%
                 date = job.args[3]  # %date%
-                groupType = job.args[5]  # SIPDirectory or transferDirectory
-                groupType = "%%%s%%" % (
-                    groupType
+                group_type = job.args[5]  # SIPDirectory or transferDirectory
+                group_type = "%%%s%%" % (
+                    group_type
                 )  # %SIPDirectory% or %transferDirectory%
-                groupSQL = job.args[6]  # transfer_id or sip_id
-                sipPath = job.args[7]  # %SIPDirectory%
+                group_sql = job.args[6]  # transfer_id or sip_id
+                sip_path = job.args[7]  # %SIPDirectory%
 
-                job.set_status(
-                    sanitize_object_names(
-                        job,
-                        objectsDirectory,
-                        sipUUID,
-                        date,
-                        groupType,
-                        groupSQL,
-                        sipPath,
-                    )
+                sanitizer = NameSanitizer(
+                    job,
+                    objects_directory,
+                    sip_uuid,
+                    date,
+                    group_type,
+                    group_sql,
+                    sip_path,
                 )
+                sanitizer.sanitize_objects()
+                job.set_status(0)

--- a/src/MCPClient/lib/clientScripts/sanitize_sip_name.py
+++ b/src/MCPClient/lib/clientScripts/sanitize_sip_name.py
@@ -31,7 +31,7 @@ from django.db import transaction
 # dashboard
 from main.models import SIP, Transfer
 
-from sanitize_names import sanitizePath
+from sanitize_names import sanitize_path
 
 
 def call(jobs):
@@ -58,7 +58,7 @@ def call(jobs):
                     job.pyprint("invalid unit type: ", unitType, file=sys.stderr)
                     job.set_status(1)
                     continue
-                dst = sanitizePath(job, SIPDirectory)
+                dst = sanitize_path(SIPDirectory)
                 if SIPDirectory != dst:
                     dst = dst.replace(sharedDirectoryPath, "%sharedPath%", 1) + "/"
                     job.pyprint(

--- a/src/MCPClient/tests/test_sanitize.py
+++ b/src/MCPClient/tests/test_sanitize.py
@@ -267,6 +267,11 @@ def test_sanitize_name(basename, expected_name):
     assert sanitize_names.sanitize_name(basename) == expected_name
 
 
+def test_sanitize_name_raises_valueerror_on_empty_string():
+    with pytest.raises(ValueError):
+        sanitize_names.sanitize_name("")
+
+
 @pytest.mark.django_db
 def test_sanitize_transfer_with_multiple_files(
     monkeypatch, tmp_path, transfer, subdir_path, multiple_transfer_file_objs

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -413,6 +413,24 @@ class SIP(models.Model):
         """Allow callers to add custom identifiers to the model's instance."""
         self.identifiers.create(type=scheme, value=value)
 
+    @property
+    def agents(self):
+        """Returns a queryset of agents related to this SIP."""
+        agent_lookups = models.Q(
+            identifiertype__in=("repository code", "preservation system")
+        )
+
+        try:
+            unit_variable = UnitVariable.objects.get(
+                unittype="SIP", unituuid=self.uuid, variable="activeAgent"
+            )
+        except UnitVariable.DoesNotExist:
+            pass
+        else:
+            agent_lookups = agent_lookups | models.Q(id=unit_variable.variablevalue)
+
+        return Agent.objects.filter(agent_lookups)
+
 
 class TransferManager(models.Manager):
     def is_hidden(self, uuid):
@@ -451,6 +469,24 @@ class Transfer(models.Model):
 
     def update_active_agent(self, user_id):
         UnitVariable.objects.update_active_agent("Transfer", self.uuid, user_id)
+
+    @property
+    def agents(self):
+        """Returns a queryset of agents related to this tranfer."""
+        agent_lookups = models.Q(
+            identifiertype__in=("repository code", "preservation system")
+        )
+
+        try:
+            unit_variable = UnitVariable.objects.get(
+                unittype="Transfer", unituuid=self.uuid, variable="activeAgent"
+            )
+        except UnitVariable.DoesNotExist:
+            pass
+        else:
+            agent_lookups = agent_lookups | models.Q(id=unit_variable.variablevalue)
+
+        return Agent.objects.filter(agent_lookups)
 
 
 class SIPArrange(models.Model):


### PR DESCRIPTION
~~WIP, but so far seems to be about 3x faster (around 3 vs 10 secs for 5k corrections).~~ ~~This is a big change, it needs some better tests.~~ ~~We can also improve perf further probably by removing more logging (as I think @sevein noted somewhere that is a big delay) and removing the use of `updateFileLocation` which does another (completely unnecessary) SELECT query per file right now.~~
EDIT: 🤦‍♂️ Due to a path mismatch I've been profiling _not_ sanitizing 5k files. It's more like 200 secs to actually sanitize them, and `updateFileLocation` is the source of most of the slowness. This PR will need some revision.

Connects to https://github.com/archivematica/Issues/issues/315.