### PR TITLE
Record stderr output of identify command

### DIFF
--- a/src/MCPClient/lib/clientScripts/identify_file_format.py
+++ b/src/MCPClient/lib/clientScripts/identify_file_format.py
@@ -139,7 +139,7 @@ def main(job, enabled, file_path, file_uuid, disable_reidentify):
     # chain.
     _save_id_preference(file_, enabled)
 
-    exitcode, output, _ = executeOrRun(
+    exitcode, output, err = executeOrRun(
         command.script_type,
         command.script,
         arguments=[file_path],
@@ -152,6 +152,7 @@ def main(job, enabled, file_path, file_uuid, disable_reidentify):
         job.print_error(
             "Error: IDCommand with UUID {} exited non-zero.".format(command_uuid)
         )
+        job.print_error("Error: {}".format(err))
         return 255
 
     job.print_output("Command output:", output)


### PR DESCRIPTION
We were encountering some unclear errors during file format identification (https://github.com/wellcometrust/platform/issues/3398). It turned out the siegfried command was failing to identify the files, but this wasn't clear. The job was recording an "exited non-zero" message but with no details of why this was. This change captures the error from the identification command and records it as part of the job output.

Maybe falls under https://github.com/archivematica/Issues/issues/97 (but I'm happy to create a separate issue if you think not)

Connected to https://github.com/archivematica/Issues/issues/882