### PR TITLE
Correct behavior of move or merge

### DIFF
--- a/src/MCPClient/tests/test_move_or_merge.py
+++ b/src/MCPClient/tests/test_move_or_merge.py
@@ -70,6 +70,15 @@ def test_moves_contents_of_directory_when_dst_does_not_exist(tmpdir):
     assert dst.read() == "hello world"
 
 
+def test_moves_contents_with_no_files_at_src(tmpdir):
+    src_dir = tmpdir.mkdir("src")
+    dst_dir = tmpdir.join("dst")
+
+    move_or_merge(src=str(src_dir), dst=str(dst_dir))
+    assert dst_dir.exists()
+    assert not len(dst_dir.listdir())
+
+
 def test_moves_contents_of_directory(src_dir, dst_dir):
     src = src_dir.join("file.txt")
     dst = dst_dir.join("file.txt")


### PR DESCRIPTION
archivematica/issues#1018 documents that Archivematica previously
assumed a `metadata` folder existed, or would be created in the
correct location in a potential AIP during the ingest workflow.

This commit fixes a regression that caused this directory not to be
created when a 'src' location was otherwise empty. If a top-level
directory doesn't exist it will now get created.

NB. We create some additional logging in the hope it will help debug in future. A character encoding is added to the head of the Python script as a matter of course.

Connected to archivematica/issues#1018