### PR TITLE
ArchivesSpace: relation: use parent_obj display_string instead of title

### DIFF
--- a/src/dashboard/src/components/access/views.py
+++ b/src/dashboard/src/components/access/views.py
@@ -464,7 +464,7 @@ def access_arrange_start_sip(client, request, mapping):
     parent = archival_object.get("parent", {}).get("ref")
     while parent:
         parent_obj = client.get_record(parent)
-        relation = [parent_obj["title"]] + relation
+        relation = [parent_obj["display_string"]] + relation
         parent = parent_obj.get("parent", {}).get("ref")
     relation = " - ".join(relation)
 


### PR DESCRIPTION
Using the parent_obj's "display_string" instead of "title" when creating the relation element ensures that SIPs can be created with an intellectual arrangement consisting of titles and/or dates, not just titles. Fixes https://github.com/archivematica/Issues/issues/799