### PR TITLE
Fix normalize jobs Python 3

### DIFF
--- a/src/MCPClient/lib/clientScripts/transcoder.py
+++ b/src/MCPClient/lib/clientScripts/transcoder.py
@@ -53,7 +53,7 @@ class Command(object):
         if self.output_location:
             self.output_location = self.replacement_dict.replace(self.output_location)[
                 0
-            ]
+            ].decode("utf8")
             self.replacement_dict["%outputLocation%"] = self.output_location
 
         # Add verification and event detail commands, if they exist
@@ -86,7 +86,7 @@ class Command(object):
         # the necessary values into the script's source
         args = []
         if self.type in ["command", "bashScript"]:
-            self.command = self.replacement_dict.replace(self.command)[0]
+            self.command = self.replacement_dict.replace(self.command)[0].decode("utf8")
         # For other command types, we translate the entries from
         # replacement_dict into GNU-style long options, e.g.
         # [%fileName%, foo] => --file-name=foo

--- a/src/dashboard/src/fpr/migrations/0031_python_3.py
+++ b/src/dashboard/src/fpr/migrations/0031_python_3.py
@@ -8,6 +8,7 @@ THUMBNAIL_TOOL_UUID = "efa8474a-8526-48c3-8279-e5a76bdc0995"
 OLD_THUMBNAIL_CMD_UUID = "7c2b65c7-6cea-4f81-9f3b-53375efc5bee"
 NEW_THUMBNAIL_CMD_UUID = "95149bc4-0620-4c20-964c-1d6c34b9400e"
 THUMBNAIL_RULES = (
+    "3a19f9a3-c5d5-4934-9286-13b3ad6c24d3",
 )
 NEW_THUMBNAIL_CMD = '''
 import argparse
@@ -38,7 +39,7 @@ o9i79TuKe9O4yaNSNxdXVxkcah1zX5LuhyBMhQpkD/e9Xv7goUODEWxpEj1Ktw8LUnOtnBqSk3Wv
 a+ook6pzWeKfNZH/2Q==\"\"\"
 
 def main(target):
-    with open(target.decode("utf8"), 'w+b') as f:
+    with open(target, 'w+b') as f:
         f.write(base64.b64decode(DEFAULT_THUMBNAIL))
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes the thumbnail command migration and the command failures in the normalize client script.

Connected to https://github.com/archivematica/Issues/issues/808