### PR TITLE
Dashboard: fix JSON serialization on DIP upload

### DIFF
--- a/src/dashboard/src/components/archival_storage/atom.py
+++ b/src/dashboard/src/components/archival_storage/atom.py
@@ -57,7 +57,10 @@ def _load_premis(data, mwfile):
             val = getattr(premis_object, prop)
         except AttributeError:
             continue
-        if not val:
+        # Calling `getattr` to find an attribute deeper in the `premis_object`
+        # structure returns a non JSON serializable tuple instead of a None
+        # value. See Issues#743 for more information.
+        if not val or isinstance(val, tuple):
             continue
         logger.debug("Extracted property %s from METS: %s", prop, val)
         data[prop] = val


### PR DESCRIPTION
Avoid `tuples` returned from the `metrw.premis_object` in some
attributes with empty vales before JSON serialization in the metadata
only DIP upload.

Refs https://github.com/archivematica/Issues/issues/857.