### PR TITLE
Improvements to move_or_merge

### DIFF
--- a/src/MCPClient/lib/clientScripts/move_or_merge.py
+++ b/src/MCPClient/lib/clientScripts/move_or_merge.py
@@ -5,6 +5,8 @@ import filecmp
 import os
 import shutil
 
+import scandir
+
 
 def mkdir_p(path):
     """Create a directory if it doesn't already exist."""
@@ -55,7 +57,7 @@ def move_or_merge(src, dst):
         # This loop walks the tree looking for files.  For every file in ``src``,
         # it finds the path relative to the top of ``src``, then moves it
         # to the corresponding path in ``dst``.
-        for root, _, filenames in os.walk(src):
+        for root, _, filenames in scandir.walk(src):
             rel_root = os.path.relpath(root, start=src)
             for f in filenames:
                 _move_file(

--- a/src/MCPClient/tests/test_move_or_merge.py
+++ b/src/MCPClient/tests/test_move_or_merge.py
@@ -1,0 +1,144 @@
+# -*- encoding: utf-8
+
+import pytest
+
+from .move_or_merge import move_or_merge
+
+
+def test_move_or_merge_when_dst_doesnt_exist(tmpdir):
+    src = tmpdir.join("src.txt")
+    dst = tmpdir.join("dst.txt")
+
+    src.write("hello world")
+
+    move_or_merge(src=src, dst=dst)
+    assert not src.exists()
+    assert dst.exists()
+    assert dst.read() == "hello world"
+
+
+def test_okay_if_dst_exists_and_is_same(tmpdir):
+    src = tmpdir.join("src.txt")
+    dst = tmpdir.join("dst.txt")
+
+    src.write("hello world")
+    dst.write("hello world")
+
+    move_or_merge(src=src, dst=dst)
+    assert not src.exists()
+    assert dst.exists()
+    assert dst.read() == "hello world"
+
+
+def test_error_if_dst_exists_and_is_different(tmpdir):
+    src = tmpdir.join("src.txt")
+    dst = tmpdir.join("dst.txt")
+
+    src.write("hello world")
+    dst.write("we come in peace")
+
+    with pytest.raises(RuntimeError, match="dst exists and is different"):
+        move_or_merge(src=src, dst=dst)
+
+    # Check the original file wasn't deleted
+    assert src.exists()
+    assert dst.exists()
+
+
+def test_moves_contents_of_directory(tmpdir):
+    src_dir = tmpdir.mkdir("src")
+    dst_dir = tmpdir.mkdir("dst")
+
+    src = src_dir.join("file.txt")
+    dst = dst_dir.join("file.txt")
+    src.write("hello world")
+
+    move_or_merge(src=str(src_dir), dst=str(dst_dir))
+    assert not src.exists()
+    assert dst.exists()
+    assert dst.read() == "hello world"
+
+
+def test_moves_nested_directory(tmpdir):
+    src_dir = tmpdir.mkdir("src")
+    dst_dir = tmpdir.mkdir("dst")
+
+    src_nested = src_dir.mkdir("nested")
+    dst_nested = dst_dir.join("nested")
+
+    src = src_nested.join("file.txt")
+    dst = dst_nested.join("file.txt")
+    src.write("hello world")
+
+    move_or_merge(src=str(src_dir), dst=str(dst_dir))
+    assert not src.exists()
+    assert dst.exists()
+    assert dst.read() == "hello world"
+
+
+def test_merges_nested_directory(tmpdir):
+    src_dir = tmpdir.mkdir("src")
+    dst_dir = tmpdir.mkdir("dst")
+
+    src_nested = src_dir.mkdir("nested")
+
+    # Unlike the previous test, we create the "nested" directory upfront,
+    # but we don't populate it.
+    dst_nested = dst_dir.mkdir("nested")
+
+    src = src_nested.join("file.txt")
+    dst = dst_nested.join("file.txt")
+    src.write("hello world")
+
+    move_or_merge(src=str(src_dir), dst=str(dst_dir))
+    assert not src.exists()
+    assert dst.exists()
+    assert dst.read() == "hello world"
+
+
+def test_merges_nested_directory_with_existing_file(tmpdir):
+    src_dir = tmpdir.mkdir("src")
+    dst_dir = tmpdir.mkdir("dst")
+
+    src_nested = src_dir.mkdir("nested")
+    dst_nested = dst_dir.mkdir("nested")
+
+    src = src_nested.join("file.txt")
+    dst = dst_nested.join("file.txt")
+    src.write("hello world")
+    dst.write("hello world")
+
+    move_or_merge(src=str(src_dir), dst=str(dst_dir))
+    assert not src.exists()
+    assert dst.exists()
+    assert dst.read() == "hello world"
+
+
+def test_merges_nested_directory_with_mismatched_existing_file(tmpdir):
+    src_dir = tmpdir.mkdir("src")
+    dst_dir = tmpdir.mkdir("dst")
+
+    src_nested = src_dir.mkdir("nested")
+    dst_nested = dst_dir.mkdir("nested")
+
+    src = src_nested.join("file.txt")
+    dst = dst_nested.join("file.txt")
+    src.write("hello world")
+    dst.write("we come in peace")
+
+    with pytest.raises(RuntimeError, match="dst exists and is different"):
+        move_or_merge(src=str(src_dir), dst=str(dst_dir))
+
+
+def test_ignores_existing_files_in_dst(tmpdir):
+    src_dir = tmpdir.mkdir("src")
+    dst_dir = tmpdir.mkdir("dst")
+
+    dst_existing = dst_dir.join("philosophy.txt")
+    dst_existing.write("i think therefore i am")
+
+    src_dir.join("file.txt").write("hello world")
+
+    move_or_merge(src=str(src_dir), dst=str(dst_dir))
+    assert dst_existing.exists()
+    assert dst_existing.read() == "i think therefore i am"

--- a/src/MCPClient/tests/test_move_or_merge.py
+++ b/src/MCPClient/tests/test_move_or_merge.py
@@ -2,52 +2,63 @@
 
 import pytest
 
-from .move_or_merge import move_or_merge
+from move_or_merge import move_or_merge
 
 
-def test_move_or_merge_when_dst_doesnt_exist(tmpdir):
-    src = tmpdir.join("src.txt")
-    dst = tmpdir.join("dst.txt")
-
-    src.write("hello world")
-
-    move_or_merge(src=src, dst=dst)
-    assert not src.exists()
-    assert dst.exists()
-    assert dst.read() == "hello world"
+@pytest.fixture
+def src_txt(tmpdir):
+    return tmpdir.join("src.txt")
 
 
-def test_okay_if_dst_exists_and_is_same(tmpdir):
-    src = tmpdir.join("src.txt")
-    dst = tmpdir.join("dst.txt")
-
-    src.write("hello world")
-    dst.write("hello world")
-
-    move_or_merge(src=src, dst=dst)
-    assert not src.exists()
-    assert dst.exists()
-    assert dst.read() == "hello world"
+@pytest.fixture
+def dst_txt(tmpdir):
+    return tmpdir.join("dst.txt")
 
 
-def test_error_if_dst_exists_and_is_different(tmpdir):
-    src = tmpdir.join("src.txt")
-    dst = tmpdir.join("dst.txt")
+@pytest.fixture
+def src_dir(tmpdir):
+    return tmpdir.mkdir("src")
 
-    src.write("hello world")
-    dst.write("we come in peace")
+
+@pytest.fixture
+def dst_dir(tmpdir):
+    return tmpdir.mkdir("dst")
+
+
+def test_move_or_merge_when_dst_doesnt_exist(src_txt, dst_txt):
+    src_txt.write("hello world")
+
+    move_or_merge(src=str(src_txt), dst=str(dst_txt))
+    assert not src_txt.exists()
+    assert dst_txt.exists()
+    assert dst_txt.read() == "hello world"
+
+
+def test_okay_if_dst_exists_and_is_same(src_txt, dst_txt):
+    src_txt.write("hello world")
+    dst_txt.write("hello world")
+
+    move_or_merge(src=str(src_txt), dst=str(dst_txt))
+    assert not src_txt.exists()
+    assert dst_txt.exists()
+    assert dst_txt.read() == "hello world"
+
+
+def test_error_if_dst_exists_and_is_different(src_txt, dst_txt):
+    src_txt.write("hello world")
+    dst_txt.write("we come in peace")
 
     with pytest.raises(RuntimeError, match="dst exists and is different"):
-        move_or_merge(src=src, dst=dst)
+        move_or_merge(src=str(src_txt), dst=str(dst_txt))
 
     # Check the original file wasn't deleted
-    assert src.exists()
-    assert dst.exists()
+    assert src_txt.exists()
+    assert dst_txt.exists()
 
 
-def test_moves_contents_of_directory(tmpdir):
+def test_moves_contents_of_directory_when_dst_does_not_exist(tmpdir):
     src_dir = tmpdir.mkdir("src")
-    dst_dir = tmpdir.mkdir("dst")
+    dst_dir = tmpdir.join("dst")
 
     src = src_dir.join("file.txt")
     dst = dst_dir.join("file.txt")
@@ -59,10 +70,18 @@ def test_moves_contents_of_directory(tmpdir):
     assert dst.read() == "hello world"
 
 
-def test_moves_nested_directory(tmpdir):
-    src_dir = tmpdir.mkdir("src")
-    dst_dir = tmpdir.mkdir("dst")
+def test_moves_contents_of_directory(src_dir, dst_dir):
+    src = src_dir.join("file.txt")
+    dst = dst_dir.join("file.txt")
+    src.write("hello world")
 
+    move_or_merge(src=str(src_dir), dst=str(dst_dir))
+    assert not src.exists()
+    assert dst.exists()
+    assert dst.read() == "hello world"
+
+
+def test_moves_nested_directory(src_dir, dst_dir):
     src_nested = src_dir.mkdir("nested")
     dst_nested = dst_dir.join("nested")
 
@@ -76,10 +95,7 @@ def test_moves_nested_directory(tmpdir):
     assert dst.read() == "hello world"
 
 
-def test_merges_nested_directory(tmpdir):
-    src_dir = tmpdir.mkdir("src")
-    dst_dir = tmpdir.mkdir("dst")
-
+def test_merges_nested_directory(src_dir, dst_dir):
     src_nested = src_dir.mkdir("nested")
 
     # Unlike the previous test, we create the "nested" directory upfront,
@@ -96,10 +112,7 @@ def test_merges_nested_directory(tmpdir):
     assert dst.read() == "hello world"
 
 
-def test_merges_nested_directory_with_existing_file(tmpdir):
-    src_dir = tmpdir.mkdir("src")
-    dst_dir = tmpdir.mkdir("dst")
-
+def test_merges_nested_directory_with_existing_file(src_dir, dst_dir):
     src_nested = src_dir.mkdir("nested")
     dst_nested = dst_dir.mkdir("nested")
 
@@ -114,10 +127,7 @@ def test_merges_nested_directory_with_existing_file(tmpdir):
     assert dst.read() == "hello world"
 
 
-def test_merges_nested_directory_with_mismatched_existing_file(tmpdir):
-    src_dir = tmpdir.mkdir("src")
-    dst_dir = tmpdir.mkdir("dst")
-
+def test_merges_nested_directory_with_mismatched_existing_file(src_dir, dst_dir):
     src_nested = src_dir.mkdir("nested")
     dst_nested = dst_dir.mkdir("nested")
 
@@ -130,10 +140,7 @@ def test_merges_nested_directory_with_mismatched_existing_file(tmpdir):
         move_or_merge(src=str(src_dir), dst=str(dst_dir))
 
 
-def test_ignores_existing_files_in_dst(tmpdir):
-    src_dir = tmpdir.mkdir("src")
-    dst_dir = tmpdir.mkdir("dst")
-
+def test_ignores_existing_files_in_dst(src_dir, dst_dir):
     dst_existing = dst_dir.join("philosophy.txt")
     dst_existing.write("i think therefore i am")
 


### PR DESCRIPTION
Addreses https://github.com/archivematica/Issues/issues/704

This was originally a PR against the wellcometrust fork: https://github.com/wellcometrust/archivematica/pull/4

From that PR:

```
It seems like move_or_merge.py gets upset if it encounters nested directories. If there's a nested directory in dst that matches one in src, it throws an error even if they're identical! This means it should error less often.

It also means it will error out if it finds existing files in dst that don't match. Plus a pile of tests.
```