### PR TITLE
Fix SIP arrange directory creation

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -626,7 +626,7 @@ def create_directory_within_arrange(request):
     """
     error = None
 
-    paths = map(base64.b64decode, request.POST.getlist("paths", []))
+    paths = map(base64.b64decode, request.POST.getlist("paths[]", []))
 
     if paths:
         try:

--- a/src/dashboard/tests/test_filesystem_ajax.py
+++ b/src/dashboard/tests/test_filesystem_ajax.py
@@ -151,7 +151,7 @@ class TestSIPArrange(TestCase):
         # Create directory
         response = self.client.post(
             reverse("components.filesystem_ajax.views.create_directory_within_arrange"),
-            data={"paths": base64.b64encode("/arrange/new_dir")},
+            data={"paths[]": [base64.b64encode("/arrange/new_dir")]},
             follow=True,
         )
         assert response.status_code == 201


### PR DESCRIPTION
The [old `create_directory_within_arrange` function](https://github.com/artefactual/archivematica/blob/48409e31b72d877b91efefd8c51dfd4c10c70b69/src/dashboard/src/components/filesystem_ajax/views.py#L543) used to take a single `path`. But this became a problem  in https://github.com/archivematica/Issues/issues/610 and the implementation was changed to support bulk creation in https://github.com/artefactual/archivematica/pull/1390.

However, the new `paths` parameter is not being processed as a list preventing the arrange directories to be created and to have levels of description set.

This PR fixes the `paths` parameter handling.

Connected to https://github.com/archivematica/Issues/issues/856