### PR TITLE
Increase timeout value for dashboard MCP RPC calls (1.9.x)

### DIFF
--- a/src/dashboard/src/contrib/mcp/client.py
+++ b/src/dashboard/src/contrib/mcp/client.py
@@ -84,7 +84,7 @@ class NoJobFoundError(RPCGearmanClientError):
         super(NoJobFoundError, self).__init__(message)
 
 
-INFLIGHT_POLL_TIMEOUT = 5.0
+INFLIGHT_POLL_TIMEOUT = 30.0
 
 
 class MCPClient(object):


### PR DESCRIPTION
Quick workaround for https://github.com/archivematica/Issues/issues/624 (for `stable/1.9.x`)

Connected to https://github.com/archivematica/Issues/issues/624