### PR TITLE
Add microservices and task API endpoints

### DIFF
--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -62,4 +62,6 @@ urlpatterns = [
     ),
     url(r"v2beta/package", views.package),
     url(r"v2beta/validate/([-\w]+)", views.validate, name="validate"),
+    url(r"v2beta/jobs/(?P<unit_uuid>" + settings.UUID_REGEX + ")", views.unit_jobs),
+    url(r"v2beta/task/(?P<task_uuid>" + settings.UUID_REGEX + ")", views.task),
 ]


### PR DESCRIPTION
This PR adds two endpoints to retrieve information about unit jobs and tasks. Their documentation in the Archivematica API wiki page would be something like this:

## Unit

**List jobs**
* **URL**: `/v2beta/jobs/<unit UUID>/`
* **Verb**: GET
* Returns a list of jobs for the passed unit (transfer or ingest).
* **Parameters**:
  * Optional filters
    * `microservice`: Name of the microservice the jobs belong to
    * `link_uuid`: UUID of the job chain link
    * `name`: Name of the job
* **Response**: JSON body
  * List of dicts with keys:
    * `uuid`: UUID of the job
    * `name`: Name of the job
    * `status`: One of `USER_INPUT`, `PROCESSING`, `COMPLETE`, `FAILED` or `UNKNOWN`
    * `microservice`: Microservice the job belongs to
    * `link_uuid`: UUID of the job chain link
    * `tasks`: List of dicts with information about the microservice's tasks:
      * `uuid`: UUID of the task
      * `exit_code`: Exit code of the task

**Task**
* **URL**: `/v2beta/task/<task UUID>/`
* **Verb**: GET
* Returns information about a task.
* **Response**: JSON body
  * `uuid`: UUID of the task
  * `exit_code`: Exit code of the task
  * `file_uuid`: UUID of the file used for the task
  * `file_name`: File used for the task,
  * `time_created`: String (`YYYY-MM-DD HH:MM:SS`) representing when the task was created
  * `time_started`: String (`YYYY-MM-DD HH:MM:SS`) representing when the task started
  * `time_ended`: String (`YYYY-MM-DD HH:MM:SS`) representing when the task finished
  * `duration`: Task duration in seconds (integer). If the duration is less than a second, this will be a `< 1` string

Connected to https://github.com/archivematica/Issues/issues/722