### PR TITLE
Don't move empty transfer dir to watched dir after creating SIP

### DIFF
--- a/src/MCPClient/lib/clientScripts/create_sip_from_transfer_objects.py
+++ b/src/MCPClient/lib/clientScripts/create_sip_from_transfer_objects.py
@@ -49,8 +49,9 @@ def call(jobs):
                 sharedPath = job.args[6]
                 sipName = transferName
 
-                tmpSIPDir = os.path.join(processingDirectory, sipName) + "/"
-                destSIPDir = os.path.join(autoProcessSIPDirectory, sipName) + "/"
+                # tmpSIPDir has a trailing slash, destSIPDir does not
+                tmpSIPDir = os.path.join(processingDirectory, sipName, "")
+                destSIPDir = os.path.join(autoProcessSIPDirectory, sipName)
                 archivematicaFunctions.create_structured_directory(
                     tmpSIPDir, manual_normalization=False
                 )
@@ -86,7 +87,7 @@ def call(jobs):
                 diruuids = len(dir_mdls) > 0
 
                 # Create row in SIPs table if one doesn't already exist
-                lookup_path = destSIPDir.replace(sharedPath, "%sharedPath%")
+                lookup_path = destSIPDir.replace(sharedPath, "%sharedPath%") + os.sep
                 try:
                     sip = SIP.objects.get(currentpath=lookup_path)
                     if diruuids:
@@ -202,4 +203,4 @@ def call(jobs):
                 shutil.copy(src, dst)
 
                 # moveSIPTo autoProcessSIPDirectory
-                shutil.move(tmpSIPDir, destSIPDir)
+                shutil.move(tmpSIPDir.rstrip(os.sep), destSIPDir)

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -4362,11 +4362,11 @@
             "exit_codes": {
                 "0": {
                     "job_status": "Completed successfully",
-                    "link_id": "3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5"
+                    "link_id": null
                 }
             },
             "fallback_job_status": "Failed",
-            "fallback_link_id": "3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5",
+            "fallback_link_id": null,
             "group": {
                 "en": "Create SIP from Transfer",
                 "es": "Crear SIP a partir de la transferencia",
@@ -4550,40 +4550,6 @@
                 "es": "Preparar AIP",
                 "fr": "Préparer l'AIP",
                 "sv": "Förbered AIP"
-            }
-        },
-        "3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5": {
-            "config": {
-                "@manager": "linkTaskManagerDirectories",
-                "@model": "StandardTaskConfig",
-                "arguments": "\"%SIPDirectory%\" \"%sharedPath%watchedDirectories/SIPCreation/completedTransfers/.\" \"%SIPUUID%\" \"%sharedPath%\"",
-                "execute": "moveTransfer_v0.0",
-                "filter_file_end": null,
-                "filter_file_start": null,
-                "filter_subdir": null,
-                "stderr_file": null,
-                "stdout_file": null
-            },
-            "description": {
-                "en": "Move to SIP creation directory for completed transfers",
-                "pt_BR": "Mover para o diretório de criação do SIP para transferências concluídas",
-                "sv": "Flytta till SIP skapande katalogen för färdigställda överföringar"
-            },
-            "exit_codes": {
-                "0": {
-                    "job_status": "Completed successfully",
-                    "link_id": null
-                }
-            },
-            "fallback_job_status": "Failed",
-            "fallback_link_id": null,
-            "group": {
-                "en": "Create SIP from Transfer",
-                "es": "Crear SIP a partir de la transferencia",
-                "fr": "Créer un SIP à partir du Transfert",
-                "ja": "転送からSIPを作成する",
-                "pt_BR": "Crie SIP a partir da transferência",
-                "sv": "Skapa SIP från överföringspaket"
             }
         },
         "3f543585-fa4f-4099-9153-dd6d53572f5c": {


### PR DESCRIPTION
Connects to https://github.com/archivematica/Issues/issues/782, https://github.com/archivematica/Issues/issues/770.

The "Create SIP from transfer objects" microservice is already doing the move, but leaves a directory containing only metadata. Because of the extra move to the watched dir, the
"Check transfer directory for objects" chain is triggered for completed transfers on restart.

I made this change as part of package queing work because the empty transfers were clogging up the queue. It seems like an improvement on the current state of affairs to me, but **It still leaves useless mostly empty directories in the currentlyProcessing folder**. Simply trying to remove the remains at the end of the "Create SIP from transfer objects" microservice fails, and I'm not sure yet why that's the case.
