### PR TITLE
Remove libxml2-utils dependency

### DIFF
--- a/src/MCPClient-base.Dockerfile
+++ b/src/MCPClient-base.Dockerfile
@@ -45,7 +45,6 @@ RUN set -ex \
 		libimage-exiftool-perl \
 		libevent-dev \
 		libjansson4 \
-		libxml2-utils \
 		mediainfo \
 		mediaconch \
 		nailgun \

--- a/src/MCPClient/osdeps/Ubuntu-16.json
+++ b/src/MCPClient/osdeps/Ubuntu-16.json
@@ -27,7 +27,6 @@
   { "name": "inkscape", "state": "latest"},
   { "name": "jhove", "state": "latest"},
   { "name": "libimage-exiftool-perl", "state": "latest"},
-  { "name": "libxml2-utils", "state": "latest"},
   { "name": "logapp", "state": "latest"},
   { "name": "md5deep", "state": "latest"},
   { "name": "mediainfo", "state": "latest"},

--- a/src/MCPClient/osdeps/Ubuntu-18.json
+++ b/src/MCPClient/osdeps/Ubuntu-18.json
@@ -27,7 +27,6 @@
   { "name": "inkscape", "state": "latest"},
   { "name": "jhove", "state": "latest"},
   { "name": "libimage-exiftool-perl", "state": "latest"},
-  { "name": "libxml2-utils", "state": "latest"},
   { "name": "logapp", "state": "latest"},
   { "name": "md5deep", "state": "latest"},
   { "name": "nailgun", "state": "latest"},


### PR DESCRIPTION
Previously used to install xmllint the dependency is no longer needed
in Archivematica and so it is removed here.

Connected to archivematica/issues#658