### PR TITLE
Perform validation later in PID pid binding script

### DIFF
--- a/src/MCPClient/lib/clientScripts/bind_pids.py
+++ b/src/MCPClient/lib/clientScripts/bind_pids.py
@@ -58,7 +58,12 @@ from main.models import DashboardSetting, Directory, SIP
 
 # archivematicaCommon
 from archivematicaFunctions import str2bool
-from bindpid import bind_pid, BindPIDException, _validate
+from bindpid import (
+    bind_pid,
+    BindPIDException,
+    _validate_handle_server_config,
+    _validate_entity_type_required_params,
+)
 from custom_handlers import get_script_logger
 import namespaces as ns
 
@@ -200,6 +205,7 @@ def _bind_pid_to_model(job, mdl, shared_path, config):
         job, mdl, is_sip, shared_path, config["handle_archive_pid_source"]
     )
     config.update({"entity_type": entity_type, "desired_pid": desired_pid})
+    _validate_entity_type_required_params(config)
     try:
         msg = bind_pid(**config)
         _add_pid_to_mdl_identifiers(mdl, config)
@@ -224,7 +230,7 @@ def main(job, sip_uuid, shared_path, bind_pids_switch):
         handle_config.get("pid_request_verify_certs", "True")
     )
     try:
-        _validate(handle_config)
+        _validate_handle_server_config(handle_config)
     except BindPIDException as err:
         logger.info(err)
         raise BindPIDsException

--- a/src/MCPClient/tests/test_pid_components.py
+++ b/src/MCPClient/tests/test_pid_components.py
@@ -122,6 +122,7 @@ class TestPIDComponents(object):
         An example scenario might be when the user has bind PIDs on in their
         processing configuration but no handle server information configured.
         """
+        DashboardSetting.objects.filter(scope="handle").delete()
         assert (
             bind_pids.main(self.job, None, None, True) == 1
         ), "Incorrect return value for bind_pids with incomplete configuration."
@@ -140,7 +141,9 @@ class TestPIDComponents(object):
         mocker.patch.object(
             bind_pids, "_get_unique_acc_no", return_value=self.package_uuid
         )
-        mocker.patch.object(bind_pids, "_validate", return_value=None)
+        mocker.patch.object(
+            bind_pids, "_validate_handle_server_config", return_value=None
+        )
         with vcr_cassettes.use_cassette(
             "test_bind_pids_to_sip_and_dirs.yaml"
         ) as cassette:
@@ -340,7 +343,9 @@ class TestPIDComponents(object):
         mocker.patch.object(
             bind_pids, "_get_unique_acc_no", return_value=self.package_uuid
         )
-        mocker.patch.object(bind_pids, "_validate", return_value=None)
+        mocker.patch.object(
+            bind_pids, "_validate_handle_server_config", return_value=None
+        )
         with vcr_cassettes.use_cassette(
             "test_bind_pids_to_sip_and_dirs.yaml"
         ) as cassette:

--- a/src/archivematicaCommon/lib/bindpid.py
+++ b/src/archivematicaCommon/lib/bindpid.py
@@ -151,14 +151,15 @@ import requests
 
 # Parameters required when requesting the binding of a handle PID.
 REQ_PARAMS = (
-    "entity_type",
-    "desired_pid",
     "naming_authority",
     "pid_web_service_endpoint",
     "pid_web_service_key",
     "handle_resolver_url",
     "pid_request_body_template",
 )
+
+# To bind a PID we require a model and a desired persistent identifier.
+REQ_ENTITY_PARAMS = ("entity_type", "desired_pid")
 
 # Parameters that may be specified in a config file instead of passed on the
 # command line.
@@ -207,8 +208,28 @@ class BindPIDException(Exception):
 
 
 def _validate(argdict):
-    """Validate the argument dictionary ``argdict`` passed to ``bind_pid``."""
+    """Call the validation functions on the separate aspects of the handle
+    server form elements.
+    """
+    _validate_handle_server_config(argdict)
+    _validate_entity_type_required_params(argdict)
+
+
+def _validate_handle_server_config(argdict):
+    """Validate the argument dictionary ``argdict`` passed to ``bind_pid`` and
+    ``bind_pids``.
+    """
     for param in REQ_PARAMS:
+        val = argdict.get(param)
+        if not val:
+            raise BindPIDException("A value for parameter {} is required".format(param))
+
+
+def _validate_entity_type_required_params(argdict):
+    """Validate entity types that we can bind PIDs to, e.g. file, unit. Ensure
+    that a URL template setting has been provided for generating that PID.
+    """
+    for param in REQ_ENTITY_PARAMS:
         val = argdict.get(param)
         if not val:
             raise BindPIDException("A value for parameter {} is required".format(param))


### PR DESCRIPTION
When validation was added in 97b1ad0c4faa328fd2e9e34724d60743c029c9af it didn't take into account that all 'required' parameters might not be available at the time validation is done. We are interested in the fields of the 'handle' configuration form in Archivematica's dashboard. If some part of that form is incomplete at the time it arrives at validation in this PR, then we can exit early and provide some useful feedback to the user. We can ignore the elements expected to be added to the configuration [here](https://github.com/artefactual/archivematica/blob/85074e77db9dc9d10f44f0d5461d269b739fea6c/src/MCPClient/lib/clientScripts/bind_pids.py#L202) in the same script for example. 

Connected to archivematica/issues#776