### PR TITLE
Browser: hide empty display_string in nodes

### DIFF
--- a/src/dashboard/frontend/app/front_page/transfer_browser.html
+++ b/src/dashboard/frontend/app/front_page/transfer_browser.html
@@ -85,7 +85,7 @@
                  selected-node="vm.selected"
                  on-node-toggle="vm.on_toggle(node, expanded)">
       <span ng-class="{'disabled-file': !vm.file_can_be_added(node)}">
-        {{ node.title }} ({{ node.properties.display_string }})
+        {{ node.title }} <span ng-if="node.properties.display_string">({{ node.properties.display_string }})</span>
       </span>
     </treecontrol>
   </div> <!-- well -->


### PR DESCRIPTION
This is what we are showing to users when `display_string` is not empty:

    - directory/ (4 objects)

This commit removes the use of parenthesis when `display_string` is undefined
or an empty string.

Connects to https://github.com/archivematica/Issues/issues/657.