### PR TITLE
Search: index SIP and File identifiers

### DIFF
--- a/src/archivematicaCommon/lib/identifier_functions.py
+++ b/src/archivematicaCommon/lib/identifier_functions.py
@@ -2,7 +2,7 @@
 """
 Functions to fetch identifiers for indexing in ElasticSearch.
 
-See also src/MCPClient/lib/clientScripts/indexAIP.py where these are used.
+See also src/MCPClient/lib/clientScripts/index_aip.py where these are used.
 """
 
 from lxml import etree

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -546,9 +546,7 @@ class Identifier(models.Model):
     )
 
     def __str__(self):
-        return u"Identifier {i.identifiervalue} of type" " {i.identifiertype}".format(
-            i=self
-        )
+        return u"Identifier {i.value} of type {i.type}".format(i=self)
 
     class Meta:
         db_table = u"Identifiers"
@@ -603,7 +601,7 @@ class File(models.Model):
 
     def __unicode__(self):
         return six.text_type(
-            _("File %(uuid)s:%(originallocation)s" " now at %(currentlocation)s")
+            _("File %(uuid)s:%(originallocation)s now at %(currentlocation)s")
             % {
                 "uuid": self.uuid,
                 "originallocation": self.originallocation,
@@ -639,7 +637,7 @@ class Directory(models.Model):
 
     def __unicode__(self):
         return six.text_type(
-            _("Directory %(uuid)s: %(originallocation)s" " now at %(currentlocation)s")
+            _("Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s")
             % {
                 "uuid": self.uuid,
                 "originallocation": self.originallocation,


### PR DESCRIPTION
This PR adds SIP and File identifiers (set by the `Load persistent identifiers from external file` job) to the existing `identifiers` field which is already indexed in ElasticSearch. This allows to search these values in the Archival storage.

I also updated a couple of docstrings, fixed the string representation of the Identifier model and changed a couple of mutable default arguments.

Connected to https://github.com/archivematica/Issues/issues/1006