### PR TITLE
MCPClient: Python 3 fixes for microservices

### DIFF
--- a/src/MCPClient/lib/clientScripts/convert_dataverse_structure.py
+++ b/src/MCPClient/lib/clientScripts/convert_dataverse_structure.py
@@ -37,6 +37,7 @@ django.setup()
 
 from custom_handlers import get_script_logger
 import metsrw
+import six
 
 
 logger = get_script_logger("archivematica.mcp.client.convert_dataverse_struct")
@@ -71,7 +72,7 @@ def output_ddi_elems_info(job, ddi_elems):
     """
     draft = False
     job.pyprint("Fields retrieved from Dataverse:")
-    for ddi_k, ddi_v in ddi_elems.iteritems():
+    for ddi_k, ddi_v in six.iteritems(ddi_elems):
         if ddi_k == "Version Type" and ddi_v == "DRAFT":
             draft = True
         job.pyprint("{}: {}".format(ddi_k, ddi_v))
@@ -472,11 +473,13 @@ def write_mets_to_file(sip, unit_path, output_md_path, output_md_name):
     mets_f.append_file(sip)
     with open(mets_path, "w") as xml_file:
         xml_file.write(
-            etree.tostring(
-                mets_f.serialize(),
-                pretty_print=True,
-                encoding="utf-8",
-                xml_declaration=True,
+            six.ensure_str(
+                etree.tostring(
+                    mets_f.serialize(),
+                    pretty_print=True,
+                    encoding="utf-8",
+                    xml_declaration=True,
+                )
             )
         )
 

--- a/src/MCPClient/lib/clientScripts/extract_contents.py
+++ b/src/MCPClient/lib/clientScripts/extract_contents.py
@@ -20,7 +20,11 @@ from fileOperations import addFileToTransfer, updateSizeAndChecksum
 from archivematicaFunctions import get_dir_uuids, format_subdir_path
 
 # clientScripts
-from has_packages import already_extracted
+try:
+    from has_packages import already_extracted
+except ImportError:
+    from .has_packages import already_extracted
+
 
 logger = get_script_logger("archivematica.mcp.client.extractContents")
 

--- a/src/MCPClient/lib/clientScripts/policy_check.py
+++ b/src/MCPClient/lib/clientScripts/policy_check.py
@@ -27,7 +27,11 @@ from main.models import Derivation, File, SIP, Transfer
 from executeOrRunSubProcess import executeOrRun
 import databaseFunctions
 from dicts import replace_string_values
-from lib import setup_dicts
+
+try:
+    from lib import setup_dicts
+except ImportError:
+    from .lib import setup_dicts
 
 # Note that linkTaskManagerFiles.py will take the highest exit code it has seen
 # from all tasks and will use that as the exit code of the job as a whole.

--- a/src/MCPClient/lib/clientScripts/transcribe_file.py
+++ b/src/MCPClient/lib/clientScripts/transcribe_file.py
@@ -146,6 +146,7 @@ def main(job, task_uuid, file_uuid):
         script = rule.command.command
         if rule.command.script_type in ("bashScript", "command"):
             script, = rd.replace(script)
+            script = script.decode("utf8")
             args = []
         else:
             args = rd.to_gnu_options
@@ -158,7 +159,7 @@ def main(job, task_uuid, file_uuid):
         if exitstatus != 0:
             succeeded = False
 
-        output_path = rd.replace(rule.command.output_location)[0]
+        output_path = rd.replace(rule.command.output_location)[0].decode("utf8")
         relative_path = output_path.replace(rd["%SIPDirectory%"], "%SIPDirectory%")
         event = insert_transcription_event(exitstatus, file_uuid, rule, relative_path)
 


### PR DESCRIPTION
A couple of python 3 fixes for https://github.com/archivematica/Issues/issues/808 (was originally just going to include one, hence the name of the branch)

1. Decode the output of rd.replace so that the transcription command runs correctly. 

2. Fix imports for the policy_check module as done in other modules.

3. Get dataverse transfers working