### PR TITLE
Appraisal: fix bulk extractor results

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -900,7 +900,7 @@ def _get_file_formats(f):
 
 def _list_bulk_extractor_reports(transfer_path, file_uuid):
     reports = []
-    log_path = os.path.join(transfer_path, "logs", "bulk-" + file_uuid)
+    log_path = os.path.join(transfer_path, "data", "logs", "bulk-" + file_uuid)
 
     if not os.path.isdir(log_path):
         return reports

--- a/src/dashboard/src/components/file/views.py
+++ b/src/dashboard/src/components/file/views.py
@@ -157,7 +157,9 @@ def bulk_extractor(request, fileuuid):
     features = {}
 
     for report in reports:
-        relative_path = os.path.join("logs", "bulk-" + fileuuid, report + ".txt")
+        relative_path = os.path.join(
+            "data", "logs", "bulk-" + fileuuid, report + ".txt"
+        )
         url = storage_service.extract_file_url(f.transfer_id, relative_path)
         response = requests.get(
             url, timeout=django_settings.STORAGE_SERVICE_CLIENT_TIMEOUT


### PR DESCRIPTION
This fixes the paths of the bulk extractor reports by adding the
`data` directory created by bags.

Connected to https://github.com/archivematica/Issues/issues/824