### PR TITLE
Revert "ESfunctions: replace ElementTree with lxml.etree" and fix AIP fileuuid parsing

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -31,7 +31,7 @@ import os
 import re
 import sys
 import time
-from lxml import etree as ElementTree
+from xml.etree import ElementTree
 
 from django.db.models import Min, Q
 from django.utils.six.moves import xrange

--- a/src/archivematicaCommon/lib/namespaces.py
+++ b/src/archivematicaCommon/lib/namespaces.py
@@ -1,3 +1,5 @@
+from xml.etree import ElementPath
+
 dcNS = "http://purl.org/dc/elements/1.1/"
 dctermsNS = "http://purl.org/dc/terms/"
 dspaceNS = "http://www.dspace.org/xmlns/dspace/dim"
@@ -41,10 +43,16 @@ def nsmap_for_premis2():
     return nsmap
 
 
+# The functions below require a cache clear, because the namespace maps
+# are being altered when falling back to PREMIS 2
+# (Ref. https://stackoverflow.com/a/24872696/1572895)
+
+
 def xml_find_premis(elem, path):
     """``find`` with PREMIS 2 fallback."""
     matches = elem.find(path, namespaces=NSMAP)
     if matches is None:
+        ElementPath._cache.clear()
         matches = elem.find(path, namespaces=nsmap_for_premis2())
     return matches
 
@@ -53,6 +61,7 @@ def xml_findall_premis(elem, path):
     """``findall`` with PREMIS 2 fallback."""
     matches = elem.findall(path, namespaces=NSMAP)
     if matches == []:
+        ElementPath._cache.clear()
         matches = elem.findall(path, namespaces=nsmap_for_premis2())
     return matches
 
@@ -61,6 +70,7 @@ def xml_findtext_premis(elem, path, default=""):
     """``findtext`` with PREMIS 2 fallback."""
     match = elem.findtext(path, namespaces=NSMAP)
     if match is None:
+        ElementPath._cache.clear()
         match = elem.findtext(path, namespaces=nsmap_for_premis2())
     return match or default
 
@@ -69,5 +79,6 @@ def xml_xpath_premis(elem, path):
     """``xpath`` with PREMIS 2 fallback."""
     matches = elem.xpath(path, namespaces=NSMAP)
     if not matches:
+        ElementPath._cache.clear()
         matches = elem.xpath(path, namespaces=nsmap_for_premis2())
     return matches

--- a/src/archivematicaCommon/tests/fixtures/test_index_fileuuid_METS_premisv2.xml
+++ b/src/archivematicaCommon/tests/fixtures/test_index_fileuuid_METS_premisv2.xml
@@ -1,0 +1,182 @@
+<?xml version='1.0' encoding='ASCII'?>
+<!--
+  This METS file has been cut-down to reduce fixture size
+-->
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version18/mets.xsd">
+  <mets:metsHdr CREATEDATE="2016-03-26T03:59:05"/>
+  <mets:amdSec ID="amdSec_1">
+    <mets:techMD ID="techMD_1">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xmlns:premis="info:lc/xmlns/premis-v2" xsi:type="premis:file" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd" version="2.2">
+            <premis:objectIdentifier>
+              <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+              <premis:objectIdentifierValue>0552c02b-8626-456f-89cc-bc5f3ce8a112</premis:objectIdentifierValue>
+            </premis:objectIdentifier>
+            <premis:objectCharacteristics>
+              <premis:compositionLevel>0</premis:compositionLevel>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>d26b5440dff6a414fb93642c7cf8f5a75647baffa42ccb7f3f527f550a7a3f37</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>99755726</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName>TIFF</premis:formatName>
+                  <premis:formatVersion></premis:formatVersion>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>fmt/353</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName>TIFF</premis:formatName>
+                  <premis:formatVersion></premis:formatVersion>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>fmt/353</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>%transferDirectory%objects/LEG1363.01.TIF</premis:originalName>
+            <premis:relationship>
+              <premis:relationshipType>derivation</premis:relationshipType>
+              <premis:relationshipSubType>is source of</premis:relationshipSubType>
+              <premis:relatedObjectIdentification>
+                <premis:relatedObjectIdentifierType>UUID</premis:relatedObjectIdentifierType>
+                <premis:relatedObjectIdentifierValue>3fec6880-97aa-4347-9eb1-fe3fc806da0b</premis:relatedObjectIdentifierValue>
+              </premis:relatedObjectIdentification>
+              <premis:relatedEventIdentification>
+                <premis:relatedEventIdentifierType>UUID</premis:relatedEventIdentifierType>
+                <premis:relatedEventIdentifierValue/>
+              </premis:relatedEventIdentification>
+            </premis:relationship>
+            <premis:relationship>
+              <premis:relationshipType>derivation</premis:relationshipType>
+              <premis:relationshipSubType>is source of</premis:relationshipSubType>
+              <premis:relatedObjectIdentification>
+                <premis:relatedObjectIdentifierType>UUID</premis:relatedObjectIdentifierType>
+                <premis:relatedObjectIdentifierValue>8ac185e7-83b8-4782-bff4-060cc306519f</premis:relatedObjectIdentifierValue>
+              </premis:relatedObjectIdentification>
+              <premis:relatedEventIdentification>
+                <premis:relatedEventIdentifierType>UUID</premis:relatedEventIdentifierType>
+                <premis:relatedEventIdentifierValue/>
+              </premis:relatedEventIdentification>
+            </premis:relationship>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="amdSec_4">
+    <mets:techMD ID="techMD_4">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xmlns:premis="info:lc/xmlns/premis-v2" xsi:type="premis:file" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd" version="2.2">
+            <premis:objectIdentifier>
+              <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+              <premis:objectIdentifierValue>44d3aa6d-8bb0-4cfb-bd93-f1121c08916e</premis:objectIdentifierValue>
+            </premis:objectIdentifier>
+            <premis:objectCharacteristics>
+              <premis:compositionLevel>0</premis:compositionLevel>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>1797d7852df1a05bb7ff1c9bcf846784867407e2a413d405b5a92ce69bd12f40</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>226</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName>Generic TXT</premis:formatName>
+                  <premis:formatVersion></premis:formatVersion>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>%SIPDirectory%objects/metadata/transfers/MAPS2015-AM641-44f3ee8e-88fd-424c-9d2b-f35d69b148e1/directory_tree.txt</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="amdSec_5">
+    <mets:techMD ID="techMD_5">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xmlns:premis="info:lc/xmlns/premis-v2" xsi:type="premis:file" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd" version="2.2">
+            <premis:objectIdentifier>
+              <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+              <premis:objectIdentifierValue>659eaf96-7676-409d-91e1-2364ee68dba7</premis:objectIdentifierValue>
+            </premis:objectIdentifier>
+            <premis:objectCharacteristics>
+              <premis:compositionLevel>0</premis:compositionLevel>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>8e54d8017da12e210f1cec3f74e029920d4d74bb26c2baef9de088bef4dae8a4</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>1017</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName>XML 1.0</premis:formatName>
+                  <premis:formatVersion>1.0</premis:formatVersion>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>fmt/101</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>%SIPDirectory%objects/submissionDocumentation/transfer-MAPS2015-AM641-44f3ee8e-88fd-424c-9d2b-f35d69b148e1/METS.xml</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:fileSec>
+    <mets:fileGrp USE="original">
+      <mets:file GROUPID="Group-0552c02b-8626-456f-89cc-bc5f3ce8a112" ID="file-0552c02b-8626-456f-89cc-bc5f3ce8a112" ADMID="amdSec_1">
+        <mets:FLocat xlink:href="objects/LEG1363.01.TIF" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="submissionDocumentation">
+      <mets:file GROUPID="Group-659eaf96-7676-409d-91e1-2364ee68dba7" ID="file-659eaf96-7676-409d-91e1-2364ee68dba7" ADMID="amdSec_5">
+        <mets:FLocat xlink:href="objects/submissionDocumentation/transfer-MAPS2015-AM641-44f3ee8e-88fd-424c-9d2b-f35d69b148e1/METS.xml" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="metadata">
+      <mets:file GROUPID="Group-44d3aa6d-8bb0-4cfb-bd93-f1121c08916e" ID="file-44d3aa6d-8bb0-4cfb-bd93-f1121c08916e" ADMID="amdSec_4">
+        <mets:FLocat xlink:href="objects/metadata/transfers/MAPS2015-AM641-44f3ee8e-88fd-424c-9d2b-f35d69b148e1/directory_tree.txt" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap TYPE="physical" ID="structMap_1" LABEL="Archivematica default">
+    <mets:div TYPE="Directory" LABEL="MAPS2015-AM641-9559945a-52e8-4eb4-ac1a-e0e794e758fb">
+      <mets:div TYPE="Directory" LABEL="objects">
+        <mets:div TYPE="Item" LABEL="LEG1363.01.TIF">
+          <mets:fptr FILEID="file-0552c02b-8626-456f-89cc-bc5f3ce8a112"/>
+        </mets:div>
+        <mets:div TYPE="Directory" LABEL="metadata">
+          <mets:div TYPE="Directory" LABEL="transfers">
+            <mets:div TYPE="Directory" LABEL="MAPS2015-AM641-44f3ee8e-88fd-424c-9d2b-f35d69b148e1">
+              <mets:div TYPE="Item" LABEL="directory_tree.txt">
+                <mets:fptr FILEID="file-44d3aa6d-8bb0-4cfb-bd93-f1121c08916e"/>
+              </mets:div>
+            </mets:div>
+          </mets:div>
+        </mets:div>
+        <mets:div TYPE="Directory" LABEL="submissionDocumentation">
+          <mets:div TYPE="Directory" LABEL="transfer-MAPS2015-AM641-44f3ee8e-88fd-424c-9d2b-f35d69b148e1">
+            <mets:div TYPE="Item" LABEL="METS.xml">
+              <mets:fptr FILEID="file-659eaf96-7676-409d-91e1-2364ee68dba7"/>
+            </mets:div>
+          </mets:div>
+        </mets:div>
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+</mets:mets>

--- a/src/archivematicaCommon/tests/fixtures/test_index_fileuuid_METS_premisv2_no_ns.xml
+++ b/src/archivematicaCommon/tests/fixtures/test_index_fileuuid_METS_premisv2_no_ns.xml
@@ -1,0 +1,147 @@
+<?xml version='1.0' encoding='ASCII'?>
+<!--
+  This METS file has been cut-down to reduce fixture size
+-->
+<mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.loc.gov/METS/" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version18/mets.xsd">
+  <amdSec ID="amdSec_1">
+    <techMD ID="techMD_1">
+      <mdWrap MDTYPE="PREMIS:OBJECT">
+        <xmlData>
+          <object xmlns="info:lc/xmlns/premis-v2" xsi:type="file" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-1.xsd" version="2.1">
+            <objectIdentifier>
+              <objectIdentifierType>UUID</objectIdentifierType>
+              <objectIdentifierValue>3a6a182a-40a0-4c2b-9752-fc7e91ac1edf</objectIdentifierValue>
+            </objectIdentifier>
+            <objectCharacteristics>
+              <compositionLevel>0</compositionLevel>
+              <fixity>
+                <messageDigestAlgorithm>sha256</messageDigestAlgorithm>
+                <messageDigest>7bab5874a44f22e9fb7240cb70e674d12ae4d61a96db15e7cf0755d55db33d81</messageDigest>
+              </fixity>
+              <size>50547000</size>
+              <format>
+                <formatDesignation>
+                  <formatName>MPEG-1 Video Format</formatName>
+                  <formatVersion></formatVersion>
+                </formatDesignation>
+                <formatRegistry>
+                  <formatRegistryName>PRONOM</formatRegistryName>
+                  <formatRegistryKey>x-fmt/385</formatRegistryKey>
+                </formatRegistry>
+              </format>
+              <format>
+                <formatDesignation>
+                  <formatName>MPEG-2 Video Format</formatName>
+                  <formatVersion></formatVersion>
+                </formatDesignation>
+                <formatRegistry>
+                  <formatRegistryName>PRONOM</formatRegistryName>
+                  <formatRegistryKey>x-fmt/386</formatRegistryKey>
+                </formatRegistry>
+              </format>
+            </objectCharacteristics>
+            <originalName>%transferDirectory%objects/V00154.MPG</originalName>
+          </object>
+        </xmlData>
+      </mdWrap>
+    </techMD>
+  </amdSec>
+  <amdSec ID="amdSec_2">
+    <techMD ID="techMD_2">
+      <mdWrap MDTYPE="PREMIS:OBJECT">
+        <xmlData>
+          <object xmlns="info:lc/xmlns/premis-v2" xsi:type="file" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-1.xsd" version="2.1">
+            <objectIdentifier>
+              <objectIdentifierType>UUID</objectIdentifierType>
+              <objectIdentifierValue>431913ba-4379-4373-8798-cc5f2b9dd769</objectIdentifierValue>
+            </objectIdentifier>
+            <objectCharacteristics>
+              <compositionLevel>0</compositionLevel>
+              <fixity>
+                <messageDigestAlgorithm>sha256</messageDigestAlgorithm>
+                <messageDigest>7c91d344e65c549b2fcba47fb28adaaec3fa45354c5d2714e7a36e97ac72bf3f</messageDigest>
+              </fixity>
+              <size>62648324</size>
+              <format>
+                <formatDesignation>
+                  <formatName>MPEG-1 Video Format</formatName>
+                  <formatVersion></formatVersion>
+                </formatDesignation>
+                <formatRegistry>
+                  <formatRegistryName>PRONOM</formatRegistryName>
+                  <formatRegistryKey>x-fmt/385</formatRegistryKey>
+                </formatRegistry>
+              </format>
+              <format>
+                <formatDesignation>
+                  <formatName>MPEG-2 Video Format</formatName>
+                  <formatVersion></formatVersion>
+                </formatDesignation>
+                <formatRegistry>
+                  <formatRegistryName>PRONOM</formatRegistryName>
+                  <formatRegistryKey>x-fmt/386</formatRegistryKey>
+                </formatRegistry>
+              </format>
+            </objectCharacteristics>
+            <originalName>%transferDirectory%objects/V00158.MPG</originalName>
+          </object>
+        </xmlData>
+      </mdWrap>
+    </techMD>
+  </amdSec>
+  <amdSec ID="amdSec_3">
+    <techMD ID="techMD_3">
+      <mdWrap MDTYPE="PREMIS:OBJECT">
+        <xmlData>
+          <object xmlns="info:lc/xmlns/premis-v2" xsi:type="file" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-1.xsd" version="2.1">
+            <objectIdentifier>
+              <objectIdentifierType>UUID</objectIdentifierType>
+              <objectIdentifierValue>fc0e52ca-a688-41c0-a10b-c1d36e21e804</objectIdentifierValue>
+            </objectIdentifier>
+            <objectCharacteristics>
+              <compositionLevel>0</compositionLevel>
+              <fixity>
+                <messageDigestAlgorithm>sha256</messageDigestAlgorithm>
+                <messageDigest>0dff86ef77411a8f6bcaf453fab5f1c9c88bd4ed7da526827d982cf767eaacfb</messageDigest>
+              </fixity>
+              <size>38</size>
+              <format>
+                <formatDesignation>
+                  <formatName>Comma Separated Values</formatName>
+                  <formatVersion></formatVersion>
+                </formatDesignation>
+                <formatRegistry>
+                  <formatRegistryName>PRONOM</formatRegistryName>
+                  <formatRegistryKey>x-fmt/18</formatRegistryKey>
+                </formatRegistry>
+              </format>
+            </objectCharacteristics>
+            <originalName>%transferDirectory%objects/AM68.csv</originalName>
+          </object>
+        </xmlData>
+      </mdWrap>
+    </techMD>
+  </amdSec>
+  <fileSec>
+    <fileGrp USE="original">
+      <file ID="V00154.MPG-3a6a182a-40a0-4c2b-9752-fc7e91ac1edf" GROUPID="Group-3a6a182a-40a0-4c2b-9752-fc7e91ac1edf" ADMID="amdSec_1">
+        <FLocat xlink:href="objects/V00154.MPG" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </file>
+      <file ID="V00158.MPG-431913ba-4379-4373-8798-cc5f2b9dd769" GROUPID="Group-431913ba-4379-4373-8798-cc5f2b9dd769" ADMID="amdSec_2">
+        <FLocat xlink:href="objects/V00158.MPG" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </file>
+      <file ID="AM68.csv-fc0e52ca-a688-41c0-a10b-c1d36e21e804" GROUPID="Group-fc0e52ca-a688-41c0-a10b-c1d36e21e804" ADMID="amdSec_3">
+        <FLocat xlink:href="objects/AM68.csv" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </file>
+    </fileGrp>
+  </fileSec>
+  <structMap TYPE="physical">
+    <div TYPE="directory" LABEL="AM68-bdcb560d-7ddd-4c13-8040-1e565b4eddff-bdcb560d-7ddd-4c13-8040-1e565b4eddff">
+      <div TYPE="directory" LABEL="objects">
+        <fptr FILEID="V00154.MPG-3a6a182a-40a0-4c2b-9752-fc7e91ac1edf"/>
+        <fptr FILEID="V00158.MPG-431913ba-4379-4373-8798-cc5f2b9dd769"/>
+        <fptr FILEID="AM68.csv-fc0e52ca-a688-41c0-a10b-c1d36e21e804"/>
+      </div>
+    </div>
+  </structMap>
+</mets>

--- a/src/archivematicaCommon/tests/fixtures/test_index_fileuuid_METS_premisv3.xml
+++ b/src/archivematicaCommon/tests/fixtures/test_index_fileuuid_METS_premisv3.xml
@@ -1,0 +1,238 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  This METS file has been cut-down to reduce fixture size
+-->
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version111/mets.xsd">
+  <mets:metsHdr CREATEDATE="2019-04-18T19:05:17"/>
+  <mets:dmdSec ID="dmdSec_1">
+    <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+      <mets:xmlData>
+        <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:intellectualEntity" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+          <premis:objectIdentifier>
+            <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>37abc30b-a258-4389-b1f2-67ccd330bc7e</premis:objectIdentifierValue>
+          </premis:objectIdentifier>
+          <premis:originalName>evelynphotos-37abc30b-a258-4389-b1f2-67ccd330bc7e</premis:originalName>
+        </premis:object>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:amdSec ID="amdSec_1">
+    <mets:techMD ID="techMD_1">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+            <premis:objectIdentifier>
+              <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+              <premis:objectIdentifierValue>696e431e-c5ae-4045-afa4-071c855fff47</premis:objectIdentifierValue>
+            </premis:objectIdentifier>
+            <premis:objectCharacteristics>
+              <premis:compositionLevel>0</premis:compositionLevel>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>a7ff7f8467ddd0b2f2f8792fb3c26f8b857abce30b15bd13fc2876a26fa513f8</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>1444992</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName>Tagged Image File Format</premis:formatName>
+                  <premis:formatVersion></premis:formatVersion>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName></premis:formatRegistryName>
+                  <premis:formatRegistryKey></premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+              <premis:creatingApplication>
+                <premis:dateCreatedByApplication>2019-04-18</premis:dateCreatedByApplication>
+              </premis:creatingApplication>
+            </premis:objectCharacteristics>
+            <premis:originalName>%SIPDirectory%objects/evelyn_s_photo-696e431e-c5ae-4045-afa4-071c855fff47.tif</premis:originalName>
+            <premis:relationship>
+              <premis:relationshipType>derivation</premis:relationshipType>
+              <premis:relationshipSubType>has source</premis:relationshipSubType>
+              <premis:relatedObjectIdentifier>
+                <premis:relatedObjectIdentifierType>UUID</premis:relatedObjectIdentifierType>
+                <premis:relatedObjectIdentifierValue>e9caf37c-93cb-4c37-ab5f-157c7d2611ac</premis:relatedObjectIdentifierValue>
+              </premis:relatedObjectIdentifier>
+              <premis:relatedEventIdentifier>
+                <premis:relatedEventIdentifierType>UUID</premis:relatedEventIdentifierType>
+                <premis:relatedEventIdentifierValue>90d670ba-ef17-41aa-a3ae-459be98fc7c9</premis:relatedEventIdentifierValue>
+              </premis:relatedEventIdentifier>
+            </premis:relationship>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="amdSec_2">
+    <mets:techMD ID="techMD_2">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+            <premis:objectIdentifier>
+              <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+              <premis:objectIdentifierValue>e9caf37c-93cb-4c37-ab5f-157c7d2611ac</premis:objectIdentifierValue>
+            </premis:objectIdentifier>
+            <premis:objectCharacteristics>
+              <premis:compositionLevel>0</premis:compositionLevel>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>d2bed92b73c7090bb30a0b30016882e7069c437488e1513e9deaacbe29d38d92</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>158131</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName>JPEG</premis:formatName>
+                  <premis:formatVersion>1.02</premis:formatVersion>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>fmt/44</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+              <premis:creatingApplication>
+                <premis:dateCreatedByApplication>2019-04-17</premis:dateCreatedByApplication>
+              </premis:creatingApplication>
+            </premis:objectCharacteristics>
+            <premis:originalName>%transferDirectory%objects/evelyn's photo.jpg</premis:originalName>
+            <premis:relationship>
+              <premis:relationshipType>derivation</premis:relationshipType>
+              <premis:relationshipSubType>is source of</premis:relationshipSubType>
+              <premis:relatedObjectIdentifier>
+                <premis:relatedObjectIdentifierType>UUID</premis:relatedObjectIdentifierType>
+                <premis:relatedObjectIdentifierValue>696e431e-c5ae-4045-afa4-071c855fff47</premis:relatedObjectIdentifierValue>
+              </premis:relatedObjectIdentifier>
+              <premis:relatedEventIdentifier>
+                <premis:relatedEventIdentifierType>UUID</premis:relatedEventIdentifierType>
+                <premis:relatedEventIdentifierValue>90d670ba-ef17-41aa-a3ae-459be98fc7c9</premis:relatedEventIdentifierValue>
+              </premis:relatedEventIdentifier>
+            </premis:relationship>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="amdSec_7">
+    <mets:techMD ID="techMD_7">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+            <premis:objectIdentifier>
+              <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+              <premis:objectIdentifierValue>61e56606-a1d6-456d-9c97-406feaa13b85</premis:objectIdentifierValue>
+            </premis:objectIdentifier>
+            <premis:objectCharacteristics>
+              <premis:compositionLevel>0</premis:compositionLevel>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>d1b55ce1c01846d926dd720e5159de15af657822b0b64203668e1a33814a6af8</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>313</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName>Plain Text</premis:formatName>
+                  <premis:formatVersion></premis:formatVersion>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+              <premis:creatingApplication>
+                <premis:dateCreatedByApplication>2019-04-18</premis:dateCreatedByApplication>
+              </premis:creatingApplication>
+            </premis:objectCharacteristics>
+            <premis:originalName>%SIPDirectory%objects/metadata/transfers/evelynphotos-96344c4e-bdaa-4e57-a271-408234de976d/directory_tree.txt</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="amdSec_8">
+    <mets:techMD ID="techMD_8">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+            <premis:objectIdentifier>
+              <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+              <premis:objectIdentifierValue>49fdc3d6-0109-4596-8847-fb80be5507be</premis:objectIdentifierValue>
+            </premis:objectIdentifier>
+            <premis:objectCharacteristics>
+              <premis:compositionLevel>0</premis:compositionLevel>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>e8cc462551ceb261f29b58b6124b103de438099f392b94ebc22fd63a89ea7bcb</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>95360</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName>XML</premis:formatName>
+                  <premis:formatVersion>1.0</premis:formatVersion>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>fmt/101</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+              <premis:creatingApplication>
+                <premis:dateCreatedByApplication>2019-04-18</premis:dateCreatedByApplication>
+              </premis:creatingApplication>
+            </premis:objectCharacteristics>
+            <premis:originalName>%SIPDirectory%objects/submissionDocumentation/transfer-evelynphotos-96344c4e-bdaa-4e57-a271-408234de976d/METS.xml</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:fileSec>
+    <mets:fileGrp USE="original">
+      <mets:file GROUPID="Group-e9caf37c-93cb-4c37-ab5f-157c7d2611ac" ID="file-e9caf37c-93cb-4c37-ab5f-157c7d2611ac" ADMID="amdSec_2">
+        <mets:FLocat xlink:href="objects/evelyn_s_photo.jpg" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="submissionDocumentation">
+      <mets:file GROUPID="Group-49fdc3d6-0109-4596-8847-fb80be5507be" ID="file-49fdc3d6-0109-4596-8847-fb80be5507be" ADMID="amdSec_8">
+        <mets:FLocat xlink:href="objects/submissionDocumentation/transfer-evelynphotos-96344c4e-bdaa-4e57-a271-408234de976d/METS.xml" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="preservation">
+      <mets:file GROUPID="Group-e9caf37c-93cb-4c37-ab5f-157c7d2611ac" ID="file-696e431e-c5ae-4045-afa4-071c855fff47" ADMID="amdSec_1">
+        <mets:FLocat xlink:href="objects/evelyn_s_photo-696e431e-c5ae-4045-afa4-071c855fff47.tif" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="metadata">
+      <mets:file GROUPID="Group-61e56606-a1d6-456d-9c97-406feaa13b85" ID="file-61e56606-a1d6-456d-9c97-406feaa13b85" ADMID="amdSec_7">
+        <mets:FLocat xlink:href="objects/metadata/transfers/evelynphotos-96344c4e-bdaa-4e57-a271-408234de976d/directory_tree.txt" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap ID="structMap_1" LABEL="Archivematica default" TYPE="physical">
+    <mets:div LABEL="evelynphotos-37abc30b-a258-4389-b1f2-67ccd330bc7e" TYPE="Directory" DMDID="dmdSec_1">
+      <mets:div LABEL="objects" TYPE="Directory">
+        <mets:div LABEL="evelyn_s_photo-696e431e-c5ae-4045-afa4-071c855fff47.tif" TYPE="Item">
+          <mets:fptr FILEID="file-696e431e-c5ae-4045-afa4-071c855fff47"/>
+        </mets:div>
+        <mets:div LABEL="evelyn_s_photo.jpg" TYPE="Item">
+          <mets:fptr FILEID="file-e9caf37c-93cb-4c37-ab5f-157c7d2611ac"/>
+        </mets:div>
+        <mets:div LABEL="metadata" TYPE="Directory">
+          <mets:div LABEL="transfers" TYPE="Directory">
+            <mets:div LABEL="evelynphotos-96344c4e-bdaa-4e57-a271-408234de976d" TYPE="Directory">
+              <mets:div LABEL="directory_tree.txt" TYPE="Item">
+                <mets:fptr FILEID="file-61e56606-a1d6-456d-9c97-406feaa13b85"/>
+              </mets:div>
+            </mets:div>
+          </mets:div>
+        </mets:div>
+        <mets:div LABEL="submissionDocumentation" TYPE="Directory">
+          <mets:div LABEL="transfer-evelynphotos-96344c4e-bdaa-4e57-a271-408234de976d" TYPE="Directory">
+            <mets:div LABEL="METS.xml" TYPE="Item">
+              <mets:fptr FILEID="file-49fdc3d6-0109-4596-8847-fb80be5507be"/>
+            </mets:div>
+          </mets:div>
+        </mets:div>
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+</mets:mets>

--- a/src/archivematicaCommon/tests/test_elasticsearch_functions.py
+++ b/src/archivematicaCommon/tests/test_elasticsearch_functions.py
@@ -97,8 +97,8 @@ class TestElasticSearchFunctions(unittest.TestCase):
         def get_dublincore_metadata(client, indexData, index, printfn):
             try:
                 dmd_section = indexData["METS"]["dmdSec"]
-                metadata_container = dmd_section["mets:xmlData_dict_list"][0]
-                dc = metadata_container["dcterms:dublincore_dict_list"][0]
+                metadata_container = dmd_section["ns0:xmlData_dict_list"][0]
+                dc = metadata_container["ns1:dublincore_dict_list"][0]
             except (KeyError, IndexError):
                 dc = None
             indexed_data[indexData["filePath"]] = dc


### PR DESCRIPTION
- Revert commit https://github.com/artefactual/archivematica/commit/7c5da722c761d42371ff7ae4b583071a9c2f6b6f to avoid changes in the way METS files are indexed
- Add AIP fileuuid tests 
- Add changes in `namespaces.py` that fixes AIP fileuuid parsing

Connected to archivematica/Issues#619