### PR TITLE
Increase default dashboard workers

### DIFF
--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -342,9 +342,11 @@ variables or in the gunicorn configuration file.
     - **Default:** `127.0.0.1:8002`
 
 - **`AM_GUNICORN_WORKERS`**:
-    - **Description:** Number of gunicorn worker processes to run.  See [WORKERS](http://docs.gunicorn.org/en/stable/settings.html#workers)
+    - **Description:** Number of gunicorn worker processes to run.  Note that since Archivematica
+    installations typically run many processes on the same system, a lower number of workers than
+    Gunicorn recommends should be used. See [WORKERS](http://docs.gunicorn.org/en/stable/settings.html#workers) and [How Many Workers?](https://docs.gunicorn.org/en/stable/design.html#how-many-workers) for more details. 
     - **Type:** `integer`
-    - **Default:** `1`
+    - **Default:** `3`
 
 - **`AM_GUNICORN_WORKER_CLASS`**:
     - **Description:** The type of worker processes to run.  See [WORKER-CLASS](http://docs.gunicorn.org/en/stable/settings.html#worker-class)

--- a/src/dashboard/install/dashboard.gunicorn-config.py
+++ b/src/dashboard/install/dashboard.gunicorn-config.py
@@ -16,7 +16,7 @@ group = os.environ.get("AM_GUNICORN_GROUP", "archivematica")
 bind = os.environ.get("AM_GUNICORN_BIND", "127.0.0.1:8002")
 
 # http://docs.gunicorn.org/en/stable/settings.html#workers
-workers = os.environ.get("AM_GUNICORN_WORKERS", "1")
+workers = os.environ.get("AM_GUNICORN_WORKERS", "3")
 
 # http://docs.gunicorn.org/en/stable/settings.html#worker-class
 worker_class = os.environ.get("AM_GUNICORN_WORKER_CLASS", "gevent")


### PR DESCRIPTION
Connects to: https://github.com/archivematica/Issues/issues/944

It's hard to determine an ideal number of workers given the number of other processes on the system. It seems clear though that 2-4 is a good minimum, even if we're using gevent, so start at 3. Systems with many available cores may wish to scale this up.