### PR TITLE
Fix move SIP service error

### DIFF
--- a/src/MCPClient/lib/job.py
+++ b/src/MCPClient/lib/job.py
@@ -28,21 +28,21 @@ class Job:
 
     def dump(self):
         return (
-            "#<%s; exit=%d; code=%s uuid=%s\n"
-            + "=============== STDOUT ===============\n"
-            + "%s"
-            + "\n=============== END STDOUT ===============\n"
-            + "=============== STDERR ===============\n"
-            + "%s"
-            + "\n=============== END STDERR ===============\n"
-            + "\n>"
+            u"#<%s; exit=%s; code=%s uuid=%s\n"
+            u"=============== STDOUT ===============\n"
+            u"%s"
+            u"\n=============== END STDOUT ===============\n"
+            u"=============== STDERR ===============\n"
+            u"%s"
+            u"\n=============== END STDERR ===============\n"
+            u"\n>"
         ) % (
             self.name,
             self.int_code,
             self.status_code,
             self.UUID,
-            self.output,
-            self.error,
+            self.get_stdout(),
+            self.get_stderr(),
         )
 
     def load_from(self, other_job):
@@ -95,10 +95,10 @@ class Job:
         return self.int_code
 
     def get_stdout(self):
-        return self.output
+        return self.output.decode("utf-8")
 
     def get_stderr(self):
-        return self.error
+        return self.error.decode("utf-8")
 
     @contextmanager
     def JobContext(self, logger=None):

--- a/src/MCPClient/tests/test_job.py
+++ b/src/MCPClient/tests/test_job.py
@@ -1,19 +1,41 @@
+# -*- coding: utf-8 -*-
 import os
 import sys
 from uuid import uuid4
+
+from django.utils import six
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.abspath(os.path.join(THIS_DIR, "../lib/clientScripts")))
 from job import Job
 
 
-def test_job(tmpdir):
-    job_name = "somejob"
-    job_uuid = str(uuid4())
-    job_args = ["a", "b"]
-    j = Job(name=job_name, uuid=job_uuid, args=job_args)
-    unicode_printable = u"change\u0301"
-    j.pyprint(unicode_printable)
-    stdout = j.get_stdout()
-    expected = "{}\n".format(unicode_printable.encode("utf8"))
-    assert expected == stdout
+UNICODE = u"‘你好‘"
+NON_ASCII_BYTES = "‘你好‘"
+
+
+def test_job_encoding():
+    job = Job(name="somejob", uuid=str(uuid4()), args=["a", "b"])
+
+    job.pyprint(UNICODE)
+    stdout = job.get_stdout()
+    expected_stdout = u"{}\n".format(UNICODE)
+    expected_output = "{}\n".format(UNICODE.encode("utf8"))
+    assert job.output == expected_output
+    assert stdout == expected_stdout
+    assert isinstance(job.output, six.binary_type)
+    assert isinstance(stdout, six.text_type)
+
+    job.print_error(NON_ASCII_BYTES)
+    stderr = job.get_stderr()
+    expected_stderr = u"{}\n".format(NON_ASCII_BYTES.decode("utf-8"))
+    expected_error = "{}\n".format(NON_ASCII_BYTES)
+    assert job.error == expected_error
+    assert stderr == expected_stderr
+    assert isinstance(job.error, six.binary_type)
+    assert isinstance(stderr, six.text_type)
+
+    job_dump = job.dump()
+    assert job.UUID in job_dump
+    assert stderr in job_dump
+    assert stdout in job_dump

--- a/src/MCPClient/tests/test_verify_checksum.py
+++ b/src/MCPClient/tests/test_verify_checksum.py
@@ -172,7 +172,7 @@ class TestHashsum(object):
         )
         assert ret == 1, self.assert_return_value.format(ret)
         assert (
-            job.get_stderr().decode("utf8").strip() == exception_string
+            job.get_stderr().strip() == exception_string
         ), self.assert_exception_string
 
     def test_compare_hashes_with_bad_files(self, mocker):
@@ -208,7 +208,7 @@ class TestHashsum(object):
             "-c", "--strict", hash_file, transfer_dir=objects_dir
         )
         assert (
-            job.get_stderr().decode("utf8").strip() == except_string_no_proper_out
+            job.get_stderr().strip() == except_string_no_proper_out
         ), self.assert_exception_string
         assert ret == 1, self.assert_return_value.format(ret)
         # Flush job.error as it isn't flushed automatically.
@@ -219,7 +219,7 @@ class TestHashsum(object):
         )
         ret = hashsum.compare_hashes("")
         assert (
-            job.get_stderr().decode("utf8").strip() == except_string_improper_format
+            job.get_stderr().strip() == except_string_improper_format
         ), self.assert_exception_string
         mock.assert_called_once_with(
             "-c", "--strict", hash_file, transfer_dir=objects_dir

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -144,6 +144,11 @@ def addFileToSIP(
 
 def rename(source, destination, printfn=print, should_exit=False):
     """Used to move/rename directories. This function was before used to wrap the operation with sudo."""
+    if source == destination:
+        # Handle this case so that we don't try to move a directory into itself
+        printfn("Source and destination are the same, nothing to do.")
+        return 0
+
     command = ["mv", source, destination]
     exitCode, stdOut, stdError = executeOrRun("command", command, "", printing=False)
     if exitCode:
@@ -152,6 +157,8 @@ def rename(source, destination, printfn=print, should_exit=False):
         printfn(stdError, file=sys.stderr)
         if should_exit:
             exit(exitCode)
+
+    return exitCode
 
 
 def updateDirectoryLocation(


### PR DESCRIPTION
Relates to: https://github.com/archivematica/Issues/issues/951

The return value of `rename` is used in many places for job status, so it shouldn't be returning
None. Also handle the case where the source and destination are the same, as that's a non-fatal error.

Edit: Connected to https://github.com/archivematica/Issues/issues/770 