### PR TITLE
Fix aips and aipfiles ES mappings

### DIFF
--- a/src/archivematicaCommon/lib/elasticsearch/aipfiles_mets_mapping.json
+++ b/src/archivematicaCommon/lib/elasticsearch/aipfiles_mets_mapping.json
@@ -2,18 +2,18 @@
   "properties": {
     "dmdSec": {
       "properties": {
-        "ns0:xmlData_dict_list": {
+        "mets:xmlData_dict_list": {
           "properties": {
-            "@xmlns:ns1": {
+            "@xmlns:premis": {
               "type": "text"
             },
-            "@xmlns:ns0": {
+            "@xmlns:mets": {
               "type": "text"
             },
             "@xmlns:xsi": {
               "type": "text"
             },
-            "ns1:dublincore_dict_list": {
+            "premis:dublincore_dict_list": {
               "properties": {
                 "dc:available": {
                   "type": "text"
@@ -44,18 +44,18 @@
     },
     "amdSec": {
       "properties": {
-        "ns0:amdSec_dict_list": {
+        "mets:amdSec_dict_list": {
           "properties": {
-            "ns0:techMD_dict_list": {
+            "mets:techMD_dict_list": {
               "properties": {
-                "ns0:mdWrap_dict_list": {
+                "mets:mdWrap_dict_list": {
                   "properties": {
                     "@MDTYPE": {
                       "type": "text"
                     },
-                    "ns0:xmlData_dict_list": {
+                    "mets:xmlData_dict_list": {
                       "properties": {
-                        "ns1:object_dict_list": {
+                        "premis:object_dict_list": {
                           "properties": {
                             "@version": {
                               "type": "text"
@@ -63,42 +63,42 @@
                             "@xsi:type": {
                               "type": "text"
                             },
-                            "ns1:objectCharacteristics_dict_list": {
+                            "premis:objectCharacteristics_dict_list": {
                               "properties": {
-                                "ns1:compositionLevel": {
+                                "premis:compositionLevel": {
                                   "type": "text"
                                 },
-                                "ns1:size": {
+                                "premis:size": {
                                   "type": "text"
                                 },
-                                "ns1:fixity_dict_list": {
+                                "premis:fixity_dict_list": {
                                   "properties": {
-                                    "ns1:messageDigest": {
+                                    "premis:messageDigest": {
                                       "type": "text"
                                     },
-                                    "ns1:messageDigestAlgorithm": {
+                                    "premis:messageDigestAlgorithm": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns1:format_dict_list": {
+                                "premis:format_dict_list": {
                                   "properties": {
-                                    "ns1:formatDesignation_dict_list": {
+                                    "premis:formatDesignation_dict_list": {
                                       "properties": {
-                                        "ns1:formatName": {
+                                        "premis:formatName": {
                                           "type": "text"
                                         },
-                                        "ns1:formatVersion": {
+                                        "premis:formatVersion": {
                                           "type": "text"
                                         }
                                       }
                                     },
-                                    "ns1:formatRegistry_dict_list": {
+                                    "premis:formatRegistry_dict_list": {
                                       "properties": {
-                                        "ns1:formatRegistryKey": {
+                                        "premis:formatRegistryKey": {
                                           "type": "text"
                                         },
-                                        "ns1:formatRegistryName": {
+                                        "premis:formatRegistryName": {
                                           "type": "text"
                                         }
                                       }
@@ -107,15 +107,15 @@
                                 }
                               }
                             },
-                            "ns1:originalName": {
+                            "premis:originalName": {
                               "type": "text"
                             },
-                            "ns1:objectIdentifier_dict_list": {
+                            "premis:objectIdentifier_dict_list": {
                               "properties": {
-                                "ns1:objectIdentifierType": {
+                                "premis:objectIdentifierType": {
                                   "type": "text"
                                 },
-                                "ns1:objectIdentifierValue": {
+                                "premis:objectIdentifierValue": {
                                   "type": "text"
                                 }
                               }
@@ -134,10 +134,10 @@
                 }
               }
             },
-            "@xmlns:ns1": {
+            "@xmlns:premis": {
               "type": "text"
             },
-            "@xmlns:ns0": {
+            "@xmlns:mets": {
               "type": "text"
             },
             "@xmlns:xsi": {
@@ -146,213 +146,213 @@
             "@ID": {
               "type": "text"
             },
-            "ns0:rightsMD_dict_list": {
+            "mets:rightsMD_dict_list": {
               "properties": {
-                "ns0:mdWrap_dict_list": {
+                "mets:mdWrap_dict_list": {
                   "properties": {
                     "@MDTYPE": {
                       "type": "text"
                     },
-                    "ns0:xmlData_dict_list": {
+                    "mets:xmlData_dict_list": {
                       "properties": {
-                        "ns1:rightsStatement_dict_list": {
+                        "premis:rightsStatement_dict_list": {
                           "properties": {
-                            "ns1:otherRightsInformation_dict_list": {
+                            "premis:otherRightsInformation_dict_list": {
                               "properties": {
-                                "ns1:otherRightsDocumentationIdentifier_dict_list": {
+                                "premis:otherRightsDocumentationIdentifier_dict_list": {
                                   "properties": {
-                                    "ns1:otherRightsDocumentationIdentifierValue": {
+                                    "premis:otherRightsDocumentationIdentifierValue": {
                                       "type": "text"
                                     },
-                                    "ns1:otherRightsDocumentationIdentifierType": {
+                                    "premis:otherRightsDocumentationIdentifierType": {
                                       "type": "text"
                                     },
-                                    "ns1:otherRightsDocumentationRole": {
+                                    "premis:otherRightsDocumentationRole": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns1:otherRightsBasis": {
+                                "premis:otherRightsBasis": {
                                   "type": "text"
                                 },
-                                "ns1:otherRightsNote": {
+                                "premis:otherRightsNote": {
                                   "type": "text"
                                 },
-                                "ns1:otherRightsApplicableDates_dict_list": {
+                                "premis:otherRightsApplicableDates_dict_list": {
                                   "properties": {
-                                    "ns1:startDate": {
+                                    "premis:startDate": {
                                       "type": "text"
                                     },
-                                    "ns1:endDate": {
+                                    "premis:endDate": {
                                       "type": "text"
                                     }
                                   }
                                 }
                               }
                             },
-                            "ns1:rightsBasis": {
+                            "premis:rightsBasis": {
                               "type": "text"
                             },
-                            "ns1:licenseInformation_dict_list": {
+                            "premis:licenseInformation_dict_list": {
                               "properties": {
-                                "ns1:licenseNote": {
+                                "premis:licenseNote": {
                                   "type": "text"
                                 },
-                                "ns1:licenseTerms": {
+                                "premis:licenseTerms": {
                                   "type": "text"
                                 },
-                                "ns1:licenseDocumentationIdentifier_dict_list": {
+                                "premis:licenseDocumentationIdentifier_dict_list": {
                                   "properties": {
-                                    "ns1:licenseDocumentationRole": {
+                                    "premis:licenseDocumentationRole": {
                                       "type": "text"
                                     },
-                                    "ns1:licenseDocumentationIdentifierValue": {
+                                    "premis:licenseDocumentationIdentifierValue": {
                                       "type": "text"
                                     },
-                                    "ns1:licenseDocumentationIdentifierType": {
+                                    "premis:licenseDocumentationIdentifierType": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns1:licenseApplicableDates_dict_list": {
+                                "premis:licenseApplicableDates_dict_list": {
                                   "properties": {
-                                    "ns1:startDate": {
+                                    "premis:startDate": {
                                       "type": "text"
                                     },
-                                    "ns1:endDate": {
+                                    "premis:endDate": {
                                       "type": "text"
                                     }
                                   }
                                 }
                               }
                             },
-                            "ns1:rightsGranted_dict_list": {
+                            "premis:rightsGranted_dict_list": {
                               "properties": {
-                                "ns1:termOfRestriction_dict_list": {
+                                "premis:termOfRestriction_dict_list": {
                                   "properties": {
-                                    "ns1:startDate": {
+                                    "premis:startDate": {
                                       "type": "text"
                                     },
-                                    "ns1:endDate": {
+                                    "premis:endDate": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns1:restriction": {
+                                "premis:restriction": {
                                   "type": "text"
                                 },
-                                "ns1:termOfGrant_dict_list": {
+                                "premis:termOfGrant_dict_list": {
                                   "properties": {
-                                    "ns1:startDate": {
+                                    "premis:startDate": {
                                       "type": "text"
                                     },
-                                    "ns1:endDate": {
+                                    "premis:endDate": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns1:rightsGrantedNote": {
+                                "premis:rightsGrantedNote": {
                                   "type": "text"
                                 },
-                                "ns1:act": {
+                                "premis:act": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns1:rightsStatementIdentifier_dict_list": {
+                            "premis:rightsStatementIdentifier_dict_list": {
                               "properties": {
-                                "ns1:rightsStatementIdentifierType": {
+                                "premis:rightsStatementIdentifierType": {
                                   "type": "text"
                                 },
-                                "ns1:rightsStatementIdentifierValue": {
+                                "premis:rightsStatementIdentifierValue": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns1:statuteInformation_dict_list": {
+                            "premis:statuteInformation_dict_list": {
                               "properties": {
-                                "ns1:statuteNote": {
+                                "premis:statuteNote": {
                                   "type": "text"
                                 },
-                                "ns1:statuteApplicableDates_dict_list": {
+                                "premis:statuteApplicableDates_dict_list": {
                                   "properties": {
-                                    "ns1:startDate": {
+                                    "premis:startDate": {
                                       "type": "text"
                                     },
-                                    "ns1:endDate": {
+                                    "premis:endDate": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns1:statuteDocumentationIdentifier_dict_list": {
+                                "premis:statuteDocumentationIdentifier_dict_list": {
                                   "properties": {
-                                    "ns1:statuteDocumentationIdentifierValue": {
+                                    "premis:statuteDocumentationIdentifierValue": {
                                       "type": "text"
                                     },
-                                    "ns1:statuteDocumentationRole": {
+                                    "premis:statuteDocumentationRole": {
                                       "type": "text"
                                     },
-                                    "ns1:statuteDocumentationIdentifierType": {
+                                    "premis:statuteDocumentationIdentifierType": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns1:statuteInformationDeterminationDate": {
+                                "premis:statuteInformationDeterminationDate": {
                                   "type": "text"
                                 },
-                                "ns1:statuteCitation": {
+                                "premis:statuteCitation": {
                                   "type": "text"
                                 },
-                                "ns1:statuteJurisdiction": {
+                                "premis:statuteJurisdiction": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns1:copyrightInformation_dict_list": {
+                            "premis:copyrightInformation_dict_list": {
                               "properties": {
-                                "ns1:copyrightDocumentationIdentifier_dict_list": {
+                                "premis:copyrightDocumentationIdentifier_dict_list": {
                                   "properties": {
-                                    "ns1:copyrightDocumentationIdentifierType": {
+                                    "premis:copyrightDocumentationIdentifierType": {
                                       "type": "text"
                                     },
-                                    "ns1:copyrightDocumentationIdentifierValue": {
+                                    "premis:copyrightDocumentationIdentifierValue": {
                                       "type": "text"
                                     },
-                                    "ns1:copyrightDocumentationRole": {
+                                    "premis:copyrightDocumentationRole": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns1:copyrightJurisdiction": {
+                                "premis:copyrightJurisdiction": {
                                   "type": "text"
                                 },
-                                "ns1:copyrightStatusDeterminationDate": {
+                                "premis:copyrightStatusDeterminationDate": {
                                   "type": "text"
                                 },
-                                "ns1:copyrightStatus": {
+                                "premis:copyrightStatus": {
                                   "type": "text"
                                 },
-                                "ns1:copyrightApplicableDates_dict_list": {
+                                "premis:copyrightApplicableDates_dict_list": {
                                   "properties": {
-                                    "ns1:startDate": {
+                                    "premis:startDate": {
                                       "type": "text"
                                     },
-                                    "ns1:endDate": {
+                                    "premis:endDate": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns1:copyrightNote": {
+                                "premis:copyrightNote": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns1:linkingObjectIdentifier_dict_list": {
+                            "premis:linkingObjectIdentifier_dict_list": {
                               "properties": {
-                                "ns1:linkingObjectIdentifierValue": {
+                                "premis:linkingObjectIdentifierValue": {
                                   "type": "text"
                                 },
-                                "ns1:linkingObjectIdentifierType": {
+                                "premis:linkingObjectIdentifierType": {
                                   "type": "text"
                                 }
                               }
@@ -371,59 +371,59 @@
                 }
               }
             },
-            "ns0:digiprovMD_dict_list": {
+            "mets:digiprovMD_dict_list": {
               "properties": {
-                "ns0:mdWrap_dict_list": {
+                "mets:mdWrap_dict_list": {
                   "properties": {
                     "@MDTYPE": {
                       "type": "text"
                     },
-                    "ns0:xmlData_dict_list": {
+                    "mets:xmlData_dict_list": {
                       "properties": {
-                        "ns1:event_dict_list": {
+                        "premis:event_dict_list": {
                           "properties": {
-                            "ns1:eventOutcomeInformation_dict_list": {
+                            "premis:eventOutcomeInformation_dict_list": {
                               "properties": {
-                                "ns1:eventOutcome": {
+                                "premis:eventOutcome": {
                                   "type": "text"
                                 },
-                                "ns1:eventOutcomeDetail_dict_list": {
+                                "premis:eventOutcomeDetail_dict_list": {
                                   "properties": {
-                                    "ns1:eventOutcomeDetailNote": {
+                                    "premis:eventOutcomeDetailNote": {
                                       "type": "text"
                                     }
                                   }
                                 }
                               }
                             },
-                            "ns1:eventIdentifier_dict_list": {
+                            "premis:eventIdentifier_dict_list": {
                               "properties": {
-                                "ns1:eventIdentifierType": {
+                                "premis:eventIdentifierType": {
                                   "type": "text"
                                 },
-                                "ns1:eventIdentifierValue": {
+                                "premis:eventIdentifierValue": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns1:linkingAgentIdentifier_dict_list": {
+                            "premis:linkingAgentIdentifier_dict_list": {
                               "properties": {
-                                "ns1:linkingAgentIdentifierValue": {
+                                "premis:linkingAgentIdentifierValue": {
                                   "type": "text"
                                 },
-                                "ns1:linkingAgentIdentifierType": {
+                                "premis:linkingAgentIdentifierType": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns1:eventDateTime": {
+                            "premis:eventDateTime": {
                               "type": "date",
                               "format": "dateOptionalTime"
                             },
-                            "ns1:eventDetail": {
+                            "premis:eventDetail": {
                               "type": "text"
                             },
-                            "ns1:eventType": {
+                            "premis:eventType": {
                               "type": "text"
                             },
                             "@version": {
@@ -434,19 +434,19 @@
                             }
                           }
                         },
-                        "ns1:agent_dict_list": {
+                        "premis:agent_dict_list": {
                           "properties": {
-                            "ns1:agentIdentifier_dict_list": {
+                            "premis:agentIdentifier_dict_list": {
                               "properties": {
-                                "ns1:agentIdentifierType": {
+                                "premis:agentIdentifierType": {
                                   "type": "text"
                                 },
-                                "ns1:agentIdentifierValue": {
+                                "premis:agentIdentifierValue": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns1:agentType": {
+                            "premis:agentType": {
                               "type": "text"
                             },
                             "@version": {
@@ -455,7 +455,7 @@
                             "@xsi:schemaLocation": {
                               "type": "text"
                             },
-                            "ns1:agentName": {
+                            "premis:agentName": {
                               "type": "text"
                             }
                           }

--- a/src/archivematicaCommon/lib/elasticsearch/aips_mets_mapping.json
+++ b/src/archivematicaCommon/lib/elasticsearch/aips_mets_mapping.json
@@ -1,8 +1,8 @@
 {
   "properties": {
-    "ns0:mets_dict_list": {
+    "mets:mets_dict_list": {
       "properties": {
-        "ns0:metsHdr_dict_list": {
+        "mets:metsHdr_dict_list": {
           "properties": {
             "@CREATEDATE": {
               "type": "date",
@@ -10,75 +10,75 @@
             }
           }
         },
-        "ns0:amdSec_dict_list": {
+        "mets:amdSec_dict_list": {
           "properties": {
-            "ns0:techMD_dict_list": {
+            "mets:techMD_dict_list": {
               "properties": {
-                "ns0:mdWrap_dict_list": {
+                "mets:mdWrap_dict_list": {
                   "properties": {
                     "@MDTYPE": {
                       "type": "text"
                     },
-                    "ns0:xmlData_dict_list": {
+                    "mets:xmlData_dict_list": {
                       "properties": {
-                        "ns4:object_dict_list": {
+                        "premis:object_dict_list": {
                           "properties": {
-                            "ns4:originalName": {
+                            "premis:originalName": {
                               "type": "text"
                             },
                             "@xsi:type": {
                               "type": "text"
                             },
-                            "ns4:objectCharacteristics_dict_list": {
+                            "premis:objectCharacteristics_dict_list": {
                               "properties": {
-                                "ns4:size": {
+                                "premis:size": {
                                   "type": "text"
                                 },
-                                "ns4:fixity_dict_list": {
+                                "premis:fixity_dict_list": {
                                   "properties": {
-                                    "ns4:messageDigestAlgorithm": {
+                                    "premis:messageDigestAlgorithm": {
                                       "type": "text"
                                     },
-                                    "ns4:messageDigest": {
+                                    "premis:messageDigest": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns4:format_dict_list": {
+                                "premis:format_dict_list": {
                                   "properties": {
-                                    "ns4:formatRegistry_dict_list": {
+                                    "premis:formatRegistry_dict_list": {
                                       "properties": {
-                                        "ns4:formatRegistryName": {
+                                        "premis:formatRegistryName": {
                                           "type": "text"
                                         },
-                                        "ns4:formatRegistryKey": {
+                                        "premis:formatRegistryKey": {
                                           "type": "text"
                                         }
                                       }
                                     },
-                                    "ns4:formatDesignation_dict_list": {
+                                    "premis:formatDesignation_dict_list": {
                                       "properties": {
-                                        "ns4:formatVersion": {
+                                        "premis:formatVersion": {
                                           "type": "text"
                                         },
-                                        "ns4:formatName": {
+                                        "premis:formatName": {
                                           "type": "text"
                                         }
                                       }
                                     }
                                   }
                                 },
-                                "ns4:compositionLevel": {
+                                "premis:compositionLevel": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns4:objectIdentifier_dict_list": {
+                            "premis:objectIdentifier_dict_list": {
                               "properties": {
-                                "ns4:objectIdentifierValue": {
+                                "premis:objectIdentifierValue": {
                                   "type": "text"
                                 },
-                                "ns4:objectIdentifierType": {
+                                "premis:objectIdentifierType": {
                                   "type": "text"
                                 }
                               }
@@ -100,14 +100,14 @@
                 }
               }
             },
-            "ns0:sourceMD_dict_list": {
+            "mets:sourceMD_dict_list": {
               "properties": {
-                "ns0:mdWrap_dict_list": {
+                "mets:mdWrap_dict_list": {
                   "properties": {
                     "@MDTYPE": {
                       "type": "text"
                     },
-                    "ns0:xmlData_dict_list": {
+                    "mets:xmlData_dict_list": {
                       "properties": {
                         "transfer_metadata_dict_list": {
                           "properties": {
@@ -174,211 +174,211 @@
             "@ID": {
               "type": "text"
             },
-            "ns0:rightsMD_dict_list": {
+            "mets:rightsMD_dict_list": {
               "properties": {
-                "ns0:mdWrap_dict_list": {
+                "mets:mdWrap_dict_list": {
                   "properties": {
                     "@MDTYPE": {
                       "type": "text"
                     },
-                    "ns0:xmlData_dict_list": {
+                    "mets:xmlData_dict_list": {
                       "properties": {
-                        "ns4:rightsStatement_dict_list": {
+                        "premis:rightsStatement_dict_list": {
                           "properties": {
-                            "ns4:copyrightInformation_dict_list": {
+                            "premis:copyrightInformation_dict_list": {
                               "properties": {
-                                "ns4:copyrightJurisdiction": {
+                                "premis:copyrightJurisdiction": {
                                   "type": "text"
                                 },
-                                "ns4:copyrightStatusDeterminationDate": {
+                                "premis:copyrightStatusDeterminationDate": {
                                   "type": "text"
                                 },
-                                "ns4:copyrightStatus": {
+                                "premis:copyrightStatus": {
                                   "type": "text"
                                 },
-                                "ns4:copyrightNote": {
+                                "premis:copyrightNote": {
                                   "type": "text"
                                 },
-                                "ns4:copyrightApplicableDates_dict_list": {
+                                "premis:copyrightApplicableDates_dict_list": {
                                   "properties": {
-                                    "ns4:endDate": {
+                                    "premis:endDate": {
                                       "type": "text"
                                     },
-                                    "ns4:startDate": {
+                                    "premis:startDate": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns4:copyrightDocumentationIdentifier_dict_list": {
+                                "premis:copyrightDocumentationIdentifier_dict_list": {
                                   "properties": {
-                                    "ns4:copyrightDocumentationIdentifierType": {
+                                    "premis:copyrightDocumentationIdentifierType": {
                                       "type": "text"
                                     },
-                                    "ns4:copyrightDocumentationRole": {
+                                    "premis:copyrightDocumentationRole": {
                                       "type": "text"
                                     },
-                                    "ns4:copyrightDocumentationIdentifierValue": {
+                                    "premis:copyrightDocumentationIdentifierValue": {
                                       "type": "text"
                                     }
                                   }
                                 }
                               }
                             },
-                            "ns4:licenseInformation_dict_list": {
+                            "premis:licenseInformation_dict_list": {
                               "properties": {
-                                "ns4:licenseDocumentationIdentifier_dict_list": {
+                                "premis:licenseDocumentationIdentifier_dict_list": {
                                   "properties": {
-                                    "ns4:licenseDocumentationIdentifierType": {
+                                    "premis:licenseDocumentationIdentifierType": {
                                       "type": "text"
                                     },
-                                    "ns4:licenseDocumentationRole": {
+                                    "premis:licenseDocumentationRole": {
                                       "type": "text"
                                     },
-                                    "ns4:licenseDocumentationIdentifierValue": {
+                                    "premis:licenseDocumentationIdentifierValue": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns4:licenseApplicableDates_dict_list": {
+                                "premis:licenseApplicableDates_dict_list": {
                                   "properties": {
-                                    "ns4:endDate": {
+                                    "premis:endDate": {
                                       "type": "text"
                                     },
-                                    "ns4:startDate": {
+                                    "premis:startDate": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns4:licenseTerms": {
+                                "premis:licenseTerms": {
                                   "type": "text"
                                 },
-                                "ns4:licenseNote": {
+                                "premis:licenseNote": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns4:rightsGranted_dict_list": {
+                            "premis:rightsGranted_dict_list": {
                               "properties": {
-                                "ns4:restriction": {
+                                "premis:restriction": {
                                   "type": "text"
                                 },
-                                "ns4:termOfRestriction_dict_list": {
+                                "premis:termOfRestriction_dict_list": {
                                   "properties": {
-                                    "ns4:endDate": {
+                                    "premis:endDate": {
                                       "type": "text"
                                     },
-                                    "ns4:startDate": {
+                                    "premis:startDate": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns4:termOfGrant_dict_list": {
+                                "premis:termOfGrant_dict_list": {
                                   "properties": {
-                                    "ns4:endDate": {
+                                    "premis:endDate": {
                                       "type": "text"
                                     },
-                                    "ns4:startDate": {
+                                    "premis:startDate": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns4:rightsGrantedNote": {
+                                "premis:rightsGrantedNote": {
                                   "type": "text"
                                 },
-                                "ns4:act": {
+                                "premis:act": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns4:rightsStatementIdentifier_dict_list": {
+                            "premis:rightsStatementIdentifier_dict_list": {
                               "properties": {
-                                "ns4:rightsStatementIdentifierType": {
+                                "premis:rightsStatementIdentifierType": {
                                   "type": "text"
                                 },
-                                "ns4:rightsStatementIdentifierValue": {
+                                "premis:rightsStatementIdentifierValue": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns4:rightsBasis": {
+                            "premis:rightsBasis": {
                               "type": "text"
                             },
-                            "ns4:otherRightsInformation_dict_list": {
+                            "premis:otherRightsInformation_dict_list": {
                               "properties": {
-                                "ns4:otherRightsNote": {
+                                "premis:otherRightsNote": {
                                   "type": "text"
                                 },
-                                "ns4:otherRightsApplicableDates_dict_list": {
+                                "premis:otherRightsApplicableDates_dict_list": {
                                   "properties": {
-                                    "ns4:endDate": {
+                                    "premis:endDate": {
                                       "type": "text"
                                     },
-                                    "ns4:startDate": {
+                                    "premis:startDate": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns4:otherRightsDocumentationIdentifier_dict_list": {
+                                "premis:otherRightsDocumentationIdentifier_dict_list": {
                                   "properties": {
-                                    "ns4:otherRightsDocumentationIdentifierValue": {
+                                    "premis:otherRightsDocumentationIdentifierValue": {
                                       "type": "text"
                                     },
-                                    "ns4:otherRightsDocumentationRole": {
+                                    "premis:otherRightsDocumentationRole": {
                                       "type": "text"
                                     },
-                                    "ns4:otherRightsDocumentationIdentifierType": {
+                                    "premis:otherRightsDocumentationIdentifierType": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns4:otherRightsBasis": {
+                                "premis:otherRightsBasis": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns4:linkingObjectIdentifier_dict_list": {
+                            "premis:linkingObjectIdentifier_dict_list": {
                               "properties": {
-                                "ns4:linkingObjectIdentifierType": {
+                                "premis:linkingObjectIdentifierType": {
                                   "type": "text"
                                 },
-                                "ns4:linkingObjectIdentifierValue": {
+                                "premis:linkingObjectIdentifierValue": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns4:statuteInformation_dict_list": {
+                            "premis:statuteInformation_dict_list": {
                               "properties": {
-                                "ns4:statuteInformationDeterminationDate": {
+                                "premis:statuteInformationDeterminationDate": {
                                   "type": "text"
                                 },
-                                "ns4:statuteNote": {
+                                "premis:statuteNote": {
                                   "type": "text"
                                 },
-                                "ns4:statuteDocumentationIdentifier_dict_list": {
+                                "premis:statuteDocumentationIdentifier_dict_list": {
                                   "properties": {
-                                    "ns4:statuteDocumentationIdentifierValue": {
+                                    "premis:statuteDocumentationIdentifierValue": {
                                       "type": "text"
                                     },
-                                    "ns4:statuteDocumentationIdentifierType": {
+                                    "premis:statuteDocumentationIdentifierType": {
                                       "type": "text"
                                     },
-                                    "ns4:statuteDocumentationRole": {
+                                    "premis:statuteDocumentationRole": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns4:statuteJurisdiction": {
+                                "premis:statuteJurisdiction": {
                                   "type": "text"
                                 },
-                                "ns4:statuteCitation": {
+                                "premis:statuteCitation": {
                                   "type": "text"
                                 },
-                                "ns4:statuteApplicableDates_dict_list": {
+                                "premis:statuteApplicableDates_dict_list": {
                                   "properties": {
-                                    "ns4:endDate": {
+                                    "premis:endDate": {
                                       "type": "text"
                                     },
-                                    "ns4:startDate": {
+                                    "premis:startDate": {
                                       "type": "text"
                                     }
                                   }
@@ -399,58 +399,58 @@
                 }
               }
             },
-            "ns0:digiprovMD_dict_list": {
+            "mets:digiprovMD_dict_list": {
               "properties": {
-                "ns0:mdWrap_dict_list": {
+                "mets:mdWrap_dict_list": {
                   "properties": {
                     "@MDTYPE": {
                       "type": "text"
                     },
-                    "ns0:xmlData_dict_list": {
+                    "mets:xmlData_dict_list": {
                       "properties": {
-                        "ns4:event_dict_list": {
+                        "premis:event_dict_list": {
                           "properties": {
-                            "ns4:eventOutcomeInformation_dict_list": {
+                            "premis:eventOutcomeInformation_dict_list": {
                               "properties": {
-                                "ns4:eventOutcomeDetail_dict_list": {
+                                "premis:eventOutcomeDetail_dict_list": {
                                   "properties": {
-                                    "ns4:eventOutcomeDetailNote": {
+                                    "premis:eventOutcomeDetailNote": {
                                       "type": "text"
                                     }
                                   }
                                 },
-                                "ns4:eventOutcome": {
+                                "premis:eventOutcome": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns4:eventType": {
+                            "premis:eventType": {
                               "type": "text"
                             },
-                            "ns4:eventDetail": {
+                            "premis:eventDetail": {
                               "type": "text"
                             },
-                            "ns4:linkingAgentIdentifier_dict_list": {
+                            "premis:linkingAgentIdentifier_dict_list": {
                               "properties": {
-                                "ns4:linkingAgentIdentifierValue": {
+                                "premis:linkingAgentIdentifierValue": {
                                   "type": "text"
                                 },
-                                "ns4:linkingAgentIdentifierType": {
+                                "premis:linkingAgentIdentifierType": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns4:eventIdentifier_dict_list": {
+                            "premis:eventIdentifier_dict_list": {
                               "properties": {
-                                "ns4:eventIdentifierType": {
+                                "premis:eventIdentifierType": {
                                   "type": "text"
                                 },
-                                "ns4:eventIdentifierValue": {
+                                "premis:eventIdentifierValue": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns4:eventDateTime": {
+                            "premis:eventDateTime": {
                               "type": "date",
                               "format": "dateOptionalTime"
                             },
@@ -462,19 +462,19 @@
                             }
                           }
                         },
-                        "ns4:agent_dict_list": {
+                        "premis:agent_dict_list": {
                           "properties": {
-                            "ns4:agentIdentifier_dict_list": {
+                            "premis:agentIdentifier_dict_list": {
                               "properties": {
-                                "ns4:agentIdentifierType": {
+                                "premis:agentIdentifierType": {
                                   "type": "text"
                                 },
-                                "ns4:agentIdentifierValue": {
+                                "premis:agentIdentifierValue": {
                                   "type": "text"
                                 }
                               }
                             },
-                            "ns4:agentName": {
+                            "premis:agentName": {
                               "type": "text"
                             },
                             "@version": {
@@ -483,7 +483,7 @@
                             "@xsi:schemaLocation": {
                               "type": "text"
                             },
-                            "ns4:agentType": {
+                            "premis:agentType": {
                               "type": "text"
                             }
                           }
@@ -499,31 +499,31 @@
             }
           }
         },
-        "@xmlns:ns0": {
+        "@xmlns:mets": {
           "type": "text"
         },
-        "@xmlns:ns2": {
+        "@xmlns:dcterms": {
           "type": "text"
         },
-        "@xmlns:ns5": {
+        "@xmlns:xlink": {
           "type": "text"
         },
-        "@xmlns:ns4": {
+        "@xmlns:premis": {
           "type": "text"
         },
-        "ns0:dmdSec_dict_list": {
+        "mets:dmdSec_dict_list": {
           "properties": {
-            "ns0:mdWrap_dict_list": {
+            "mets:mdWrap_dict_list": {
               "properties": {
                 "@MDTYPE": {
                   "type": "text"
                 },
-                "ns0:xmlData_dict_list": {
+                "mets:xmlData_dict_list": {
                   "properties": {
                     "date_available": {
                         "type": "text"
                     },
-                    "ns2:dublincore_dict_list": {
+                    "dcterms:dublincore_dict_list": {
                       "properties": {
                         "dc:available": {
                           "type": "text"
@@ -593,7 +593,7 @@
         "@xmlns:xsi": {
           "type": "text"
         },
-        "ns0:structMap_dict_list": {
+        "mets:structMap_dict_list": {
           "properties": {
             "@LABEL": {
               "type": "text"
@@ -604,7 +604,7 @@
             "@TYPE": {
               "type": "text"
             },
-            "ns0:div_dict_list": {
+            "mets:div_dict_list": {
               "properties": {
                 "@LABEL": {
                   "type": "text"
@@ -612,7 +612,7 @@
                 "@TYPE": {
                   "type": "text"
                 },
-                "ns0:div_dict_list": {
+                "mets:div_dict_list": {
                   "properties": {
                     "@ADMID": {
                       "type": "text"
@@ -626,9 +626,9 @@
                     "@DMDID": {
                       "type": "text"
                     },
-                    "ns0:div_dict_list": {
+                    "mets:div_dict_list": {
                       "properties": {
-                        "ns0:fptr_dict_list": {
+                        "mets:fptr_dict_list": {
                           "properties": {
                             "@FILEID": {
                               "type": "text"
@@ -644,9 +644,9 @@
                         "@DMDID": {
                           "type": "text"
                         },
-                        "ns0:div_dict_list": {
+                        "mets:div_dict_list": {
                           "properties": {
-                            "ns0:fptr_dict_list": {
+                            "mets:fptr_dict_list": {
                               "properties": {
                                 "@FILEID": {
                                   "type": "text"
@@ -659,9 +659,9 @@
                             "@TYPE": {
                               "type": "text"
                             },
-                            "ns0:div_dict_list": {
+                            "mets:div_dict_list": {
                               "properties": {
-                                "ns0:fptr_dict_list": {
+                                "mets:fptr_dict_list": {
                                   "properties": {
                                     "@FILEID": {
                                       "type": "text"
@@ -674,9 +674,9 @@
                                 "@TYPE": {
                                   "type": "text"
                                 },
-                                "ns0:div_dict_list": {
+                                "mets:div_dict_list": {
                                   "properties": {
-                                    "ns0:fptr_dict_list": {
+                                    "mets:fptr_dict_list": {
                                       "properties": {
                                         "@FILEID": {
                                           "type": "text"
@@ -709,11 +709,11 @@
         "@xmlns:dc": {
           "type": "text"
         },
-        "ns0:fileSec_dict_list": {
+        "mets:fileSec_dict_list": {
           "properties": {
-            "ns0:fileGrp_dict_list": {
+            "mets:fileGrp_dict_list": {
               "properties": {
-                "ns0:file_dict_list": {
+                "mets:file_dict_list": {
                   "properties": {
                     "@ADMID": {
                       "type": "text"
@@ -724,7 +724,7 @@
                     "@ID": {
                       "type": "text"
                     },
-                    "ns0:FLocat_dict_list": {
+                    "mets:FLocat_dict_list": {
                       "properties": {
                         "@OTHERLOCTYPE": {
                           "type": "text"
@@ -732,7 +732,7 @@
                         "@LOCTYPE": {
                           "type": "text"
                         },
-                        "@ns5:href": {
+                        "@xlink:href": {
                           "type": "text"
                         }
                       }


### PR DESCRIPTION
elasticSearchFunctions now use lxml.etree instead of ElementTree, which
does not replace namespace prefixes with its own ones. Fix mappings
accordingly.

Connected to https://github.com/archivematica/Issues/issues/619