### PR TITLE
Ensure agents are written out for fixity event

### DIFF
--- a/src/MCPClient/tests/fixtures/verify_checksum_microservice/hashsum_agents.json
+++ b/src/MCPClient/tests/fixtures/verify_checksum_microservice/hashsum_agents.json
@@ -1,0 +1,32 @@
+[
+    {
+        "fields": {
+            "agenttype": "software",
+            "identifiertype": "preservation system",
+            "identifiervalue": "Archivematica-1.10",
+            "name": "Archivematica"
+        },
+        "model": "main.agent",
+        "pk": 1
+    },
+    {
+        "fields": {
+            "agenttype": "organization",
+            "identifiertype": "repository code",
+            "identifiervalue": "Atefactual Systems Inc.",
+            "name": "Artefactual Systems Corporate Archive"
+        },
+        "model": "main.agent",
+        "pk": 2
+    },
+    {
+        "fields": {
+            "agenttype": "Archivematica user",
+            "identifiertype": "Archivematica user pk",
+            "identifiervalue": "\u30a8\u30ba\u30e1\u30ec\u30eb\u30c0",
+            "name": "username=\"\u30a8\u30ba\u30e1\u30ec\u30eb\u30c0\", first_name=\"\u3053\u3093\u306b\u3061\u306f\", last_name=\"\u4e16\u754c\""
+        },
+        "model": "main.agent",
+        "pk": 3
+    }
+]

--- a/src/MCPClient/tests/fixtures/verify_checksum_microservice/hashsum_unitvars.json
+++ b/src/MCPClient/tests/fixtures/verify_checksum_microservice/hashsum_unitvars.json
@@ -1,0 +1,15 @@
+[
+{
+  "fields": {
+    "updatedtime": "2019-07-02T09:10:07.161Z",
+    "unituuid": "e95ab50f-9c84-45d5-a3ca-1b0b3f58d9b6",
+    "microservicechainlink": null,
+    "createdtime": "2019-07-02T09:10:07.161Z",
+    "unittype": "Transfer",
+    "variablevalue": "3",
+    "variable": "activeAgent"
+  },
+  "model": "main.unitvariable",
+  "pk": "2f7caa64-9ca9-11e9-bdd4-0242ac120002"
+}
+]


### PR DESCRIPTION
When events are output for fixity check, we need to ensure that the
linking agents are also output. We make sure that happens here as
well as including tests that should ensure there are fewer
regressions in this area in future.

Connected to archivematica/issues#774