### PR TITLE
Reorder processing configuration choices

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -826,9 +826,37 @@
                 "@manager": "linkTaskManagerReplacementDicFromChoice",
                 "@model": "MicroServiceChoiceReplacementDic",
                 "replacements": [
+                  {
+                      "description": {
+                          "en": "1 - fastest compression",
+                          "es": "1 - el modo más rápido",
+                          "fr": "1 - mode rapide",
+                          "ja": "1 - 最高速モード",
+                          "pt_BR": "1 - modo mais rápido",
+                          "sv": "1 - snabbaste läget"
+                      },
+                      "id": "ecfad581-b007-4612-a0e0-fcc551f4057f",
+                      "items": {
+                          "AIPCompressionLevel": "1"
+                      }
+                  },
+                  {
+                      "description": {
+                          "en": "3 - fast compression",
+                          "es": "3 - mode de compresión rápido",
+                          "fr": "3 - mode de compression rapide",
+                          "ja": "3 - 高速圧縮モード",
+                          "pt_BR": "3 - modo de compressão rápida",
+                          "sv": "3 - snabbkomprimeringsläge"
+                      },
+                      "id": "85b2243e-ff97-4ca8-80e8-3c6b0842b360",
+                      "items": {
+                          "AIPCompressionLevel": "3"
+                      }
+                  },
                     {
                         "description": {
-                            "en": "5 - normal compression mode",
+                            "en": "5 - normal compression",
                             "es": "5 - modo de compresión normal",
                             "fr": "5 - mode de compression normal",
                             "ja": "5 - 通常の圧縮モード",
@@ -866,34 +894,6 @@
                         "id": "6d52fd24-8c06-4c8e-997a-e427ba0acc36",
                         "items": {
                             "AIPCompressionLevel": "9"
-                        }
-                    },
-                    {
-                        "description": {
-                            "en": "3 - fast compression mode",
-                            "es": "3 - mode de compresión rápido",
-                            "fr": "3 - mode de compression rapide",
-                            "ja": "3 - 高速圧縮モード",
-                            "pt_BR": "3 - modo de compressão rápida",
-                            "sv": "3 - snabbkomprimeringsläge"
-                        },
-                        "id": "85b2243e-ff97-4ca8-80e8-3c6b0842b360",
-                        "items": {
-                            "AIPCompressionLevel": "3"
-                        }
-                    },
-                    {
-                        "description": {
-                            "en": "1 - fastest mode",
-                            "es": "1 - el modo más rápido",
-                            "fr": "1 - mode rapide",
-                            "ja": "1 - 最高速モード",
-                            "pt_BR": "1 - modo mais rápido",
-                            "sv": "1 - snabbaste läget"
-                        },
-                        "id": "ecfad581-b007-4612-a0e0-fcc551f4057f",
-                        "items": {
-                            "AIPCompressionLevel": "1"
                         }
                     }
                 ]
@@ -3187,8 +3187,8 @@
                 "@manager": "linkTaskManagerChoice",
                 "@model": "MicroServiceChainChoice",
                 "chain_choices": [
-                    "433f4e6b-1ef4-49f8-b1e4-49693791a806",
-                    "9efab23c-31dc-4cbd-a39d-bb1665460cbe"
+                    "9efab23c-31dc-4cbd-a39d-bb1665460cbe",
+                    "433f4e6b-1ef4-49f8-b1e4-49693791a806"
                 ]
             },
             "description": {
@@ -4487,9 +4487,23 @@
                 "@manager": "linkTaskManagerReplacementDicFromChoice",
                 "@model": "MicroServiceChoiceReplacementDic",
                 "replacements": [
+                  {
+                      "description": {
+                          "en": "Yes",
+                          "es": "Sí",
+                          "fr": "Oui",
+                          "ja": "はい",
+                          "pt_BR": "Sim",
+                          "sv": "Ja"
+                      },
+                      "id": "c318b224-b718-4535-a911-494b1af6ff26",
+                      "items": {
+                          "ThumbnailMode": "generate"
+                      }
+                  },
                     {
                         "description": {
-                            "en": "Yes, without default",
+                            "en": "Yes, without default icons",
                             "pt_BR": "Sim, sem padrão"
                         },
                         "id": "89f098ef-1cb2-4a97-ad67-4c0f14d0546b",
@@ -4507,20 +4521,6 @@
                         "id": "972fce6c-52c8-4c00-99b9-d6814e377974",
                         "items": {
                             "ThumbnailMode": "do_not_generate"
-                        }
-                    },
-                    {
-                        "description": {
-                            "en": "Yes",
-                            "es": "Sí",
-                            "fr": "Oui",
-                            "ja": "はい",
-                            "pt_BR": "Sim",
-                            "sv": "Ja"
-                        },
-                        "id": "c318b224-b718-4535-a911-494b1af6ff26",
-                        "items": {
-                            "ThumbnailMode": "generate"
                         }
                     }
                 ]
@@ -5283,8 +5283,8 @@
                 "@manager": "linkTaskManagerChoice",
                 "@model": "MicroServiceChainChoice",
                 "chain_choices": [
-                    "4500f34e-f004-4ccf-8720-5c38d0be2254",
-                    "8d29eb3d-a8a8-4347-806e-3d8227ed44a1"
+                    "8d29eb3d-a8a8-4347-806e-3d8227ed44a1",
+                    "4500f34e-f004-4ccf-8720-5c38d0be2254"
                 ]
             },
             "description": {
@@ -6231,9 +6231,9 @@
                 "@manager": "linkTaskManagerChoice",
                 "@model": "MicroServiceChainChoice",
                 "chain_choices": [
-                    "a6ed697e-6189-4b4e-9f80-29209abc7937",
+                    "612e3609-ce9a-4df6-a9a3-63d634d2d934",
                     "e8544c5e-9cbb-4b8f-a68b-6d9b4d7f7362",
-                    "612e3609-ce9a-4df6-a9a3-63d634d2d934"
+                    "a6ed697e-6189-4b4e-9f80-29209abc7937"
                 ]
             },
             "description": {
@@ -7582,10 +7582,10 @@
                 "@manager": "linkTaskManagerChoice",
                 "@model": "MicroServiceChainChoice",
                 "chain_choices": [
-                    "526eded3-2280-4f10-ac86-eff6c464cc81",
                     "0fe9842f-9519-4067-a691-8a363132ae24",
-                    "6eb8ebe7-fab3-4e4c-b9d7-14de17625baa",
-                    "3572f844-5e69-4000-a24b-4e32d3487f82"
+                    "3572f844-5e69-4000-a24b-4e32d3487f82",
+                    "526eded3-2280-4f10-ac86-eff6c464cc81",
+                    "6eb8ebe7-fab3-4e4c-b9d7-14de17625baa"
                 ]
             },
             "description": {
@@ -8320,8 +8320,8 @@
                 "@manager": "linkTaskManagerChoice",
                 "@model": "MicroServiceChainChoice",
                 "chain_choices": [
-                    "e0a39199-c62a-4a2f-98de-e9d1116460a8",
-                    "06f03bb3-121d-4c85-bec7-abbc5320a409"
+                    "06f03bb3-121d-4c85-bec7-abbc5320a409",
+                    "e0a39199-c62a-4a2f-98de-e9d1116460a8"
                 ]
             },
             "description": {
@@ -8990,8 +8990,8 @@
                 "@model": "MicroServiceChainChoice",
                 "chain_choices": [
                     "1b04ec43-055c-43b7-9543-bd03c6a778ba",
-                    "7065d256-2f47-4b7d-baec-2c4699626121",
-                    "61cfa825-120e-4b17-83e6-51a42b67d969"
+                    "61cfa825-120e-4b17-83e6-51a42b67d969",
+                    "7065d256-2f47-4b7d-baec-2c4699626121"
                 ]
             },
             "description": {
@@ -9592,11 +9592,11 @@
                 "chain_choices": [
                     "b93cecd4-71f2-4e28-bc39-d32fd62c5a94",
                     "612e3609-ce9a-4df6-a9a3-63d634d2d934",
+                    "fb7a326e-1e50-4b48-91b9-4917ff8d0ae8",
+                    "e600b56d-1a43-4031-9d7c-f64f123e5662",
                     "c34bd22a-d077-4180-bf58-01db35bdb644",
                     "89cb80dd-0636-464f-930d-57b61e3928b2",
-                    "a6ed697e-6189-4b4e-9f80-29209abc7937",
-                    "e600b56d-1a43-4031-9d7c-f64f123e5662",
-                    "fb7a326e-1e50-4b48-91b9-4917ff8d0ae8"
+                    "a6ed697e-6189-4b4e-9f80-29209abc7937"
                 ]
             },
             "description": {

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -838,22 +838,22 @@
                         "id": "ecfad581-b007-4612-a0e0-fcc551f4057f",
                         "items": {
                             "AIPCompressionLevel": "1"
-                      	}
+                        }
                     },
                     {
-                      	"description": {
-	                          "en": "3 - fast compression",
-	                          "es": "3 - mode de compresión rápido",
-	                          "fr": "3 - mode de compression rapide",
-	                          "ja": "3 - 高速圧縮モード",
-	                          "pt_BR": "3 - modo de compressão rápida",
-	                          "sv": "3 - snabbkomprimeringsläge"
-                      	},
-	                      "id": "85b2243e-ff97-4ca8-80e8-3c6b0842b360",
-	                      "items": {
-	                          "AIPCompressionLevel": "3"
-	                      }
-	                  },
+                        "description": {
+                            "en": "3 - fast compression",
+                            "es": "3 - mode de compresión rápido",
+                            "fr": "3 - mode de compression rapide",
+                            "ja": "3 - 高速圧縮モード",
+                            "pt_BR": "3 - modo de compressão rápida",
+                            "sv": "3 - snabbkomprimeringsläge"
+                        },
+                        "id": "85b2243e-ff97-4ca8-80e8-3c6b0842b360",
+                        "items": {
+                            "AIPCompressionLevel": "3"
+                        }
+                    },
                     {
                         "description": {
                             "en": "5 - normal compression",
@@ -11355,7 +11355,7 @@
                         "id": "85b1e45d-8f98-4cae-8336-72f40e12cbef",
                         "items": {
                             "DeletePackage": "True"
-                      }
+                        }
                     },
                     {
                         "description": {

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -11343,6 +11343,20 @@
                 "@manager": "linkTaskManagerReplacementDicFromChoice",
                 "@model": "MicroServiceChoiceReplacementDic",
                 "replacements": [
+                  {
+                      "description": {
+                          "en": "Yes",
+                          "es": "Sí",
+                          "fr": "Oui",
+                          "ja": "はい",
+                          "pt_BR": "Sim",
+                          "sv": "Ja"
+                      },
+                      "id": "85b1e45d-8f98-4cae-8336-72f40e12cbef",
+                      "items": {
+                          "DeletePackage": "True"
+                      }
+                  },
                     {
                         "description": {
                             "en": "No",
@@ -11353,20 +11367,6 @@
                         "id": "72e8443e-a8eb-49a8-ba5f-76d52f960bde",
                         "items": {
                             "DeletePackage": "False"
-                        }
-                    },
-                    {
-                        "description": {
-                            "en": "Yes",
-                            "es": "Sí",
-                            "fr": "Oui",
-                            "ja": "はい",
-                            "pt_BR": "Sim",
-                            "sv": "Ja"
-                        },
-                        "id": "85b1e45d-8f98-4cae-8336-72f40e12cbef",
-                        "items": {
-                            "DeletePackage": "True"
                         }
                     }
                 ]

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -826,34 +826,34 @@
                 "@manager": "linkTaskManagerReplacementDicFromChoice",
                 "@model": "MicroServiceChoiceReplacementDic",
                 "replacements": [
-                  {
-                      "description": {
-                          "en": "1 - fastest compression",
-                          "es": "1 - el modo más rápido",
-                          "fr": "1 - mode rapide",
-                          "ja": "1 - 最高速モード",
-                          "pt_BR": "1 - modo mais rápido",
-                          "sv": "1 - snabbaste läget"
-                      },
-                      "id": "ecfad581-b007-4612-a0e0-fcc551f4057f",
-                      "items": {
-                          "AIPCompressionLevel": "1"
-                      }
-                  },
-                  {
-                      "description": {
-                          "en": "3 - fast compression",
-                          "es": "3 - mode de compresión rápido",
-                          "fr": "3 - mode de compression rapide",
-                          "ja": "3 - 高速圧縮モード",
-                          "pt_BR": "3 - modo de compressão rápida",
-                          "sv": "3 - snabbkomprimeringsläge"
-                      },
-                      "id": "85b2243e-ff97-4ca8-80e8-3c6b0842b360",
-                      "items": {
-                          "AIPCompressionLevel": "3"
-                      }
-                  },
+                    {
+                        "description": {
+                            "en": "1 - fastest compression",
+                            "es": "1 - el modo más rápido",
+                            "fr": "1 - mode rapide",
+                            "ja": "1 - 最高速モード",
+                            "pt_BR": "1 - modo mais rápido",
+                            "sv": "1 - snabbaste läget"
+                        },
+                        "id": "ecfad581-b007-4612-a0e0-fcc551f4057f",
+                        "items": {
+                            "AIPCompressionLevel": "1"
+                      	}
+                    },
+                    {
+                      	"description": {
+	                          "en": "3 - fast compression",
+	                          "es": "3 - mode de compresión rápido",
+	                          "fr": "3 - mode de compression rapide",
+	                          "ja": "3 - 高速圧縮モード",
+	                          "pt_BR": "3 - modo de compressão rápida",
+	                          "sv": "3 - snabbkomprimeringsläge"
+                      	},
+	                      "id": "85b2243e-ff97-4ca8-80e8-3c6b0842b360",
+	                      "items": {
+	                          "AIPCompressionLevel": "3"
+	                      }
+	                  },
                     {
                         "description": {
                             "en": "5 - normal compression",
@@ -4487,7 +4487,7 @@
                 "@manager": "linkTaskManagerReplacementDicFromChoice",
                 "@model": "MicroServiceChoiceReplacementDic",
                 "replacements": [
-                  {
+                    {
                       "description": {
                           "en": "Yes",
                           "es": "Sí",
@@ -4500,7 +4500,7 @@
                       "items": {
                           "ThumbnailMode": "generate"
                       }
-                  },
+                    },
                     {
                         "description": {
                             "en": "Yes, without default icons",
@@ -11343,20 +11343,6 @@
                 "@manager": "linkTaskManagerReplacementDicFromChoice",
                 "@model": "MicroServiceChoiceReplacementDic",
                 "replacements": [
-                  {
-                      "description": {
-                          "en": "Yes",
-                          "es": "Sí",
-                          "fr": "Oui",
-                          "ja": "はい",
-                          "pt_BR": "Sim",
-                          "sv": "Ja"
-                      },
-                      "id": "85b1e45d-8f98-4cae-8336-72f40e12cbef",
-                      "items": {
-                          "DeletePackage": "True"
-                      }
-                  },
                     {
                         "description": {
                             "en": "No",
@@ -11367,6 +11353,20 @@
                         "id": "72e8443e-a8eb-49a8-ba5f-76d52f960bde",
                         "items": {
                             "DeletePackage": "False"
+                        }
+                    },
+                    {
+                        "description": {
+                            "en": "Yes",
+                            "es": "Sí",
+                            "fr": "Oui",
+                            "ja": "はい",
+                            "pt_BR": "Sim",
+                            "sv": "Ja"
+                        },
+                        "id": "85b1e45d-8f98-4cae-8336-72f40e12cbef",
+                        "items": {
+                            "DeletePackage": "True"
                         }
                     }
                 ]

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -6144,8 +6144,8 @@
                 "@manager": "linkTaskManagerChoice",
                 "@model": "MicroServiceChainChoice",
                 "chain_choices": [
-                    "3e891cc4-39d2-4989-a001-5107a009a223",
-                    "c611a6ff-dfdb-46d1-b390-f366a6ea6f66"
+                    "c611a6ff-dfdb-46d1-b390-f366a6ea6f66",
+                    "3e891cc4-39d2-4989-a001-5107a009a223"
                 ]
             },
             "description": {
@@ -8989,9 +8989,9 @@
                 "@manager": "linkTaskManagerChoice",
                 "@model": "MicroServiceChainChoice",
                 "chain_choices": [
-                    "1b04ec43-055c-43b7-9543-bd03c6a778ba",
                     "61cfa825-120e-4b17-83e6-51a42b67d969",
-                    "7065d256-2f47-4b7d-baec-2c4699626121"
+                    "7065d256-2f47-4b7d-baec-2c4699626121",
+                    "1b04ec43-055c-43b7-9543-bd03c6a778ba"
                 ]
             },
             "description": {
@@ -10442,8 +10442,8 @@
                 "@manager": "linkTaskManagerChoice",
                 "@model": "MicroServiceChainChoice",
                 "chain_choices": [
-                    "cbe9b4a3-e4e6-4a32-8d7c-3adfc409cb6f",
                     "1e0df175-d56d-450d-8bee-7df1dc7ae815",
+                    "cbe9b4a3-e4e6-4a32-8d7c-3adfc409cb6f",
                     "169a5448-c756-4705-a920-737de6b8d595"
                 ]
             },
@@ -11345,18 +11345,6 @@
                 "replacements": [
                     {
                         "description": {
-                            "en": "No",
-                            "fr": "Non",
-                            "ja": "いいえ",
-                            "sv": "Nej"
-                        },
-                        "id": "72e8443e-a8eb-49a8-ba5f-76d52f960bde",
-                        "items": {
-                            "DeletePackage": "False"
-                        }
-                    },
-                    {
-                        "description": {
                             "en": "Yes",
                             "es": "Sí",
                             "fr": "Oui",
@@ -11367,6 +11355,18 @@
                         "id": "85b1e45d-8f98-4cae-8336-72f40e12cbef",
                         "items": {
                             "DeletePackage": "True"
+                      }
+                    },
+                    {
+                        "description": {
+                            "en": "No",
+                            "fr": "Non",
+                            "ja": "いいえ",
+                            "sv": "Nej"
+                        },
+                        "id": "72e8443e-a8eb-49a8-ba5f-76d52f960bde",
+                        "items": {
+                            "DeletePackage": "False"
                         }
                     }
                 ]

--- a/src/MCPServer/lib/server/jobs/decisions.py
+++ b/src/MCPServer/lib/server/jobs/decisions.py
@@ -3,6 +3,7 @@
 Jobs relating to user decisions.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+from collections import OrderedDict
 
 import abc
 import logging
@@ -103,7 +104,7 @@ class NextChainDecisionJob(DecisionJob):
     """
 
     def get_choices(self):
-        choices = {}
+        choices = OrderedDict()
         for chain_id in self.link.config["chain_choices"]:
             try:
                 chain = self.workflow.get_chain(chain_id)
@@ -147,7 +148,7 @@ class OutputDecisionJob(DecisionJob):
         return None
 
     def get_choices(self):
-        choices = {}
+        choices = OrderedDict()
 
         if self.job_chain.generated_choices:
             for _, value in self.job_chain.generated_choices.items():
@@ -280,7 +281,7 @@ class UpdateContextDecisionJob(DecisionJob):
         return None
 
     def get_choices(self):
-        choices = {}
+        choices = OrderedDict()
         # TODO: this is kind of an odd side effect here; refactor
         self.choice_items = []
 

--- a/src/MCPServer/lib/server/rpc_server.py
+++ b/src/MCPServer/lib/server/rpc_server.py
@@ -27,10 +27,10 @@ from lxml import etree
 
 
 from main.models import Job, SIP, Transfer
-
 from server.db import auto_close_old_connections
 from server.packages import create_package, get_approve_transfer_chain_id
 from server.processing_config import get_processing_fields
+from collections import OrderedDict
 
 
 logger = logging.getLogger("archivematica.mcp.server.rpc_server")
@@ -475,7 +475,9 @@ def _pull_choices(job_id, lang, jobs_awaiting_for_approval):
     The caller should expect ``JobNotWaitingForApprovalError`` to be raised
     when the job does not need a decision to be made.
     """
-    ret = {}
+
+    ret = OrderedDict()
+
     try:
         choices = jobs_awaiting_for_approval[job_id].get_choices()
     except (KeyError, AttributeError):

--- a/src/MCPServer/lib/server/rpc_server.py
+++ b/src/MCPServer/lib/server/rpc_server.py
@@ -8,6 +8,7 @@ need it, but it needs to be tested further. The main thing to check is whether
 the client is ready to handle application-level exceptions.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+from collections import OrderedDict
 
 import calendar
 import cPickle
@@ -30,7 +31,6 @@ from main.models import Job, SIP, Transfer
 from server.db import auto_close_old_connections
 from server.packages import create_package, get_approve_transfer_chain_id
 from server.processing_config import get_processing_fields
-from collections import OrderedDict
 
 
 logger = logging.getLogger("archivematica.mcp.server.rpc_server")
@@ -475,9 +475,7 @@ def _pull_choices(job_id, lang, jobs_awaiting_for_approval):
     The caller should expect ``JobNotWaitingForApprovalError`` to be raised
     when the job does not need a decision to be made.
     """
-
     ret = OrderedDict()
-
     try:
         choices = jobs_awaiting_for_approval[job_id].get_choices()
     except (KeyError, AttributeError):


### PR DESCRIPTION
I've gone through each of the processing configuration choices and reordered where necessary. Many of the changes are just for consistency - I've changed the order to `None`, `Yes`, `No` where those were the only options. For some of the jobs with more complex options I've tried to apply a more logical order:

```
Normalize:
* Normalize for preservation and access
* Normalize for preservation
* Normalize for access
* Normalize service files for access
* Normalize manually
* Do not normalize
```

```
Select compression level:
* 1 - fastest compression
* 3 - fast compression
* 5 - normal compression
* 7 - maximum compression
* 9 - ultra compression
```

```
Upload DIP:
* Upload DIP to AtoM/Binder
* Upload DIP to ArchivesSpace
* Upload DIP to CONTENTdm
* Do not upload DIP
```

One other change I've made here is in the `Generate thumbnails` option, where I've clarified the options:

```
Generate thumbnails:
* Yes
* Yes, without default icons
* No
```

The reason that this is still a WIP is because while the changes appear on the processing configuration page (Administration > Processing configuration > Default), they're not all reflected on the Transfer/Ingest tab drop-down menus. I'm not sure if this is a not-knowing-enough-about-docker problem or if there's something else in the code that I need to change.

Connected to #891
Requires https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/154