### PR TITLE
Support LDAP authenticaion config via env

### DIFF
--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -10,6 +10,7 @@
   - [Parameter list](#parameter-list)
     - [Application variables](#application-variables)
     - [Gunicorn variables](#gunicorn-variables)
+    - [LDAP variables](#ldap-variables)
   - [Logging configuration](#logging-configuration)
 
 ## Introduction
@@ -390,7 +391,7 @@ variables or in the gunicorn configuration file.
     - **Type:** `string`
     - **Default:** `archivematica-dashboard`
 
-### LDAP-specific environment variables
+### LDAP variables
 
     These variables specify the behaviour of LDAP authentication. Only applicable if `ARCHIVEMATICA_DASHBOARD_DASHBOARD_LDAP_AUTHENTICATION` is set.
 

--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -390,6 +390,139 @@ variables or in the gunicorn configuration file.
     - **Type:** `string`
     - **Default:** `archivematica-dashboard`
 
+### LDAP-specific environment variables
+
+    These variables specify the behaviour of LDAP authentication. Only applicable if `ARCHIVEMATICA_DASHBOARD_DASHBOARD_LDAP_AUTHENTICATION` is set.
+
+- **`AUTH_LDAP_USERNAME_SUFFIX`**:
+    - **Description:** A suffix that is _stripped_ from LDAP usernames when
+      generating Dashboard usernames (e.g., if set to `_ldap`, LDAP user
+      `demo_ldap` will be saved as `demo`).
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_SERVER_URI`**:
+    - **Description:** Address of the LDAP server to authenticate against.
+    - **Type:** `string`
+    - **Default:** `ldap://localhost`
+
+- **`AUTH_LDAP_BIND_DN`**:
+    - **Description:** LDAP "bind DN"; the object to authenticate against the LDAP server with, in order
+    to lookup users, e.g. "cn=admin,dc=example,dc=com".  Empty string for anonymous.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_BIND_PASSWORD`**:
+    - **Description:** Password for the LDAP bind DN.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_USER_SEARCH_BASE_DN`**:
+    - **Description:** Base LDAP DN for user search, e.g. "ou=users,dc=example,dc=com".
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_USER_SEARCH_BASE_FILTERSTR`**:
+    - **Description:** Filter for identifying LDAP user objects, e.g. "(uid=%(user)s)". The `%(user)s`
+    portion of the string will be replaced by the username. This variable is only used if
+    `AUTH_LDAP_USER_SEARCH_BASE_DN` is not empty.
+    - **Type:** `string`
+    - **Default:** `(uid=%(user)s)`
+
+- **`AUTH_LDAP_USER_DN_TEMPLATE`**:
+    - **Description:** Template for LDAP user search, e.g. "uid=%(user)s,ou=users,dc=example,dc=com".
+    Not applicable if `AUTH_LDAP_USER_SEARCH_BASE_DN` is set.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_GROUP_IS_ACTIVE`**:
+    - **Description:** Template for LDAP group used to set the Django user `is_active` flag, e.g.
+    "cn=active,ou=django,ou=groups,dc=example,dc=com".
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_GROUP_IS_STAFF`**:
+    - **Description:** Template for LDAP group used to set the Django user `is_staff` flag, e.g.
+    "cn=staff,ou=django,ou=groups,dc=example,dc=com".
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_GROUP_IS_SUPERUSER`**:
+    - **Description:** Template for LDAP group used to set the Django user `is_superuser` flag, e.g.
+    "cn=admins,ou=django,ou=groups,dc=example,dc=com".
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_GROUP_SEARCH_BASE_DN`**:
+    - **Description:** Base LDAP DN for group search, e.g. "ou=django,ou=groups,dc=example,dc=com".
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_GROUP_SEARCH_BASE_FILTERSTR`**:
+    - **Description:** Filter for identifying LDAP group objects, e.g. "(objectClass=groupOfNames)".
+    This variable is only used if `AUTH_LDAP_GROUP_SEARCH_BASE_DN` is not empty.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_REQUIRE_GROUP`**:
+    - **Description:** Filter for a group that LDAP users must belong to in order to authenticate, e.g.
+    "cn=enabled,ou=django,ou=groups,dc=example,dc=com"
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_DENY_GROUP`**:
+    - **Description:** Filter for a group that LDAP users must _not_ belong to in order to authenticate,
+    e.g. "cn=disabled,ou=django,ou=groups,dc=example,dc=com"
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_FIND_GROUP_PERMS`**:
+    - **Description:** If we should use LDAP group membership to calculate group permissions.
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`AUTH_LDAP_CACHE_GROUPS`**:
+    - **Description:** If we should cache groups to minimize LDAP traffic.
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`AUTH_LDAP_GROUP_CACHE_TIMEOUT`**:
+    - **Description:** How long we should cache LDAP groups for (in seconds). Only applies if
+    `AUTH_LDAP_CACHE_GROUPS` is true.
+    - **Type:** `integer`
+    - **Default:** `3600`
+
+- **`AUTH_LDAP_START_TLS`**:
+    - **Description:** Determines if we update to a secure LDAP connection using StartTLS after connecting.
+    - **Type:** `boolean`
+    - **Default:** `true`
+
+- **`AUTH_LDAP_PROTOCOL_VERSION`**:
+    - **Description:** If set, forces LDAP protocol version 3.
+    - **Type:** `integer`
+    - **Default:** ``
+
+- **`AUTH_LDAP_TLS_CACERTFILE`**:
+    - **Description:** Path to a custom LDAP certificate authority file.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_TLS_CERTFILE`**:
+    - **Description:** Path to a custom LDAP certificate file.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_TLS_KEYFILE`**:
+    - **Description:** Path to a custom LDAP key file (matching the cert given in `AUTH_LDAP_TLS_CERTFILE`).
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AUTH_LDAP_TLS_REQUIRE_CERT`**:
+    - **Description:** How strict to be regarding TLS cerfiticate verification. Allowed values are "never",
+    "allow", "try", "demand", or "hard". Corresponds to the TLSVerifyClient OpenLDAP setting.
+    - **Type:** `string`
+    - **Default:** ``
+
 ## Logging configuration
 
 Archivematica 1.6.1 and earlier releases are configured by default to log to

--- a/src/dashboard/src/components/accounts/__init__.py
+++ b/src/dashboard/src/components/accounts/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "components.accounts.apps.AccountsConfig"

--- a/src/dashboard/src/components/accounts/apps.py
+++ b/src/dashboard/src/components/accounts/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+
+
+class AccountsConfig(AppConfig):
+    name = "components.accounts"
+    verbose_name = "Dashboard Accounts"
+
+    def ready(self):
+        try:
+            import components.accounts.signals  # noqa
+        except ImportError:
+            pass

--- a/src/dashboard/src/components/accounts/backends.py
+++ b/src/dashboard/src/components/accounts/backends.py
@@ -1,9 +1,6 @@
-import re
-
 from django.conf import settings
-from django.dispatch import receiver
 
-from django_auth_ldap.backend import LDAPBackend, populate_user
+from django_auth_ldap.backend import LDAPBackend
 from shibboleth.backends import ShibbolethRemoteUserBackend
 
 from components.helpers import generate_api_key
@@ -16,23 +13,10 @@ class CustomShibbolethRemoteUserBackend(ShibbolethRemoteUserBackend):
 
 
 class CustomLDAPBackend(LDAPBackend):
-    """Customize LDAP config."""
-
-    def __init__(self):
-        super(CustomLDAPBackend, self).__init__()
-        self._username_suffix = settings.AUTH_LDAP_USERNAME_SUFFIX
+    """Append a usernamed suffix to LDAP users, if configured"""
 
     def ldap_to_django_username(self, username):
-        # Replaces user creation in get_ldap_users
-        return re.sub(self._username_suffix + "$", "", username)
+        return username.rstrip(settings.AUTH_LDAP_USERNAME_SUFFIX)
 
     def django_to_ldap_username(self, username):
-        # Replaces user creation in get_ldap_users
-        return username + self._username_suffix
-
-
-@receiver(populate_user)
-def ldap_populate_user(sender, user, ldap_user, **kwargs):
-    if user.pk is None:
-        user.save()
-        generate_api_key(user)
+        return username + settings.AUTH_LDAP_USERNAME_SUFFIX

--- a/src/dashboard/src/components/accounts/signals.py
+++ b/src/dashboard/src/components/accounts/signals.py
@@ -10,5 +10,7 @@ def ldap_populate_user(sender, user, ldap_user, **kwargs):
         generate_api_key(user)
 
 
-if settings.LDAP_AUTHENTICATION:
+# This code is imported from MCPClient, which has no
+# LDAP_AUTHENTICATION setting :(
+if getattr(settings, "LDAP_AUTHENTICATION", False):
     populate_user.connect(ldap_populate_user)

--- a/src/dashboard/src/components/accounts/signals.py
+++ b/src/dashboard/src/components/accounts/signals.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+from django_auth_ldap.backend import populate_user
+
+from components.helpers import generate_api_key
+
+
+def ldap_populate_user(sender, user, ldap_user, **kwargs):
+    if user.pk is None:
+        user.save()
+        generate_api_key(user)
+
+
+if settings.LDAP_AUTHENTICATION:
+    populate_user.connect(ldap_populate_user)

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -510,8 +510,8 @@ if SHIBBOLETH_AUTHENTICATION:
 LDAP_AUTHENTICATION = config.get("ldap_authentication")
 if LDAP_AUTHENTICATION:
     ALLOW_USER_EDITS = False
+    AUTHENTICATION_BACKENDS.insert(0, "components.accounts.backends.CustomLDAPBackend")
 
-    AUTHENTICATION_BACKENDS += ["components.accounts.backends.CustomLDAPBackend"]
     from .components.ldap_auth import *  # noqa
 
 PROMETHEUS_ENABLED = config.get("prometheus_enabled")

--- a/src/dashboard/src/settings/components/ldap_auth.py
+++ b/src/dashboard/src/settings/components/ldap_auth.py
@@ -1,69 +1,118 @@
-import os
+from os import environ
 
-import ldap
-from django_auth_ldap.config import LDAPSearch, ActiveDirectoryGroupType
+from django.core.exceptions import ImproperlyConfigured
 
-
-# LDAP config
-# See: https://pythonhosted.org/django-auth-ldap/index.html
-
-# Environment variables this is configured to read:
-# From django_auth_ldap:
-# * AUTH_LDAP_SERVER_URI
-# * AUTH_LDAP_BIND_DN
-# * AUTH_LDAP_BIND_PASSWORD
-# * AUTH_LDAP_USER_SEARCH
-# * AUTH_LDAP_USER_DN_TEMPLATE
-# * AUTH_LDAP_GROUP_SEARCH_BASE_DN
-# * AUTH_LDAP_GROUP_SEARCH_FILTERSTR
-# * AUTH_LDAP_REQUIRE_GROUP
-# Custom:
-# * AUTH_LDAP_USERNAME_SUFFIX:
-#    Remove this suffix from LDAP username to make Django username
-# * AUTH_LDAP_GROUP_IS_ACTIVE
-#    Set Django's is_active based on membership in this group
-# * AUTH_LDAP_GROUP_IS_STAFF
-#    Set Django's is_staff based on membership in this group
-
-# Server Config
-AUTH_LDAP_SERVER_URI = os.environ.get("AUTH_LDAP_SERVER_URI", "")
-AUTH_LDAP_BIND_DN = os.environ.get("AUTH_LDAP_BIND_DN", "")
-AUTH_LDAP_BIND_PASSWORD = os.environ.get("AUTH_LDAP_BIND_PASSWORD", "")
+try:
+    import ldap
+    from django_auth_ldap import config as ldap_config
+except ImportError:
+    raise ImproperlyConfigured(
+        "python-ldap and django-auth-ldap must be installed to use LDAP authentication."
+    )
 
 
-# User search/bind
-# Use one of AUTH_LDAP_USER_SEARCH or AUTH_LDAP_USER_DN_TEMPLATE
-AUTH_LDAP_USER_SEARCH = os.environ.get("AUTH_LDAP_USER_SEARCH", None)
-AUTH_LDAP_USER_DN_TEMPLATE = os.environ.get("AUTH_LDAP_USER_DN_TEMPLATE", None)
+# All LDAP usernames have this suffix - it is removed when creating Django users
+AUTH_LDAP_USERNAME_SUFFIX = environ.get("AUTH_LDAP_USERNAME_SUFFIX", "")
+
+AUTH_LDAP_SERVER_URI = environ.get("AUTH_LDAP_SERVER_URI", "ldap://localhost")
+AUTH_LDAP_BIND_DN = environ.get("AUTH_LDAP_BIND_DN", "")
+AUTH_LDAP_BIND_PASSWORD = environ.get("AUTH_LDAP_BIND_PASSWORD", "")
+
+if "AUTH_LDAP_USER_SEARCH_BASE_DN" in environ:
+    AUTH_LDAP_USER_SEARCH = ldap_config.LDAPSearch(
+        environ.get("AUTH_LDAP_USER_SEARCH_BASE_DN"),
+        ldap.SCOPE_SUBTREE,
+        environ.get("AUTH_LDAP_USER_SEARCH_BASE_FILTERSTR", "(uid=%(user)s)"),
+    )
+AUTH_LDAP_USER_DN_TEMPLATE = environ.get("AUTH_LDAP_USER_DN_TEMPLATE", None)
 AUTH_LDAP_USER_ATTR_MAP = {
     "first_name": "givenName",
     "last_name": "sn",
     "email": "mail",
 }
-AUTH_LDAP_USER_FLAGS_BY_GROUP = {
-    "is_active": os.environ.get("AUTH_LDAP_GROUP_IS_ACTIVE", ""),
-    "is_staff": os.environ.get("AUTH_LDAP_GROUP_IS_STAFF", ""),
-}
-AUTH_LDAP_START_TLS = True  # Recommended
 
+AUTH_LDAP_USER_FLAGS_BY_GROUP = {}
+if "AUTH_LDAP_GROUP_IS_ACTIVE" in environ:
+    AUTH_LDAP_USER_FLAGS_BY_GROUP["is_active"] = environ.get(
+        "AUTH_LDAP_GROUP_IS_ACTIVE"
+    )
+if "AUTH_LDAP_GROUP_IS_STAFF" in environ:
+    AUTH_LDAP_USER_FLAGS_BY_GROUP["is_staff"] = environ.get("AUTH_LDAP_GROUP_IS_STAFF")
+if "AUTH_LDAP_GROUP_IS_SUPERUSER" in environ:
+    AUTH_LDAP_USER_FLAGS_BY_GROUP["is_superuser"] = environ.get(
+        "AUTH_LDAP_GROUP_IS_SUPERUSER"
+    )
 
-# Group config
-AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
-    base_dn=os.environ.get("AUTH_LDAP_GROUP_SEARCH_BASE_DN", ""),
-    scope=ldap.SCOPE_SUBTREE,
-    filterstr=os.environ.get("AUTH_LDAP_GROUP_SEARCH_FILTERSTR", ""),
-)
-# For choices see:
+if "AUTH_LDAP_GROUP_SEARCH_BASE_DN" in environ:
+    AUTH_LDAP_GROUP_SEARCH = ldap_config.LDAPSearch(
+        base_dn=environ.get("AUTH_LDAP_GROUP_SEARCH_BASE_DN", ""),
+        scope=ldap.SCOPE_SUBTREE,
+        filterstr=environ.get("AUTH_LDAP_GROUP_SEARCH_FILTERSTR", ""),
+    )
+
 # https://pythonhosted.org/django-auth-ldap/groups.html#types-of-groups
-AUTH_LDAP_GROUP_TYPE = ActiveDirectoryGroupType()
+AUTH_LDAP_GROUP_TYPE = ldap_config.ActiveDirectoryGroupType()
 
-AUTH_LDAP_REQUIRE_GROUP = os.environ.get("AUTH_LDAP_REQUIRE_GROUP", None)
+AUTH_LDAP_REQUIRE_GROUP = environ.get("AUTH_LDAP_REQUIRE_GROUP", None)
+AUTH_LDAP_DENY_GROUP = environ.get("AUTH_LDAP_DENY_GROUP", None)
 
-# Options
-AUTH_LDAP_GLOBAL_OPTIONS = {
-    ldap.OPT_X_TLS_REQUIRE_CERT: False,
-    ldap.OPT_REFERRALS: False,
-}
+AUTH_LDAP_FIND_GROUP_PERMS = environ.get(
+    "AUTH_LDAP_FIND_GROUP_PERMS", "FALSE"
+).upper() in ("TRUE", "YES", "ON", "1")
+AUTH_LDAP_CACHE_GROUPS = environ.get("AUTH_LDAP_CACHE_GROUPS", "FALSE").upper() in (
+    "TRUE",
+    "YES",
+    "ON",
+    "1",
+)
+try:
+    AUTH_LDAP_GROUP_CACHE_TIMEOUT = int(
+        environ.get("AUTH_LDAP_GROUP_CACHE_TIMEOUT", "3600")
+    )
+except ValueError:
+    AUTH_LDAP_GROUP_CACHE_TIMEOUT = 3600
 
-# All LDAP usernames have this suffix - it is removed when creating Django users
-AUTH_LDAP_USERNAME_SUFFIX = os.environ.get("AUTH_LDAP_USERNAME_SUFFIX", "")
+AUTH_LDAP_START_TLS = environ.get("AUTH_LDAP_START_TLS", "TRUE").upper() in (
+    "TRUE",
+    "YES",
+    "ON",
+    "1",
+)
+
+AUTH_LDAP_GLOBAL_OPTIONS = {}
+if environ.get("AUTH_LDAP_PROTOCOL_VERSION", None) == "3":
+    AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_PROTOCOL_VERSION] = ldap.VERSION3
+if environ.get("AUTH_LDAP_TLS_CACERTFILE", None):
+    AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_CACERTFILE] = environ.get(
+        "AUTH_LDAP_TLS_CACERTFILE"
+    )
+if environ.get("AUTH_LDAP_TLS_CERTFILE", None):
+    AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_CERTFILE] = environ.get(
+        "AUTH_LDAP_TLS_CERTFILE"
+    )
+if environ.get("AUTH_LDAP_TLS_KEYFILE", None):
+    AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_KEYFILE] = environ.get(
+        "AUTH_LDAP_TLS_KEYFILE"
+    )
+if environ.get("AUTH_LDAP_TLS_REQUIRE_CERT", None):
+    require_cert = environ.get("AUTH_LDAP_TLS_REQUIRE_CERT").lower()
+    if require_cert == "never":
+        AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_NEVER
+    elif require_cert == "allow":
+        AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_ALLOW
+    elif require_cert == "try":
+        AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_TRY
+    elif require_cert == "demand":
+        AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_DEMAND
+    elif require_cert == "hard":
+        AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_HARD
+    else:
+        raise ImproperlyConfigured(
+            (
+                "Unexpected value for AUTH_LDAP_TLS_REQUIRE_CERT: {}. "
+                "Supported values: 'never', 'allow', try', 'hard', or 'demand'."
+            ).format(require_cert)
+        )
+
+# Non-configurable sane defaults
+AUTH_LDAP_ALWAYS_UPDATE_USER = True


### PR DESCRIPTION
Connects to: https://github.com/archivematica/Issues/issues/841, https://github.com/archivematica/Issues/issues/798

Tested with the following env vars:
```
      AUTH_LDAP_SERVER_URI="ldap://openldap"
      AUTH_LDAP_BIND_DN="cn=admin,dc=artefactual,dc=org"
      AUTH_LDAP_BIND_PASSWORD="admin"
      AUTH_LDAP_USER_SEARCH_BASE_DN="dc=artefactual,dc=org"
      AUTH_LDAP_USER_SEARCH_BASE_FILTERSTR="(cn=%(user)s)"
      AUTH_LDAP_START_TLS="false"
```

Using a docker container with this configuration:

```
  openldap:
    image: osixia/openldap:1.3.0
    environment:
      LDAP_LOG_LEVEL: "256"
      LDAP_ORGANISATION: "Artefacutal"
      LDAP_DOMAIN: "artefactual.org"
      LDAP_ADMIN_PASSWORD: "admin"
      LDAP_CONFIG_PASSWORD: "config"
      LDAP_READONLY_USER: "true"
      LDAP_READONLY_USER_USERNAME: "ldapuser"
      LDAP_READONLY_USER_PASSWORD: "password"
      LDAP_TLS: "false"
      LDAP_TLS_ENFORCE: "false"
      LDAP_REPLICATION: "false"
    ports:
      - "389:389"
      - "636:636"
```