### PR TITLE
Fix constant gearman polling in MCPServer

### DIFF
--- a/src/MCPServer/lib/server/tasks/backends/__init__.py
+++ b/src/MCPServer/lib/server/tasks/backends/__init__.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import threading
 
 from server.tasks.backends.base import TaskBackend
-from server.tasks.backends.gearman import GearmanTaskBackend
+from server.tasks.backends.gearman_backend import GearmanTaskBackend
 
 
 backend_local = threading.local()

--- a/src/MCPServer/tests/test_gearman.py
+++ b/src/MCPServer/tests/test_gearman.py
@@ -64,7 +64,7 @@ def format_gearman_response(task_results):
 
 def test_gearman_task_submission(simple_job, simple_task, mocker):
     # Mock to avoid db writes
-    mocker.patch("server.tasks.backends.gearman.Task.bulk_log")
+    mocker.patch("server.tasks.backends.gearman_backend.Task.bulk_log")
     mocker.patch.object(GearmanTaskBackend, "TASK_BATCH_SIZE", 1)
     mock_client = mocker.patch("gearman.GearmanClient")
 
@@ -89,7 +89,7 @@ def test_gearman_task_submission(simple_job, simple_task, mocker):
 
 def test_gearman_task_result_success(simple_job, simple_task, mocker):
     # Mock to avoid db writes
-    mocker.patch("server.tasks.backends.gearman.Task.bulk_log")
+    mocker.patch("server.tasks.backends.gearman_backend.Task.bulk_log")
 
     mock_client = mocker.patch("gearman.GearmanClient")
     backend = GearmanTaskBackend()
@@ -136,7 +136,7 @@ def test_gearman_task_result_success(simple_job, simple_task, mocker):
 
 def test_gearman_task_result_error(simple_job, simple_task, mocker):
     # Mock to avoid db writes
-    mocker.patch("server.tasks.backends.gearman.Task.bulk_log")
+    mocker.patch("server.tasks.backends.gearman_backend.Task.bulk_log")
 
     mock_client = mocker.patch("gearman.GearmanClient")
     backend = GearmanTaskBackend()
@@ -175,7 +175,7 @@ def test_gearman_multiple_batches(
     simple_job, simple_task, mocker, reverse_result_order
 ):
     # Mock to avoid db writes
-    mocker.patch("server.tasks.backends.gearman.Task.bulk_log")
+    mocker.patch("server.tasks.backends.gearman_backend.Task.bulk_log")
     mocker.patch.object(GearmanTaskBackend, "TASK_BATCH_SIZE", 2)
     mock_client = mocker.patch("gearman.GearmanClient")
 

--- a/src/MCPServer/tests/test_gearman.py
+++ b/src/MCPServer/tests/test_gearman.py
@@ -66,7 +66,7 @@ def test_gearman_task_submission(simple_job, simple_task, mocker):
     # Mock to avoid db writes
     mocker.patch("server.tasks.backends.gearman_backend.Task.bulk_log")
     mocker.patch.object(GearmanTaskBackend, "TASK_BATCH_SIZE", 1)
-    mock_client = mocker.patch("gearman.GearmanClient")
+    mock_client = mocker.patch("server.tasks.backends.gearman_backend.MCPGearmanClient")
 
     backend = GearmanTaskBackend()
     backend.submit_task(simple_job, simple_task)
@@ -91,7 +91,7 @@ def test_gearman_task_result_success(simple_job, simple_task, mocker):
     # Mock to avoid db writes
     mocker.patch("server.tasks.backends.gearman_backend.Task.bulk_log")
 
-    mock_client = mocker.patch("gearman.GearmanClient")
+    mock_client = mocker.patch("server.tasks.backends.gearman_backend.MCPGearmanClient")
     backend = GearmanTaskBackend()
 
     mock_gearman_job = mocker.Mock()
@@ -117,7 +117,9 @@ def test_gearman_task_result_success(simple_job, simple_task, mocker):
         return [job_request]
 
     mock_client.return_value.submit_job.return_value = job_request
-    mock_client.return_value.get_job_statuses.side_effect = mock_jobs_completed
+    mock_client.return_value.wait_until_any_job_completed.side_effect = (
+        mock_jobs_completed
+    )
 
     backend.submit_task(simple_job, simple_task)
     results = list(backend.wait_for_results(simple_job))
@@ -125,7 +127,7 @@ def test_gearman_task_result_success(simple_job, simple_task, mocker):
     assert len(results) == 1
 
     mock_client.return_value.submit_job.assert_called_once()
-    mock_client.return_value.get_job_statuses.assert_called_once()
+    mock_client.return_value.wait_until_any_job_completed.assert_called_once()
 
     task_result = results[0]
     assert task_result.exit_code == 0
@@ -138,7 +140,7 @@ def test_gearman_task_result_error(simple_job, simple_task, mocker):
     # Mock to avoid db writes
     mocker.patch("server.tasks.backends.gearman_backend.Task.bulk_log")
 
-    mock_client = mocker.patch("gearman.GearmanClient")
+    mock_client = mocker.patch("server.tasks.backends.gearman_backend.MCPGearmanClient")
     backend = GearmanTaskBackend()
 
     mock_gearman_job = mocker.Mock()
@@ -153,7 +155,9 @@ def test_gearman_task_result_error(simple_job, simple_task, mocker):
         return [job_request]
 
     mock_client.return_value.submit_job.return_value = job_request
-    mock_client.return_value.get_job_statuses.side_effect = mock_jobs_completed
+    mock_client.return_value.wait_until_any_job_completed.side_effect = (
+        mock_jobs_completed
+    )
 
     backend.submit_task(simple_job, simple_task)
     results = list(backend.wait_for_results(simple_job))
@@ -161,7 +165,7 @@ def test_gearman_task_result_error(simple_job, simple_task, mocker):
     assert len(results) == 1
 
     mock_client.return_value.submit_job.assert_called_once()
-    mock_client.return_value.get_job_statuses.assert_called_once()
+    mock_client.return_value.wait_until_any_job_completed.assert_called_once()
 
     task_result = results[0]
     assert task_result.exit_code == 1
@@ -177,7 +181,7 @@ def test_gearman_multiple_batches(
     # Mock to avoid db writes
     mocker.patch("server.tasks.backends.gearman_backend.Task.bulk_log")
     mocker.patch.object(GearmanTaskBackend, "TASK_BATCH_SIZE", 2)
-    mock_client = mocker.patch("gearman.GearmanClient")
+    mock_client = mocker.patch("server.tasks.backends.gearman_backend.MCPGearmanClient")
 
     tasks = []
     for i in range(5):
@@ -231,7 +235,9 @@ def test_gearman_multiple_batches(
         return job_requests
 
     mock_client.return_value.submit_job.side_effect = job_requests
-    mock_client.return_value.get_job_statuses.side_effect = mock_get_job_statuses
+    mock_client.return_value.wait_until_any_job_completed.side_effect = (
+        mock_get_job_statuses
+    )
 
     for task in tasks:
         backend.submit_task(simple_job, task)
@@ -243,4 +249,6 @@ def test_gearman_multiple_batches(
     assert len(results) == 5
     assert results[0] is expected_first_result
     assert mock_client.return_value.submit_job.call_count == expected_batch_count
-    assert mock_client.return_value.get_job_statuses.call_count == len(job_requests)
+    assert mock_client.return_value.wait_until_any_job_completed.call_count == len(
+        job_requests
+    )


### PR DESCRIPTION
A tight loop in GearmanTaskBackend resulted in constant polling of gearman for status updates while waiting for a job to complete, which burns a lot of CPU for no reason 😭 .  This PR uses a lower level client method to wait for job activity.

Also removes possible naming confusion by renaming `gearman` to `gearman_backend`, so it doesn't have the same name as the library.

This issue was the worst when running more packages in parallel than there are MCPClients on the system, or with longer gearman jobs.

Test results with 3 transfers, 2 mcp clients:

Original (CPU seconds by process, orange is MCPServer):
<img width="584" alt="Screen Shot 2019-11-01 at 10 59 59 AM" src="https://user-images.githubusercontent.com/134694/68047289-40df0980-fc9b-11e9-9bda-0e9055da9e8e.png">

Revised (CPU seconds by process, orange is MCPServer):
<img width="583" alt="Screen Shot 2019-11-01 at 11 26 27 AM" src="https://user-images.githubusercontent.com/134694/68047291-43d9fa00-fc9b-11e9-8704-9c7bfa95628f.png">

Note that MCPServer still uses the most cpu! 😞 However, this is a huge improvement.

Connects to archivematica/Issues#911.