### PR TITLE
Ensure processing config is preserved with zipfile

### DIFF
--- a/src/MCPClient/lib/clientScripts/extract_bag_transfer.py
+++ b/src/MCPClient/lib/clientScripts/extract_bag_transfer.py
@@ -33,6 +33,7 @@ from django.db import transaction
 from main.models import Transfer
 
 # archivematicaCommon
+from fileOperations import get_extract_dir_name
 from executeOrRunSubProcess import executeOrRun
 
 
@@ -77,16 +78,9 @@ def call(jobs):
                 sharedPath = job.args[4]
 
                 basename = os.path.basename(target)
-                basename = basename[: basename.rfind(".")]
-
                 destinationDirectory = os.path.join(processingDirectory, basename)
 
-                # trim off '.tar' if present (os.path.basename doesn't deal well with '.tar.gz')
-                try:
-                    tar_extension_position = destinationDirectory.rindex(".tar")
-                    destinationDirectory = destinationDirectory[:tar_extension_position]
-                except ValueError:
-                    pass
+                destinationDirectory = get_extract_dir_name(destinationDirectory)
 
                 zipLocation = os.path.join(
                     processingDirectory, os.path.basename(target)

--- a/src/MCPClient/lib/clientScripts/extract_bag_transfer.py
+++ b/src/MCPClient/lib/clientScripts/extract_bag_transfer.py
@@ -96,14 +96,29 @@ def call(jobs):
                     job.set_status(exit_code)
                     continue
 
-                # checkForTopLevelBag
-                listdir = os.listdir(destinationDirectory)
+                # Ensure that the only thing in the destination dir is the
+                # top level directory from the extracted file, with the
+                # exception of certain files that may have been copied here
+                # previously. (For now this is just the processing config.)
+                # These files will need to be moved down a level.
+                preexisting_files = {"processingMCP.xml"}
+
+                listdir = set(os.listdir(destinationDirectory))
+                to_move = listdir & preexisting_files
+                listdir -= preexisting_files
+
                 if len(listdir) == 1:
-                    internalBagName = listdir[0]
+                    internalBagName = listdir.pop()
+
+                    for filename in to_move:
+                        shutil.move(
+                            os.path.join(destinationDirectory, filename),
+                            os.path.join(destinationDirectory, internalBagName),
+                        )
+
                     # print "ignoring BagIt internal name: ", internalBagName
                     temp = destinationDirectory + "-tmp"
                     shutil.move(destinationDirectory, temp)
-                    # destinationDirectory = os.path.join(processingDirectory, internalBagName)
                     shutil.move(
                         os.path.join(temp, internalBagName), destinationDirectory
                     )

--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -201,7 +201,7 @@ def _copy_from_transfer_sources(paths, relative_destination):
     files = {l["uuid"]: {"location": l, "files": []} for l in transfer_sources}
 
     for item in paths:
-        location, path = Path(item).parts()
+        location, path = LocationPath(item).parts()
         if location is None:
             location = _default_transfer_source_location_uuid()
         if location not in files:
@@ -303,8 +303,6 @@ def _move_to_internal_shared_dir(filepath, dest, transfer):
                     extract_dir,
                     e,
                 )
-
-
 
 
 @auto_close_old_connections()

--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -291,18 +291,14 @@ def _move_to_internal_shared_dir(filepath, dest, transfer):
 
         # Move the processing config into the extraction directory so that it
         # is preserved and used in the workflow
-        processing_config = "processingMCP.xml"
-        config_path = filepath.parent / processing_config
-        if config_path.exists():
-            try:
-                config_path.rename(extract_dir / processing_config)
-            except OSError as e:
-                raise Exception(
-                    "Error moving processing config %s to %s (%s)",
-                    config_path,
-                    extract_dir,
-                    e,
-                )
+        files_to_preserve = {"processingMCP.xml"}
+        for filename in files_to_preserve:
+            path = filepath.parent / filename
+            if path.exists():
+                try:
+                    path.rename(extract_dir / filename)
+                except OSError as e:
+                    raise Exception("Error moving %s to %s (%s)", path, extract_dir, e)
 
 
 @auto_close_old_connections()

--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -124,6 +124,14 @@ def _file_is_an_archive(filepath):
 
 
 def _pad_destination_filepath_if_it_already_exists(filepath, original=None, attempt=0):
+    """
+    Return a version of the filepath that does not yet exist, padding with numbers
+    as necessary and reattempting until a non-existent filepath is found
+
+    :param filepath: `Path` or string of the desired destination filepath
+    :param original: `Path` or string of the original filepath (before padding attempts)
+    :param attempt: Number
+    """
     if original is None:
         original = filepath
     filepath = Path(filepath)

--- a/src/MCPServer/requirements/base.in
+++ b/src/MCPServer/requirements/base.in
@@ -9,3 +9,4 @@ inotify_simple==1.1.8
 enum34==1.1.6; python_version < "3.4" # required by inotify_simple
 futures==3.3.0; python_version < "3.2"
 contextdecorator==0.10.0; python_version < "3.2"
+pathlib2==2.3.4 ; python_version < '3'

--- a/src/MCPServer/requirements/base.txt
+++ b/src/MCPServer/requirements/base.txt
@@ -15,5 +15,7 @@ inotify_simple==1.1.8
 jsonschema==2.6.0
 lxml==3.5.0
 mysqlclient==1.3.7
+pathlib2==2.3.4 ; python_version < "3"
 prometheus_client==0.7.1
-six==1.12.0               # via django-extensions
+scandir==1.10.0           # via pathlib2
+six==1.12.0               # via django-extensions, pathlib2

--- a/src/MCPServer/requirements/dev.txt
+++ b/src/MCPServer/requirements/dev.txt
@@ -22,7 +22,7 @@ lxml==3.5.0
 mock==2.0.0
 more-itertools==5.0.0
 mysqlclient==1.3.7
-pathlib2==2.3.3
+pathlib2==2.3.4 ; python_version < "3"
 pbr==5.1.3
 pip-tools==3.7.0
 pluggy==0.9.0

--- a/src/MCPServer/requirements/production.txt
+++ b/src/MCPServer/requirements/production.txt
@@ -15,5 +15,7 @@ inotify_simple==1.1.8
 jsonschema==2.6.0
 lxml==3.5.0
 mysqlclient==1.3.7
+pathlib2==2.3.4 ; python_version < "3"
 prometheus_client==0.7.1
+scandir==1.10.0
 six==1.12.0

--- a/src/MCPServer/requirements/test.txt
+++ b/src/MCPServer/requirements/test.txt
@@ -21,7 +21,7 @@ lxml==3.5.0
 mock==2.0.0               # via pytest-mock
 more-itertools==5.0.0     # via pytest
 mysqlclient==1.3.7
-pathlib2==2.3.3           # via pytest, pytest-django
+pathlib2==2.3.4 ; python_version < "3"
 pbr==5.1.3                # via mock
 pluggy==0.9.0             # via pytest, tox
 prometheus_client==0.7.1
@@ -30,7 +30,7 @@ pytest-django==3.4.8
 pytest-mock==1.10.2
 pytest-pythonpath==0.7.3
 pytest==4.3.1
-scandir==1.10.0           # via pathlib2
+scandir==1.10.0
 six==1.12.0
 toml==0.10.0              # via tox
 tox==3.8.3

--- a/src/MCPServer/tests/test_package.py
+++ b/src/MCPServer/tests/test_package.py
@@ -89,25 +89,25 @@ def test_dip_get_or_create_from_db_path_with_uuid(tmp_path):
 class TestPadDestinationFilePath:
     def test_zipfile_is_not_padded_if_does_not_exist(self, tmp_path):
         transfer_path = tmp_path / "transfer.zip"
-        padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
-        assert padded_path == str(transfer_path)
+        padded_path = _pad_destination_filepath_if_it_already_exists(transfer_path)
+        assert padded_path == transfer_path
 
     def test_zipfile_is_padded_if_exists(self, tmp_path):
         transfer_path = tmp_path / "transfer.zip"
         transfer_path.touch()
-        padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
-        assert padded_path == str(tmp_path / "transfer_1.zip")
+        padded_path = _pad_destination_filepath_if_it_already_exists(transfer_path)
+        assert padded_path == tmp_path / "transfer_1.zip"
 
     def test_dir_is_not_padded_if_does_not_exist(self, tmp_path):
         transfer_path = tmp_path / "transfer/"
-        padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
-        assert padded_path == str(transfer_path)
+        padded_path = _pad_destination_filepath_if_it_already_exists(transfer_path)
+        assert padded_path == transfer_path
 
     def test_dir_is_padded_if_exists(self, tmp_path):
         transfer_path = tmp_path / "transfer/"
         transfer_path.mkdir()
-        padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
-        assert padded_path == str(tmp_path / "transfer_1")
+        padded_path = _pad_destination_filepath_if_it_already_exists(transfer_path)
+        assert padded_path == tmp_path / "transfer_1"
 
 
 @pytest.fixture

--- a/src/MCPServer/tests/test_package.py
+++ b/src/MCPServer/tests/test_package.py
@@ -6,7 +6,17 @@ import pytest
 
 from main import models
 
-from server.packages import DIP, _determine_transfer_paths
+from server.packages import (
+    DIP,
+    _determine_transfer_paths,
+    _move_to_internal_shared_dir,
+    _pad_destination_filepath_if_it_already_exists,
+)
+
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 
 
 @pytest.mark.parametrize(
@@ -74,3 +84,80 @@ def test_dip_get_or_create_from_db_path_with_uuid(tmp_path):
         models.SIP.objects.get(uuid=dip_uuid)
     except models.SIP.DoesNotExist:
         pytest.fail("DIP.get_or_create_from_db_by_path didn't create a SIP model")
+
+
+class TestPadDestinationFilePath:
+    def test_zipfile_does_not_exist(self, tmp_path):
+        transfer_path = tmp_path / "transfer.zip"
+        padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
+        assert padded_path == str(transfer_path)
+
+    def test_zipfile_is_padded_if_exists(self, tmp_path):
+        transfer_path = tmp_path / "transfer.zip"
+        transfer_path.touch()
+        padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
+        assert padded_path == str(tmp_path / "transfer_1.zip")
+
+    def test_dir_does_not_exist(self, tmp_path):
+        transfer_path = tmp_path / "transfer/"
+        padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
+        assert padded_path == str(transfer_path)
+
+    def test_dir_is_padded_if_exists(self, tmp_path):
+        transfer_path = tmp_path / "transfer/"
+        transfer_path.mkdir()
+        padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
+        assert padded_path == str(tmp_path / "transfer_1")
+
+
+@pytest.fixture
+def transfer():
+    return models.Transfer.objects.create()
+
+
+@pytest.fixture
+def processing_dir(tmp_path):
+    proc_dir = tmp_path / "processing"
+    proc_dir.mkdir()
+    return proc_dir
+
+
+@pytest.mark.django_db(transaction=True)
+class TestMoveToInternalSharedDir:
+    def test_move_dir(self, tmp_path, processing_dir, transfer):
+        filepath = tmp_path / "transfer"
+        filepath.mkdir()
+
+        _move_to_internal_shared_dir(str(filepath), str(processing_dir), transfer)
+
+        transfer.refresh_from_db()
+        dest_path = processing_dir / "transfer"
+        assert dest_path.is_dir()
+        assert Path(transfer.currentlocation) == dest_path
+
+    def test_move_file(self, tmp_path, processing_dir, transfer):
+        filepath = tmp_path / "transfer.zip"
+        filepath.touch()
+
+        _move_to_internal_shared_dir(str(filepath), str(processing_dir), transfer)
+
+        dest_path = processing_dir / "transfer.zip"
+        assert dest_path.is_file()
+        assert (processing_dir / "transfer").is_dir()
+
+        transfer.refresh_from_db()
+        assert Path(transfer.currentlocation) == dest_path
+
+    def test_move_processing_config_with_zipfile(
+        self, tmp_path, processing_dir, transfer
+    ):
+        filepath = tmp_path / "transfer.zip"
+        filepath.touch()
+
+        config = tmp_path / "processingMCP.xml"
+        config.touch()
+
+        _move_to_internal_shared_dir(str(filepath), str(processing_dir), transfer)
+
+        config_dest = processing_dir / "transfer/processingMCP.xml"
+        assert config_dest.is_file()

--- a/src/MCPServer/tests/test_package.py
+++ b/src/MCPServer/tests/test_package.py
@@ -87,7 +87,7 @@ def test_dip_get_or_create_from_db_path_with_uuid(tmp_path):
 
 
 class TestPadDestinationFilePath:
-    def test_zipfile_does_not_exist(self, tmp_path):
+    def test_zipfile_is_not_padded_if_does_not_exist(self, tmp_path):
         transfer_path = tmp_path / "transfer.zip"
         padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
         assert padded_path == str(transfer_path)
@@ -98,7 +98,7 @@ class TestPadDestinationFilePath:
         padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
         assert padded_path == str(tmp_path / "transfer_1.zip")
 
-    def test_dir_does_not_exist(self, tmp_path):
+    def test_dir_is_not_padded_if_does_not_exist(self, tmp_path):
         transfer_path = tmp_path / "transfer/"
         padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
         assert padded_path == str(transfer_path)

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -401,3 +401,23 @@ def findFileInNormalizationCSV(
                 file=sys.stderr,
             )
             raise FindFileInNormalizatonCSVError(2)
+
+
+def get_extract_dir_name(filename):
+    """
+    Given the name of a compressed file, return the stem directory name into
+    which it should be extracted.
+
+    e.g. transfer1.zip will be extracted into transfer1
+         transfer2.tar.gz will be extracted into transfer2
+    """
+    extract_dir = filename[: filename.rfind(".")]
+
+    # trim off '.tar' if present
+    try:
+        tar_extension_position = extract_dir.rindex(".tar")
+        extract_dir = extract_dir[:tar_extension_position]
+    except ValueError:
+        pass
+
+    return extract_dir

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -425,7 +425,7 @@ def get_extract_dir_name(filename):
     extract_dir = filename.parent / filename.stem
 
     # trim off '.tar' if present
-    if extract_dir.suffix in ('.tar', '.TAR'):
+    if extract_dir.suffix in (".tar", ".TAR"):
         extract_dir = extract_dir.stem
 
     return str(extract_dir)

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -26,6 +26,11 @@ import uuid
 import sys
 import shutil
 
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
 from databaseFunctions import insertIntoFiles
 from executeOrRunSubProcess import executeOrRun
 from databaseFunctions import insertIntoEvents
@@ -408,16 +413,19 @@ def get_extract_dir_name(filename):
     Given the name of a compressed file, return the stem directory name into
     which it should be extracted.
 
+    :param filename: `Path` object or string representation of filename
+
     e.g. transfer1.zip will be extracted into transfer1
          transfer2.tar.gz will be extracted into transfer2
     """
-    extract_dir = filename[: filename.rfind(".")]
+    filename = Path(filename)
+    if not filename.suffix:
+        raise ValueError("Filename '%s' must have an extension", filename)
+
+    extract_dir = filename.parent / filename.stem
 
     # trim off '.tar' if present
-    try:
-        tar_extension_position = extract_dir.rindex(".tar")
-        extract_dir = extract_dir[:tar_extension_position]
-    except ValueError:
-        pass
+    if extract_dir.suffix in ('.tar', '.TAR'):
+        extract_dir = extract_dir.stem
 
-    return extract_dir
+    return str(extract_dir)

--- a/src/archivematicaCommon/requirements/base.in
+++ b/src/archivematicaCommon/requirements/base.in
@@ -5,3 +5,4 @@ elasticsearch>=6.0.0,<7.0.0
 requests==2.21.0
 python-dateutil==2.4.2
 prometheus_client==0.7.1
+pathlib2==2.3.4 ; python_version < '3'

--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -13,7 +13,9 @@ elasticsearch==6.3.1
 idna==2.8                 # via requests
 mysqlclient==1.4.2.post1  # via agentarchives
 prometheus_client==0.7.1
+pathlib2==2.3.4 ; python_version < "3"
 python-dateutil==2.4.2
 requests==2.21.0
-six==1.12.0               # via python-dateutil
+scandir==1.10.0           # via pathlib2
+six==1.12.0               # via pathlib2, python-dateutil
 urllib3==1.24.1           # via elasticsearch, requests

--- a/src/archivematicaCommon/requirements/dev.txt
+++ b/src/archivematicaCommon/requirements/dev.txt
@@ -20,7 +20,7 @@ idna==2.8
 mock==2.0.0
 more-itertools==5.0.0
 mysqlclient==1.4.2.post1
-pathlib2==2.3.3
+pathlib2==2.3.4 ; python_version < "3"
 pbr==5.1.3
 pip-tools==3.7.0
 pluggy==0.9.0

--- a/src/archivematicaCommon/requirements/production.txt
+++ b/src/archivematicaCommon/requirements/production.txt
@@ -13,7 +13,9 @@ elasticsearch==6.3.1
 idna==2.8
 mysqlclient==1.4.2.post1
 prometheus_client==0.7.1
+pathlib2==2.3.4 ; python_version < "3"
 python-dateutil==2.4.2
 requests==2.21.0
+scandir==1.10.0
 six==1.12.0
 urllib3==1.24.1

--- a/src/archivematicaCommon/requirements/test.txt
+++ b/src/archivematicaCommon/requirements/test.txt
@@ -19,7 +19,7 @@ idna==2.8
 mock==2.0.0
 more-itertools==5.0.0     # via pytest
 mysqlclient==1.4.2.post1
-pathlib2==2.3.3           # via pytest, pytest-django
+pathlib2==2.3.4 ; python_version < "3"
 pbr==5.1.3                # via mock
 pluggy==0.9.0             # via pytest, tox
 prometheus_client==0.7.1
@@ -30,7 +30,7 @@ pytest==4.3.1
 python-dateutil==2.4.2
 pyyaml==5.1               # via vcrpy
 requests==2.21.0
-scandir==1.10.0           # via pathlib2
+scandir==1.10.0
 six==1.12.0
 toml==0.10.0              # via tox
 tox==3.8.3

--- a/src/archivematicaCommon/tests/test_file_operations.py
+++ b/src/archivematicaCommon/tests/test_file_operations.py
@@ -1,0 +1,10 @@
+import pytest
+
+from fileOperations import get_extract_dir_name
+
+
+@pytest.mark.parametrize(
+    "filename,dirname", [("test.zip", "test"), ("test.tar.gz", "test")]
+)
+def test_get_extract_dir_name(filename, dirname):
+    assert get_extract_dir_name(filename) == dirname

--- a/src/archivematicaCommon/tests/test_file_operations.py
+++ b/src/archivematicaCommon/tests/test_file_operations.py
@@ -4,13 +4,14 @@ from fileOperations import get_extract_dir_name
 
 
 @pytest.mark.parametrize(
-    "filename,dirname", [
+    "filename,dirname",
+    [
         ("test.zip", "test"),
         ("test.tar.gz", "test"),
         ("test.TAR.GZ", "test"),
         ("test.TAR.GZ", "test"),
         ("test.target.tar.gz", "test.target"),  # something beginning with "tar"
-    ]
+    ],
 )
 def test_get_extract_dir_name(filename, dirname):
     assert get_extract_dir_name(filename) == dirname
@@ -18,4 +19,4 @@ def test_get_extract_dir_name(filename, dirname):
 
 def test_get_extract_dir_name_raises_if_no_extension():
     with pytest.raises(ValueError):
-        get_extract_dir_name('test')
+        get_extract_dir_name("test")

--- a/src/archivematicaCommon/tests/test_file_operations.py
+++ b/src/archivematicaCommon/tests/test_file_operations.py
@@ -4,7 +4,18 @@ from fileOperations import get_extract_dir_name
 
 
 @pytest.mark.parametrize(
-    "filename,dirname", [("test.zip", "test"), ("test.tar.gz", "test")]
+    "filename,dirname", [
+        ("test.zip", "test"),
+        ("test.tar.gz", "test"),
+        ("test.TAR.GZ", "test"),
+        ("test.TAR.GZ", "test"),
+        ("test.target.tar.gz", "test.target"),  # something beginning with "tar"
+    ]
 )
 def test_get_extract_dir_name(filename, dirname):
     assert get_extract_dir_name(filename) == dirname
+
+
+def test_get_extract_dir_name_raises_if_no_extension():
+    with pytest.raises(ValueError):
+        get_extract_dir_name('test')


### PR DESCRIPTION
This ensures the processing config is copied across when a zipfile package is moved to an internal Archivematica directory. Some tidyups and tests have been added.

This should fix https://github.com/archivematica/Issues/issues/771 