### PR TITLE
Workflow: ensure that disabled jobs are no-ops

### DIFF
--- a/src/MCPClient/lib/clientScripts/transcribe_file.py
+++ b/src/MCPClient/lib/clientScripts/transcribe_file.py
@@ -178,10 +178,5 @@ def call(jobs):
             with job.JobContext():
                 task_uuid = job.args[1]
                 file_uuid = job.args[2]
-                transcribe = job.args[3]
 
-                if transcribe == "False":
-                    job.print_output("Skipping transcription")
-                    job.set_status(0)
-                else:
-                    job.set_status(main(job, task_uuid, file_uuid))
+                job.set_status(main(job, task_uuid, file_uuid))

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -44,6 +44,15 @@
             },
             "link_id": "5cf308fd-a6dc-4033-bda1-61689bb55ce2"
         },
+        "0a24787c-00e3-4710-b324-90e792bfb484": {
+            "description": {
+                "en": "No",
+                "fr": "Non",
+                "ja": "いいえ",
+                "sv": "Nej"
+            },
+            "link_id": "f574b2a0-6e0b-4c74-ac5b-a73ddb9593a0"
+        },
         "0ea3a6f9-ff37-4f32-ac01-eec5393f008a": {
             "description": {
                 "en": "Pre-normalize identify file format",
@@ -210,6 +219,17 @@
             },
             "link_id": "4430077a-92c5-4d86-b0f8-0d31bdb731fb"
         },
+        "35151db8-3a11-4b49-8865-f6697ef0ac75": {
+            "description": {
+                "en": "Yes",
+                "es": "Sí",
+                "fr": "Oui",
+                "ja": "はい",
+                "pt_BR": "Sim",
+                "sv": "Ja"
+            },
+            "link_id": "2900f6d8-b64c-4f2a-8f7f-bb60a57394f6"
+        },
         "3572f844-5e69-4000-a24b-4e32d3487f82": {
             "description": {
                 "en": "Upload DIP to ArchivesSpace",
@@ -334,7 +354,7 @@
                 "pt_BR": "Continua",
                 "sv": "Fortsätt"
             },
-            "link_id": "7079be6d-3a25-41e6-a481-cee5f352fe6e"
+            "link_id": "82ee9ad2-2c74-4c7c-853e-e4eaf68fc8b6"
         },
         "5f34245e-5864-4199-aafc-bc0ada01d4cd": {
             "description": {
@@ -3414,7 +3434,7 @@
             "config": {
                 "@manager": "linkTaskManagerFiles",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%taskUUID%\" \"%fileUUID%\" \"%transcribe%\"",
+                "arguments": "\"%taskUUID%\" \"%fileUUID%\"",
                 "execute": "transcribeFile_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -6693,60 +6713,6 @@
                 "sv": "Kontrollera SIPs följsamhet"
             }
         },
-        "7079be6d-3a25-41e6-a481-cee5f352fe6e": {
-            "config": {
-                "@manager": "linkTaskManagerReplacementDicFromChoice",
-                "@model": "MicroServiceChoiceReplacementDic",
-                "replacements": [
-                    {
-                        "description": {
-                            "en": "No",
-                            "fr": "Non",
-                            "ja": "いいえ",
-                            "sv": "Nej"
-                        },
-                        "id": "1170e555-cd4e-4b2f-a3d6-bfb09e8fcc53",
-                        "items": {
-                            "transcribe": "False"
-                        }
-                    },
-                    {
-                        "description": {
-                            "en": "Yes",
-                            "es": "Sí",
-                            "fr": "Oui",
-                            "ja": "はい",
-                            "pt_BR": "Sim",
-                            "sv": "Ja"
-                        },
-                        "id": "5a9985d3-ce7e-4710-85c1-f74696770fa9",
-                        "items": {
-                            "transcribe": "True"
-                        }
-                    }
-                ]
-            },
-            "description": {
-                "en": "Transcribe SIP contents",
-                "fr": "Transcrire le contenu du SIP",
-                "pt_BR": "Transcreva o conteúdo do SIP",
-                "sv": "Transkribera SIP-innehåll"
-            },
-            "exit_codes": {
-                "0": {
-                    "job_status": "Completed successfully",
-                    "link_id": "2900f6d8-b64c-4f2a-8f7f-bb60a57394f6"
-                }
-            },
-            "fallback_job_status": "Failed",
-            "fallback_link_id": null,
-            "group": {
-                "en": "Transcribe SIP contents",
-                "fr": "Transcrire le contenu du SIP",
-                "pt_BR": "Transcreva o conteúdo do SIP",
-                "sv": "Transkribera SIP-innehåll"
-            }
-        },
         "70f41678-baa5-46e6-a71c-4b6b4d99f4a6": {
             "config": {
                 "@manager": "linkTaskManagerDirectories",
@@ -7507,6 +7473,28 @@
                 "ja": "SIPに失敗",
                 "pt_BR": "SIP falhou",
                 "sv": "SIP misslyckades"
+            }
+        },
+        "82ee9ad2-2c74-4c7c-853e-e4eaf68fc8b6": {
+            "config": {
+                "@manager": "linkTaskManagerChoice",
+                "@model": "MicroServiceChainChoice",
+                "chain_choices": [
+                    "35151db8-3a11-4b49-8865-f6697ef0ac75",
+                    "0a24787c-00e3-4710-b324-90e792bfb484"
+                ]
+            },
+            "description": {
+                "en": "Transcribe SIP contents?"
+            },
+            "exit_codes": {},
+            "fallback_job_status": "Failed",
+            "fallback_link_id": null,
+            "group": {
+                "en": "Transcribe SIP contents",
+                "fr": "Transcrire le contenu du SIP",
+                "pt_BR": "Transcreva o conteúdo do SIP",
+                "sv": "Transkribera SIP-innehåll"
             }
         },
         "83484326-7be7-4f9f-b252-94553cd42370": {

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -275,6 +275,15 @@
             },
             "link_id": "f2e784a0-356b-4b92-9a5a-11887aa3cf48"
         },
+        "44a7c397-8187-4fd2-b8f7-c61737c4df49": {
+            "description": {
+                "en": "No",
+                "fr": "Non",
+                "ja": "いいえ",
+                "sv": "Nej"
+            },
+            "link_id": "d0dfa5fc-e3c2-4638-9eda-f96eea1070e0"
+        },
         "4500f34e-f004-4ccf-8720-5c38d0be2254": {
             "description": {
                 "en": "Do not store",
@@ -477,6 +486,17 @@
                 "sv": "Lagra DIP"
             },
             "link_id": "d026e5a4-96cf-4e4c-938d-a74b0d211da0"
+        },
+        "8f9dceb5-b978-43e0-a364-8b317a3ac43b": {
+            "description": {
+                "en": "Yes",
+                "es": "Sí",
+                "fr": "Oui",
+                "ja": "はい",
+                "pt_BR": "Sim",
+                "sv": "Ja"
+            },
+            "link_id": "873b428f-2c86-42b6-b463-aeda925bf559"
         },
         "94f764ad-805a-4d4e-8a2b-a6f2515b30c7": {
             "description": {
@@ -1265,64 +1285,6 @@
                 "fr": "Vérifier la conformité du transfert",
                 "pt_BR": "Verificar a conformidade da transferência",
                 "sv": "Kontrollera överförings följsamhet"
-            }
-        },
-        "05357876-a095-4c11-86b5-a7fff01af668": {
-            "config": {
-                "@manager": "linkTaskManagerReplacementDicFromChoice",
-                "@model": "MicroServiceChoiceReplacementDic",
-                "replacements": [
-                    {
-                        "description": {
-                            "en": "Yes",
-                            "es": "Sí",
-                            "fr": "Oui",
-                            "ja": "はい",
-                            "pt_BR": "Sim",
-                            "sv": "Ja"
-                        },
-                        "id": "1e79e1b6-cf50-49ff-98a3-fa51d73553dc",
-                        "items": {
-                            "BindPIDs": "True"
-                        }
-                    },
-                    {
-                        "description": {
-                            "en": "No",
-                            "fr": "Non",
-                            "ja": "いいえ",
-                            "sv": "Nej"
-                        },
-                        "id": "fcfea449-158c-452c-a8ad-4ae009c4eaba",
-                        "items": {
-                            "BindPIDs": "False"
-                        }
-                    }
-                ]
-            },
-            "description": {
-                "en": "Bind PIDs?",
-                "fr": "Lier les PIDs?",
-                "pt_BR": "Vincular PIDs?",
-                "sv": "Lås PID:er?"
-            },
-            "exit_codes": {
-                "0": {
-                    "job_status": "Completed successfully",
-                    "link_id": "87e93d08-36e4-4c81-99a8-beea00b18400"
-                },
-                "1": {
-                    "job_status": "Failed",
-                    "link_id": "87e93d08-36e4-4c81-99a8-beea00b18400"
-                }
-            },
-            "fallback_job_status": "Failed",
-            "fallback_link_id": "87e93d08-36e4-4c81-99a8-beea00b18400",
-            "group": {
-                "en": "Bind PIDs",
-                "fr": "Lier les PIDs",
-                "pt_BR": "Vincular PIDs",
-                "sv": "Lås PID:er."
             }
         },
         "05f99ffd-abf2-4f5a-9ec8-f80a59967b89": {
@@ -6981,11 +6943,11 @@
             "exit_codes": {
                 "0": {
                     "job_status": "Completed successfully",
-                    "link_id": "873b428f-2c86-42b6-b463-aeda925bf559"
+                    "link_id": "a2ba5278-459a-4638-92d9-38eb1588717d"
                 }
             },
             "fallback_job_status": "Failed",
-            "fallback_link_id": "873b428f-2c86-42b6-b463-aeda925bf559",
+            "fallback_link_id": "a2ba5278-459a-4638-92d9-38eb1588717d",
             "group": {
                 "en": "Process metadata directory",
                 "es": "Procesar directorio de metadatos",
@@ -6997,7 +6959,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%SIPUUID%\" \"%sharedPath%\" --bind-pids \"%BindPIDs%\"",
+                "arguments": "\"%SIPUUID%\" \"%sharedPath%\"",
                 "execute": "bindPIDs_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -7015,14 +6977,10 @@
                 "0": {
                     "job_status": "Completed successfully",
                     "link_id": "d0dfa5fc-e3c2-4638-9eda-f96eea1070e0"
-                },
-                "1": {
-                    "job_status": "Failed",
-                    "link_id": "d0dfa5fc-e3c2-4638-9eda-f96eea1070e0"
                 }
             },
             "fallback_job_status": "Failed",
-            "fallback_link_id": "ccf8ec5c-3a9a-404a-a7e7-8f567d3b36a0",
+            "fallback_link_id": "d0dfa5fc-e3c2-4638-9eda-f96eea1070e0",
             "group": {
                 "en": "Bind PIDs",
                 "fr": "Lier les PIDs",
@@ -7625,7 +7583,7 @@
             "exit_codes": {
                 "0": {
                     "job_status": "Completed successfully",
-                    "link_id": "05357876-a095-4c11-86b5-a7fff01af668"
+                    "link_id": "87e93d08-36e4-4c81-99a8-beea00b18400"
                 }
             },
             "fallback_job_status": "Failed",
@@ -7674,7 +7632,7 @@
             "config": {
                 "@manager": "linkTaskManagerFiles",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%fileUUID%\" --bind-pids \"%BindPIDs%\"",
+                "arguments": "\"%fileUUID%\"",
                 "execute": "bindPID_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -8739,6 +8697,31 @@
                 "fr": "Normaliser ",
                 "pt_BR": "Normalizar",
                 "sv": "Normalisera"
+            }
+        },
+        "a2ba5278-459a-4638-92d9-38eb1588717d": {
+            "config": {
+                "@manager": "linkTaskManagerChoice",
+                "@model": "MicroServiceChainChoice",
+                "chain_choices": [
+                    "8f9dceb5-b978-43e0-a364-8b317a3ac43b",
+                    "44a7c397-8187-4fd2-b8f7-c61737c4df49"
+                ]
+            },
+            "description": {
+                "en": "Bind PIDs?",
+                "fr": "Lier les PIDs?",
+                "pt_BR": "Vincular PIDs?",
+                "sv": "Lås PID:er?"
+            },
+            "exit_codes": {},
+            "fallback_job_status": "Failed",
+            "fallback_link_id": null,
+            "group": {
+                "en": "Bind PIDs",
+                "fr": "Lier les PIDs",
+                "pt_BR": "Vincular PIDs",
+                "sv": "Lås PID:er."
             }
         },
         "a329d39b-4711-4231-b54e-b5958934dccb": {

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -407,15 +407,6 @@
             },
             "link_id": "b4567e89-9fea-4256-99f5-a88987026488"
         },
-        "69f4a4b9-93e2-481c-99a0-fa92d68c3ebd": {
-            "description": {
-                "en": "SIP Creation complete",
-                "fr": "Création du SIP complète",
-                "pt_BR": "Criação do SIP concluída",
-                "sv": "SIP skapelse fullföljd"
-            },
-            "link_id": "01fd7a29-deb9-4dd1-8e28-1c48fc1ac41b"
-        },
         "6eb8ebe7-fab3-4e4c-b9d7-14de17625baa": {
             "description": {
                 "en": "Do not upload DIP",
@@ -726,26 +717,6 @@
             },
             "link_id": "d7e6404a-a186-4806-a130-7e6d27179a15"
         },
-        "d456dfde-1cdb-4178-babc-1a4537fe1b87": {
-            "description": {
-                "en": "Store DIP",
-                "es": "Almacenar DIP",
-                "fr": "Stocker le DIP",
-                "ja": "DIPを蓄える",
-                "pt_BR": "Armazenar DIP",
-                "sv": "Lagra DIP"
-            },
-            "link_id": "2e31580d-1678-474b-83e5-a53d97d150f6"
-        },
-        "d4ff46d4-5c57-408c-943b-fed63c1a9d75": {
-            "description": {
-                "en": "SIP Creation complete",
-                "fr": "Création du SIP complète",
-                "pt_BR": "Criação do SIP concluída",
-                "sv": "SIP skapelse fullföljd"
-            },
-            "link_id": "4430077a-92c5-4d86-b0f8-0d31bdb731fb"
-        },
         "d9760427-b488-4381-832a-de10106de6fe": {
             "description": {
                 "en": "Yes",
@@ -815,15 +786,6 @@
                 "sv": "Nej"
             },
             "link_id": "2584b25c-8d98-44b7-beca-2b3ea2ea2505"
-        },
-        "f1311d19-54c9-4484-9b3c-9bda40457559": {
-            "description": {
-                "en": "Add README file",
-                "ja": "READMEファイルを追加",
-                "pt_BR": "Adicionar arquivo README",
-                "sv": "Lägg till README-fil"
-            },
-            "link_id": "523c97cc-b267-4cfb-8209-d99e523bf4b3"
         },
         "f6df8882-d076-441e-bb00-2f58d5eda098": {
             "description": {
@@ -9530,34 +9492,6 @@
                 }
             },
             "fallback_job_status": "Completed successfully",
-            "fallback_link_id": null,
-            "group": {
-                "en": "Normalize",
-                "es": "Normalizar",
-                "fr": "Normaliser ",
-                "pt_BR": "Normalizar",
-                "sv": "Normalisera"
-            }
-        },
-        "b3c5e343-5940-4aad-8a9f-fb0eccbfb3a3": {
-            "config": {
-                "@manager": "linkTaskManagerChoice",
-                "@model": "MicroServiceChainChoice",
-                "chain_choices": [
-                    "c34bd22a-d077-4180-bf58-01db35bdb644",
-                    "fb7a326e-1e50-4b48-91b9-4917ff8d0ae8",
-                    "e600b56d-1a43-4031-9d7c-f64f123e5662"
-                ]
-            },
-            "description": {
-                "en": "Normalize",
-                "es": "Normalizar",
-                "fr": "Normaliser ",
-                "pt_BR": "Normalizar",
-                "sv": "Normalisera"
-            },
-            "exit_codes": {},
-            "fallback_job_status": "Failed",
             "fallback_link_id": null,
             "group": {
                 "en": "Normalize",

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -1267,36 +1267,6 @@
                 "sv": "Kontrollera överförings följsamhet"
             }
         },
-        "873b428f-2c86-42b6-b463-aeda925bf559": {
-            "config": {
-                "@manager": "linkTaskManagerDirectories",
-                "@model": "StandardTaskConfig",
-                "arguments": "\"%SIPUUID%\" \"%SIPDirectory%\"",
-                "execute": "declarepids_v0.0",
-                "filter_file_end": "",
-                "filter_file_start": null,
-                "filter_subdir": null,
-                "stderr_file": null,
-                "stdout_file": null
-            },
-            "description": {
-                "en": "Persistent identifier (PID) declaration"
-            },
-            "exit_codes": {
-                "0": {
-                    "job_status": "Completed successfully",
-                    "link_id": "05357876-a095-4c11-86b5-a7fff01af668"
-                }
-            },
-            "fallback_job_status": "Failed",
-            "fallback_link_id": "7d728c39-395f-4892-8193-92f086c0546f",
-            "group": {
-                "en": "Bind PIDs",
-                "fr": "Lier les PIDs",
-                "pt_BR": "Vincular PIDs",
-                "sv": "Lås PID:er."
-            }
-        },
         "05357876-a095-4c11-86b5-a7fff01af668": {
             "config": {
                 "@manager": "linkTaskManagerReplacementDicFromChoice",
@@ -7425,6 +7395,41 @@
                 "sv": "SIP misslyckades"
             }
         },
+        "7e6330c6-0280-4b25-8bf8-4b8143b69bde": {
+            "config": {
+                "@manager": "linkTaskManagerDirectories",
+                "@model": "StandardTaskConfig",
+                "arguments": "\"%clientAssetsDirectory%README/TRANSFER_README.html\" \"%SIPDirectory%README.html\"",
+                "execute": "copy_v0.0",
+                "filter_file_end": null,
+                "filter_file_start": null,
+                "filter_subdir": null,
+                "stderr_file": null,
+                "stdout_file": null
+            },
+            "description": {
+                "en": "Add README file",
+                "ja": "READMEファイルを追加",
+                "pt_BR": "Adicionar arquivo README",
+                "sv": "Lägg till README-fil"
+            },
+            "exit_codes": {
+                "0": {
+                    "job_status": "Completed successfully",
+                    "link_id": "e6e553cf-85f5-4e2f-abf4-d276acd66f5a"
+                }
+            },
+            "fallback_job_status": "Failed",
+            "fallback_link_id": "e6e553cf-85f5-4e2f-abf4-d276acd66f5a",
+            "group": {
+                "en": "Create SIP from Transfer",
+                "es": "Crear SIP a partir de la transferencia",
+                "fr": "Créer un SIP à partir du Transfert",
+                "ja": "転送からSIPを作成する",
+                "pt_BR": "Crie SIP a partir da transferência",
+                "sv": "Skapa SIP från överföringspaket"
+            }
+        },
         "7e65c627-c11d-4aad-beed-65ceb7053fe8": {
             "config": {
                 "@manager": "linkTaskManagerSetUnitVariable",
@@ -7600,6 +7605,36 @@
                 "ja": "AIPの再インジェスト",
                 "pt_BR": "Readmitir AIP",
                 "sv": "Återingestera AIP"
+            }
+        },
+        "873b428f-2c86-42b6-b463-aeda925bf559": {
+            "config": {
+                "@manager": "linkTaskManagerDirectories",
+                "@model": "StandardTaskConfig",
+                "arguments": "\"%SIPUUID%\" \"%SIPDirectory%\"",
+                "execute": "declarepids_v0.0",
+                "filter_file_end": "",
+                "filter_file_start": null,
+                "filter_subdir": null,
+                "stderr_file": null,
+                "stdout_file": null
+            },
+            "description": {
+                "en": "Persistent identifier (PID) declaration"
+            },
+            "exit_codes": {
+                "0": {
+                    "job_status": "Completed successfully",
+                    "link_id": "05357876-a095-4c11-86b5-a7fff01af668"
+                }
+            },
+            "fallback_job_status": "Failed",
+            "fallback_link_id": "7d728c39-395f-4892-8193-92f086c0546f",
+            "group": {
+                "en": "Bind PIDs",
+                "fr": "Lier les PIDs",
+                "pt_BR": "Vincular PIDs",
+                "sv": "Lås PID:er."
             }
         },
         "87e7659c-d5de-4541-a09c-6deec966a0c0": {
@@ -9002,41 +9037,6 @@
                 "ja": "SIP作成を承認",
                 "pt_BR": "Confirmar criação SIP",
                 "sv": "Godkänn skapande av SIP"
-            }
-        },
-        "7e6330c6-0280-4b25-8bf8-4b8143b69bde": {
-            "config": {
-                "@manager": "linkTaskManagerDirectories",
-                "@model": "StandardTaskConfig",
-                "arguments": "\"%clientAssetsDirectory%README/TRANSFER_README.html\" \"%SIPDirectory%README.html\"",
-                "execute": "copy_v0.0",
-                "filter_file_end": null,
-                "filter_file_start": null,
-                "filter_subdir": null,
-                "stderr_file": null,
-                "stdout_file": null
-            },
-            "description": {
-                "en": "Add README file",
-                "ja": "READMEファイルを追加",
-                "pt_BR": "Adicionar arquivo README",
-                "sv": "Lägg till README-fil"
-            },
-            "exit_codes": {
-                "0": {
-                    "job_status": "Completed successfully",
-                    "link_id": "e6e553cf-85f5-4e2f-abf4-d276acd66f5a"
-                }
-            },
-            "fallback_job_status": "Failed",
-            "fallback_link_id": "e6e553cf-85f5-4e2f-abf4-d276acd66f5a",
-            "group": {
-                "en": "Create SIP from Transfer",
-                "es": "Crear SIP a partir de la transferencia",
-                "fr": "Créer un SIP à partir du Transfert",
-                "ja": "転送からSIPを作成する",
-                "pt_BR": "Crie SIP a partir da transferência",
-                "sv": "Skapa SIP från överföringspaket"
             }
         },
         "abd6d60c-d50f-4660-a189-ac1b34fafe85": {

--- a/src/MCPServer/lib/processing_config.py
+++ b/src/MCPServer/lib/processing_config.py
@@ -116,11 +116,11 @@ processing_fields["eeb23509-57e2-4529-8857-9d62525db048"] = {
     "type": "chain_choice",
     "name": "reminder",
 }
-processing_fields["7079be6d-3a25-41e6-a481-cee5f352fe6e"] = {
+processing_fields["82ee9ad2-2c74-4c7c-853e-e4eaf68fc8b6"] = {
     "type": "boolean",
     "name": "transcribe_file",
-    "yes_option": "5a9985d3-ce7e-4710-85c1-f74696770fa9",
-    "no_option": "1170e555-cd4e-4b2f-a3d6-bfb09e8fcc53",
+    "yes_option": "35151db8-3a11-4b49-8865-f6697ef0ac75",
+    "no_option": "0a24787c-00e3-4710-b324-90e792bfb484",
 }
 processing_fields["087d27be-c719-47d8-9bbb-9a7d8b609c44"] = {
     "type": "replace_dict",

--- a/src/MCPServer/lib/processing_config.py
+++ b/src/MCPServer/lib/processing_config.py
@@ -100,11 +100,11 @@ processing_fields["8ce07e94-6130-4987-96f0-2399ad45c5c2"] = {
     "yes_option": "d9760427-b488-4381-832a-de10106de6fe",
     "no_option": "76befd52-14c3-44f9-838f-15a4e01624b0",
 }
-processing_fields["05357876-a095-4c11-86b5-a7fff01af668"] = {
+processing_fields["a2ba5278-459a-4638-92d9-38eb1588717d"] = {
     "type": "boolean",
     "name": "bind_pids",
-    "yes_option": "1e79e1b6-cf50-49ff-98a3-fa51d73553dc",
-    "no_option": "fcfea449-158c-452c-a8ad-4ae009c4eaba",
+    "yes_option": "8f9dceb5-b978-43e0-a364-8b317a3ac43b",
+    "no_option": "44a7c397-8187-4fd2-b8f7-c61737c4df49",
 }
 processing_fields["d0dfa5fc-e3c2-4638-9eda-f96eea1070e0"] = {
     "type": "boolean",

--- a/src/archivematicaCommon/lib/processing.py
+++ b/src/archivematicaCommon/lib/processing.py
@@ -23,8 +23,8 @@ DEFAULT_PROCESSING_CONFIG = u"""<processingMCP>
     </preconfiguredChoice>
     <!-- Bind PIDs -->
     <preconfiguredChoice>
-      <appliesTo>05357876-a095-4c11-86b5-a7fff01af668</appliesTo>
-      <goToChain>fcfea449-158c-452c-a8ad-4ae009c4eaba</goToChain>
+      <appliesTo>a2ba5278-459a-4638-92d9-38eb1588717d</appliesTo>
+      <goToChain>44a7c397-8187-4fd2-b8f7-c61737c4df49</goToChain>
     </preconfiguredChoice>
     <!-- Generate transfer structure report -->
     <preconfiguredChoice>
@@ -114,8 +114,8 @@ AUTOMATED_PROCESSING_CONFIG = """<processingMCP>
     </preconfiguredChoice>
     <!-- Bind PIDs -->
     <preconfiguredChoice>
-      <appliesTo>05357876-a095-4c11-86b5-a7fff01af668</appliesTo>
-      <goToChain>fcfea449-158c-452c-a8ad-4ae009c4eaba</goToChain>
+      <appliesTo>a2ba5278-459a-4638-92d9-38eb1588717d</appliesTo>
+      <goToChain>44a7c397-8187-4fd2-b8f7-c61737c4df49</goToChain>
     </preconfiguredChoice>
     <!-- Create SIP(s) -->
     <preconfiguredChoice>

--- a/src/archivematicaCommon/lib/processing.py
+++ b/src/archivematicaCommon/lib/processing.py
@@ -129,8 +129,8 @@ AUTOMATED_PROCESSING_CONFIG = """<processingMCP>
     </preconfiguredChoice>
     <!-- Transcribe files (OCR) -->
     <preconfiguredChoice>
-      <appliesTo>7079be6d-3a25-41e6-a481-cee5f352fe6e</appliesTo>
-      <goToChain>1170e555-cd4e-4b2f-a3d6-bfb09e8fcc53</goToChain>
+      <appliesTo>82ee9ad2-2c74-4c7c-853e-e4eaf68fc8b6</appliesTo>
+      <goToChain>0a24787c-00e3-4710-b324-90e792bfb484</goToChain>
     </preconfiguredChoice>
     <!-- Perform file format identification (Transfer) -->
     <preconfiguredChoice>

--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -300,7 +300,7 @@ class ProcessingConfigurationForm(forms.Form):
         "8ce07e94-6130-4987-96f0-2399ad45c5c2": _(
             "Perform policy checks on access derivatives"
         ),
-        "05357876-a095-4c11-86b5-a7fff01af668": _("Bind PIDs"),
+        "a2ba5278-459a-4638-92d9-38eb1588717d": _("Bind PIDs"),
         "d0dfa5fc-e3c2-4638-9eda-f96eea1070e0": _("Document empty directories"),
         "eeb23509-57e2-4529-8857-9d62525db048": _("Reminder: add metadata if desired"),
         "7079be6d-3a25-41e6-a481-cee5f352fe6e": _("Transcribe files (OCR)"),

--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -303,7 +303,7 @@ class ProcessingConfigurationForm(forms.Form):
         "a2ba5278-459a-4638-92d9-38eb1588717d": _("Bind PIDs"),
         "d0dfa5fc-e3c2-4638-9eda-f96eea1070e0": _("Document empty directories"),
         "eeb23509-57e2-4529-8857-9d62525db048": _("Reminder: add metadata if desired"),
-        "7079be6d-3a25-41e6-a481-cee5f352fe6e": _("Transcribe files (OCR)"),
+        "82ee9ad2-2c74-4c7c-853e-e4eaf68fc8b6": _("Transcribe files (OCR)"),
         "087d27be-c719-47d8-9bbb-9a7d8b609c44": _(
             "Perform file format identification (Submission documentation & metadata)"
         ),


### PR DESCRIPTION
This PR updates transcription and PID binding only. We should do the same in FileID but it's much harder because it uses passVar to pass the choice to all related links.

Connects to https://github.com/archivematica/Issues/issues/866.