### PR TITLE
PID declaration feature

### DIFF
--- a/src/MCPClient/lib/archivematicaClientModules
+++ b/src/MCPClient/lib/archivematicaClientModules
@@ -94,6 +94,7 @@ checktransferdirectoryforobjects_v0.0 = check_transfer_directory_for_objects
 checkforsubmissiondocumenation_v0.0 = check_for_submission_documentation
 checkforservicedirectory_v0.0 = check_for_service_directory
 checkforaccessdirectory_v0.0 = check_for_access_directory
+declarepids_v0.0 = pid_declaration
 bindpids_v0.0 = bind_pids
 extractbagtransfer_v0.0 = extract_bag_transfer
 assignuuidstodirectories_v0.0 = assign_uuids_to_directories

--- a/src/MCPClient/lib/clientScripts/bind_pid.py
+++ b/src/MCPClient/lib/clientScripts/bind_pid.py
@@ -50,7 +50,7 @@ import django
 
 django.setup()
 # dashboard
-from main.models import DashboardSetting, File, Identifier
+from main.models import DashboardSetting, File
 
 # archivematicaCommon
 import bindpid
@@ -99,6 +99,7 @@ def _get_bind_pid_config(file_uuid):
     """Return dict to pass to ``bindpid`` function as keyword arguments."""
     _args = {"entity_type": "file", "desired_pid": file_uuid}
     _args.update(DashboardSetting.objects.get_dict("handle"))
+    bindpid._validate(_args)
     _args["pid_request_verify_certs"] = str2bool(
         _args.get("pid_request_verify_certs", "True")
     )
@@ -123,8 +124,7 @@ def _update_file_mdl(file_uuid, naming_authority, resolver_url):
             True for id_ in existing_ids if id_.type == id_type and id_.value == id_val
         ]
         if len(matches) == 0:
-            idfr = Identifier.objects.create(type=id_type, value=id_val)
-            file_mdl.identifiers.add(idfr)
+            file_mdl.add_custom_identifier(scheme=id_type, value=id_val)
 
 
 @exit_on_known_exception

--- a/src/MCPClient/lib/clientScripts/pid_declaration.py
+++ b/src/MCPClient/lib/clientScripts/pid_declaration.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python2
+# -*- coding: utf8
+
+"""pid_declaration.py
+
+Given an identifiers.json file, supplying third-party persistent identifiers
+(PIDS), such as handle (hdl) or doi, identifiers; associate those identifiers
+with the objects in the transfer, so be translated to PREMIS objects in the
+AIP METS.
+"""
+from __future__ import unicode_literals
+from functools import wraps
+import json
+import os
+import sys
+
+import django
+
+django.setup()
+
+from main.models import Directory, File, SIP
+
+from sanitize_names import sanitizeName
+
+
+class DeclarePIDsException(Exception):
+    """Exception to raise if there's a more fundamental issue with the running
+    of this script and we want to exit and stop the workflow from continuing.
+    """
+
+
+class DeclarePIDsExceptionNonCritical(Exception):
+    """Exception to raise when we have problems trying to open identifiers.json
+    or the file doesn't exist.
+    """
+
+    exit_code = 0
+
+
+class DeclarePIDs(object):
+    """Class to wrap PID declaration features and provide some mechanism of
+    recording state.
+    """
+
+    SIP_IDENTIFIER = "SIP"
+    SIP_DIRECTORY = "%SIPDirectory%"
+
+    def __init__(self, job):
+        self.job = job
+        self.identifier_count = 0
+        self.actual_count = 0
+
+    def exit_on_known_exception(func):
+        """Decorator to allows us to raise an exception but still exit-zero when
+        the exception is cleaner to return than ad-hoc integer values.
+        """
+
+        @wraps(func)
+        def wrapped(*args, **kwargs):
+            try:
+                func(*args, **kwargs)
+            except (DeclarePIDsExceptionNonCritical) as err:
+                return err.exit_code
+
+        return wrapped
+
+    def _fixup_path_input_by_user(self, path):
+        """Fix-up paths submitted by a user, e.g. in custom structmap examples
+        so that they don't have to anticipate the Archivematica normalization
+        process.
+        """
+        return "{}{}".format(
+            self.SIP_DIRECTORY,
+            os.path.join(
+                "",
+                *[sanitizeName(name.encode("utf8")) for name in path.split(os.path.sep)]
+            ),
+        )
+
+    def _log_identifer_to_stdout(self, mdl, identifier_type, identifier):
+        """Create a consistent string to log information about our identifiers
+        to stdout for the user.
+        """
+        try:
+            if isinstance(mdl, SIP):
+                msg = "Identifier {}: {} added for: {}: {}".format(
+                    identifier_type,
+                    identifier,
+                    "SIP",
+                    os.path.basename(os.path.split(mdl.currentpath)[0]),
+                )
+            elif isinstance(mdl, Directory):
+                msg = "Identifier {}: {} added for: {}: {}".format(
+                    identifier_type,
+                    identifier,
+                    "Directory",
+                    os.path.basename(os.path.split(mdl.currentlocation)[0]),
+                )
+            else:
+                msg = "Identifier {}: {} added for: {}: {}".format(
+                    identifier_type,
+                    identifier,
+                    "File",
+                    os.path.basename(mdl.currentlocation),
+                )
+            self.job.pyprint(msg)
+        except KeyError:
+            self.job.pyprint(
+                "Identifier {}: {} added to {}".format(identifier_type, identifier, mdl)
+            )
+
+    def _validate_identifier(self, mdl, id_):
+        """Provide some feedback for the user if the identifier information is
+        somehow incomplete.
+        """
+        identifier_type = id_.get("identifierType", None)
+        identifier = id_.get("identifier", None)
+        if identifier_type is None:
+            self.job.pyprint(
+                "None value returned for identifier type: {} on object: {}".format(
+                    id_, mdl
+                ),
+                file=sys.stderr,
+            )
+            return (False,)
+        if identifier is None:
+            self.job.pyprint(
+                "None value returned for identifier: {} on object: {}".format(id_, mdl),
+                file=sys.stderr,
+            )
+            return (False,)
+        return identifier_type, identifier
+
+    def _add_identifier_to_model(self, mdl, id_):
+        """Add custom identifier to the model we found a match for. We treat
+        incomplete information as a warning which then allows the script to
+        continue. This behavior will be easy to change if required with further
+        usage and greater understanding of this feature.
+        """
+        identifier_type, identifier = self._validate_identifier(mdl, id_)
+        if identifier_type:
+            mdl.add_custom_identifier(identifier_type, identifier)
+            self._log_identifer_to_stdout(mdl, identifier_type, identifier)
+            self.actual_count += 1
+
+    def parse_and_attach_identifiers(self, unit_uuid, json_data):
+        """Take our identifiers and add them to the model objects that we want
+        them to belong to by the time we create the AIP METS.
+        """
+        self.identifier_count = len(json_data)
+        for file_object in json_data:
+            file_path = file_object.get("file")
+            identifiers = file_object.get("identifiers", [])
+            objects_dir, base_name = os.path.split(file_path)
+            if (objects_dir == "objects" or objects_dir == "") and not base_name:
+                file_path = self.SIP_IDENTIFIER
+            else:
+                # Run name normalization to allow us to pair our data with
+                # information already in the database.
+                file_path = self._fixup_path_input_by_user(file_path)
+            for id_ in identifiers:
+                if file_path == self.SIP_IDENTIFIER:
+                    mdl = SIP.objects.get(uuid=unit_uuid)
+                    self._add_identifier_to_model(mdl, id_)
+                    continue
+                try:
+                    mdl = File.objects.get(sip_id=unit_uuid, currentlocation=file_path)
+                    self._add_identifier_to_model(mdl, id_)
+                    continue
+                except File.DoesNotExist:
+                    pass
+                try:
+                    mdl = Directory.objects.get(
+                        sip_id=unit_uuid, currentlocation=os.path.join(file_path, "")
+                    )
+                    self._add_identifier_to_model(mdl, id_)
+                except Directory.DoesNotExist:
+                    pass
+        self.job.pyprint(
+            "{} identifiers added for {} objects in the package".format(
+                self.actual_count, self.identifier_count
+            )
+        )
+
+    def _retrieve_identifiers_path(self, unit_uuid, sip_directory):
+        """Retrieve a path to the identifiers.json file from the database."""
+        try:
+            return File.objects.get(
+                sip_id=unit_uuid,
+                filegrpuse="metadata",
+                currentlocation__endswith="identifiers.json",
+            ).currentlocation.replace(self.SIP_DIRECTORY, sip_directory)
+        except File.DoesNotExist:
+            self.job.pyprint("No identifiers.json file found", file=sys.stderr)
+            raise DeclarePIDsExceptionNonCritical()
+
+    @exit_on_known_exception
+    def pid_declaration(self, unit_uuid, sip_directory):
+        """Process an identifiers.json file and add its values to the correct
+        models in the database.
+        """
+        identifiers = self._retrieve_identifiers_path(unit_uuid, sip_directory)
+        try:
+            with open(identifiers, "r") as identifiers_file:
+                json_data = json.load(identifiers_file)
+        except (ValueError, IOError) as err:
+            raise DeclarePIDsException(
+                "Error loading identifiers.json file: {}".format(err)
+            )
+        self.parse_and_attach_identifiers(unit_uuid, json_data)
+
+
+def call(jobs):
+    """Primary entry point for this script."""
+    for job in jobs:
+        with job.JobContext():
+            try:
+                DeclarePIDs(job).pid_declaration(
+                    unit_uuid=job.args[1], sip_directory=job.args[2]
+                )
+            except IndexError as err:
+                job.pyprint("Cannot access Job arguments:", err, file=sys.stderr)

--- a/src/MCPClient/tests/fixtures/pid_binding/dashboard_settings.json
+++ b/src/MCPClient/tests/fixtures/pid_binding/dashboard_settings.json
@@ -1,0 +1,132 @@
+[
+{
+  "fields": {
+    "scope": "handle",
+    "name": "resolve_url_template_file_access",
+    "value": "https://access.iisg.nl/access/{{ naming_authority }}/{{ pid }}",
+    "lastmodified": "2019-04-22T16:12:01.868Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 101
+},
+{
+  "fields": {
+    "scope": "handle",
+    "name": "resolve_url_template_file_preservation",
+    "value": "https://access.iisg.nl/preservation/{{ naming_authority }}/{{ pid }}",
+    "lastmodified": "2019-04-22T16:12:01.868Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 102
+},
+{
+  "fields": {
+    "scope": "handle",
+    "name": "handle_resolver_url",
+    "value": "http://195.169.88.240:8017/",
+    "lastmodified": "2019-04-22T16:12:01.868Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 103
+},
+{
+  "fields": {
+    "scope": "handle",
+    "name": "resolve_url_template_file",
+    "value": "https://access.iisg.nl/access/{{ naming_authority }}/{{ pid }}",
+    "lastmodified": "2019-04-22T16:12:01.868Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 104
+},
+{
+  "fields": {
+    "scope": "handle",
+    "name": "pid_request_verify_certs",
+    "value": "False",
+    "lastmodified": "2019-04-22T16:12:01.868Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 105
+},
+{
+  "fields": {
+    "scope": "handle",
+    "name": "resolve_url_template_archive",
+    "value": "https://access.iisg.nl/dip/{{ naming_authority }}/{{ pid }}",
+    "lastmodified": "2019-04-22T16:12:01.868Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 106
+},
+{
+  "fields": {
+    "scope": "handle",
+    "name": "resolve_url_template_mets",
+    "value": "https://access.iisg.nl/mets/{{ naming_authority }}/{{ pid }}",
+    "lastmodified": "2019-04-22T16:12:01.868Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 107
+},
+{
+  "fields": {
+    "scope": "handle",
+    "name": "pid_web_service_key",
+    "value": "84214c59-8694-48d5-89b5-d40a88cd7768",
+    "lastmodified": "1970-01-01T00:00:01.002Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 108
+},
+{
+  "fields": {
+    "scope": "handle",
+    "name": "handle_archive_pid_source",
+    "value": "accession_no",
+    "lastmodified": "2019-04-22T16:12:01.868Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 109
+},
+{
+  "fields": {
+    "scope": "handle",
+    "name": "pid_web_service_endpoint",
+    "value": "https://pid.socialhistoryservices.org/secure",
+    "lastmodified": "2019-04-22T16:12:01.869Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 110
+},
+{
+  "fields": {
+    "scope": "handle",
+    "name": "resolve_url_template_file_original",
+    "value": "https://access.iisg.nl/original/{{ naming_authority }}/{{ pid }}",
+    "lastmodified": "2019-04-22T16:12:01.869Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 111
+},
+{
+  "fields": {
+    "scope": "handle",
+    "name": "naming_authority",
+    "value": "12345",
+    "lastmodified": "2019-04-22T16:12:01.869Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 112
+},
+{
+  "fields": {
+    "scope": "handle",
+    "name": "pid_request_body_template",
+    "value": "<?xml version='1.0' encoding='UTF-8'?>\r\n        <soapenv:Envelope\r\n            xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'\r\n            xmlns:pid='http://pid.socialhistoryservices.org/'>\r\n            <soapenv:Body>\r\n                <pid:UpsertPidRequest>\r\n                    <pid:na>{{ naming_authority }}</pid:na>\r\n                    <pid:handle>\r\n                        <pid:pid>{{ naming_authority }}/{{ pid }}</pid:pid>\r\n                        <pid:locAtt>\r\n                            <pid:location weight='1' href='{{ base_resolve_url }}'/>\r\n                            {% for qrurl in qualified_resolve_urls %}\r\n                                <pid:location\r\n                                    weight='0'\r\n                                    href='{{ qrurl.url }}'\r\n                                    view='{{ qrurl.qualifier }}'/>\r\n                            {% endfor %}\r\n                        </pid:locAtt>\r\n                    </pid:handle>\r\n                </pid:UpsertPidRequest>\r\n            </soapenv:Body>\r\n        </soapenv:Envelope>",
+    "lastmodified": "2019-04-22T16:12:01.869Z"
+  },
+  "model": "main.dashboardsetting",
+  "pk": 113
+}
+]

--- a/src/MCPClient/tests/fixtures/pid_binding/directories.json
+++ b/src/MCPClient/tests/fixtures/pid_binding/directories.json
@@ -1,0 +1,74 @@
+[
+{
+  "fields": {
+    "sip": null,
+    "originallocation": "%transferDirectory%metadata/",
+    "transfer": "29460c83-957e-481f-9ca2-873bca42229a",
+    "identifiers": [],
+    "currentlocation": "%transferDirectory%metadata/",
+    "enteredsystem": "2019-04-23T12:45:34.925Z"
+  },
+  "model": "main.directory",
+  "pk": "3cc124e1-4e5c-433b-8f15-a7831d70145a"
+},
+{
+  "fields": {
+    "sip": null,
+    "originallocation": "%transferDirectory%logs/",
+    "transfer": "29460c83-957e-481f-9ca2-873bca42229a",
+    "identifiers": [],
+    "currentlocation": "%transferDirectory%logs/",
+    "enteredsystem": "2019-04-23T12:45:34.925Z"
+  },
+  "model": "main.directory",
+  "pk": "41b3fcfd-36ed-4cf7-b5af-56127238b362"
+},
+{
+  "fields": {
+    "sip": "cb5ebaf5-beda-40b4-8d0c-fefbd546b8de",
+    "originallocation": "%transferDirectory%objects/images/",
+    "transfer": "29460c83-957e-481f-9ca2-873bca42229a",
+    "identifiers": [],
+    "currentlocation": "%SIPDirectory%objects/images/",
+    "enteredsystem": "2019-04-23T12:45:34.925Z"
+  },
+  "model": "main.directory",
+  "pk": "966755bd-0ae3-4f85-b4ec-b359fefeff33"
+},
+{
+  "fields": {
+    "sip": "cb5ebaf5-beda-40b4-8d0c-fefbd546b8de",
+    "originallocation": "%transferDirectory%objects/documents/",
+    "transfer": "29460c83-957e-481f-9ca2-873bca42229a",
+    "identifiers": [],
+    "currentlocation": "%SIPDirectory%objects/documents/",
+    "enteredsystem": "2019-04-23T12:45:34.925Z"
+  },
+  "model": "main.directory",
+  "pk": "d298dd3f-c5d1-4445-99fe-09123fba8b30"
+},
+{
+  "fields": {
+    "sip": null,
+    "originallocation": "%transferDirectory%logs/fileMeta/",
+    "transfer": "29460c83-957e-481f-9ca2-873bca42229a",
+    "identifiers": [],
+    "currentlocation": "%transferDirectory%logs/fileMeta/",
+    "enteredsystem": "2019-04-23T12:45:34.925Z"
+  },
+  "model": "main.directory",
+  "pk": "e7ae9b01-4c07-4915-a7a0-1833b1078a5b"
+},
+{
+  "fields": {
+    "sip": null,
+    "originallocation": "%transferDirectory%metadata/submissionDocumentation/",
+    "transfer": "29460c83-957e-481f-9ca2-873bca42229a",
+    "identifiers": [],
+    "currentlocation": "%transferDirectory%metadata/submissionDocumentation/",
+    "enteredsystem": "2019-04-23T12:45:34.925Z"
+  },
+  "model": "main.directory",
+  "pk": "f9e8c91a-bfbc-48f0-8ff0-eed210ff6fde"
+}
+]

--- a/src/MCPClient/tests/fixtures/pid_binding/files.json
+++ b/src/MCPClient/tests/fixtures/pid_binding/files.json
@@ -1,0 +1,102 @@
+[
+    {
+        "fields": {
+            "checksum": "012661d0de5ed60973e5cb0f123df74e95118734345b2bdf35432ac7442dd8c8",
+            "checksumtype": "sha256",
+            "currentlocation": "%SIPDirectory%objects/metadata/transfers/pid_tests-29460c83-957e-481f-9ca2-873bca42229a/directory_tree.txt",
+            "enteredsystem": "2019-05-02T11:16:08.195Z",
+            "filegrpuse": "metadata",
+            "filegrpuuid": "",
+            "identifiers": [],
+            "label": "",
+            "modificationtime": "2019-05-02T11:16:08.195Z",
+            "originallocation": "%SIPDirectory%objects/metadata/transfers/pid_tests-29460c83-957e-481f-9ca2-873bca42229a/directory_tree.txt",
+            "removedtime": null,
+            "sip": "cb5ebaf5-beda-40b4-8d0c-fefbd546b8de",
+            "size": 233,
+            "transfer": null
+        },
+        "model": "main.file",
+        "pk": "06da9555-dc5b-425c-b967-6f30a740f1c3"
+    },
+    {
+        "fields": {
+            "checksum": "cd2b6311b1552b32c9bed90209bb219ab8216fd777b12dd36ad06aba959cba6e",
+            "checksumtype": "sha256",
+            "currentlocation": "%SIPDirectory%objects/images/image_001.jpg",
+            "enteredsystem": "2019-05-02T11:15:31.856Z",
+            "filegrpuse": "original",
+            "filegrpuuid": "",
+            "identifiers": [],
+            "label": "",
+            "modificationtime": "2019-04-23T12:25:01Z",
+            "originallocation": "%transferDirectory%objects/images/image_001.jpg",
+            "removedtime": null,
+            "sip": "cb5ebaf5-beda-40b4-8d0c-fefbd546b8de",
+            "size": 11,
+            "transfer": "29460c83-957e-481f-9ca2-873bca42229a"
+        },
+        "model": "main.file",
+        "pk": "52e4900a-b096-4815-856a-81b3cbe0952d"
+    },
+    {
+        "fields": {
+            "checksum": "cd2b6311b1552b32c9bed90209bb219ab8216fd777b12dd36ad06aba959cba6e",
+            "checksumtype": "sha256",
+            "currentlocation": "%SIPDirectory%objects/documents/Document001.doc",
+            "enteredsystem": "2019-05-02T11:15:31.869Z",
+            "filegrpuse": "original",
+            "filegrpuuid": "",
+            "identifiers": [],
+            "label": "",
+            "modificationtime": "2019-04-23T12:26:18Z",
+            "originallocation": "%transferDirectory%objects/documents/Document001.doc",
+            "removedtime": null,
+            "sip": "cb5ebaf5-beda-40b4-8d0c-fefbd546b8de",
+            "size": 11,
+            "transfer": "29460c83-957e-481f-9ca2-873bca42229a"
+        },
+        "model": "main.file",
+        "pk": "697c407f-7a43-43d2-b7e2-fefc956ea5fd"
+    },
+    {
+        "fields": {
+            "checksum": "e4bdbed4732746727a013431d87126a43e99ee7350c4d7ba27eb4927d8d06f15",
+            "checksumtype": "sha256",
+            "currentlocation": "%SIPDirectory%objects/submissionDocumentation/transfer-pid_tests-29460c83-957e-481f-9ca2-873bca42229a/METS.xml",
+            "enteredsystem": "2019-05-02T11:16:00.917Z",
+            "filegrpuse": "submissionDocumentation",
+            "filegrpuuid": "",
+            "identifiers": [],
+            "label": "",
+            "modificationtime": "2019-05-02T11:16:00.917Z",
+            "originallocation": "%SIPDirectory%objects/submissionDocumentation/transfer-pid_tests-29460c83-957e-481f-9ca2-873bca42229a/METS.xml",
+            "removedtime": null,
+            "sip": "cb5ebaf5-beda-40b4-8d0c-fefbd546b8de",
+            "size": 37119,
+            "transfer": null
+        },
+        "model": "main.file",
+        "pk": "c91d7725-f363-4e8a-bde1-0f5416b4f7f8"
+    },
+    {
+        "fields": {
+            "checksum": "28045d295e79a3666bd4c9a09536e2b6c65e2f917972e15c46c6eb2cad1e5700",
+            "checksumtype": "sha256",
+            "currentlocation": "%SIPDirectory%objects/metadata/transfers/pid_tests-29460c83-957e-481f-9ca2-873bca42229a/identifiers.json",
+            "enteredsystem": "2019-05-02T11:16:08.217Z",
+            "filegrpuse": "metadata",
+            "filegrpuuid": "",
+            "identifiers": [],
+            "label": "",
+            "modificationtime": "2019-05-02T11:16:08.217Z",
+            "originallocation": "%SIPDirectory%objects/metadata/transfers/pid_tests-29460c83-957e-481f-9ca2-873bca42229a/identifiers.json",
+            "removedtime": null,
+            "sip": "cb5ebaf5-beda-40b4-8d0c-fefbd546b8de",
+            "size": 1768,
+            "transfer": null
+        },
+        "model": "main.file",
+        "pk": "d94dbb6b-1082-4747-9d4c-4ddea8ce85b8"
+    }
+]

--- a/src/MCPClient/tests/fixtures/pid_binding/sip.json
+++ b/src/MCPClient/tests/fixtures/pid_binding/sip.json
@@ -1,0 +1,15 @@
+[
+{
+  "fields": {
+    "aip_filename": "pid_tests-cb5ebaf5-beda-40b4-8d0c-fefbd546b8de.7z",
+    "diruuids": true,
+    "currentpath": "%sharedPath%currentlyProcessing/pid_tests-cb5ebaf5-beda-40b4-8d0c-fefbd546b8de/",
+    "identifiers": [],
+    "sip_type": "SIP",
+    "createdtime": "2019-04-23T12:45:51.524Z",
+    "hidden": false
+  },
+  "model": "main.sip",
+  "pk": "cb5ebaf5-beda-40b4-8d0c-fefbd546b8de"
+}
+]

--- a/src/MCPClient/tests/fixtures/pid_binding/transfer.json
+++ b/src/MCPClient/tests/fixtures/pid_binding/transfer.json
@@ -1,0 +1,19 @@
+[
+{
+  "fields": {
+    "accessionid": "",
+    "access_system_id": "",
+    "description": "",
+    "diruuids": true,
+    "transfermetadatasetrow": null,
+    "notes": "",
+    "typeoftransfer": "",
+    "hidden": false,
+    "type": "Standard",
+    "currentlocation": "%sharedPath%watchedDirectories/SIPCreation/completedTransfers/pid_tests-29460c83-957e-481f-9ca2-873bca42229a/",
+    "sourceofacquisition": ""
+  },
+  "model": "main.transfer",
+  "pk": "29460c83-957e-481f-9ca2-873bca42229a"
+}
+]

--- a/src/MCPClient/tests/fixtures/pid_declaration/bad_identifiers.json
+++ b/src/MCPClient/tests/fixtures/pid_declaration/bad_identifiers.json
@@ -1,0 +1,15 @@
+[
+    {
+        "file": "",
+        "identifiers": [
+            {
+                "identiferType": "ULID",
+                "identifier": "01D9T8MJM9NEQ390H239VT50CQ"
+            },
+            {
+                "identiferType": "https://example.com/AIP/id/1348554167",
+                "identifier": "EX"
+            }
+        ]
+    },
+]

--- a/src/MCPClient/tests/fixtures/pid_declaration/identifiers.json
+++ b/src/MCPClient/tests/fixtures/pid_declaration/identifiers.json
@@ -1,0 +1,67 @@
+[
+    {
+        "file": "",
+        "identifiers": [
+            {
+                "identifierType": "ULID",
+                "identifier": "∅1D9T8MJM9NEQ390H239VT50CQ"
+            },
+            {
+                "identifier": "https://éxample.com/AIP/id/134855∅167",
+                "identifierType": "EXÎD"
+            }
+        ]
+    },
+    {
+        "file": "objects/documents/Dōcumēnt001.doc",
+        "identifiers": [
+            {
+                "identifierType": "ULID",
+                "identifier": "01D9T8NFX0DYQY∅ZDN0HX4J5B9"
+            },
+            {
+                "identifier": "https://éxample.com/file/id/758748901",
+                "identifierType": "EXÎD"
+            }
+        ]
+    },
+    {
+        "file": "objects/images/image 001.jpg",
+        "identifiers": [
+            {
+                "identifierType": "ULID",
+                "identifier": "01D9T8NGAQ2DBN8M4D23HM5FYN"
+            },
+            {
+                "identifier": "https://éxample.com/file/id/",
+                "identifierType": "EXÎD"
+            }
+        ]
+    },
+    {
+        "file": "objects/documents",
+        "identifiers": [
+            {
+                "identifierType": "ULID",
+                "identifier": "∅1D9T8NGS76TCN890Z2H6D1SKS"
+            },
+            {
+                "identifier": "https://éxample.com/directory/id/3742112915",
+                "identifierType": "EXÎD"
+            }
+        ]
+    },
+    {
+        "file": "objects/images",
+        "identifiers": [
+            {
+                "identifierType": "ULID",
+                "identifier": "01D9T8NH7QF5WW5CJ4KTW15J3C"
+            },
+            {
+                "identifier": "https://éxample.com/directory/id/2924688∅6",
+                "identifierType": "EXÎD"
+            }
+        ]
+    }
+]

--- a/src/MCPClient/tests/fixtures/vcr_cassettes/test_bind_pid_to_files.yaml
+++ b/src/MCPClient/tests/fixtures/vcr_cassettes/test_bind_pid_to_files.yaml
@@ -1,0 +1,65 @@
+interactions:
+- request:
+    body: !!python/object/new:django.utils.safestring.SafeText
+    - !!python/unicode "<?xml version='1.0' encoding='UTF-8'?>\r\n        <soapenv:Envelope\r\n
+      \           xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'\r\n            xmlns:pid='http://pid.socialhistoryservices.org/'>\r\n
+      \           <soapenv:Body>\r\n                <pid:UpsertPidRequest>\r\n                    <pid:na>12345</pid:na>\r\n
+      \                   <pid:handle>\r\n                        <pid:pid>12345/06da9555-dc5b-425c-b967-6f30a740f1c3</pid:pid>\r\n
+      \                       <pid:locAtt>\r\n                            <pid:location
+      weight='1' href='https://access.iisg.nl/access/12345/06da9555-dc5b-425c-b967-6f30a740f1c3'/>\r\n
+      \                           \r\n                                <pid:location\r\n
+      \                                   weight='0'\r\n                                    href='https://access.iisg.nl/access/12345/06da9555-dc5b-425c-b967-6f30a740f1c3'\r\n
+      \                                   view='access'/>\r\n                            \r\n
+      \                               <pid:location\r\n                                    weight='0'\r\n
+      \                                   href='https://access.iisg.nl/preservation/12345/06da9555-dc5b-425c-b967-6f30a740f1c3'\r\n
+      \                                   view='preservation'/>\r\n                            \r\n
+      \                               <pid:location\r\n                                    weight='0'\r\n
+      \                                   href='https://access.iisg.nl/original/12345/06da9555-dc5b-425c-b967-6f30a740f1c3'\r\n
+      \                                   view='original'/>\r\n                            \r\n
+      \                       </pid:locAtt>\r\n                    </pid:handle>\r\n
+      \               </pid:UpsertPidRequest>\r\n            </soapenv:Body>\r\n        </soapenv:Envelope>"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - !!python/unicode bearer 84214c59-8694-48d5-89b5-d40a88cd7768
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1711'
+      Content-Type:
+      - !!python/unicode text/xml
+      User-Agent:
+      - python-requests/2.21.0
+    method: POST
+    uri: https://pid.socialhistoryservices.org/secure
+  response:
+    body:
+      string: !!python/unicode <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Header/><SOAP-ENV:Body><ns2:UpsertPidResponse
+        xmlns:ns2="http://pid.socialhistoryservices.org/"><ns2:handle><ns2:pid>12345/06DA9555-DC5B-425C-B967-6F30A740F1C3</ns2:pid><ns2:locAtt><ns2:location
+        ns2:href="https://access.iisg.nl/access/12345/06da9555-dc5b-425c-b967-6f30a740f1c3"
+        ns2:weight="1"/><ns2:location ns2:href="https://access.iisg.nl/access/12345/06da9555-dc5b-425c-b967-6f30a740f1c3"
+        ns2:view="access" ns2:weight="0"/><ns2:location ns2:href="https://access.iisg.nl/preservation/12345/06da9555-dc5b-425c-b967-6f30a740f1c3"
+        ns2:view="preservation" ns2:weight="0"/><ns2:location ns2:href="https://access.iisg.nl/original/12345/06da9555-dc5b-425c-b967-6f30a740f1c3"
+        ns2:view="original" ns2:weight="0"/></ns2:locAtt></ns2:handle></ns2:UpsertPidResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
+    headers:
+      accept:
+      - text/xml, text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
+      connection:
+      - keep-alive
+      content-length:
+      - '881'
+      content-type:
+      - text/xml;charset=utf-8
+      date:
+      - Thu, 02 May 2019 12:44:02 GMT
+      server:
+      - nginx
+      soapaction:
+      - '""'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/MCPClient/tests/fixtures/vcr_cassettes/test_bind_pids_to_sip_and_dirs.yaml
+++ b/src/MCPClient/tests/fixtures/vcr_cassettes/test_bind_pids_to_sip_and_dirs.yaml
@@ -1,0 +1,183 @@
+interactions:
+- request:
+    body: !!python/object/new:django.utils.safestring.SafeText
+    - !!python/unicode "<?xml version='1.0' encoding='UTF-8'?>\r\n        <soapenv:Envelope\r\n
+      \           xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'\r\n            xmlns:pid='http://pid.socialhistoryservices.org/'>\r\n
+      \           <soapenv:Body>\r\n                <pid:UpsertPidRequest>\r\n                    <pid:na>12345</pid:na>\r\n
+      \                   <pid:handle>\r\n                        <pid:pid>12345/cb5ebaf5-beda-40b4-8d0c-fefbd546b8de</pid:pid>\r\n
+      \                       <pid:locAtt>\r\n                            <pid:location
+      weight='1' href='https://access.iisg.nl/dip/12345/cb5ebaf5-beda-40b4-8d0c-fefbd546b8de'/>\r\n
+      \                           \r\n                                <pid:location\r\n
+      \                                   weight='0'\r\n                                    href='https://access.iisg.nl/mets/12345/cb5ebaf5-beda-40b4-8d0c-fefbd546b8de'\r\n
+      \                                   view='mets'/>\r\n                            \r\n
+      \                       </pid:locAtt>\r\n                    </pid:handle>\r\n
+      \               </pid:UpsertPidRequest>\r\n            </soapenv:Body>\r\n        </soapenv:Envelope>"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - !!python/unicode bearer 84214c59-8694-48d5-89b5-d40a88cd7768
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1098'
+      Content-Type:
+      - !!python/unicode text/xml
+      User-Agent:
+      - python-requests/2.21.0
+    method: POST
+    uri: https://pid.socialhistoryservices.org/secure
+  response:
+    body:
+      string: !!python/unicode <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Header/><SOAP-ENV:Body><ns2:UpsertPidResponse
+        xmlns:ns2="http://pid.socialhistoryservices.org/"><ns2:handle><ns2:pid>12345/CB5EBAF5-BEDA-40B4-8D0C-FEFBD546B8DE</ns2:pid><ns2:locAtt><ns2:location
+        ns2:href="https://access.iisg.nl/dip/12345/cb5ebaf5-beda-40b4-8d0c-fefbd546b8de"
+        ns2:weight="1"/><ns2:location ns2:href="https://access.iisg.nl/mets/12345/cb5ebaf5-beda-40b4-8d0c-fefbd546b8de"
+        ns2:view="mets" ns2:weight="0"/></ns2:locAtt></ns2:handle></ns2:UpsertPidResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
+    headers:
+      accept:
+      - text/xml, text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
+      connection:
+      - keep-alive
+      content-length:
+      - '594'
+      content-type:
+      - text/xml;charset=utf-8
+      date:
+      - Thu, 02 May 2019 13:08:30 GMT
+      server:
+      - nginx
+      soapaction:
+      - '""'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/object/new:django.utils.safestring.SafeText
+    - !!python/unicode "<?xml version='1.0' encoding='UTF-8'?>\r\n        <soapenv:Envelope\r\n
+      \           xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'\r\n            xmlns:pid='http://pid.socialhistoryservices.org/'>\r\n
+      \           <soapenv:Body>\r\n                <pid:UpsertPidRequest>\r\n                    <pid:na>12345</pid:na>\r\n
+      \                   <pid:handle>\r\n                        <pid:pid>12345/966755bd-0ae3-4f85-b4ec-b359fefeff33</pid:pid>\r\n
+      \                       <pid:locAtt>\r\n                            <pid:location
+      weight='1' href='https://access.iisg.nl/access/12345/966755bd-0ae3-4f85-b4ec-b359fefeff33'/>\r\n
+      \                           \r\n                                <pid:location\r\n
+      \                                   weight='0'\r\n                                    href='https://access.iisg.nl/access/12345/966755bd-0ae3-4f85-b4ec-b359fefeff33'\r\n
+      \                                   view='access'/>\r\n                            \r\n
+      \                               <pid:location\r\n                                    weight='0'\r\n
+      \                                   href='https://access.iisg.nl/preservation/12345/966755bd-0ae3-4f85-b4ec-b359fefeff33'\r\n
+      \                                   view='preservation'/>\r\n                            \r\n
+      \                               <pid:location\r\n                                    weight='0'\r\n
+      \                                   href='https://access.iisg.nl/original/12345/966755bd-0ae3-4f85-b4ec-b359fefeff33'\r\n
+      \                                   view='original'/>\r\n                            \r\n
+      \                       </pid:locAtt>\r\n                    </pid:handle>\r\n
+      \               </pid:UpsertPidRequest>\r\n            </soapenv:Body>\r\n        </soapenv:Envelope>"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - !!python/unicode bearer 84214c59-8694-48d5-89b5-d40a88cd7768
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1711'
+      Content-Type:
+      - !!python/unicode text/xml
+      User-Agent:
+      - python-requests/2.21.0
+    method: POST
+    uri: https://pid.socialhistoryservices.org/secure
+  response:
+    body:
+      string: !!python/unicode <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Header/><SOAP-ENV:Body><ns2:UpsertPidResponse
+        xmlns:ns2="http://pid.socialhistoryservices.org/"><ns2:handle><ns2:pid>12345/966755BD-0AE3-4F85-B4EC-B359FEFEFF33</ns2:pid><ns2:locAtt><ns2:location
+        ns2:href="https://access.iisg.nl/access/12345/966755bd-0ae3-4f85-b4ec-b359fefeff33"
+        ns2:weight="1"/><ns2:location ns2:href="https://access.iisg.nl/access/12345/966755bd-0ae3-4f85-b4ec-b359fefeff33"
+        ns2:view="access" ns2:weight="0"/><ns2:location ns2:href="https://access.iisg.nl/preservation/12345/966755bd-0ae3-4f85-b4ec-b359fefeff33"
+        ns2:view="preservation" ns2:weight="0"/><ns2:location ns2:href="https://access.iisg.nl/original/12345/966755bd-0ae3-4f85-b4ec-b359fefeff33"
+        ns2:view="original" ns2:weight="0"/></ns2:locAtt></ns2:handle></ns2:UpsertPidResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
+    headers:
+      accept:
+      - text/xml, text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
+      connection:
+      - keep-alive
+      content-length:
+      - '881'
+      content-type:
+      - text/xml;charset=utf-8
+      date:
+      - Thu, 02 May 2019 13:08:30 GMT
+      server:
+      - nginx
+      soapaction:
+      - '""'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!python/object/new:django.utils.safestring.SafeText
+    - !!python/unicode "<?xml version='1.0' encoding='UTF-8'?>\r\n        <soapenv:Envelope\r\n
+      \           xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'\r\n            xmlns:pid='http://pid.socialhistoryservices.org/'>\r\n
+      \           <soapenv:Body>\r\n                <pid:UpsertPidRequest>\r\n                    <pid:na>12345</pid:na>\r\n
+      \                   <pid:handle>\r\n                        <pid:pid>12345/d298dd3f-c5d1-4445-99fe-09123fba8b30</pid:pid>\r\n
+      \                       <pid:locAtt>\r\n                            <pid:location
+      weight='1' href='https://access.iisg.nl/access/12345/d298dd3f-c5d1-4445-99fe-09123fba8b30'/>\r\n
+      \                           \r\n                                <pid:location\r\n
+      \                                   weight='0'\r\n                                    href='https://access.iisg.nl/access/12345/d298dd3f-c5d1-4445-99fe-09123fba8b30'\r\n
+      \                                   view='access'/>\r\n                            \r\n
+      \                               <pid:location\r\n                                    weight='0'\r\n
+      \                                   href='https://access.iisg.nl/preservation/12345/d298dd3f-c5d1-4445-99fe-09123fba8b30'\r\n
+      \                                   view='preservation'/>\r\n                            \r\n
+      \                               <pid:location\r\n                                    weight='0'\r\n
+      \                                   href='https://access.iisg.nl/original/12345/d298dd3f-c5d1-4445-99fe-09123fba8b30'\r\n
+      \                                   view='original'/>\r\n                            \r\n
+      \                       </pid:locAtt>\r\n                    </pid:handle>\r\n
+      \               </pid:UpsertPidRequest>\r\n            </soapenv:Body>\r\n        </soapenv:Envelope>"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - !!python/unicode bearer 84214c59-8694-48d5-89b5-d40a88cd7768
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1711'
+      Content-Type:
+      - !!python/unicode text/xml
+      User-Agent:
+      - python-requests/2.21.0
+    method: POST
+    uri: https://pid.socialhistoryservices.org/secure
+  response:
+    body:
+      string: !!python/unicode <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Header/><SOAP-ENV:Body><ns2:UpsertPidResponse
+        xmlns:ns2="http://pid.socialhistoryservices.org/"><ns2:handle><ns2:pid>12345/D298DD3F-C5D1-4445-99FE-09123FBA8B30</ns2:pid><ns2:locAtt><ns2:location
+        ns2:href="https://access.iisg.nl/access/12345/d298dd3f-c5d1-4445-99fe-09123fba8b30"
+        ns2:weight="1"/><ns2:location ns2:href="https://access.iisg.nl/access/12345/d298dd3f-c5d1-4445-99fe-09123fba8b30"
+        ns2:view="access" ns2:weight="0"/><ns2:location ns2:href="https://access.iisg.nl/preservation/12345/d298dd3f-c5d1-4445-99fe-09123fba8b30"
+        ns2:view="preservation" ns2:weight="0"/><ns2:location ns2:href="https://access.iisg.nl/original/12345/d298dd3f-c5d1-4445-99fe-09123fba8b30"
+        ns2:view="original" ns2:weight="0"/></ns2:locAtt></ns2:handle></ns2:UpsertPidResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
+    headers:
+      accept:
+      - text/xml, text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
+      connection:
+      - keep-alive
+      content-length:
+      - '881'
+      content-type:
+      - text/xml;charset=utf-8
+      date:
+      - Thu, 02 May 2019 13:08:30 GMT
+      server:
+      - nginx
+      soapaction:
+      - '""'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/MCPClient/tests/test_parse_dataverse.py
+++ b/src/MCPClient/tests/test_parse_dataverse.py
@@ -62,12 +62,6 @@ class TestParseDataverse(TestCase):
         self.unit_path = os.path.join(THIS_DIR, "fixtures", "dataverse", "")
         models.Agent.objects.all().delete()
 
-    @staticmethod
-    def test_fixture():
-        """Test that the fixture has been loaded as expected."""
-        assert models.Transfer.objects.count() == 1
-        assert models.File.objects.count() == 12
-
     def test_mapping(self):
         """The first test in is to find the Dataverse objects in the Database
         and ensure they are there as expected.
@@ -166,7 +160,12 @@ class TestParseDataverse(TestCase):
                 "file_group_use": "metadata",
             },
         ]
-        assert models.File.objects.exclude(filegrpuse="original").count() == 0
+        assert (
+            models.File.objects.filter(transfer="6741c782-f22b-47b3-8bcf-72fd0c94e195")
+            .exclude(filegrpuse="original")
+            .count()
+            == 0
+        )
         mapping = parse_dataverse.get_db_objects(self.job, self.mets, self.uuid)
         parse_dataverse.update_file_use(self.job, mapping)
         for test_case in test_cases:

--- a/src/MCPClient/tests/test_pid_components.py
+++ b/src/MCPClient/tests/test_pid_components.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Unit tests for the various components associated with PID (persistent
+identifier binding and declaration in Archivematica.
+
+The tests in this module cover both the two bind_pid(s) microservice jobs but
+also limited unit testing in create_mets_v2 (AIP METS generation).
+"""
+from __future__ import unicode_literals
+from itertools import chain
+import os
+import sys
+
+from django.core.management import call_command
+
+from job import Job
+from main.models import Directory, File, SIP, DashboardSetting
+
+import pytest
+import vcr
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(THIS_DIR, "../lib/clientScripts")))
+sys.path.append(
+    os.path.abspath(os.path.join(THIS_DIR, "../../archivematicaCommon/lib"))
+)
+
+vcr_cassettes = vcr.VCR(
+    cassette_library_dir=os.path.join(THIS_DIR, "fixtures", "vcr_cassettes"),
+    path_transformer=vcr.VCR.ensure_suffix(".yaml"),
+)
+
+import bind_pid
+import bind_pids
+import create_mets_v2
+import namespaces as ns
+from pid_declaration import DeclarePIDs, DeclarePIDsException
+
+
+class TestPIDComponents(object):
+    """PID binding and declaration test runner class."""
+
+    # Information we'll refer back to in our tests.
+    package_uuid = "cb5ebaf5-beda-40b4-8d0c-fefbd546b8de"
+    fake_package_uuid = "eb6b860e-611c-45c8-8d3e-b9396ed6c751"
+    do_not_bind = "Configuration indicates that PIDs should not be bound."
+    incomplete_configuration_msg = "A value for parameter"
+    bound_uri = "http://195.169.88.240:8017/12345/"
+    bound_hdl = "12345/"
+    traditional_identifiers = ("UUID",)
+    bound_identifier_types = ("hdl", "URI")
+    pid_exid = "EXÎD"
+    pid_ulid = "ULID"
+    declared_identifier_types = (pid_exid, pid_ulid)
+    package_files = [
+        "directory_tree.txt",
+        "image 001.jpg",
+        "Dōcumēnt001.doc",
+        "METS.xml",
+        "identifiers.json",
+    ]
+    # At time of writing, the Bind PIDs functions only binds to the content
+    # folders and the SIP itself, it doesn't bind to the metadata or
+    # submissionDocumentation directories in the package.
+    package_directories = ["images/", "documents"]
+    pid_declaration_dir = "pid_declaration"
+
+    @property
+    def job(self):
+        """Cleanly initiate a new Job so we don't maintain unnecessary state in
+        this object as the tests continue.
+        """
+        return Job("stub", "stub", [])
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def django_db_setup(django_db_blocker):
+        """Load the various database fixtures required for our tests."""
+        pid_dir = "pid_binding"
+        fixture_files = [
+            "sip.json",
+            "dashboard_settings.json",
+            "transfer.json",
+            "files.json",
+            "directories.json",
+        ]
+        fixtures = []
+        for fixture in fixture_files:
+            fixtures.append(os.path.join(THIS_DIR, "fixtures", pid_dir, fixture))
+        with django_db_blocker.unblock():
+            for fixture in fixtures:
+                call_command("loaddata", fixture)
+
+    def test_bind_pids_not_set(self, caplog):
+        """Test the output of the code without any args.
+
+        bind_pids should return zero, for no-error. It won't have performed
+        any actions on the database either.
+        """
+        assert (
+            bind_pids.main(self.job, None, None, None) == 0
+        ), "Return from bind_pids is something other than expected."
+        assert (
+            caplog.records[0].message == self.do_not_bind
+        ), "Captured logging message from bind_pids is different than anticipated."
+        assert (
+            bind_pids.main(self.job, None, None, False) == 0
+        ), "Return from bind_pids is something other than expected."
+        assert (
+            caplog.records[1].message == self.do_not_bind
+        ), "Captured logging message from bind_pids is different than anticipated."
+
+    @pytest.mark.django_db
+    def test_bind_pids_no_config(self, caplog):
+        """Test the output of the code without any args.
+
+        In this instance, we want bind_pids to think that there is some
+        configuration available but we haven't provided any other information.
+        We should see the microservice job exit without failing for the user.
+        An example scenario might be when the user has bind PIDs on in their
+        processing configuration but no handle server information configured.
+        """
+        assert (
+            bind_pids.main(self.job, None, None, True) == 1
+        ), "Incorrect return value for bind_pids with incomplete configuration."
+        assert caplog.records[0].message.startswith(self.incomplete_configuration_msg)
+
+    @pytest.mark.django_db
+    def test_bind_pids(self, mocker):
+        """Test the bind_pids function end-to-end and ensure that the
+        result is that which is anticipated.
+
+        The bind_pids module is responsible for binding persistent identifiers
+        to the SIP and the SIP's directories so we only test that here.
+        """
+        # We might want to return a unique accession number, but we can also
+        # test here using the package UUID, the function's fallback position.
+        mocker.patch.object(
+            bind_pids, "_get_unique_acc_no", return_value=self.package_uuid
+        )
+        mocker.patch.object(bind_pids, "_validate", return_value=None)
+        with vcr_cassettes.use_cassette(
+            "test_bind_pids_to_sip_and_dirs.yaml"
+        ) as cassette:
+            # Primary entry-point for the bind_pids microservice job.
+            bind_pids.main(self.job, self.package_uuid, "", True)
+        assert cassette.all_played
+        sip_mdl = SIP.objects.filter(uuid=self.package_uuid).first()
+        assert len(sip_mdl.identifiers.all()) == len(
+            self.bound_identifier_types
+        ), "Number of SIP identifiers is greater than anticipated"
+        dirs = Directory.objects.filter(sip=self.package_uuid).all()
+        assert len(dirs) == len(
+            self.package_directories
+        ), "Number of directories is incorrect"
+        for mdl in chain(dirs, (sip_mdl,)):
+            bound = [(idfr.type, idfr.value) for idfr in mdl.identifiers.all()]
+            assert len(bound) == len(self.bound_identifier_types)
+            pid_types = []
+            for pid in bound:
+                pid_types.append(pid[0])
+            assert (
+                "hdl" in pid_types
+            ), "An expected hdl persistent identifier isn't in the result set"
+            assert "URI" in pid_types, "An expected URI isn't in the result set"
+            bound_hdl = "{}{}".format(self.bound_hdl, mdl.pk)
+            bound_uri = "{}{}".format(self.bound_uri, mdl.pk)
+            pids = []
+            for pid in bound:
+                pids.append(pid[1])
+            assert bound_hdl in pids, "Handle PID bound to SIP is incorrect"
+            assert bound_uri in pids, "URI PID bound to SIP is incorrect"
+            # Once we know we're creating identifiers as expected, test to ensure
+            # that those identifiers are output as expected by the METS functions
+            # doing that work.
+            dir_dmd_sec = create_mets_v2.getDirDmdSec(mdl, "")
+            id_type = dir_dmd_sec.xpath(
+                "//premis:objectIdentifierType", namespaces={"premis": ns.premisNS}
+            )
+            id_value = dir_dmd_sec.xpath(
+                "//premis:objectIdentifierValue", namespaces={"premis": ns.premisNS}
+            )
+            id_types = [item.text for item in id_type]
+            id_values = [item.text for item in id_value]
+            identifiers_dict = dict(zip(id_types, id_values))
+            for key in identifiers_dict.keys():
+                assert key in chain(
+                    self.traditional_identifiers, self.bound_identifier_types
+                )
+            assert bound_hdl in identifiers_dict.values()
+            assert bound_uri in identifiers_dict.values()
+
+    @pytest.mark.django_db
+    def test_bind_pid_no_config(self, caplog):
+        """Test the output of the code when bind_pids is set to True but there
+        are no handle settings in the Dashboard. Conceivably then the dashboard
+        settings could be in-between two states, complete and not-complete,
+        here we test for the two opposites on the assumption they'll be the
+        most visible errors to the user.
+        """
+        DashboardSetting.objects.filter(scope="handle").delete()
+        assert bind_pid.main(self.job, self.package_uuid, True) == 1
+        assert caplog.records[0].message.startswith(self.incomplete_configuration_msg)
+
+    def test_bind_pid_not_set(self, caplog):
+        """Ensure that the behavior of bind_pid is as anticipated when we're
+        not asking it to bind_pids, i.e. it doesn't runaway and try and bind
+        anyway, or something that isn't there.
+        """
+        assert (
+            bind_pid.main(self.job, None, None) == 0
+        ), "Return from bind_pid is incorrect"
+        assert (
+            caplog.records[0].message == self.do_not_bind
+        ), "Captured logging message from bind_pid is incorrect"
+        assert (
+            bind_pid.main(self.job, None, False) == 0
+        ), "Return from bind_pid is something other than expected"
+        assert (
+            caplog.records[1].message == self.do_not_bind
+        ), "Captured logging message from bind_pid is incorrect"
+
+    @pytest.mark.django_db
+    def test_bind_pid(self):
+        """Test the bind_pid function end-to-end and ensure that the
+        result is that which is anticipated.
+
+        The bind_pid module is responsible for binding persistent identifiers
+        to the SIP's files and so we test for that here.
+        """
+        files = File.objects.filter(sip=self.package_uuid).all()
+        assert len(files) is len(
+            self.package_files
+        ), "Number of files returned from package is incorrect"
+        for file_ in files:
+            with vcr_cassettes.use_cassette("test_bind_pid_to_files.yaml") as cassette:
+                bind_pid.main(self.job, file_.pk, True)
+        assert cassette.all_played
+        for file_mdl in files:
+            bound = {idfr.type: idfr.value for idfr in file_mdl.identifiers.all()}
+            assert (
+                "hdl" in bound
+            ), "An expected hdl persistent identifier isn't in the result set"
+            assert "URI" in bound, "An expected URI isn't in the result set"
+            bound_hdl = "{}{}".format(self.bound_hdl, file_mdl.pk)
+            bound_uri = "{}{}".format(self.bound_uri, file_mdl.pk)
+            assert bound.get("hdl") == bound_hdl
+            assert bound.get("URI") == bound_uri
+            # Then test to see that the PREMIS objects are created correctly in
+            # the AIP METS generation code.
+            file_level_premis = create_mets_v2.create_premis_object(file_mdl.pk)
+            id_type = file_level_premis.xpath(
+                "//premis:objectIdentifierType", namespaces={"premis": ns.premisNS}
+            )
+            id_value = file_level_premis.xpath(
+                "//premis:objectIdentifierValue", namespaces={"premis": ns.premisNS}
+            )
+            id_types = [item.text for item in id_type]
+            id_values = [item.text for item in id_value]
+            identifiers_dict = dict(zip(id_types, id_values))
+            for key in identifiers_dict.keys():
+                assert key in chain(
+                    self.traditional_identifiers, self.bound_identifier_types
+                ), "Identifier type not in expected schemes list"
+            assert bound_hdl in identifiers_dict.values()
+            assert bound_uri in identifiers_dict.values()
+
+    @pytest.mark.django_db
+    def test_bind_pid_no_settings(self, caplog):
+        """Test the output of the code when bind_pids is set to True but there
+        are no handle settings in the Dashboard. Conceivably then the dashboard
+        settings could be in-between two states, complete and not-complete,
+        here we test for the two opposites on the assumption they'll be the
+        most visible errors to the user.
+        """
+        file_count = 5
+        DashboardSetting.objects.filter(scope="handle").delete()
+        files = File.objects.filter(sip=self.package_uuid).all()
+        assert (
+            files is not None
+        ), "Files haven't been retrieved from the model as expected"
+        for file_ in files:
+            bind_pid.main(self.job, file_.pk, True)
+        for file_number in range(file_count):
+            assert caplog.records[file_number].message.startswith(
+                self.incomplete_configuration_msg
+            )
+
+    @pytest.mark.django_db
+    def test_pid_declaration(self, mocker):
+        """Test that the overall functionality of the PID declaration functions
+        work as expected.
+        """
+        job = self.job
+        files_no = 2
+        dirs_no = 2
+        example_ulid = "EXAMPLE0RE60SW7SVM2C8EGQAD"
+        example_uri = "https://éxample.com/"
+        expected_identifiers = 2
+        identifers_file = "identifiers.json"
+        identifiers_loc = os.path.join(
+            THIS_DIR, "fixtures", self.pid_declaration_dir, identifers_file
+        )
+        all_identifier_types = (
+            self.traditional_identifiers
+            + self.bound_identifier_types
+            + self.declared_identifier_types
+        )
+        mocker.patch.object(
+            DeclarePIDs, "_retrieve_identifiers_path", return_value=identifiers_loc
+        )
+        DeclarePIDs(job).pid_declaration(unit_uuid=self.package_uuid, sip_directory="")
+        # Declare PIDs allows us to assign PIDs to very specific objects in a
+        # transfer.
+        sip_mdl = SIP.objects.filter(uuid=self.package_uuid).first()
+        files = File.objects.filter(sip=self.package_uuid, filegrpuse="original").all()
+        dir_mdl = Directory.objects.filter(
+            currentlocation__contains="%SIPDirectory%objects/"
+        )
+        assert len(files) == files_no, "Number of files returned is incorrect"
+        assert len(dir_mdl) == dirs_no, "Number of directories returned is incorrect"
+        for mdl in chain((sip_mdl,), files, dir_mdl):
+            bound = {idfr.type: idfr.value for idfr in mdl.identifiers.all()}
+            assert (
+                len(bound) == expected_identifiers
+            ), "Number of identifiers is incorrect"
+            assert set(bound.keys()) == set(
+                self.declared_identifier_types
+            ), "Returned keys are not in expected list"
+            for key, value in bound.items():
+                assert value, "Returned an empty value for an identifier"
+                if key == self.pid_exid:
+                    assert example_uri in value, "Example URI type not preserved"
+                if key == self.pid_ulid:
+                    assert len(example_ulid) == len(value)
+        # Use the previous PID binding vcr cassettes to ensure declared PIDs can
+        # co-exist with bound ones.
+        mocker.patch.object(
+            bind_pids, "_get_unique_acc_no", return_value=self.package_uuid
+        )
+        mocker.patch.object(bind_pids, "_validate", return_value=None)
+        with vcr_cassettes.use_cassette(
+            "test_bind_pids_to_sip_and_dirs.yaml"
+        ) as cassette:
+            # Primary entry-point for the bind_pids microservice job.
+            bind_pids.main(self.job, self.package_uuid, "", True)
+        for mdl in chain((sip_mdl,), dir_mdl):
+            dir_dmd_sec = create_mets_v2.getDirDmdSec(mdl, "")
+            id_type = dir_dmd_sec.xpath(
+                "//premis:objectIdentifierType", namespaces={"premis": ns.premisNS}
+            )
+            id_value = dir_dmd_sec.xpath(
+                "//premis:objectIdentifierValue", namespaces={"premis": ns.premisNS}
+            )
+            assert len(id_type) == len(
+                all_identifier_types
+            ), "Identifier type count is incorrect"
+            assert len(id_value) == len(
+                all_identifier_types
+            ), "Identifier value count is incorrect"
+            for key, value in dict(zip(id_type, id_value)).items():
+                if key == self.pid_exid:
+                    assert example_uri in value, "Example URI not preserved"
+                if key == self.pid_ulid:
+                    assert len(example_ulid) == len(value)
+        for file_ in files:
+            with vcr_cassettes.use_cassette("test_bind_pid_to_files.yaml") as cassette:
+                bind_pid.main(self.job, file_.pk, True)
+            assert cassette.all_played
+        for file_mdl in files:
+            file_level_premis = create_mets_v2.create_premis_object(file_mdl.pk)
+            id_type = file_level_premis.xpath(
+                "//premis:objectIdentifierType", namespaces={"premis": ns.premisNS}
+            )
+            id_value = file_level_premis.xpath(
+                "//premis:objectIdentifierValue", namespaces={"premis": ns.premisNS}
+            )
+            assert len(id_type) == len(
+                all_identifier_types
+            ), "Identifier type count is incorrect"
+            assert len(id_value) == len(
+                all_identifier_types
+            ), "Identifier value count is incorrect"
+            for key, value in dict(zip(id_type, id_value)).items():
+                if key == self.pid_exid:
+                    assert example_uri in value, "Example URI not preserved"
+                if key == self.pid_ulid:
+                    assert len(example_ulid) == len(value)
+
+    @pytest.mark.django_db
+    def test_pid_declaration_exceptions(self, mocker):
+        """Ensure that the PID declaration feature exits when the JSOn cannot
+        be loaded.
+        """
+        job = self.job
+        # Test behavior when there isn't an identifiers.json file, e.g. we
+        # simulate this by passing an incorrect Unit UUID.
+        DeclarePIDs(job).pid_declaration(
+            unit_uuid=self.fake_package_uuid, sip_directory=""
+        )
+        assert (
+            "No identifiers.json file found" in job.get_stderr().strip()
+        ), "Expecting no identifiers.json file, but got something else"
+        # Test behavior when identifiers.json is badly formatted.
+        bad_identifers_file = "bad_identifiers.json"
+        bad_identifiers_loc = os.path.join(
+            THIS_DIR, "fixtures", self.pid_declaration_dir, bad_identifers_file
+        )
+        mocker.patch.object(
+            DeclarePIDs, "_retrieve_identifiers_path", return_value=bad_identifiers_loc
+        )
+        try:
+            DeclarePIDs(job).pid_declaration(unit_uuid="", sip_directory="")
+        except DeclarePIDsException as err:
+            assert "No JSON object could be decoded" in str(
+                err
+            ), "Error message something other than anticipated for invalid JSON"

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -1267,6 +1267,36 @@
                 "sv": "Kontrollera överförings följsamhet"
             }
         },
+        "873b428f-2c86-42b6-b463-aeda925bf559": {
+            "config": {
+                "@manager": "linkTaskManagerDirectories",
+                "@model": "StandardTaskConfig",
+                "arguments": "\"%SIPUUID%\" \"%SIPDirectory%\"",
+                "execute": "declarepids_v0.0",
+                "filter_file_end": "",
+                "filter_file_start": null,
+                "filter_subdir": null,
+                "stderr_file": null,
+                "stdout_file": null
+            },
+            "description": {
+                "en": "Persistent identifier (PID) declaration"
+            },
+            "exit_codes": {
+                "0": {
+                    "job_status": "Completed successfully",
+                    "link_id": "05357876-a095-4c11-86b5-a7fff01af668"
+                }
+            },
+            "fallback_job_status": "Failed",
+            "fallback_link_id": "7d728c39-395f-4892-8193-92f086c0546f",
+            "group": {
+                "en": "Bind PIDs",
+                "fr": "Lier les PIDs",
+                "pt_BR": "Vincular PIDs",
+                "sv": "Lås PID:er."
+            }
+        },
         "05357876-a095-4c11-86b5-a7fff01af668": {
             "config": {
                 "@manager": "linkTaskManagerReplacementDicFromChoice",
@@ -6981,11 +7011,11 @@
             "exit_codes": {
                 "0": {
                     "job_status": "Completed successfully",
-                    "link_id": "05357876-a095-4c11-86b5-a7fff01af668"
+                    "link_id": "873b428f-2c86-42b6-b463-aeda925bf559"
                 }
             },
             "fallback_job_status": "Failed",
-            "fallback_link_id": "05357876-a095-4c11-86b5-a7fff01af668",
+            "fallback_link_id": "873b428f-2c86-42b6-b463-aeda925bf559",
             "group": {
                 "en": "Process metadata directory",
                 "es": "Procesar directorio de metadatos",

--- a/src/archivematicaCommon/lib/bindpid.py
+++ b/src/archivematicaCommon/lib/bindpid.py
@@ -332,7 +332,6 @@ def bind_pid(**kwargs):
       - If the Payload is invalid XML, then the response will have a 400 status
         code and the response body will be HTML.
     """
-    _validate(kwargs)
     resolve_url, qualified_resolve_urls, purl_map = _render_url_templates(kwargs)
     request_body = _render_request_body(kwargs, resolve_url, qualified_resolve_urls)
     response = requests.post(

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -409,6 +409,10 @@ class SIP(models.Model):
     def update_active_agent(self, user_id):
         UnitVariable.objects.update_active_agent("SIP", self.uuid, user_id)
 
+    def add_custom_identifier(self, scheme, value):
+        """Allow callers to add custom identifiers to the model's instance."""
+        self.identifiers.create(type=scheme, value=value)
+
 
 class TransferManager(models.Manager):
     def is_hidden(self, uuid):
@@ -570,6 +574,10 @@ class File(models.Model):
             }
         )
 
+    def add_custom_identifier(self, scheme, value):
+        """Allow callers to add custom identifiers to the model's instance."""
+        self.identifiers.create(type=scheme, value=value)
+
 
 class Directory(models.Model):
     """Information about Directories in units (Transfers, SIPs).
@@ -601,6 +609,10 @@ class Directory(models.Model):
                 "currentlocation": self.currentlocation,
             }
         )
+
+    def add_custom_identifier(self, scheme, value):
+        """Allow callers to add custom identifiers to the model's instance."""
+        self.identifiers.create(type=scheme, value=value)
 
     @classmethod
     def create_many(cls, dir_paths_uuids, unit_mdl, unit_type="transfer"):


### PR DESCRIPTION
This feature is broken into different commits as logically as was possible:

* [x] [Introduce unit tests to the PID binding feature to avoid feature shift.](https://github.com/artefactual/archivematica/pull/1410/commits/c2df783d27f324f86b813100efff7e3db367769b)
* [x] [Introduce a new declare PIDs microservice and changes to unit tests in reaction to understanding Bind PIDs better as a result.](https://github.com/artefactual/archivematica/pull/1410/commits/de4cf440569a08efd98485017abedeaf61dd2f0b) 
* [x] [Introduce additional configuration checks for PID binding so that the microservice doesn't fail if accidentally enabled with zero-configuration.](https://github.com/artefactual/archivematica/pull/1410/commits/3e9113d7bd0326794b0692df73340cb21bb5ad4b)
* [x] [Pylint changes prior to CR](https://github.com/artefactual/archivematica/pull/1410/commits/99a112fca386513b24374c29cb4dc63f18744fee)
* [x] [First round of CR changes](https://github.com/artefactual/archivematica/pull/1410/commits/a39783e0dde1615c6fa792cf9dac3aa1a2c82be4).

Connected to archivematica/issues#133
Replaces https://github.com/artefactual/archivematica/pull/1300 
Sample data here: https://github.com/artefactual/archivematica-sampledata/pull/53 