### PR TITLE
Performance: add basic indexes

### DIFF
--- a/src/MCPClient/lib/clientScripts/email_fail_report.py
+++ b/src/MCPClient/lib/clientScripts/email_fail_report.py
@@ -127,7 +127,7 @@ def get_unit_job_log_html(sip_uuid):
     """
     parser = etree.HTMLParser(remove_blank_text=True)
     rows = (
-        Job.objects.filter(sipuuid=sip_uuid, subjobof="")
+        Job.objects.filter(sipuuid=sip_uuid)
         .exclude(jobtype="Email fail report")
         .order_by("-createdtime", "-createdtimedec")
         .values_list("jobtype", "currentstep", "createdtime")

--- a/src/dashboard/src/components/decorators.py
+++ b/src/dashboard/src/components/decorators.py
@@ -27,7 +27,7 @@ from main import models
 def load_jobs(view):
     @wraps(view)
     def inner(request, uuid, *args, **kwargs):
-        jobs = models.Job.objects.filter(sipuuid=uuid, subjobof="")
+        jobs = models.Job.objects.filter(sipuuid=uuid)
         if 0 == jobs.count:
             raise Http404
         kwargs["jobs"] = jobs

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -150,7 +150,7 @@ def ingest_metadata_edit(request, uuid, id=None):
         dc.type = dc_type
         dc.save()
         return redirect("components.ingest.views.ingest_metadata_list", uuid)
-    jobs = models.Job.objects.filter(sipuuid=uuid, subjobof="")
+    jobs = models.Job.objects.filter(sipuuid=uuid)
     name = jobs.get_directory_name()
 
     return render(request, "ingest/metadata_edit.html", locals())
@@ -176,7 +176,7 @@ def ingest_metadata_add_files(request, sip_uuid):
                 ),
             )
     # Get name of SIP from directory name of most recent job
-    jobs = models.Job.objects.filter(sipuuid=sip_uuid, subjobof="")
+    jobs = models.Job.objects.filter(sipuuid=sip_uuid)
     name = jobs.get_directory_name()
 
     return render(request, "ingest/metadata_add_files.html", locals())
@@ -253,7 +253,7 @@ def ingest_metadata_event_detail(request, uuid):
         )
 
     # Get name of SIP from directory name of most recent job
-    jobs = models.Job.objects.filter(sipuuid=uuid, subjobof="")
+    jobs = models.Job.objects.filter(sipuuid=uuid)
     name = jobs.get_directory_name()
     return render(request, "ingest/metadata_event_detail.html", locals())
 
@@ -372,7 +372,7 @@ def derivative_validation_report_by_purpose(exit_code, file_id):
 
 
 def ingest_normalization_report(request, uuid, current_page=None):
-    jobs = models.Job.objects.filter(sipuuid=uuid, subjobof="")
+    jobs = models.Job.objects.filter(sipuuid=uuid)
     sipname = jobs.get_directory_name()
 
     objects = getNormalizationReportQuery(sipUUID=uuid)
@@ -410,7 +410,7 @@ def ingest_browse(request, browse_type, jobuuid):
     else:
         raise Http404
 
-    jobs = models.Job.objects.filter(jobuuid=jobuuid, subjobof="")
+    jobs = models.Job.objects.filter(jobuuid=jobuuid)
     name = jobs.get_directory_name()
 
     return render(request, "ingest/aip_browse.html", locals())

--- a/src/dashboard/src/components/rights/views.py
+++ b/src/dashboard/src/components/rights/views.py
@@ -115,7 +115,7 @@ def rights_parse_agent_id(input):
 
 
 def rights_edit(request, uuid, id=None, section="ingest"):
-    jobs = models.Job.objects.filter(sipuuid=uuid, subjobof="")
+    jobs = models.Job.objects.filter(sipuuid=uuid)
     name = jobs.get_directory_name()
 
     # flag indicating what kind of new content, if any, has been created
@@ -606,7 +606,7 @@ def rights_edit(request, uuid, id=None, section="ingest"):
 
 
 def rights_grants_edit(request, uuid, id, section="ingest"):
-    jobs = models.Job.objects.filter(sipuuid=uuid, subjobof="")
+    jobs = models.Job.objects.filter(sipuuid=uuid)
     name = jobs.get_directory_name()
 
     viewRights = models.RightsStatement.objects.get(pk=id)
@@ -770,7 +770,7 @@ def rights_holders_autocomplete(request):
 
 
 def rights_list(request, uuid, section):
-    jobs = models.Job.objects.filter(sipuuid=uuid, subjobof="")
+    jobs = models.Job.objects.filter(sipuuid=uuid)
     name = jobs.get_directory_name()
 
     # See MetadataAppliesToTypes table

--- a/src/dashboard/src/components/transfer/views.py
+++ b/src/dashboard/src/components/transfer/views.py
@@ -174,7 +174,7 @@ def transfer_metadata_edit(request, uuid, id=None):
             return redirect("components.transfer.views.transfer_metadata_list", uuid)
     else:
         form = DublinCoreMetadataForm(instance=dc)
-        jobs = models.Job.objects.filter(sipuuid=uuid, subjobof="")
+        jobs = models.Job.objects.filter(sipuuid=uuid)
         name = jobs.get_directory_name()
 
     return render(request, "transfer/metadata_edit.html", locals())

--- a/src/dashboard/src/components/unit/views.py
+++ b/src/dashboard/src/components/unit/views.py
@@ -33,7 +33,7 @@ def detail(request, unit_type, unit_uuid):
     :param unit_type: 'transfer' or 'ingest' for a Transfer or SIP respectively
     :param unit_uuid: UUID of the Transfer or SIP
     """
-    jobs = models.Job.objects.filter(sipuuid=unit_uuid, subjobof="")
+    jobs = models.Job.objects.filter(sipuuid=unit_uuid)
     name = jobs.get_directory_name()
     is_waiting = (
         jobs.filter(currentstep=models.Job.STATUS_AWAITING_DECISION).count() > 0

--- a/src/dashboard/src/main/migrations/0070_index_jobs.py
+++ b/src/dashboard/src/main/migrations/0070_index_jobs.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("main", "0069_remove_atk")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="job",
+            name="sipuuid",
+            field=models.CharField(max_length=36, db_column=b"SIPUUID", db_index=True),
+        ),
+        migrations.AlterIndexTogether(
+            name="job",
+            index_together=set(
+                [
+                    ("sipuuid", "createdtime", "createdtimedec"),
+                    (
+                        "sipuuid",
+                        "currentstep",
+                        "microservicegroup",
+                        "microservicechainlink",
+                    ),
+                    ("sipuuid", "jobtype", "createdtime", "createdtimedec"),
+                    ("jobtype", "currentstep"),
+                ]
+            ),
+        ),
+    ]

--- a/src/dashboard/src/main/migrations/0071_index_unitvariables_runsql.py
+++ b/src/dashboard/src/main/migrations/0071_index_unitvariables_runsql.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""A MySQL specific index for UnitVariables
+"""
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def create_index(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+
+    schema_editor.execute(
+        "CREATE INDEX UnitVariables_ep46xp7f_idx ON UnitVariables (unitUUID, unitType, variable(255));"
+    )
+
+
+def drop_index(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+
+    schema_editor.execute("DROP INDEX UnitVariables_ep46xp7f_idx ON UnitVariables;")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("main", "0070_index_jobs")]
+
+    # MySQL specific syntax
+    operations = [migrations.RunPython(create_index, drop_index, atomic=True)]

--- a/src/dashboard/src/main/migrations/0072_index_files.py
+++ b/src/dashboard/src/main/migrations/0072_index_files.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("main", "0071_index_unitvariables_runsql")]
+
+    operations = [
+        migrations.AlterIndexTogether(
+            name="file", index_together=set([("sip", "filegrpuse")])
+        )
+    ]

--- a/src/dashboard/src/main/migrations/0073_index_files_runsql.py
+++ b/src/dashboard/src/main/migrations/0073_index_files_runsql.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""MySQL specific indexes for Files
+"""
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def create_indexes(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+
+    schema_editor.execute(
+        "CREATE INDEX Files_transfer_lvrgv3pn_idx ON Files (transferUUID, currentLocation(767));"
+    )
+    schema_editor.execute(
+        "CREATE INDEX Files_transfer_bru5if1u_idx ON Files (transferUUID, originalLocation(767));"
+    )
+    schema_editor.execute(
+        "CREATE INDEX Files_sip_1x6rkqbm_idx ON Files (sipUUID, currentLocation(767));"
+    )
+    schema_editor.execute(
+        "CREATE INDEX Files_sip_orpn8lfh_idx ON Files (sipUUID, originalLocation(767));"
+    )
+
+
+def drop_indexes(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+
+    schema_editor.execute("DROP INDEX Files_transfer_lvrgv3pn_idx ON Files;")
+    schema_editor.execute("DROP INDEX Files_transfer_bru5if1u_idx ON Files;")
+    schema_editor.execute("DROP INDEX Files_sip_1x6rkqbm_idx ON Files;")
+    schema_editor.execute("DROP INDEX Files_sip_orpn8lfh_idx ON Files;")
+
+
+class Migration(migrations.Migration):
+    dependencies = [("main", "0072_index_files")]
+
+    operations = [migrations.RunPython(create_indexes, drop_indexes, atomic=True)]

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -723,7 +723,7 @@ class Job(models.Model):
     )
     directory = models.TextField(blank=True)
     sipuuid = models.CharField(
-        max_length=36, db_column="SIPUUID"
+        max_length=36, db_column="SIPUUID", db_index=True
     )  # Foreign key to SIPs or Transfers
     unittype = models.CharField(max_length=50, db_column="unitType", blank=True)
     STATUS_UNKNOWN = 0
@@ -754,6 +754,12 @@ class Job(models.Model):
 
     class Meta:
         db_table = u"Jobs"
+        index_together = (
+            ("sipuuid", "createdtime", "createdtimedec"),
+            ("sipuuid", "jobtype", "createdtime", "createdtimedec"),
+            ("sipuuid", "currentstep", "microservicegroup", "microservicechainlink"),
+            ("jobtype", "currentstep"),
+        )
 
     def get_directory_name(self, default=None):
         if not self.directory:

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -594,6 +594,12 @@ class File(models.Model):
 
     class Meta:
         db_table = u"Files"
+        # Additional fields indexed via raw migration (as they are blobs):
+        # ("transfer", "currentlocation"),
+        # ("sip", "currentlocation"),
+        # ("transfer", "originallocation"),
+        # ("sip", "originallocation"),
+        index_together = (("sip", "filegrpuse"),)
 
     def __unicode__(self):
         return six.text_type(

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -1367,6 +1367,8 @@ class UnitVariable(models.Model):
 
     class Meta:
         db_table = u"UnitVariables"
+        # Fields indexed via raw migration (as they are blobs):
+        # ("unituuid", "unittype", "variable")
 
 
 class ArchivesSpaceDIPObjectResourcePairing(models.Model):


### PR DESCRIPTION
Adds indexes to very active tables (Jobs, UnitVariables, and Files) handling many common query cases. These should mostly be helpful in situations where the database has grown too large to fit into memory.

We're using often using `BLOB`/`TEXT` columns as lookups (not a good practice). Adding indexes to those requires setting a key length, which isn't something Django supports, so I've added those indexes via manual SQL. These aren't perfect, they can't be used in `LIKE '%foo'` (or ends with) queries, and in my testing MySQL seems to be ignoring them in `LIKE 'foo%'` (or starts with) queries. The most common case though is equals, and that works great (for values up to 767 bytes at least, the innodb max).

I've also looked at SIP, Transfer and Task, but those models are usually queried by uuid, which has an index.

Also removes subjob from Jobs queries, which was unnecessary and slowing things down.

Connected to archivematica/Issues#907.