### PR TITLE
elasticsearch: parse size in index_aip_and_files

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -433,7 +433,7 @@ def index_aip_and_files(
         "uuid": uuid,
         "name": name,
         "filePath": aip_stored_path,
-        "size": aip_size / (1024 * 1024),
+        "size": int(aip_size) / (1024 * 1024),
         "origin": get_dashboard_uuid(),
         "created": created,
         "AICID": aic_identifier,


### PR DESCRIPTION
The `aip_size` in `index_aip_and_and_files` is assumed to be an `int`. This was the case until we changed the size field in the Storage Service Package form Integer to BigInterger ([PR in the storage service](https://github.com/artefactual/archivematica-storage-service/pull/496)). Since this change, the requests library deserializes the size field as a `string`, instead of an `int`.

To make sure that such arbitrary input changes cannot break this function we convert the `aip_size` to an `int`. This means that if the input is of type `int`, we convert the `int` to an `int`. If the input type is a `str`, we convert the `str` to an `int`.

An alternative for this change would be to parse the `size` field in the storage service [get_file_info()](https://github.com/artefactual/archivematica/blob/stable/1.10.x/src/archivematicaCommon/lib/storageService.py#L357). However, I think this adds complexity to a simple API call over sanitizing function input.

Adresses [#981](https://github.com/archivematica/Issues/issues/981).
