### PR TITLE
Ensure structmap isn't included and METS create V2 fails under various error conditions

### DIFF
--- a/src/MCPClient/tests/fixtures/custom_structmaps/custom-structmap-3a915449-d1bb-4920-b274-c917c7bb5929/objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/empty_filenames.xml
+++ b/src/MCPClient/tests/fixtures/custom_structmaps/custom-structmap-3a915449-d1bb-4920-b274-c917c7bb5929/objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/empty_filenames.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- structMap contains empty strings in the CONTENTIDS attributes. -->
+<mets:mets xmlns:mets="http://www.loc.gov/METS/">
+  <mets:structMap TYPE="lógico" ID="custom_structmap">
+    <mets:div TYPE="libro" LABEL="Cómo crear un libro jerárquico">
+      <mets:div TYPE="página" LABEL="Cubierta interior">
+        <mets:fptr FILEID="página_de_prueba.png" CONTENTIDS=""/>
+      </mets:div>
+      <mets:div TYPE="capítulo" LABEL="Capítulo 1">
+        <mets:div TYPE="página" LABEL="Página 1">
+          <mets:fptr FILEID="página_de_prueba.jpg" CONTENTIDS=""/>
+        </mets:div>
+      </mets:div>
+      <!-- capítulo 1 -->
+    </mets:div>
+    <!-- book -->
+  </mets:structMap>
+</mets:mets>

--- a/src/MCPClient/tests/fixtures/custom_structmaps/custom-structmap-3a915449-d1bb-4920-b274-c917c7bb5929/objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/file_does_not_exist.xml
+++ b/src/MCPClient/tests/fixtures/custom_structmaps/custom-structmap-3a915449-d1bb-4920-b274-c917c7bb5929/objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/file_does_not_exist.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- structMap contains references to files that do not exist in the SIP. -->
+<mets:mets xmlns:mets="http://www.loc.gov/METS/">
+  <mets:structMap TYPE="lógico" ID="custom_structmap">
+    <mets:div TYPE="libro" LABEL="Cómo crear un libro jerárquico">
+      <mets:div TYPE="página" LABEL="Cubierta interior">
+        <mets:fptr FILEID="página_de_prueba.png" CONTENTIDS="objects/página_de_prueba.DOES_NOT_EXIST"/>
+      </mets:div>
+      <mets:div TYPE="capítulo" LABEL="Capítulo 1">
+        <mets:div TYPE="página" LABEL="Página 1">
+          <mets:fptr FILEID="página_de_prueba.jpg" CONTENTIDS="objects/página_de_prueba.DOES_NOT_EXIST"/>
+        </mets:div>
+      </mets:div>
+      <!-- capítulo 1 -->
+    </mets:div>
+    <!-- book -->
+  </mets:structMap>
+</mets:mets>

--- a/src/MCPClient/tests/fixtures/custom_structmaps/custom-structmap-3a915449-d1bb-4920-b274-c917c7bb5929/objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/missing_contentid.xml
+++ b/src/MCPClient/tests/fixtures/custom_structmaps/custom-structmap-3a915449-d1bb-4920-b274-c917c7bb5929/objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/missing_contentid.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/">
+  <mets:structMap TYPE="logical">
+    <mets:div TYPE="book" LABEL="How to create a hierarchical book">
+      <mets:div TYPE="page" LABEL="Cover">
+        <mets:fptr FILEID="cover.jpg" CONTENTIDS="objects/cover.jpg"/>
+      </mets:div>
+      <mets:div TYPE="page" LABEL="Inside cover">
+        <mets:fptr FILEID="inside_cover.jpg" CONTENTIDS="objects/inside_cover.jpg"/>
+      </mets:div>
+      <mets:div TYPE="chapter" LABEL="Chapter 1">
+        <mets:div TYPE="page" LABEL="Page 1">
+          <!-- Expecting a CONTENTID here to map to a FILEID UUID -->
+          <mets:fptr FILEID="page_01.jpg"/>
+        </mets:div>
+        <mets:div TYPE="subchapter" LABEL="Subchapter 1.1">
+          <mets:div TYPE="page" LABEL="Page 2">
+            <mets:fptr FILEID="page_02.jpg" CONTENTIDS="objects/page_02.jpg"/>
+          </mets:div>
+          <mets:div TYPE="page" LABEL="Page 3">
+            <mets:fptr FILEID="page_03.jpg" CONTENTIDS="objects/page_03.jpg"/>
+          </mets:div>
+          <mets:div TYPE="page" LABEL="Page 4">
+            <mets:fptr FILEID="page_04.jpg" CONTENTIDS="objects/page_04.jpg"/>
+          </mets:div>
+        </mets:div>
+        <!-- Subchapter 1.1 -->
+        <mets:div TYPE="subchapter" LABEL="Subchapter 1.2">
+          <mets:div TYPE="page" LABEL="Page 5">
+            <mets:fptr FILEID="page_05.jpg" CONTENTIDS="objects/page_05.jpg"/>
+          </mets:div>
+          <mets:div TYPE="page" LABEL="Page 6">
+            <mets:fptr FILEID="page_06.jpg" CONTENTIDS="objects/page_06.jpg"/>
+          </mets:div>
+          <mets:div TYPE="page" LABEL="Page 7">
+            <mets:fptr FILEID="page_07.jpg" CONTENTIDS="objects/page_07.jpg"/>
+          </mets:div>
+        </mets:div>
+        <!-- Subchapter 1.2 -->
+      </mets:div>
+      <!-- Chapter 1 -->
+      <!-- Chapters 2 and 3, each with their own subchapters as in Chapter 1, omitted from this example. -->
+      <mets:div TYPE="afterword" LABEL="Afterword">
+        <mets:div TYPE="page" LABEL="Page 20">
+          <mets:fptr FILEID="page_20.jpg" CONTENTIDS="objects/page_20.jpg"/>
+        </mets:div>
+      </mets:div>
+      <!-- afterword -->
+      <mets:div TYPE="index" LABEL="Index">
+        <mets:div TYPE="page" LABEL="Index, page 1">
+          <mets:fptr FILEID="index_01.jpg" CONTENTIDS="objects/index_01.jpg"/>
+        </mets:div>
+        <mets:div TYPE="page" LABEL="Index, page 2">
+          <mets:fptr FILEID="index_02.jpg" CONTENTIDS="objects/index_02.jpg"/>
+        </mets:div>
+      </mets:div>
+      <!-- index -->
+      <mets:div TYPE="page" LABEL="Back cover">
+        <mets:fptr FILEID="back_cover.jpg" CONTENTIDS="objects/back_cover.jpg"/>
+      </mets:div>
+      <!-- back cover -->
+    </mets:div>
+    <!-- book -->
+  </mets:structMap>
+</mets:mets>

--- a/src/MCPClient/tests/fixtures/custom_structmaps/custom-structmap-3a915449-d1bb-4920-b274-c917c7bb5929/objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/no-contentids.xml
+++ b/src/MCPClient/tests/fixtures/custom_structmaps/custom-structmap-3a915449-d1bb-4920-b274-c917c7bb5929/objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/no-contentids.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- structMap contains no CONTENTIDS which are required by the mechanism. -->
+<mets:mets xmlns:mets="http://www.loc.gov/METS/">
+  <mets:structMap TYPE="lógico" ID="custom_structmap">
+    <mets:div TYPE="libro" LABEL="Cómo crear un libro jerárquico">
+      <mets:div TYPE="página" LABEL="Cubierta interior">
+        <mets:fptr FILEID="página_de_prueba.png" />
+      </mets:div>
+      <mets:div TYPE="capítulo" LABEL="Capítulo 1">
+        <mets:div TYPE="página" LABEL="Página 1">
+          <mets:fptr FILEID="página_de_prueba.jpg" />
+        </mets:div>
+      </mets:div>
+      <!-- capítulo 1 -->
+    </mets:div>
+    <!-- book -->
+  </mets:structMap>
+</mets:mets>

--- a/src/MCPClient/tests/fixtures/custom_structmaps/model/files.json
+++ b/src/MCPClient/tests/fixtures/custom_structmaps/model/files.json
@@ -322,5 +322,77 @@
         "currentlocation": "%SIPDirectory%objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/broken_structmap.xml",
         "size": 2600
     }
+},
+{
+    "pk": "4dd084c7-f59d-4f0d-98a0-c7a166464dca",
+    "model": "main.file",
+    "fields": {
+        "filegrpuuid": "",
+        "sip": "3a915449-d1bb-4920-b274-c917c7bb5929",
+        "originallocation": "%SIPDirectory%objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/no-contentids.xml",
+        "transfer": null,
+        "filegrpuse": "metadata",
+        "removedtime": null,
+        "label": "",
+        "checksum": "",
+        "enteredsystem": "2019-04-10T23:13:00Z",
+        "modificationtime": "1970-01-01T00:00:00Z",
+        "currentlocation": "%SIPDirectory%objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/no-contentids.xml",
+        "size": 2600
+    }
+},
+{
+    "pk": "7e76e93e-3c1b-4780-8ac3-eabf6844e243",
+    "model": "main.file",
+    "fields": {
+        "filegrpuuid": "",
+        "sip": "3a915449-d1bb-4920-b274-c917c7bb5929",
+        "originallocation": "%SIPDirectory%objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/file_does_not_exist.xml",
+        "transfer": null,
+        "filegrpuse": "metadata",
+        "removedtime": null,
+        "label": "",
+        "checksum": "",
+        "enteredsystem": "2019-04-10T23:13:00Z",
+        "modificationtime": "1970-01-01T00:00:00Z",
+        "currentlocation": "%SIPDirectory%objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/file_does_not_exist.xml",
+        "size": 2600
+    }
+},
+{
+    "pk": "a6482fad-68bf-4fc2-815e-c966c890d21b",
+    "model": "main.file",
+    "fields": {
+        "filegrpuuid": "",
+        "sip": "3a915449-d1bb-4920-b274-c917c7bb5929",
+        "originallocation": "%SIPDirectory%objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/empty_filenames.xml",
+        "transfer": null,
+        "filegrpuse": "metadata",
+        "removedtime": null,
+        "label": "",
+        "checksum": "",
+        "enteredsystem": "2019-04-10T23:13:00Z",
+        "modificationtime": "1970-01-01T00:00:00Z",
+        "currentlocation": "%SIPDirectory%objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/empty_filenames.xml",
+        "size": 2600
+    }
+},
+{
+    "pk": "8c414261-57e3-4530-aad9-4d46f66e68ce",
+    "model": "main.file",
+    "fields": {
+        "filegrpuuid": "",
+        "sip": "3a915449-d1bb-4920-b274-c917c7bb5929",
+        "originallocation": "%SIPDirectory%objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/missing_contentid.xml",
+        "transfer": null,
+        "filegrpuse": "metadata",
+        "removedtime": null,
+        "label": "",
+        "checksum": "",
+        "enteredsystem": "2019-04-10T23:13:00Z",
+        "modificationtime": "1970-01-01T00:00:00Z",
+        "currentlocation": "%SIPDirectory%objects/metadata/transfers/custom-structmap-41ab1f1a-34d0-4a83-a2a3-0ad1b1ee1c51/missing_contentid.xml",
+        "size": 2600
+    }
 }
 ]


### PR DESCRIPTION
A number of different error conditions were spotted during testing of
the Archivematica 1.10 release candidate. Rather than failing
silently in the system we introduce logic to make the output more
robust. Example failure conditions for custom structMaps include when
files do not exist, or there are empty attributes for the CONTENTID
field.

Additionally, small sections of the code have been made simpler.

Tests have been added, and all sample structmaps created for this feature will still pass. Those are available from [here](https://github.com/artefactual/archivematica-sampledata/blob/master/SampleTransfers/StructMapTransferSamples).

Connected to archivematica/issues#283 