### PR TITLE
Dashboard: add pathlib2 as base dependency

### DIFF
--- a/src/dashboard/src/requirements/base.in
+++ b/src/dashboard/src/requirements/base.in
@@ -23,8 +23,10 @@ pytz
 pyopenssl
 python-dateutil==2.6.0
 ndg-httpsclient
+pathlib2==2.3.3    # used by rebuild_transfer_backlog command
 pyasn1
 requests==2.21.0
+scandir==1.10.0    # via pathlib2
 whitenoise==3.3.0
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
 

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -38,6 +38,7 @@ lxml==3.5.0
 metsrw==0.3.11
 mysqlclient==1.3.7
 ndg-httpsclient==0.5.1
+pathlib2==2.3.3
 pyasn1-modules==0.2.5     # via python-ldap
 pyasn1==0.4.5
 pycparser==2.19           # via cffi
@@ -47,6 +48,7 @@ python-ldap==3.2.0
 python-mimeparse==1.6.0   # via django-tastypie
 pytz==2018.9
 requests==2.21.0
-six==1.12.0               # via cryptography, django-extensions, metsrw, pyopenssl, python-dateutil
+scandir==1.10.0
+six==1.12.0               # via cryptography, django-extensions, metsrw, pathlib2, pyopenssl, python-dateutil
 urllib3==1.24.1           # via elasticsearch, requests
 whitenoise==3.3.0

--- a/src/dashboard/src/requirements/production.txt
+++ b/src/dashboard/src/requirements/production.txt
@@ -38,6 +38,7 @@ lxml==3.5.0
 metsrw==0.3.11
 mysqlclient==1.3.7
 ndg-httpsclient==0.5.1
+pathlib2==2.3.3
 pyasn1-modules==0.2.5
 pyasn1==0.4.5
 pycparser==2.19
@@ -47,6 +48,7 @@ python-ldap==3.2.0
 python-mimeparse==1.6.0
 pytz==2018.9
 requests==2.21.0
+scandir==1.10.0
 six==1.12.0
 urllib3==1.24.1
 whitenoise==3.3.0

--- a/src/dashboard/src/requirements/test.txt
+++ b/src/dashboard/src/requirements/test.txt
@@ -48,7 +48,7 @@ mockldap==0.2.8
 more-itertools==5.0.0     # via pytest
 mysqlclient==1.3.7
 ndg-httpsclient==0.5.1
-pathlib2==2.3.3           # via pytest, pytest-django
+pathlib2==2.3.3
 pbr==5.1.3                # via mock
 pluggy==0.9.0             # via pytest, tox
 py==1.8.0                 # via pytest, tox
@@ -66,7 +66,7 @@ python-mimeparse==1.6.0
 pytz==2018.9
 pyyaml==5.1               # via vcrpy
 requests==2.21.0
-scandir==1.10.0           # via pathlib2
+scandir==1.10.0
 six==1.12.0
 toml==0.10.0              # via tox
 tox==3.8.3
@@ -75,3 +75,4 @@ vcrpy==1.13.0
 virtualenv==16.4.3        # via tox
 whitenoise==3.3.0
 wrapt==1.11.1             # via vcrpy
+


### PR DESCRIPTION
It was being loaded in dev.txt, but it's needed by the
rebuild_transfer_backlog dashboard command

Connects to https://github.com/archivematica/Issues/issues/367