### PR TITLE
FPR only shows enabled tools, does not display versions

### DIFF
--- a/src/dashboard/src/fpr/models.py
+++ b/src/dashboard/src/fpr/models.py
@@ -368,9 +368,7 @@ class IDTool(models.Model):
     active = Enabled()
 
     def __unicode__(self):
-        return _("%(description)s") % {
-            "description": self.description,
-        }
+        return _("%(description)s") % {"description": self.description}
 
     def _slug(self):
         """ Returns string to be slugified. """
@@ -484,8 +482,11 @@ class FPCommand(VersionedModel, models.Model):
     )
     # ManyToManyField may not be the best choice here
     tool = models.ForeignKey(
-        "FPTool", limit_choices_to={'enabled': True}, to_field="uuid", null=True, 
-        verbose_name=_("the related tool")
+        "FPTool",
+        limit_choices_to={"enabled": True},
+        to_field="uuid",
+        null=True,
+        verbose_name=_("the related tool"),
     )
     description = models.CharField(_("description"), max_length=256)
     command = models.TextField(_("command"))
@@ -561,9 +562,7 @@ class FPTool(models.Model):
         verbose_name = _("Normalization tool")
 
     def __unicode__(self):
-        return _("%(description)s") % {
-            "description": self.description,
-        }
+        return _("%(description)s") % {"description": self.description}
 
     def _slug(self):
         """ Returns string to be slugified. """

--- a/src/dashboard/src/fpr/models.py
+++ b/src/dashboard/src/fpr/models.py
@@ -368,9 +368,8 @@ class IDTool(models.Model):
     active = Enabled()
 
     def __unicode__(self):
-        return _("%(description)s version %(version)s") % {
+        return _("%(description)s") % {
             "description": self.description,
-            "version": self.version,
         }
 
     def _slug(self):
@@ -485,7 +484,8 @@ class FPCommand(VersionedModel, models.Model):
     )
     # ManyToManyField may not be the best choice here
     tool = models.ForeignKey(
-        "FPTool", to_field="uuid", null=True, verbose_name=_("the related tool")
+        "FPTool", limit_choices_to={'enabled': True}, to_field="uuid", null=True, 
+        verbose_name=_("the related tool")
     )
     description = models.CharField(_("description"), max_length=256)
     command = models.TextField(_("command"))
@@ -561,9 +561,8 @@ class FPTool(models.Model):
         verbose_name = _("Normalization tool")
 
     def __unicode__(self):
-        return _("%(description)s version %(version)s") % {
+        return _("%(description)s") % {
             "description": self.description,
-            "version": self.version,
         }
 
     def _slug(self):


### PR DESCRIPTION
This is related to https://github.com/archivematica/Issues/issues/394.
This is also related to https://github.com/archivematica/Issues/issues/191. 

Only shows enabled tools, not legacy ones, and hides versions.

Fundamentally this part of the codebase needs more work and I know that. This is more like a patch to clear up confusion to users and prevent misinformation than it is a holistic change, due to time-and-money restraints.