### PR TITLE
Use scandir.walk instead of os.walk

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py
@@ -4,6 +4,7 @@ from lxml import etree
 import os
 
 import metsrw
+import scandir
 
 import create_mets_v2 as createmets2
 import archivematicaCreateMETSRights as createmetsrights
@@ -427,7 +428,7 @@ def add_new_files(job, mets, sip_uuid, sip_dir):
     old_mets_rel_path = _get_old_mets_rel_path(sip_uuid)
     metadata_csv = None
     objects_dir = os.path.join(sip_dir, "objects")
-    for dirpath, _, filenames in os.walk(objects_dir):
+    for dirpath, _, filenames in scandir.walk(objects_dir):
         for filename in filenames:
             # Find in METS
             current_loc = os.path.join(dirpath, filename).replace(

--- a/src/MCPClient/lib/clientScripts/assign_uuids_to_directories.py
+++ b/src/MCPClient/lib/clientScripts/assign_uuids_to_directories.py
@@ -35,6 +35,7 @@ from functools import wraps
 import os
 
 import django
+import scandir
 
 django.setup()
 # dashboard
@@ -110,7 +111,7 @@ def _get_subdir_paths(root_path):
     exclude_paths = (root_path, os.path.join(root_path, "objects"))
     return (
         format_subdir_path(dir_path, root_path)
-        for dir_path, __, ___ in os.walk(root_path)
+        for dir_path, __, ___ in scandir.walk(root_path)
         if dir_path not in exclude_paths
     )
 

--- a/src/MCPClient/lib/clientScripts/bag_with_empty_directories.py
+++ b/src/MCPClient/lib/clientScripts/bag_with_empty_directories.py
@@ -26,6 +26,7 @@ import os
 import shutil
 
 import django
+import scandir
 
 django.setup()
 from django.conf import settings as mcpclient_settings
@@ -39,7 +40,7 @@ from bagit import make_bag
 def get_sip_directories(job, sip_dir):
     """ Get a list of directories in the SIP, to be created after bagged. """
     directory_list = []
-    for directory, subdirs, _ in os.walk(sip_dir):
+    for directory, subdirs, _ in scandir.walk(sip_dir):
         for subdir in subdirs:
             path = os.path.join(directory, subdir).replace(sip_dir + "/", "", 1)
             directory_list.append(path)

--- a/src/MCPClient/lib/clientScripts/check_for_access_directory.py
+++ b/src/MCPClient/lib/clientScripts/check_for_access_directory.py
@@ -26,6 +26,7 @@ import sys
 from optparse import OptionParser
 
 import django
+import scandir
 from django.db import transaction
 
 django.setup()
@@ -52,7 +53,7 @@ def something(
     exitCode = 179
     job.pyprint(SIPDirectory)
     # For every file, & directory Try to find the matching file & directory in the objects directory
-    for (path, dirs, files) in os.walk(accessDirectory):
+    for (path, dirs, files) in scandir.walk(accessDirectory):
         for file in files:
             accessPath = os.path.join(path, file)
             objectPath = accessPath.replace(accessDirectory, objectsDirectory, 1)

--- a/src/MCPClient/lib/clientScripts/check_for_service_directory.py
+++ b/src/MCPClient/lib/clientScripts/check_for_service_directory.py
@@ -26,6 +26,7 @@ from optparse import OptionParser
 import re
 
 import django
+import scandir
 from django.db import transaction
 
 django.setup()
@@ -38,7 +39,7 @@ def something(job, SIPDirectory, serviceDirectory, objectsDirectory, SIPUUID, da
     exitCode = 0
     job.pyprint(SIPDirectory)
     # For every file, & directory Try to find the matching file & directory in the objects directory
-    for (path, dirs, files) in os.walk(serviceDirectory):
+    for (path, dirs, files) in scandir.walk(serviceDirectory):
         for file in files:
             servicePreExtension = "_me"
             originalPreExtension = "_m"
@@ -83,7 +84,7 @@ def regular(SIPDirectory, objectsDirectory, SIPUUID, date):
     if not searchForRegularExpressions:
         return
 
-    for (path, dirs, files) in os.walk(objectsDirectory):
+    for (path, dirs, files) in scandir.walk(objectsDirectory):
         for file in files:
             m = re.search("_me\.[a-zA-Z0-9]{2,4}$", file)
             if m is not None:

--- a/src/MCPClient/lib/clientScripts/check_transfer_directory_for_objects.py
+++ b/src/MCPClient/lib/clientScripts/check_transfer_directory_for_objects.py
@@ -22,6 +22,9 @@
 # @author Joseph Perry <joseph@artefactual.com>
 import os
 
+import scandir
+
+
 exitInidcatingThereAreObjects = 179
 
 
@@ -31,7 +34,7 @@ def call(jobs):
             objectsDir = job.args[1]
             os.path.isdir(objectsDir)
             ret = 0
-            for dirs, subDirs, files in os.walk(objectsDir):
+            for dirs, subDirs, files in scandir.walk(objectsDir):
                 if files is not None and files != []:
                     ret = exitInidcatingThereAreObjects
                     break

--- a/src/MCPClient/lib/clientScripts/create_mets_v2.py
+++ b/src/MCPClient/lib/clientScripts/create_mets_v2.py
@@ -35,6 +35,7 @@ import traceback
 from uuid import uuid4
 
 import django
+import scandir
 
 django.setup()
 # dashboard
@@ -1370,7 +1371,7 @@ def find_source_metadata(path):
     """
     transfer = []
     source = []
-    for dirpath, subdirs, filenames in os.walk(path):
+    for dirpath, subdirs, filenames in scandir.walk(path):
         if "transfer_metadata.xml" in filenames:
             transfer.append(os.path.join(dirpath, "transfer_metadata.xml"))
 
@@ -1513,7 +1514,7 @@ def get_paths_as_fsitems(baseDirectoryPath, objectsDirectoryPath):
     :returns: list of ``FSItem`` instances representing paths
     """
     all_fsitems = []
-    for root, dirs, files in os.walk(objectsDirectoryPath):
+    for root, dirs, files in scandir.walk(objectsDirectoryPath):
         root = root.replace(baseDirectoryPath, "", 1)
         if files or dirs:
             all_fsitems.append(FSItem("dir", root, is_empty=False))
@@ -1722,7 +1723,7 @@ def call(jobs):
                     normativeStructMap = None
 
                 # Delete empty directories, see #8427
-                for root, _, _ in os.walk(baseDirectoryPath, topdown=False):
+                for root, _, _ in scandir.walk(baseDirectoryPath, topdown=False):
                     try:
                         os.rmdir(root)
                         job.pyprint("Deleted empty directory", root)

--- a/src/MCPClient/lib/clientScripts/extract_contents.py
+++ b/src/MCPClient/lib/clientScripts/extract_contents.py
@@ -5,6 +5,7 @@ import sys
 import uuid
 
 import django
+import scandir
 from django.db import transaction
 
 django.setup()
@@ -37,7 +38,7 @@ def temporary_directory(file_path, date, file_path_cache):
 
 
 def tree(root):
-    for dirpath, __, files in os.walk(root):
+    for dirpath, __, files in scandir.walk(root):
         for file in files:
             yield os.path.join(dirpath, file)
 
@@ -98,7 +99,7 @@ def _get_subdir_paths(job, root_path, path_prefix_to_repl, original_location):
 
     # Return a generator here that contains information about the current path
     # and the original path for the PREMIS information in the METS file.
-    for dir_path, __, ___ in os.walk(root_path):
+    for dir_path, __, ___ in scandir.walk(root_path):
         formatted_path = format_subdir_path(dir_path, path_prefix_to_repl)
         for dir_uuid in get_dir_uuids([formatted_path], logger, printfn=job.pyprint):
             dir_uuid["originalLocation"] = formatted_path.replace(

--- a/src/MCPClient/lib/clientScripts/manual_normalization_remove_mn_directories.py
+++ b/src/MCPClient/lib/clientScripts/manual_normalization_remove_mn_directories.py
@@ -25,6 +25,7 @@ import os
 import sys
 
 import django
+import scandir
 
 django.setup()
 from django.db import transaction
@@ -38,7 +39,7 @@ import databaseFunctions
 
 def recursivelyRemoveEmptyDirectories(job, dir):
     error_count = 0
-    for root, dirs, files in os.walk(dir, topdown=False):
+    for root, dirs, files in scandir.walk(dir, topdown=False):
         for directory in dirs:
             try:
                 os.rmdir(os.path.join(root, directory))

--- a/src/MCPClient/lib/clientScripts/move_to_backlog.py
+++ b/src/MCPClient/lib/clientScripts/move_to_backlog.py
@@ -16,6 +16,7 @@ import shutil
 import uuid
 
 import django
+import scandir
 
 django.setup()
 from django.conf import settings as mcpclient_settings
@@ -191,7 +192,7 @@ def main(job, transfer_id, transfer_path, created_at):
 
     logger.info("Calculating size...")
     size = 0
-    for dirpath, _, filenames in os.walk(transfer_path):
+    for dirpath, _, filenames in scandir.walk(transfer_path):
         for filename in filenames:
             file_path = os.path.join(dirpath, filename)
             size += os.path.getsize(file_path)

--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from . import transcoder
 
 import django
+import scandir
 
 django.setup()
 # dashboard
@@ -208,7 +209,7 @@ def once_normalized(job, command, opts, replacement_dict):
     if os.path.isfile(command.output_location):
         transcoded_files.append(command.output_location)
     elif os.path.isdir(command.output_location):
-        for w in os.walk(command.output_location):
+        for w in scandir.walk(command.output_location):
             path, _, files = w
             for p in files:
                 p = os.path.join(path, p)

--- a/src/MCPClient/lib/clientScripts/restructure_for_compliance_sip.py
+++ b/src/MCPClient/lib/clientScripts/restructure_for_compliance_sip.py
@@ -6,6 +6,7 @@ import shutil
 
 # fileOperations requires Django to be set up
 import django
+import scandir
 
 django.setup()
 from django.db import transaction
@@ -53,7 +54,7 @@ def restructureForComplianceFileUUIDsAssigned(
                 os.mkdir(entry_objects_path)
             # Walk and move to objects dir, preserving directory structure
             # and updating the DB
-            for dirpath, dirnames, filenames in os.walk(entry_path):
+            for dirpath, dirnames, filenames in scandir.walk(entry_path):
                 # Create children dirs in new location, otherwise move fails
                 for dirname in dirnames:
                     create_dir = os.path.join(dirpath, dirname).replace(

--- a/src/MCPClient/lib/clientScripts/set_maildir_file_grp_use_and_file_ids.py
+++ b/src/MCPClient/lib/clientScripts/set_maildir_file_grp_use_and_file_ids.py
@@ -27,6 +27,7 @@ import os
 from custom_handlers import get_script_logger
 
 import django
+import scandir
 
 django.setup()
 from django.db import connection
@@ -70,7 +71,7 @@ def set_maildir_files(sip_uuid, sip_path):
         maildir_path,
         sip_uuid,
     )
-    for root, dirs, files in os.walk(maildir_path):
+    for root, dirs, files in scandir.walk(maildir_path):
         for item in files:
             file_relative_path = os.path.join(root, item).replace(
                 sip_path, "%SIPDirectory%", 1
@@ -90,7 +91,7 @@ def set_archivematica_maildir_files(sip_uuid, sip_path):
         attachments_path,
         sip_uuid,
     )
-    for root, dirs, files in os.walk(attachments_path):
+    for root, dirs, files in scandir.walk(attachments_path):
         for item in files:
             if not item.endswith(".archivematicaMaildir"):
                 continue

--- a/src/MCPClient/lib/clientScripts/store_aip.py
+++ b/src/MCPClient/lib/clientScripts/store_aip.py
@@ -29,6 +29,7 @@ from uuid import uuid4
 
 # storageService requires Django to be set up
 import django
+import scandir
 
 django.setup()
 from django.db import transaction
@@ -208,7 +209,7 @@ def store_aip(job, aip_destination_uri, aip_path, sip_uuid, sip_name, sip_type):
     # If AIP is a directory, calculate size recursively
     if os.path.isdir(aip_path):
         size = 0
-        for dirpath, _, filenames in os.walk(aip_path):
+        for dirpath, _, filenames in scandir.walk(aip_path):
             for filename in filenames:
                 file_path = os.path.join(dirpath, filename)
                 size += os.path.getsize(file_path)

--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -15,6 +15,7 @@ from agentarchives.archivesspace import ArchivesSpaceClient
 
 # initialize Django (required for Django 1.7)
 import django
+import scandir
 
 django.setup()
 from django.db import transaction
@@ -26,7 +27,7 @@ logger.addHandler(logging.FileHandler("/tmp/as_upload.log", mode="a"))
 
 
 def recursive_file_gen(mydir):
-    for root, dirs, files in os.walk(mydir):
+    for root, dirs, files in scandir.walk(mydir):
         for file in files:
             yield os.path.join(root, file)
 

--- a/src/MCPClient/lib/clientScripts/verify_checksum.py
+++ b/src/MCPClient/lib/clientScripts/verify_checksum.py
@@ -39,6 +39,7 @@ import sys
 import uuid
 
 import django
+import scandir
 from django.db import transaction
 
 django.setup()
@@ -208,7 +209,7 @@ class Hashsum(object):
     def _count_files(path):
         """Walk the directories on a given path and count the number of files.
         """
-        return sum([len(files) for _, _, files in os.walk(path)])
+        return sum([len(files) for _, _, files in scandir.walk(path)])
 
 
 def get_file_queryset(transfer_uuid):

--- a/src/MCPClient/lib/clientScripts/verify_sip_compliance.py
+++ b/src/MCPClient/lib/clientScripts/verify_sip_compliance.py
@@ -24,6 +24,8 @@
 import os
 import sys
 
+import scandir
+
 import metrics
 
 
@@ -39,7 +41,7 @@ ALLOWABLE_FILES = ("processingMCP.xml",)
 
 def checkDirectory(job, directory, ret=0):
     try:
-        for directory, subDirectories, files in os.walk(directory):
+        for directory, subDirectories, files in scandir.walk(directory):
             for file in files:
                 os.path.join(directory, file)
     except Exception as inst:

--- a/src/MCPClient/lib/clientScripts/verify_transfer_compliance.py
+++ b/src/MCPClient/lib/clientScripts/verify_transfer_compliance.py
@@ -23,6 +23,9 @@
 
 import os
 import sys
+
+import scandir
+
 from verify_sip_compliance import checkDirectory
 
 REQUIRED_DIRECTORIES = (
@@ -60,7 +63,7 @@ def verifyNothingElseAtTopLevel(job, SIPDir, ret=0):
 
 def verifyThereAreFiles(job, SIPDir, ret=0):
     """Make sure there are files in the transfer."""
-    if not any(files for (_, _, files) in os.walk(SIPDir)):
+    if not any(files for (_, _, files) in scandir.walk(SIPDir)):
         job.pyprint("Error, no files found", file=sys.stderr)
         ret += 1
     return ret

--- a/src/MCPClient/requirements/base.in
+++ b/src/MCPClient/requirements/base.in
@@ -10,5 +10,5 @@ metsrw==0.3.13
 requests==2.21.0
 unidecode==0.04.19
 opf-fido==1.3.10
-scandir==1.9.0
+scandir==1.10.0
 prometheus_client==0.7.1

--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -21,7 +21,7 @@ olefile==0.46             # via opf-fido
 opf-fido==1.3.10
 prometheus_client==0.7.1
 requests==2.21.0
-scandir==1.9.0
+scandir==1.10.0
 six==1.12.0               # via django-extensions, metsrw, opf-fido
 unidecode==0.04.19
 urllib3==1.24.1           # via requests

--- a/src/MCPClient/requirements/dev.txt
+++ b/src/MCPClient/requirements/dev.txt
@@ -37,7 +37,7 @@ pytest-mock==1.10.2
 pytest-pythonpath==0.7.3
 pytest==4.3.1
 requests==2.21.0
-scandir==1.9.0
+scandir==1.10.0
 six==1.12.0
 toml==0.10.0
 tox==3.8.3

--- a/src/MCPClient/requirements/production.txt
+++ b/src/MCPClient/requirements/production.txt
@@ -21,7 +21,7 @@ olefile==0.46
 opf-fido==1.3.10
 prometheus_client==0.7.1
 requests==2.21.0
-scandir==1.9.0
+scandir==1.10.0
 six==1.12.0
 unidecode==0.04.19
 urllib3==1.24.1

--- a/src/MCPClient/requirements/test.txt
+++ b/src/MCPClient/requirements/test.txt
@@ -35,7 +35,7 @@ pytest-mock==1.10.2
 pytest-pythonpath==0.7.3
 pytest==4.3.1
 requests==2.21.0
-scandir==1.9.0
+scandir==1.10.0
 six==1.12.0
 toml==0.10.0              # via tox
 tox==3.8.3

--- a/src/MCPClient/tests/test_create_aip_mets.py
+++ b/src/MCPClient/tests/test_create_aip_mets.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import unittest
 
+import scandir
 from django.test import TestCase
 
 from lxml import etree
@@ -770,7 +771,7 @@ class TestCustomStructMap(TempDirMixin, TestCase):
     @staticmethod
     def count_dir_objects(path):
         """Count all objects on a given path tree."""
-        return sum([len(files) for _, dir_, files in os.walk(path)])
+        return sum([len(files) for _, dir_, files in scandir.walk(path)])
 
     @staticmethod
     def validate_mets(mets_xsd, mets_structmap):

--- a/src/archivematicaCommon/lib/externals/maildirToMbox.py
+++ b/src/archivematicaCommon/lib/externals/maildirToMbox.py
@@ -39,6 +39,8 @@ import sys
 import email
 import os
 
+import scandir
+
 
 def maildir2mailbox(maildirname, mboxfilename):
     """
@@ -70,7 +72,7 @@ def maildir2mailbox2(dirname, mboxname):
     # if not os.path.exists(mboxdirname): os.makedirs(mboxdirname)
 
     listofdirs = [
-        dn for dn in os.walk(dirname).next()[1] if dn not in ["new", "cur", "tmp"]
+        dn for dn in scandir.walk(dirname).next()[1] if dn not in ["new", "cur", "tmp"]
     ]
     for curfold in listofdirs:
         curlist = [mboxname] + curfold.split(".")

--- a/src/dashboard/src/main/management/commands/rebuild_elasticsearch_aip_index_from_files.py
+++ b/src/dashboard/src/main/management/commands/rebuild_elasticsearch_aip_index_from_files.py
@@ -36,6 +36,7 @@ import sys
 import time
 import tempfile
 
+import scandir
 from django.conf import settings as django_settings
 from lxml import etree
 
@@ -255,7 +256,7 @@ class Command(DashboardCommand):
         name_regex = r"-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         dir_regex = r"-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
 
-        for root, directories, files in os.walk(options["rootdir"]):
+        for root, directories, files in scandir.walk(options["rootdir"]):
             # Ignore top-level directories inside ``rootdir`` that are not hex,
             # e.g. we walk ``0771`` but we're ignoring ``transferBacklog``.
             if root == options["rootdir"]:


### PR DESCRIPTION
Relates to: https://github.com/archivematica/Issues/issues/908

Moves usage of `os.walk` to `scandir.walk` which is very low impact, and an easy win.

Moving from `os.listdir` to `scandir.scandir` is a bit harder, and since much of the relevant code can't easily be tested, I think it's not worth undertaking for now.