### PR TITLE
Update migration script to change jhove version too

### DIFF
--- a/src/dashboard/src/fpr/migrations/0030_update_jhove_command.py
+++ b/src/dashboard/src/fpr/migrations/0030_update_jhove_command.py
@@ -91,7 +91,7 @@ def data_migration_up(apps, schema_editor):
     FPCommand = apps.get_model("fpr", "FPCommand")
     FPRule = apps.get_model("fpr", "FPRule")
 
-    FPTool.objects.filter(uuid=JHOVE_TOOL_UUID).update(version="1.20", slug="fido-120")
+    FPTool.objects.filter(uuid=JHOVE_TOOL_UUID).update(version="1.20", slug="jhove-120")
 
     new_cmd = """
 import json

--- a/src/dashboard/src/fpr/migrations/0030_update_jhove_command.py
+++ b/src/dashboard/src/fpr/migrations/0030_update_jhove_command.py
@@ -91,9 +91,7 @@ def data_migration_up(apps, schema_editor):
     FPCommand = apps.get_model("fpr", "FPCommand")
     FPRule = apps.get_model("fpr", "FPRule")
 
-    FPTool.objects.filter(uuid=JHOVE_TOOL_UUID).update(
-        version="1.20", slug="fido-120"
-    )
+    FPTool.objects.filter(uuid=JHOVE_TOOL_UUID).update(version="1.20", slug="fido-120")
 
     new_cmd = """
 import json
@@ -199,9 +197,7 @@ if __name__ == '__main__':
         command_id=NEW_JHOVE_CMD_UUID
     )
 
-    old_jhove_command = FPCommand.objects.get(
-        uuid=OLD_JHOVE_CMD_UUID
-    )
+    old_jhove_command = FPCommand.objects.get(uuid=OLD_JHOVE_CMD_UUID)
     old_jhove_command.enabled = False
     old_jhove_command.save()
 


### PR DESCRIPTION
This is connected to https://github.com/archivematica/Issues/issues/524.

I know jumping in and editing a previously-merged migration is not-so-good, but this one was very newly created -- a couple of weeks ago at most -- and it was missing the bit that involves disabling the previous version of JHOVE and needed a comment removed anyway.