### PR TITLE
Remove mutable default argument

### DIFF
--- a/src/MCPClient/lib/clientScripts/index_aip.py
+++ b/src/MCPClient/lib/clientScripts/index_aip.py
@@ -19,6 +19,7 @@ django.setup()
 
 from django.conf import settings as mcpclient_settings
 
+
 logger = get_script_logger("archivematica.mcp.client.indexAIP")
 
 
@@ -42,28 +43,21 @@ def get_identifiers(job, sip_path):
 
 
 def index_aip(job):
-    """ Write AIP information to ElasticSearch. """
-    sip_uuid = job.args[1]  # %SIPUUID%
-    sip_name = job.args[2]  # %SIPName%
-    sip_path = job.args[3]  # %SIPDirectory%
-    sip_type = job.args[4]  # %SIPType%
-
+    """Write AIP information to ElasticSearch. """
+    sip_uuid = job.args[1]          # %SIPUUID%
+    sip_name = job.args[2]          # %SIPName%
+    sip_staging_path = job.args[3]  # %SIPDirectory%
+    sip_type = job.args[4]          # %SIPType%
     if 'aips' not in mcpclient_settings.SEARCH_ENABLED:
         logger.info('Skipping indexing: AIPs indexing is currently disabled.')
         return 0
-
     elasticSearchFunctions.setup_reading_from_conf(mcpclient_settings)
     client = elasticSearchFunctions.get_client()
-
     aip_info = storage_service.get_file_info(uuid=sip_uuid)
     job.pyprint('AIP info:', aip_info)
     aip_info = aip_info[0]
-
-    mets_name = 'METS.{}.xml'.format(sip_uuid)
-    mets_path = os.path.join(sip_path, mets_name)
-
-    identifiers = get_identifiers(job, sip_path)
-
+    mets_staging_path = os.path.join(sip_staging_path, 'METS.{}.xml'.format(sip_uuid))
+    identifiers = get_identifiers(job, sip_staging_path)
     # If this is an AIC, find the number of AIP stored in it and index that
     aips_in_aic = None
     if sip_type == "AIC":
@@ -74,13 +68,11 @@ def index_aip(job):
             aips_in_aic = uv.variablevalue
         except UnitVariable.DoesNotExist:
             pass
-
     # Delete ES index before creating new one if reingesting
     if 'REIN' in sip_type:
         job.pyprint('Deleting outdated entry for AIP and AIP files with UUID', sip_uuid, 'from archival storage')
         elasticSearchFunctions.delete_aip(client, sip_uuid)
         elasticSearchFunctions.delete_aip_files(client, sip_uuid)
-
     job.pyprint('Indexing AIP and AIP files')
     # Even though we treat MODS identifiers as SIP-level, we need to index them
     # here because the archival storage tab actually searches on the
@@ -88,19 +80,17 @@ def index_aip(job):
     ret = elasticSearchFunctions.index_aip_and_files(
         client=client,
         uuid=sip_uuid,
-        path=aip_info['current_full_path'],
-        mets_path=mets_path,
+        aip_stored_path=aip_info['current_full_path'],
+        mets_staging_path=mets_staging_path,
         name=sip_name,
-        size=aip_info['size'],
+        aip_size=aip_info['size'],
         aips_in_aic=aips_in_aic,
         identifiers=identifiers,
         encrypted=aip_info['encrypted'],
         printfn=job.pyprint,
     )
-
     if ret == 1:
         job.pyprint('Error indexing AIP and AIP files', file=sys.stderr)
-
     return ret
 
 

--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-jessie
+FROM python:2.7-stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DJANGO_SETTINGS_MODULE settings.common
@@ -9,7 +9,7 @@ RUN set -ex \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		gettext \
-		libmysqlclient-dev \
+		default-libmysqlclient-dev \
 		libldap2-dev \
 		libsasl2-dev \
 		locales \

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -874,7 +874,10 @@ def _list_bulk_extractor_reports(transfer_path, file_uuid):
     return reports
 
 
-def _list_files_in_dir(path, filepaths=[]):
+def _list_files_in_dir(path, filepaths=None):
+    if filepaths is None:
+        filepaths = []
+
     # Define entries
     for file in os.listdir(path):
         child_path = os.path.join(path, file)

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -419,7 +419,7 @@ def index_aip_and_files(
         'uuid': uuid,
         'name': name,
         'filePath': aip_stored_path,
-        'size': aip_size,
+        'size': aip_size / (1024 * 1024),
         'mets': mets_data,
         'origin': get_dashboard_uuid(),
         'created': created,

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -79,6 +79,8 @@ DOC_TYPE = '_doc'
 # Maximun ES result window. Use the scroll API for a better way to get all
 # results or change `index.max_result_window` on each index settings.
 MAX_QUERY_SIZE = 10000
+# Maximun amount of fields per index (increased from the ES default of 1000).
+TOTAL_FIELDS_LIMIT = 10000
 
 
 def setup(hosts, timeout=DEFAULT_TIMEOUT, enabled=['aips', 'transfers']):
@@ -339,22 +341,25 @@ def _load_mets_mapping(index):
 def _get_index_settings():
     """Returns a dictionary with the settings used in all indexes."""
     return {
-        'analysis': {
-            'analyzer': {
-                # Use the char_group tokenizer to split paths and filenames,
-                # including file extensions, which avoids the overhead of the
-                # pattern tokenizer.
-                'file_path_and_name': {
-                    'tokenizer': 'char_tokenizer',
-                    'filter': ['lowercase'],
-                }
+        "index": {
+            "mapping": {"total_fields": {"limit": TOTAL_FIELDS_LIMIT}},
+            "analysis": {
+                "analyzer": {
+                    # Use the char_group tokenizer to split paths and filenames,
+                    # including file extensions, which avoids the overhead of
+                    # the pattern tokenizer.
+                    "file_path_and_name": {
+                        "tokenizer": "char_tokenizer",
+                        "filter": ["lowercase"],
+                    }
+                },
+                "tokenizer": {
+                    "char_tokenizer": {
+                        "type": "char_group",
+                        "tokenize_on_chars": ["-", "_", ".", "/", "\\"],
+                    }
+                },
             },
-            'tokenizer': {
-                'char_tokenizer': {
-                    'type': 'char_group',
-                    'tokenize_on_chars': ['-', '_', '.', '/', '\\'],
-                }
-            }
         }
     }
 

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -364,40 +364,35 @@ def _get_index_settings():
 # ---------------
 
 
-def index_aip_and_files(client, uuid, path, mets_path, name, size=None, aips_in_aic=None, identifiers=[], encrypted=False, printfn=print):
+def index_aip_and_files(
+        client, uuid, aip_stored_path, mets_staging_path, name, aip_size,
+        aips_in_aic=None, identifiers=[], encrypted=False, printfn=print):
     """Index AIP and AIP files with UUID `uuid` at path `path`.
 
     :param client: The ElasticSearch client.
     :param uuid: The UUID of the AIP we're indexing.
-    :param path: path on disk where the AIP is located.
-    :param path: path on disk where the AIP's METS file is located.
+    :param aip_stored_path: path on disk where the AIP is located.
+    :param mets_staging_path: path on disk where the AIP METS file is located.
     :param name: AIP name.
-    :param size: optional AIP size.
+    :param aip_size: AIP size.
     :param aips_in_aic: optional number of AIPs stored in AIC.
     :param identifiers: optional additional identifiers (MODS, Islandora, etc.).
     :param identifiers: optional AIP encrypted boolean (defaults to `False`).
     :param printfn: optional print funtion.
     :return: 0 is succeded, 1 otherwise.
     """
-    # Stop if AIP or METS file don't not exist
+    # Stop if AIP or METS file don't not exist.
     error_message = None
-    if not os.path.exists(path):
-        error_message = 'AIP does not exist at: ' + path
-    if not os.path.exists(mets_path):
-        error_message = 'METS file does not exist at: ' + mets_path
+    if not os.path.exists(mets_staging_path):
+        error_message = 'METS file does not exist at: ' + mets_staging_path
     if error_message:
         logger.error(error_message)
         printfn(error_message, file=sys.stderr)
         return 1
-
     printfn('AIP UUID: ' + uuid)
     printfn('Indexing AIP ...')
-
-    tree = ElementTree.parse(mets_path)
-
-    # TODO: Add a conditional to toggle this
+    tree = ElementTree.parse(mets_staging_path)
     _remove_tool_output_from_mets(tree)
-
     root = tree.getroot()
     # Extract AIC identifier, other specially-indexed information
     aic_identifier = None
@@ -408,28 +403,23 @@ def index_aip_and_files(client, uuid, path, mets_path, name, size=None, aips_in_
         if aip_type == 'Archival Information Collection':
             aic_identifier = dublincore.findtext('dc:identifier', namespaces=ns.NSMAP) or dublincore.findtext('dcterms:identifier', namespaces=ns.NSMAP)
         is_part_of = dublincore.findtext('dcterms:isPartOf', namespaces=ns.NSMAP)
-
     # Convert METS XML to dict
     xml = ElementTree.tostring(root)
     mets_data = _rename_dict_keys_with_child_dicts(_normalize_dict_values(xmltodict.parse(xml)))
-
     # Pull the create time from the METS header
     mets_hdr = root.find('mets:metsHdr', namespaces=ns.NSMAP)
     mets_created_attr = mets_hdr.get('CREATEDATE')
-
     created = time.time()
-
     if mets_created_attr:
         try:
             created = calendar.timegm(time.strptime(mets_created_attr, '%Y-%m-%dT%H:%M:%S'))
         except ValueError:
             printfn('Failed to parse METS CREATEDATE: %s' % (mets_created_attr))
-
     aip_data = {
         'uuid': uuid,
         'name': name,
-        'filePath': path,
-        'size': (size or os.path.getsize(path)) / 1024 / 1024,
+        'filePath': aip_stored_path,
+        'size': aip_size,
         'mets': mets_data,
         'origin': get_dashboard_uuid(),
         'created': created,
@@ -443,17 +433,15 @@ def index_aip_and_files(client, uuid, path, mets_path, name, size=None, aips_in_
     _wait_for_cluster_yellow_status(client)
     _try_to_index(client, aip_data, 'aips', printfn=printfn)
     printfn('Done.')
-
     printfn('Indexing AIP files ...')
     files_indexed = _index_aip_files(
         client=client,
         uuid=uuid,
-        mets_path=mets_path,
+        mets_path=mets_staging_path,
         name=name,
         identifiers=identifiers,
         printfn=printfn,
     )
-
     printfn('Files indexed: ' + str(files_indexed))
     return 0
 

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -552,17 +552,24 @@ def _index_aip_files(client, uuid, mets_path, name, identifiers=[], printfn=prin
             # its data from the descriptive metadata section (dmdSec)
             dmd_section_id = file_pointer_division.attrib.get('DMDID', None)
             if dmd_section_id is not None:
-                dmd_section_info = root.find(
-                    "mets:dmdSec[@ID='{}']/mets:mdWrap/mets:xmlData".format(
-                        dmd_section_id
-                    ),
-                    namespaces=ns.NSMAP
-                )
-                xml = ElementTree.tostring(dmd_section_info)
-                data = _rename_dict_keys_with_child_dicts(
-                    _normalize_dict_values(xmltodict.parse(xml))
-                )
-                indexData['METS']['dmdSec'] = data
+                # dmd_section_id can contain one id (e.g., "dmdSec_2")
+                # or more than one (e.g., "dmdSec_2 dmdSec_3",
+                # when a file has both DC and non-DC metadata).
+                # Attempt to index only the DC dmdSec if available
+                for dmd_section_id_item in dmd_section_id.split():
+                    dmd_section_info = root.find(
+                        "mets:dmdSec[@ID='{}']/mets:mdWrap[@MDTYPE='DC']/mets:xmlData".format(
+                            dmd_section_id_item
+                        ),
+                        namespaces=ns.NSMAP
+                    )
+                    if dmd_section_info is not None:
+                        xml = ElementTree.tostring(dmd_section_info)
+                        data = _rename_dict_keys_with_child_dicts(
+                            _normalize_dict_values(xmltodict.parse(xml))
+                        )
+                        indexData["METS"]["dmdSec"] = data
+                        break
 
         indexData['FILEUUID'] = fileUUID
 

--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -81,6 +81,10 @@ DOC_TYPE = '_doc'
 MAX_QUERY_SIZE = 10000
 # Maximun amount of fields per index (increased from the ES default of 1000).
 TOTAL_FIELDS_LIMIT = 10000
+# Maximum index depth (increased from the ES default of 20). The way the
+# `structMap` element from the METS file is parsed may create a big depth
+# in documents for AIPs with a big directories hierarchy.
+DEPTH_LIMIT = 1000
 
 
 def setup(hosts, timeout=DEFAULT_TIMEOUT, enabled=['aips', 'transfers']):
@@ -342,7 +346,10 @@ def _get_index_settings():
     """Returns a dictionary with the settings used in all indexes."""
     return {
         "index": {
-            "mapping": {"total_fields": {"limit": TOTAL_FIELDS_LIMIT}},
+            "mapping": {
+                "total_fields": {"limit": TOTAL_FIELDS_LIMIT},
+                "depth": {"limit": DEPTH_LIMIT},
+            },
             "analysis": {
                 "analyzer": {
                     # Use the char_group tokenizer to split paths and filenames,

--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -6,7 +6,6 @@ import platform
 import requests
 from requests.auth import AuthBase
 import urllib
-import time
 
 from django.conf import settings as django_settings
 
@@ -200,38 +199,6 @@ def browse_location(uuid, path):
     return browse
 
 
-def wait_for_async(response, poll_seconds=2, poll_timeout_seconds=600):
-    """
-    Poll for results on an async endpoint.
-
-    `response` should have a HTTP 202 (Accepted) status code, and is expected to
-    contain a Location header telling us where to get our results from.
-
-    `poll_seconds` controls how long we wait between poll requests.
-
-    `poll_timeout_seconds` controls how long we wait for a poll request to
-    complete before giving up and throwing an exception.
-
-    This function may raise exceptions. The caller can expect them to be
-    instances of ``requests.exceptions.RequestException``.
-    """
-    response.raise_for_status()
-    poll_url = response.headers['Location']
-    while True:
-        poll_response = _storage_api_session(
-            timeout=poll_timeout_seconds).get(poll_url)
-        poll_response.raise_for_status()
-        payload = poll_response.json()
-        if not payload['completed']:
-            time.sleep(poll_seconds)
-            continue
-        if payload['was_error']:
-            errmsg = 'Failure storing file: {}'.format(payload['error'])
-            LOGGER.warning(errmsg)
-            raise WaitForAsyncError(errmsg)
-        return payload['result']
-
-
 def copy_files(source_location, destination_location, files):
     """
     Copies `files` from `source_location` to `destination_location` using SS.
@@ -263,10 +230,11 @@ def copy_files(source_location, destination_location, files):
             except UnicodeError:
                 pass
 
-    url = _storage_service_url() + 'location/' + destination_location['uuid'] + '/async/'
+    url = _storage_service_url() + "location/" + destination_location["uuid"] + "/"
     try:
-        response = _storage_api_session().post(url, json=move_files)
-        return (wait_for_async(response), None)
+        response = _storage_api_slow_session().post(url, json=move_files)
+        response.raise_for_status()
+        return (response.json(), None)
     except requests.exceptions.RequestException as e:
         LOGGER.warning("Unable to move files with %s because %s", move_files, e)
         return (None, e)
@@ -344,10 +312,11 @@ def create_file(uuid, origin_location, origin_path, current_location,
             ret = response.json()
     else:
         try:
-            session = _storage_api_session()
-            url = _storage_service_url() + 'file/async/'
-            response = session.post(url, json=new_file, allow_redirects=False)
-            ret = wait_for_async(response)
+            session = _storage_api_slow_session()
+            url = _storage_service_url() + "file/"
+            response = session.post(url, json=new_file)
+            response.raise_for_status()
+            ret = response.json()
         except requests.exceptions.RequestException as err:
             LOGGER.warning(errmsg, new_file, err)
             raise

--- a/src/archivematicaCommon/lib/version.py
+++ b/src/archivematicaCommon/lib/version.py
@@ -1,4 +1,4 @@
-ARCHIVEMATICA_VERSION = (1, 9, 0)
+ARCHIVEMATICA_VERSION = (1, 9, 1)
 
 
 def get_version():

--- a/src/archivematicaCommon/lib/version.py
+++ b/src/archivematicaCommon/lib/version.py
@@ -1,4 +1,4 @@
-ARCHIVEMATICA_VERSION = (1, 9, 1)
+ARCHIVEMATICA_VERSION = (1, 9, 2)
 
 
 def get_version():

--- a/src/archivematicaCommon/tests/fixtures/test_index_aipfile_dmdsec_METS_dconly.xml
+++ b/src/archivematicaCommon/tests/fixtures/test_index_aipfile_dmdsec_METS_dconly.xml
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  This METS file has been cut-down to reduce fixture size
+-->
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version111/mets.xsd">
+  <mets:metsHdr CREATEDATE="2019-05-09T18:23:26"/>
+  <mets:dmdSec ID="dmdSec_1">
+    <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+      <mets:xmlData>
+        <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:intellectualEntity" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+          <premis:objectIdentifier>
+            <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>399e20dd-5cc7-465c-a406-3c6afdebee76</premis:objectIdentifierValue>
+          </premis:objectIdentifier>
+          <premis:originalName>dconly-399e20dd-5cc7-465c-a406-3c6afdebee76</premis:originalName>
+        </premis:object>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="dmdSec_2">
+    <mets:mdWrap MDTYPE="DC">
+      <mets:xmlData>
+        <dcterms:dublincore xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd">
+          <dc:title>Test Title</dc:title>
+          <dc:date>2019-05-03</dc:date>
+          <dc:description>Test description</dc:description>
+          <dc:language>English</dc:language>
+        </dcterms:dublincore>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:amdSec ID="amdSec_1">
+    <mets:techMD ID="techMD_1">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+            <premis:objectIdentifier>
+              <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+              <premis:objectIdentifierValue>5c1af9c3-0edd-4f99-a681-8894309e9bf2</premis:objectIdentifierValue>
+            </premis:objectIdentifier>
+            <premis:objectCharacteristics>
+              <premis:compositionLevel>0</premis:compositionLevel>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>f78615cd834f7fb84832177e73f13e3479f5b5b22ae7a9506c7fa0a14fd9df9e</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>18324</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName>Unknown</premis:formatName>
+                </premis:formatDesignation>
+              </premis:format>
+              <premis:creatingApplication>
+                <premis:dateCreatedByApplication>2019-05-03</premis:dateCreatedByApplication>
+              </premis:creatingApplication>
+            </premis:objectCharacteristics>
+            <premis:originalName>%transferDirectory%objects/lion.svg</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+ <mets:fileSec>
+    <mets:fileGrp USE="original">
+      <mets:file GROUPID="Group-5c1af9c3-0edd-4f99-a681-8894309e9bf2" ID="file-5c1af9c3-0edd-4f99-a681-8894309e9bf2" ADMID="amdSec_1">
+        <mets:FLocat xlink:href="objects/lion.svg" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+    </mets:fileGrp>
+ </mets:fileSec>
+  <mets:structMap ID="structMap_1" LABEL="Archivematica default" TYPE="physical">
+    <mets:div LABEL="dconly-399e20dd-5cc7-465c-a406-3c6afdebee76" TYPE="Directory" DMDID="dmdSec_1">
+      <mets:div LABEL="objects" TYPE="Directory">
+        <mets:div LABEL="lion.svg" TYPE="Item" DMDID="dmdSec_2">
+          <mets:fptr FILEID="file-5c1af9c3-0edd-4f99-a681-8894309e9bf2"/>
+        </mets:div>
+     </mets:div>
+    </mets:div>
+  </mets:structMap>
+</mets:mets>

--- a/src/archivematicaCommon/tests/fixtures/test_index_aipfile_dmdsec_METS_mixed.xml
+++ b/src/archivematicaCommon/tests/fixtures/test_index_aipfile_dmdsec_METS_mixed.xml
@@ -1,0 +1,95 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  This METS file has been cut-down to reduce fixture size
+-->
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version111/mets.xsd">
+  <mets:metsHdr CREATEDATE="2019-05-03T19:34:45"/>
+  <mets:dmdSec ID="dmdSec_1">
+    <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+      <mets:xmlData>
+        <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:intellectualEntity" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+          <premis:objectIdentifier>
+            <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>917acb24-763d-4c97-a4ab-40b45ea556af</premis:objectIdentifierValue>
+          </premis:objectIdentifier>
+          <premis:originalName>test-metadata-mixed-917acb24-763d-4c97-a4ab-40b45ea556af</premis:originalName>
+        </premis:object>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="dmdSec_2">
+    <mets:mdWrap MDTYPE="DC">
+      <mets:xmlData>
+        <dcterms:dublincore xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd">
+          <dc:title>Test Title</dc:title>
+          <dc:date>2019-05-03</dc:date>
+          <dc:description>Test description</dc:description>
+          <dc:language>English</dc:language>
+        </dcterms:dublincore>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="dmdSec_3">
+    <mets:mdWrap MDTYPE="OTHER" OTHERMDTYPE="CUSTOM">
+      <mets:xmlData>
+        <fonds_collection>Test fonds</fonds_collection>
+        <source_of_title>Title taken from the document label and accompanying material</source_of_title>
+        <inventory_remarks>Some inventory remarks.</inventory_remarks>
+        <reformatting_remarks>Some reformatting remarks.</reformatting_remarks>
+        <reformatting_dates>preservation copy 2019-02-27</reformatting_dates>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:amdSec ID="amdSec_1">
+    <mets:techMD ID="techMD_1">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xmlns:premis="info:lc/xmlns/premis-v2" xsi:type="premis:file" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd" version="2.2">
+            <premis:objectIdentifier>
+              <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+              <premis:objectIdentifierValue>923e2e11-1497-4f93-995b-d932b7d580cd</premis:objectIdentifierValue>
+            </premis:objectIdentifier>
+            <premis:objectCharacteristics>
+              <premis:compositionLevel>0</premis:compositionLevel>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>f78615cd834f7fb84832177e73f13e3479f5b5b22ae7a9506c7fa0a14fd9df9e</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>18324</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName>Scalable Vector Graphics</premis:formatName>
+                  <premis:formatVersion>1.0</premis:formatVersion>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>fmt/91</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+              <premis:creatingApplication>
+                <premis:dateCreatedByApplication>2019-05-03</premis:dateCreatedByApplication>
+              </premis:creatingApplication>
+            </premis:objectCharacteristics>
+            <premis:originalName>%transferDirectory%objects/lion.svg</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+ <mets:fileSec>
+    <mets:fileGrp USE="original">
+      <mets:file GROUPID="Group-923e2e11-1497-4f93-995b-d932b7d580cd" ID="file-923e2e11-1497-4f93-995b-d932b7d580cd" ADMID="amdSec_1">
+        <mets:FLocat xlink:href="objects/lion.svg" LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM"/>
+      </mets:file>
+    </mets:fileGrp>
+ </mets:fileSec>
+  <mets:structMap ID="structMap_1" LABEL="Archivematica default" TYPE="physical">
+    <mets:div LABEL="test-metadata-mixed-917acb24-763d-4c97-a4ab-40b45ea556af" TYPE="Directory" DMDID="dmdSec_1">
+      <mets:div LABEL="objects" TYPE="Directory">
+        <mets:div LABEL="lion.svg" TYPE="Item" DMDID="dmdSec_2 dmdSec_3">
+          <mets:fptr FILEID="file-923e2e11-1497-4f93-995b-d932b7d580cd"/>
+        </mets:div>
+     </mets:div>
+    </mets:div>
+  </mets:structMap>
+</mets:mets>

--- a/src/archivematicaCommon/tests/test_elasticsearch_functions.py
+++ b/src/archivematicaCommon/tests/test_elasticsearch_functions.py
@@ -233,3 +233,68 @@ class TestElasticSearchFunctions(unittest.TestCase):
         elasticSearchFunctions.create_indexes_if_needed(
             self.client, ['aips', 'aipfiles', 'unknown'])
         assert patch.call_count == 2
+
+
+dmdsec_dconly = {
+    "filePath": "objects/lion.svg",
+    "dublincore_dict": {
+        "dc:language": "English",
+        "dc:title": "Test Title",
+        "dc:date": "2019-05-03",
+        "dc:description": "Test description",
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "metsfile,dmdsec_dict",
+    [
+        ("test_index_aipfile_dmdsec_METS_dconly.xml", dmdsec_dconly),
+        (
+            "test_index_aipfile_dmdsec_METS_mixed.xml",
+            dmdsec_dconly,  # non-DC metadata should be ignored without error
+        ),
+    ],
+)
+@mock.patch("elasticSearchFunctions.get_dashboard_uuid")
+@mock.patch("elasticSearchFunctions._wait_for_cluster_yellow_status")
+@mock.patch("elasticSearchFunctions._try_to_index")
+def test_index_aipfile_dmdsec(
+    dummy_try_to_index,
+    dummy_wait_for_cluster_yellow_status,
+    dummy_get_dashboard_uuid,
+    metsfile,
+    dmdsec_dict,
+):
+    """Check AIP file dmdSec is correctly parsed from METS files.
+
+    Mock _try_to_index() with a function that populates a dict
+    indexed_data, with the dmdSec data that _index_aip_files() obtained
+    from the METS
+    """
+
+    dummy_get_dashboard_uuid.return_value = "test-uuid"
+
+    indexed_data = {}
+
+    def get_dublincore_metadata(client, indexData, index, printfn):
+        try:
+            dmd_section = indexData["METS"]["dmdSec"]
+            metadata_container = dmd_section["ns0:xmlData_dict_list"][0]
+            dc = metadata_container["ns1:dublincore_dict_list"][0]
+        except (KeyError, IndexError):
+            dc = None
+        indexed_data[indexData["filePath"]] = dc
+
+    dummy_try_to_index.side_effect = get_dublincore_metadata
+
+    elasticSearchFunctions._index_aip_files(
+        client=None,
+        uuid="DUMMYUUID",
+        mets_path=os.path.join(THIS_DIR, "fixtures", metsfile),
+        name="{}-{}".format("DUMMYNAME", "DUMMYUUID"),
+        identifiers=[],
+    )
+
+    for key, value in dmdsec_dict["dublincore_dict"].iteritems():
+        assert indexed_data[dmdsec_dict["filePath"]][key] == value

--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-jessie
+FROM python:2.7-stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DJANGO_SETTINGS_MODULE settings.production
@@ -12,7 +12,7 @@ RUN set -ex \
 	&& curl -sL https://deb.nodesource.com/setup_8.x | bash - \
 	&& apt-get install -y --no-install-recommends \
 		gettext \
-		libmysqlclient-dev \
+		default-libmysqlclient-dev \
 		libldap2-dev \
 		libsasl2-dev \
 		nodejs \

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -42,6 +42,7 @@ from main import models
 from processing import install_builtin_config
 
 LOGGER = logging.getLogger('archivematica.dashboard')
+SHARED_PATH_TEMPLATE_VAL = "%sharedPath%"
 SHARED_DIRECTORY_ROOT = django_settings.SHARED_DIRECTORY
 UUID_REGEX = re.compile(r'^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$', re.IGNORECASE)
 
@@ -228,7 +229,7 @@ def status(request, unit_uuid, unit_type):
             content_type='application/json',
         )
     directory = unit.currentpath if unit_type == 'unitSIP' else unit.currentlocation
-    response['path'] = directory.replace('%sharedPath%', SHARED_DIRECTORY_ROOT, 1)
+    response['path'] = directory.replace(SHARED_PATH_TEMPLATE_VAL, SHARED_DIRECTORY_ROOT, 1)
     response['directory'] = os.path.basename(os.path.normpath(directory))
     response['name'] = response['directory'].replace('-' + unit_uuid, '', 1)
     response['uuid'] = unit_uuid
@@ -324,7 +325,6 @@ def start_transfer_api(request):
     paths = request.POST.getlist('paths[]', [])
     paths = [base64.b64decode(path) for path in paths]
     row_ids = request.POST.getlist('row_ids[]', [''])
-
     try:
         response = filesystem_ajax_views.start_transfer(transfer_name, transfer_type, accession, access_id, paths, row_ids)
         return helpers.json_response(response)
@@ -449,20 +449,22 @@ def approve_transfer(request):
         return _error_response(
             "Please specify a transfer directory.", status_code=500)
     directory = archivematicaFunctions.unicodeToStr(directory)
-
     transfer_type = request.POST.get("type", "standard")
     if not transfer_type:
-        return _error_response("Please specify a transfer type.", status_code=500)
-
+        return _error_response(
+            "Please specify a transfer type.", status_code=500)
     modified_transfer_path = get_modified_standard_transfer_path(transfer_type)
     if modified_transfer_path is None:
         return _error_response("Invalid transfer type.", status_code=500)
-
-    if transfer_type == 'zipped bag':
-        db_transfer_path = os.path.join(modified_transfer_path, directory)
+    watched_path = os.path.join(modified_transfer_path, directory)
+    transfer_file = watched_path.replace(
+        SHARED_PATH_TEMPLATE_VAL, SHARED_DIRECTORY_ROOT
+    )
+    if transfer_type in ("zipped bag", "dspace") and os.path.isfile(transfer_file):
+        db_transfer_path = watched_path
     else:
-        db_transfer_path = os.path.join(modified_transfer_path, directory, "")
-
+        # Append a slash to complete the directory path.
+        db_transfer_path = os.path.join(watched_path, "")
     try:
         client = MCPClient(request.user)
         unit_uuid = client.approve_transfer_by_path(
@@ -478,14 +480,14 @@ def approve_transfer(request):
 def get_modified_standard_transfer_path(transfer_type=None):
     path = os.path.join(django_settings.WATCH_DIRECTORY, "activeTransfers")
     if transfer_type is None:
-        return path.replace(SHARED_DIRECTORY_ROOT, "%sharedPath%", 1)
+        return path.replace(SHARED_DIRECTORY_ROOT, SHARED_PATH_TEMPLATE_VAL, 1)
     try:
         path = os.path.join(
             path,
             filesystem_ajax_views.TRANSFER_TYPE_DIRECTORIES[transfer_type])
     except KeyError:
         return None
-    return path.replace(SHARED_DIRECTORY_ROOT, "%sharedPath%", 1)
+    return path.replace(SHARED_DIRECTORY_ROOT, SHARED_PATH_TEMPLATE_VAL, 1)
 
 
 @_api_endpoint(expected_methods=['POST'])
@@ -564,7 +566,7 @@ def reingest(request, target):
 
         # Persist transfer record in the database
         tdetails = {
-            'currentlocation': '%sharedPath%' + dest[len(shared_directory_path):],
+            'currentlocation': SHARED_PATH_TEMPLATE_VAL + dest[len(shared_directory_path):],
             'uuid': str(uuid.uuid4()),
             'type': 'Archivematica AIP',
         }

--- a/src/dashboard/src/contrib/mcp/client.py
+++ b/src/dashboard/src/contrib/mcp/client.py
@@ -84,7 +84,7 @@ class NoJobFoundError(RPCGearmanClientError):
         super(NoJobFoundError, self).__init__(message)
 
 
-INFLIGHT_POLL_TIMEOUT = 5.0
+INFLIGHT_POLL_TIMEOUT = 30.0
 
 
 class MCPClient(object):

--- a/src/dashboard/src/main/management/commands/rebuild_elasticsearch_aip_index_from_files.py
+++ b/src/dashboard/src/main/management/commands/rebuild_elasticsearch_aip_index_from_files.py
@@ -164,10 +164,10 @@ def processAIPThenDeleteMETSFile(path, temp_dir, es_client,
     return elasticSearchFunctions.index_aip_and_files(
         client=es_client,
         uuid=aip_uuid,
-        path=path,
-        mets_path=path_to_mets,
+        aip_stored_path=path,
+        mets_staging_path=path_to_mets,
         name=aip_name,
-        size=aip_info[0]['size'],
+        aip_size=aip_info[0]["size"],
         aips_in_aic=aips_in_aic,
         identifiers=[],  # TODO get these
     )


### PR DESCRIPTION
When reindexing, `_list_files_in_dir()` is run once for each item. If the `filepaths` argument is left set to `[]`, then each item will erroneously include all previously indexed files.

By setting it to `None` and initing the `[]` default inside the function body, we avoid this undesirable behavior because the list is inited anew each time the function runs.

To demonstrate what was happening before this change, you can see what I mean by running the following in the python console:

```python
def f(x=[]):
    x.append(5)
    print x

f()
f()
f()
f(["hi"])
f()
```

[more information](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments)

Thanks!