### PR TITLE
Workflow: move pid declaration job

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -507,7 +507,7 @@
                 "pt_BR": "Sim",
                 "sv": "Ja"
             },
-            "link_id": "873b428f-2c86-42b6-b463-aeda925bf559"
+            "link_id": "87e93d08-36e4-4c81-99a8-beea00b18400"
         },
         "94f764ad-805a-4d4e-8a2b-a6f2515b30c7": {
             "description": {
@@ -1224,11 +1224,11 @@
             "exit_codes": {
                 "0": {
                     "job_status": "Completed successfully",
-                    "link_id": "75fb5d67-5efa-4232-b00b-d85236de0d3f"
+                    "link_id": "873b428f-2c86-42b6-b463-aeda925bf559"
                 }
             },
             "fallback_job_status": "Failed",
-            "fallback_link_id": "75fb5d67-5efa-4232-b00b-d85236de0d3f",
+            "fallback_link_id": "873b428f-2c86-42b6-b463-aeda925bf559",
             "group": {
                 "en": "Process metadata directory",
                 "es": "Procesar directorio de metadatos",
@@ -7526,21 +7526,21 @@
                 "stdout_file": null
             },
             "description": {
-                "en": "Persistent identifier (PID) declaration"
+                "en": "Load persistent identifiers from external file"
             },
             "exit_codes": {
                 "0": {
                     "job_status": "Completed successfully",
-                    "link_id": "87e93d08-36e4-4c81-99a8-beea00b18400"
+                    "link_id": "75fb5d67-5efa-4232-b00b-d85236de0d3f"
                 }
             },
             "fallback_job_status": "Failed",
-            "fallback_link_id": "7d728c39-395f-4892-8193-92f086c0546f",
+            "fallback_link_id": "75fb5d67-5efa-4232-b00b-d85236de0d3f",
             "group": {
-                "en": "Bind PIDs",
-                "fr": "Lier les PIDs",
-                "pt_BR": "Vincular PIDs",
-                "sv": "Lås PID:er."
+                "en": "Process metadata directory",
+                "es": "Procesar directorio de metadatos",
+                "pt_BR": "Processar diretório de metadados",
+                "sv": "Bearbeta metadatamapp"
             }
         },
         "87e7659c-d5de-4541-a09c-6deec966a0c0": {


### PR DESCRIPTION
This PR moves the `Persistent identifier (PID) declaration` job from the `Bind PIDs` microservice to the `Process metadata directory` microservice in the Ingest tab so it can be executed when the `Bind PIDs` config option is set to `No`.

The description of the job has also been updated to `Load persistent identifiers from metadata/identifiers.json` for more transparency.

**Here's the position of the job (highlighted in grey) in the workflow before the change:**

![before](https://user-images.githubusercontent.com/560781/68160354-3f227980-ff19-11e9-85ae-742de331c05d.png)

**And this is its position (and label) now:**

![after](https://user-images.githubusercontent.com/560781/68160428-7002ae80-ff19-11e9-8c91-60f56997e5d7.png)

Connected to https://github.com/archivematica/Issues/issues/963