### PR TITLE
Reingest: include all new agents

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py
@@ -343,8 +343,13 @@ def add_rights_elements(job, rights_list, files, state, updated=False):
                         break
 
 
-def _orphan_agents(fsentry):
-    """Find linking agents used in events not listed as agents."""
+def _extract_event_agents(fsentry):
+    """Find linked agents that have not been described yet.
+
+    When altering PREMIS events for a filesystem entry, it is likely to end up
+    with an incomplete set of PREMIS agents. This function returns the linked
+    agents that have no corresponding PREMIS agents yet defined.
+    """
     agents, orphans = set(), set()
 
     for premis_agent in fsentry.get_premis_agents():
@@ -395,7 +400,7 @@ def add_events(job, mets, sip_uuid):
         fsentry.add_premis_event(createmets2.createEvent(event))
 
     for fsentry in six.itervalues(visited):
-        for identifier_type, identifier_value in _orphan_agents(fsentry):
+        for identifier_type, identifier_value in _extract_event_agents(fsentry):
             try:
                 agent = agents[(identifier_type, identifier_value)]
             except KeyError:

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py
@@ -13,6 +13,8 @@ import namespaces as ns
 # dashboard
 from main import models
 
+from django.utils import six
+
 
 def _create_premis_object(premis_object_type):
     """Return new PREMIS element container (``lxml._Element`` instance).
@@ -341,32 +343,45 @@ def add_rights_elements(job, rights_list, files, state, updated=False):
                         break
 
 
+def _orphan_agents(fsentry):
+    """Find linking agents used in events not listed as agents."""
+    agents, orphans = set(), set()
+
+    for premis_agent in fsentry.get_premis_agents():
+        for identifier in premis_agent.agent_identifier:
+            agents.add(
+                (identifier.agent_identifier_type, identifier.agent_identifier_value)
+            )
+
+    for premis_event in fsentry.get_premis_events():
+        for linking_agent in premis_event.linking_agent_identifier:
+            item = (
+                linking_agent.linking_agent_identifier_type,
+                linking_agent.linking_agent_identifier_value,
+            )
+            if item in agents:
+                continue
+            orphans.add(item)
+
+    return orphans
+
+
 def add_events(job, mets, sip_uuid):
     """
     Add reingest events for all existing files.
     """
-    # Get all events for files in this SIP
-    events = models.Event.objects.filter(file_uuid__sip__uuid=sip_uuid)
+    fsentries = {item.file_uuid: item for item in mets.all_files()}
+    visited = {}  # Not using a set because FSEntry is not hashable.
+    agents = {
+        (agent.identifiertype, agent.identifiervalue): agent
+        for agent in models.Agent.objects.all()
+    }
 
-    # Get Agent
-    try:
-        agent = models.Agent.objects.get(
-            identifiertype="preservation system",
-            name="Archivematica",
-            agenttype="software",
-        )
-    except models.Agent.DoesNotExist:
-        agent = None
-    except models.Agent.MultipleObjectsReturned:
-        agent = None
-        job.pyprint("WARNING multiple agents found for Archivematica")
-
-    needs_agent = set()
-
-    for event in events:
+    for event in models.Event.objects.filter(file_uuid__sip__uuid=sip_uuid).iterator():
         job.pyprint("Adding", event.event_type, "event to file", event.file_uuid_id)
-        fsentry = mets.get_file(file_uuid=event.file_uuid_id)
-        if fsentry is None:
+        try:
+            fsentry = fsentries[event.file_uuid_id]
+        except KeyError:
             job.pyprint(
                 "File with UUID",
                 event.file_uuid_id,
@@ -375,24 +390,18 @@ def add_events(job, mets, sip_uuid):
                 "event.",
             )
             continue
+        if fsentry.file_uuid not in visited:
+            visited[fsentry.file_uuid] = fsentry
         fsentry.add_premis_event(createmets2.createEvent(event))
 
-        amdsec = fsentry.amdsecs[0]
-
-        # Add agent if it's not already in this amdSec
-        if agent and not mets.tree.xpath(
-            'mets:amdSec[@AMDID="'
-            + amdsec.id_string
-            + '"]//mets:mdWrap[@MDTYPE="PREMIS:AGENT"]//premis:agentIdentifierValue[text()="'
-            + agent.identifiervalue
-            + '"]',
-            namespaces=ns.NSMAP,
-        ):
-            needs_agent.add(fsentry)
-
-    for fsentry in needs_agent:
-        job.pyprint("Adding Agent for", agent.identifiervalue)
-        fsentry.add_premis_agent(createmets2.createAgent(agent))
+    for fsentry in six.itervalues(visited):
+        for identifier_type, identifier_value in _orphan_agents(fsentry):
+            try:
+                agent = agents[(identifier_type, identifier_value)]
+            except KeyError:
+                continue
+            job.pyprint("Adding Agent for", agent.identifiervalue)
+            fsentry.add_premis_agent(createmets2.createAgent(agent))
 
     return mets
 

--- a/src/MCPClient/tests/test_reingest_mets.py
+++ b/src/MCPClient/tests/test_reingest_mets.py
@@ -1362,6 +1362,10 @@ class TestAddEvents(TestCase):
             )
             == 9
         )
+        models.Agent.objects.filter(
+            identifiertype="repository code", agenttype="organization"
+        ).update(identifiervalue="new-repo-code")
+        nsmap_v2 = nsmap_for_premis2()
         mets = archivematicaCreateMETSReingest.add_events(
             Job("stub", "stub", []), mets, self.sip_uuid
         )
@@ -1376,7 +1380,7 @@ class TestAddEvents(TestCase):
             len(
                 root.findall('.//mets:mdWrap[@MDTYPE="PREMIS:AGENT"]', namespaces=NSMAP)
             )
-            == 12
+            == 15
         )
         # Preservation
         assert (
@@ -1400,6 +1404,20 @@ class TestAddEvents(TestCase):
             )
             != []
         )
+        assert (
+            root.xpath(
+                'mets:amdSec[@ID="amdSec_1"]//premis:agentIdentifierValue[text()="demo"]',
+                namespaces=nsmap_v2,
+            )
+            != []
+        )
+        assert (
+            root.xpath(
+                'mets:amdSec[@ID="amdSec_1"]//premis:agentIdentifierValue[text()="new-repo-code"]',
+                namespaces=NSMAP,
+            )
+            != []
+        )
         # Original
         assert (
             root.xpath(
@@ -1408,31 +1426,44 @@ class TestAddEvents(TestCase):
             )
             != []
         )
-        namespaces = nsmap_for_premis2()
         assert (
             root.xpath(
                 'mets:amdSec[@ID="amdSec_2"]//premis:eventType[text()="format identification"]',
-                namespaces=namespaces,
+                namespaces=nsmap_v2,
             )
             != []
         )
         assert (
             root.xpath(
                 'mets:amdSec[@ID="amdSec_2"]//premis:eventType[text()="normalization"]',
-                namespaces=namespaces,
+                namespaces=nsmap_v2,
             )
             != []
         )
         assert (
             root.xpath(
                 'mets:amdSec[@ID="amdSec_2"]//premis:eventType[text()="fixity check"]',
-                namespaces=namespaces,
+                namespaces=nsmap_v2,
             )
             != []
         )
         assert (
             root.xpath(
                 'mets:amdSec[@ID="amdSec_2"]//premis:agentIdentifierValue[text()="Archivematica-1.4.0"]',
+                namespaces=NSMAP,
+            )
+            != []
+        )
+        assert (
+            root.xpath(
+                'mets:amdSec[@ID="amdSec_2"]//premis:agentIdentifierValue[text()="demo"]',
+                namespaces=nsmap_v2,
+            )
+            != []
+        )
+        assert (
+            root.xpath(
+                'mets:amdSec[@ID="amdSec_2"]//premis:agentIdentifierValue[text()="new-repo-code"]',
                 namespaces=NSMAP,
             )
             != []
@@ -1448,6 +1479,20 @@ class TestAddEvents(TestCase):
         assert (
             root.xpath(
                 'mets:amdSec[@ID="amdSec_3"]//premis:agentIdentifierValue[text()="Archivematica-1.4.0"]',
+                namespaces=NSMAP,
+            )
+            != []
+        )
+        assert (
+            root.xpath(
+                'mets:amdSec[@ID="amdSec_3"]//premis:agentIdentifierValue[text()="demo"]',
+                namespaces=nsmap_v2,
+            )
+            != []
+        )
+        assert (
+            root.xpath(
+                'mets:amdSec[@ID="amdSec_3"]//premis:agentIdentifierValue[text()="new-repo-code"]',
                 namespaces=NSMAP,
             )
             != []


### PR DESCRIPTION
This commit updates `add_events` to ensure that all PREMIS agents are listed
as new PREMIS events are incorporated during reingest. Before, we were only
covering the "software" agent.

Connects to https://github.com/archivematica/Issues/issues/659.