### PR TITLE
Remove need to supply objects dir for checksums

### DIFF
--- a/src/MCPClient/lib/clientScripts/verify_checksum.py
+++ b/src/MCPClient/lib/clientScripts/verify_checksum.py
@@ -125,10 +125,11 @@ class Hashsum(object):
 
     def compare_hashes(self, transfer_dir):
         """Compare transfer files with the checksum file provided."""
-        if not self.count_and_compare_lines(os.path.join(transfer_dir, "objects")):
+        objects_dir = os.path.join(transfer_dir, "objects")
+        if not self.count_and_compare_lines(objects_dir):
             return 1
         try:
-            self._call("-c", "--strict", self.hashfile, transfer_dir=transfer_dir)
+            self._call("-c", "--strict", self.hashfile, transfer_dir=objects_dir)
             return 0
         except subprocess.CalledProcessError as err:
             if self.EXIT_NON_ZERO in str(err):

--- a/src/MCPClient/tests/test_verify_checksum.py
+++ b/src/MCPClient/tests/test_verify_checksum.py
@@ -147,6 +147,7 @@ class TestHashsum(object):
         job = Job("stub", "stub", ["", ""])
         hashsum = self.setup_hashsum(hash_file, job)
         toolname = "sha256sum"
+        objects_dir = "objects"
         output_string = (
             b"objects/file1.bin: OK\n"
             b"objects/file2.bin: FAILED\n"
@@ -166,7 +167,9 @@ class TestHashsum(object):
             returncode=1, cmd=toolname, output=output_string
         )
         ret = hashsum.compare_hashes("")
-        mock.assert_called_once_with("-c", "--strict", hash_file, transfer_dir="")
+        mock.assert_called_once_with(
+            "-c", "--strict", hash_file, transfer_dir=objects_dir
+        )
         assert ret == 1, self.assert_return_value.format(ret)
         assert (
             job.get_stderr().decode("utf8").strip() == exception_string
@@ -180,6 +183,7 @@ class TestHashsum(object):
         job = Job("stub", "stub", ["", ""])
         hashsum = self.setup_hashsum(hash_file, job)
         toolname = "sha1sum"
+        objects_dir = "objects"
         no_proper_output = (
             b"sha1sum: metadata/checksum.sha1: no properly formatted SHA1 "
             b"checksum lines found"
@@ -200,7 +204,9 @@ class TestHashsum(object):
             returncode=1, cmd=toolname, output=no_proper_output
         )
         ret = hashsum.compare_hashes("")
-        mock.assert_called_once_with("-c", "--strict", hash_file, transfer_dir="")
+        mock.assert_called_once_with(
+            "-c", "--strict", hash_file, transfer_dir=objects_dir
+        )
         assert (
             job.get_stderr().decode("utf8").strip() == except_string_no_proper_out
         ), self.assert_exception_string
@@ -215,7 +221,9 @@ class TestHashsum(object):
         assert (
             job.get_stderr().decode("utf8").strip() == except_string_improper_format
         ), self.assert_exception_string
-        mock.assert_called_once_with("-c", "--strict", hash_file, transfer_dir="")
+        mock.assert_called_once_with(
+            "-c", "--strict", hash_file, transfer_dir=objects_dir
+        )
         assert ret == 1, self.assert_return_value.format(ret)
 
     def test_line_comparison_fail(self, mocker):


### PR DESCRIPTION
Changes made for 1.10 meant the 'objects/' directory needed to be
encoded in a checksum manifest's file listing, e.g. checksum.sha512.
This is reverted here where we were able to find a better way of
achieving the same result without this requirement.

Connected to archivematica/issues#844
Sample data to test against https://github.com/artefactual/archivematica-sampledata/pull/59
Docs changes: https://github.com/artefactual/archivematica-docs/pull/303