### PR TITLE
MCPClient: capture std{out,err} after failure

### DIFF
--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -222,7 +222,10 @@ def execute_command(supported_modules, gearman_worker, gearman_job):
                         end_time = getUTCDate()
 
                         kwargs = {"exitcode": exit_code, "endtime": end_time}
-                        if django_settings.CAPTURE_CLIENT_SCRIPT_OUTPUT:
+                        if (
+                            django_settings.CAPTURE_CLIENT_SCRIPT_OUTPUT
+                            or kwargs["exitcode"] > 0
+                        ):
                             kwargs.update(
                                 {
                                     "stdout": job.get_stdout(),

--- a/src/MCPClient/lib/job.py
+++ b/src/MCPClient/lib/job.py
@@ -57,7 +57,7 @@ class Job:
 
     def set_status(self, int_code, status_code="success"):
         if int_code:
-            self.int_code = int_code
+            self.int_code = int(int_code)
         self.status_code = status_code
 
     def write_output(self, s):


### PR DESCRIPTION
This pull request ensures that the the standard error stream of a job is captured (persisted in the database) when the task errors, regardless the value in the output capturing setting.

Connects to https://github.com/archivematica/Issues/issues/873.