### PR TITLE
Correct checksum verification issues discovered through 1.10 testing

### DIFF
--- a/src/MCPClient/lib/clientScripts/verify_checksum.py
+++ b/src/MCPClient/lib/clientScripts/verify_checksum.py
@@ -28,7 +28,6 @@ us to easily call each of the tools packaged against its different algorithms:
     * SHA1
     * SHA256
     * SHA512
-    * Blake2
 """
 
 from __future__ import print_function, unicode_literals
@@ -75,7 +74,6 @@ class Hashsum(object):
         "checksum.sha1": "sha1sum",
         "checksum.sha256": "sha256sum",
         "checksum.sha512": "sha512sum",
-        "checksum.b2": "b2sum",
     }
 
     OKAY_STRING = ": OK"

--- a/src/MCPClient/lib/clientScripts/verify_checksum.py
+++ b/src/MCPClient/lib/clientScripts/verify_checksum.py
@@ -229,7 +229,7 @@ def get_file_queryset(transfer_uuid):
 
 def write_premis_event_per_file(file_uuids, transfer_uuid, event_detail):
     """Generate PREMIS events per File object verified in this transfer."""
-    event_type = "fixity_check"
+    event_type = "fixity check"
     event_outcome = "pass"
     events = []
     agents = Transfer.objects.get(uuid=transfer_uuid).agents

--- a/src/MCPClient/tests/test_verify_checksum.py
+++ b/src/MCPClient/tests/test_verify_checksum.py
@@ -296,7 +296,7 @@ class TestHashsum(object):
         """
         # Values the job will write.
         algorithms = ["md5", "sha512", "b2"]
-        event_type = "fixity_check"
+        event_type = "fixity check"
         event_outcome = "pass"
         # Values we will write.
         detail = "suma de verificación validada: OK"

--- a/src/MCPClient/tests/test_verify_checksum.py
+++ b/src/MCPClient/tests/test_verify_checksum.py
@@ -80,12 +80,10 @@ class TestHashsum(object):
             ("metadata/checksum.sha1", True),
             ("metadata/checksum.sha256", True),
             ("metadata/checksum.sha512", True),
-            ("metadata/checksum.b2", True),
             ("metadata/checksum_md5", False),
             ("metadata/checksum_sha1", False),
             ("metadata/checksum_sha256", False),
             ("metadata/checksum_sha512", False),
-            ("metadata/checksum_b2", False),
         ],
     )
     def test_valid_initialisation(self, fixture):
@@ -135,7 +133,7 @@ class TestHashsum(object):
         then it should be practically impossible to write to the database and
         generate some form of false-positive.
         """
-        hash_file = "metadata/checksum.b2"
+        hash_file = "metadata/checksum.sha1"
         hashsum = self.setup_hashsum(hash_file, Job("stub", "stub", ["", ""]))
         try:
             hashsum.get_command_detail()
@@ -295,7 +293,7 @@ class TestHashsum(object):
         anticipated, writes its data, and that data can then be retrieved.
         """
         # Values the job will write.
-        algorithms = ["md5", "sha512", "b2"]
+        algorithms = ["md5", "sha512", "sha1"]
         event_type = "fixity check"
         event_outcome = "pass"
         # Values we will write.


### PR DESCRIPTION
Fixes are separated by commit: 

* 457e6c9dae0488764490906787f38d96d53c1456 removes Blake2, per 796 below.
* c00b1763d71dcc41677a1c403af6b64cb8c3395c corrects the fixity event name per 789 below.

Once approved the commits will be preserved as-is rather than rebasing.

Connected to: https://github.com/archivematica/Issues/issues/789 
Connected to https://github.com/archivematica/Issues/issues/796 
