### PR TITLE
Fix Upload to ArchivesSpace job status

### DIFF
--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -312,24 +312,26 @@ def call(jobs):
 
                 try:
                     files = get_files_from_dip(args.dip_location)
+                    if not upload_to_archivesspace(
+                        files,
+                        client,
+                        args.xlink_show,
+                        args.xlink_actuate,
+                        args.object_type,
+                        args.use_statement,
+                        args.uri_prefix,
+                        args.dip_uuid,
+                        args.access_conditions,
+                        args.use_conditions,
+                        args.restrictions,
+                        args.dip_location,
+                        args.inherit_notes,
+                    ):
+                        raise ValueError("not all files could be paired")
                 except ValueError:
                     job.set_status(2)
                     continue
                 except Exception:
                     job.set_status(3)
                     continue
-                upload_to_archivesspace(
-                    files,
-                    client,
-                    args.xlink_show,
-                    args.xlink_actuate,
-                    args.object_type,
-                    args.use_statement,
-                    args.uri_prefix,
-                    args.dip_uuid,
-                    args.access_conditions,
-                    args.use_conditions,
-                    args.restrictions,
-                    args.dip_location,
-                    args.inherit_notes,
-                )
+                job.set_status(0)

--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -104,7 +104,7 @@ def upload_to_archivesspace(
         uuid = file_name[0:36]
 
         if uuid not in pairs:
-            logger.warning("Skipping file {} ({}) - no pairing found".format(f, uuid))
+            logger.error("Skipping file {} ({}) - no pairing found".format(f, uuid))
             all_files_paired_successfully = False
             continue
 

--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -137,6 +137,7 @@ def upload_to_archivesspace(
                     ]
 
         # determine restrictions
+        restrictions_apply = False
         if restrictions == "no":
             restrictions_apply = False
         elif restrictions == "yes":

--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -34,11 +34,14 @@ def recursive_file_gen(mydir):
 
 def get_files_from_dip(dip_location):
     # need to find files in objects dir of dip:
-    # go to dipLocation/dipName/objects
+    # go to dipLocation/objects
     # get a directory listing
     # for each item, set fileName and go
     try:
-        mydir = dip_location + "objects/"
+        # remove trailing slash
+        if dip_location != os.path.sep:
+            dip_location = dip_location.rstrip(os.path.sep)
+        mydir = os.path.join(dip_location, "objects")
         mylist = list(recursive_file_gen(mydir))
 
         if len(mylist) > 0:

--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -235,12 +235,7 @@ def upload_to_archivesspace(
         delete_pairs(dip_uuid)
 
 
-def call(jobs):
-    RESTRICTIONS_CHOICES = ["yes", "no", "premis"]
-    EAD_SHOW_CHOICES = ["embed", "new", "none", "other", "replace"]
-    EAD_ACTUATE_CHOICES = ["none", "onLoad", "other", "onRequest"]
-    INHERIT_NOTES_CHOICES = ["yes", "y", "true", "1"]
-
+def get_parser(RESTRICTIONS_CHOICES, EAD_ACTUATE_CHOICES, EAD_SHOW_CHOICES):
     parser = argparse.ArgumentParser(
         description="A program to take digital objects from a DIP and upload them to an ArchivesSpace db"
     )
@@ -285,6 +280,16 @@ def call(jobs):
         type=str,
     )
     parser.add_argument("--version", action="version", version="%(prog)s 0.1.0")
+    return parser
+
+
+def call(jobs):
+    RESTRICTIONS_CHOICES = ["yes", "no", "premis"]
+    EAD_SHOW_CHOICES = ["embed", "new", "none", "other", "replace"]
+    EAD_ACTUATE_CHOICES = ["none", "onLoad", "other", "onRequest"]
+    INHERIT_NOTES_CHOICES = ["yes", "y", "true", "1"]
+
+    parser = get_parser(RESTRICTIONS_CHOICES, EAD_ACTUATE_CHOICES, EAD_SHOW_CHOICES)
 
     with transaction.atomic():
         for job in jobs:

--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -32,7 +32,7 @@ def recursive_file_gen(mydir):
             yield os.path.join(root, file)
 
 
-def get_files_from_dip(dip_location, dip_name, dip_uuid):
+def get_files_from_dip(dip_location):
     # need to find files in objects dir of dip:
     # go to dipLocation/dipName/objects
     # get a directory listing
@@ -303,9 +303,7 @@ def call(jobs):
                 )
 
                 try:
-                    files = get_files_from_dip(
-                        args.dip_location, args.dip_name, args.dip_uuid
-                    )
+                    files = get_files_from_dip(args.dip_location)
                 except ValueError:
                     job.set_status(2)
                     continue

--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -12,6 +12,7 @@ from xml2obj import mets_file
 
 # Third party dependencies, alphabetical by import source
 from agentarchives.archivesspace import ArchivesSpaceClient
+from agentarchives.archivesspace import ArchivesSpaceError
 
 # initialize Django (required for Django 1.7)
 import django
@@ -217,26 +218,35 @@ def upload_to_archivesspace(
         logger.info(
             "Uploading {} to ArchivesSpace record {}".format(file_name, as_resource)
         )
-        client.add_digital_object(
-            parent_archival_object=as_resource,
-            identifier=uuid,
-            # TODO: fetch a title from DC?
-            #       Use the title of the parent record?
-            title=original_name,
-            uri=uri + file_name,
-            location_of_originals=dip_uuid,
-            object_type=object_type,
-            use_statement=use_statement,
-            xlink_show=xlink_show,
-            xlink_actuate=xlink_actuate,
-            restricted=restrictions_apply,
-            use_conditions=use_conditions,
-            access_conditions=access_conditions,
-            size=size,
-            format_name=format_name,
-            format_version=format_version,
-            inherit_notes=inherit_notes,
-        )
+        try:
+            client.add_digital_object(
+                parent_archival_object=as_resource,
+                identifier=uuid,
+                # TODO: fetch a title from DC?
+                #       Use the title of the parent record?
+                title=original_name,
+                uri=uri + file_name,
+                location_of_originals=dip_uuid,
+                object_type=object_type,
+                use_statement=use_statement,
+                xlink_show=xlink_show,
+                xlink_actuate=xlink_actuate,
+                restricted=restrictions_apply,
+                use_conditions=use_conditions,
+                access_conditions=access_conditions,
+                size=size,
+                format_name=format_name,
+                format_version=format_version,
+                inherit_notes=inherit_notes,
+            )
+        except ArchivesSpaceError as e:
+
+            logger.error(
+                "Could not upload {} to ArchivesSpace record {}. Error: {}".format(
+                    file_name, as_resource, str(e)
+                )
+            )
+            all_files_paired_successfully = False
 
         delete_pairs(dip_uuid)
 

--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -98,12 +98,14 @@ def upload_to_archivesspace(
         mets = mets_file(mets_source)
         logger.debug("Found mets file at path: {}".format(mets_source))
 
+    all_files_paired_successfully = True
     for f in files:
         file_name = os.path.basename(f)
         uuid = file_name[0:36]
 
         if uuid not in pairs:
             logger.warning("Skipping file {} ({}) - no pairing found".format(f, uuid))
+            all_files_paired_successfully = False
             continue
 
         as_resource = pairs[uuid]
@@ -238,6 +240,8 @@ def upload_to_archivesspace(
 
         delete_pairs(dip_uuid)
 
+    return all_files_paired_successfully
+
 
 def get_parser(RESTRICTIONS_CHOICES, EAD_ACTUATE_CHOICES, EAD_SHOW_CHOICES):
     parser = argparse.ArgumentParser(
@@ -314,7 +318,6 @@ def call(jobs):
                 except Exception:
                     job.set_status(3)
                     continue
-
                 upload_to_archivesspace(
                     files,
                     client,

--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -94,7 +94,7 @@ def upload_to_archivesspace(
         or len(use_conditions) == 0
     ):
         logger.debug("Looking for mets: {}".format(dip_uuid))
-        mets_source = dip_location + "METS." + dip_uuid + ".xml"
+        mets_source = os.path.join(dip_location, "METS." + dip_uuid + ".xml")
         mets = mets_file(mets_source)
         logger.debug("Found mets file at path: {}".format(mets_source))
 

--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -320,26 +320,27 @@ def call(jobs):
 
                 try:
                     files = get_files_from_dip(args.dip_location)
-                    if not upload_to_archivesspace(
-                        files,
-                        client,
-                        args.xlink_show,
-                        args.xlink_actuate,
-                        args.object_type,
-                        args.use_statement,
-                        args.uri_prefix,
-                        args.dip_uuid,
-                        args.access_conditions,
-                        args.use_conditions,
-                        args.restrictions,
-                        args.dip_location,
-                        args.inherit_notes,
-                    ):
-                        raise ValueError("not all files could be paired")
                 except ValueError:
                     job.set_status(2)
                     continue
                 except Exception:
                     job.set_status(3)
                     continue
-                job.set_status(0)
+                if upload_to_archivesspace(
+                    files,
+                    client,
+                    args.xlink_show,
+                    args.xlink_actuate,
+                    args.object_type,
+                    args.use_statement,
+                    args.uri_prefix,
+                    args.dip_uuid,
+                    args.access_conditions,
+                    args.use_conditions,
+                    args.restrictions,
+                    args.dip_location,
+                    args.inherit_notes,
+                ):
+                    job.set_status(0)
+                else:
+                    job.set_status(2)

--- a/src/MCPClient/lib/clientScripts/upload_archivesspace.py
+++ b/src/MCPClient/lib/clientScripts/upload_archivesspace.py
@@ -95,7 +95,7 @@ def upload_to_archivesspace(
         or len(use_conditions) == 0
     ):
         logger.debug("Looking for mets: {}".format(dip_uuid))
-        mets_source = os.path.join(dip_location, "METS." + dip_uuid + ".xml")
+        mets_source = os.path.join(dip_location, "METS.{}.xml".format(dip_uuid))
         mets = mets_file(mets_source)
         logger.debug("Found mets file at path: {}".format(mets_source))
 
@@ -141,9 +141,7 @@ def upload_to_archivesspace(
 
         # determine restrictions
         restrictions_apply = False
-        if restrictions == "no":
-            restrictions_apply = False
-        elif restrictions == "yes":
+        if restrictions == "yes":
             restrictions_apply = True
             xlink_actuate = "none"
             xlink_show = "none"
@@ -239,11 +237,11 @@ def upload_to_archivesspace(
                 format_version=format_version,
                 inherit_notes=inherit_notes,
             )
-        except ArchivesSpaceError as e:
+        except ArchivesSpaceError as error:
 
             logger.error(
                 "Could not upload {} to ArchivesSpace record {}. Error: {}".format(
-                    file_name, as_resource, str(e)
+                    file_name, as_resource, str(error)
                 )
             )
             all_files_paired_successfully = False

--- a/src/MCPClient/tests/test_upload_archivesspace.py
+++ b/src/MCPClient/tests/test_upload_archivesspace.py
@@ -140,8 +140,7 @@ def test_upload_to_archivespace_gets_mets_if_needed(mocker, params):
         params["access_conditions"],
         params["use_conditions"],
         params["restrictions"],
-        # TODO: use os.path.join to make this trailing slash optional
-        "/dip/location/path/",
+        "/dip/location/path",
         "",
     )
     mets_file_mock.assert_called_once_with("/dip/location/path/METS.dipuuid.xml")

--- a/src/MCPClient/tests/test_upload_archivesspace.py
+++ b/src/MCPClient/tests/test_upload_archivesspace.py
@@ -183,3 +183,64 @@ def test_upload_to_archivespace_logs_files_with_no_pairs(db, mocker):
     logger.warning.assert_called_once_with(
         "Skipping file {} ({}) - no pairing found".format(files[1], file2_uuid)
     )
+
+
+def test_call(db, mocker):
+    parser_mock = mocker.Mock(
+        **{
+            "parse_args.return_value": mocker.Mock(
+                **{
+                    "base_url": "some_base_url",
+                    "user": "some_user",
+                    "passwd": "some_passwd",
+                    "dip_location": "some_dip_location",
+                    "dip_name": "some_dip_name",
+                    "dip_uuid": "some_dip_uuid",
+                    "xlink_show": "some_xlink_show",
+                    "xlink_actuate": "some_xlink_actuate",
+                    "object_type": "some_object_type",
+                    "use_statement": "some_use_statement",
+                    "uri_prefix": "some_uri_prefix",
+                    "access_conditions": "some_access_conditions",
+                    "use_conditions": "some_use_conditions",
+                    "restrictions": "some_restrictions",
+                    "inherit_notes": "some_inherit_notes",
+                }
+            )
+        }
+    )
+    mocker.patch("upload_archivesspace.get_parser", return_value=parser_mock)
+    client_mock = mocker.Mock()
+    client_factory_mock = mocker.patch(
+        "upload_archivesspace.ArchivesSpaceClient", return_value=client_mock
+    )
+    get_files_from_dip_mock = mocker.patch(
+        "upload_archivesspace.get_files_from_dip", return_value=[]
+    )
+    upload_to_archivesspace = mocker.patch(
+        "upload_archivesspace.upload_to_archivesspace"
+    )
+    job = mocker.Mock(args=[])
+    job.JobContext = mocker.MagicMock()
+    upload_archivesspace.call([job])
+    client_factory_mock.assert_called_once_with(
+        host="some_base_url", user="some_user", passwd="some_passwd"
+    )
+    get_files_from_dip_mock.assert_called_once_with(
+        "some_dip_location", "some_dip_name", "some_dip_uuid"
+    )
+    upload_to_archivesspace.assert_called_once_with(
+        [],
+        client_mock,
+        "some_xlink_show",
+        "some_xlink_actuate",
+        "some_object_type",
+        "some_use_statement",
+        "some_uri_prefix",
+        "some_dip_uuid",
+        "some_access_conditions",
+        "some_use_conditions",
+        "some_restrictions",
+        "some_dip_location",
+        False,
+    )

--- a/src/MCPClient/tests/test_upload_archivesspace.py
+++ b/src/MCPClient/tests/test_upload_archivesspace.py
@@ -172,7 +172,7 @@ def test_upload_to_archivesspace_logs_files_with_no_pairs(db, mocker):
     success = upload_archivesspace.upload_to_archivesspace(
         files, client_mock, "", "", "", "", "", "", "", "", "", "", ""
     )
-    logger.warning.assert_called_once_with(
+    logger.error.assert_called_once_with(
         "Skipping file {} ({}) - no pairing found".format(files[1], file2_uuid)
     )
     assert not success

--- a/src/MCPClient/tests/test_upload_archivesspace.py
+++ b/src/MCPClient/tests/test_upload_archivesspace.py
@@ -235,6 +235,7 @@ def test_call(db, mocker):
         "some_dip_location",
         False,
     )
+    job.set_status.assert_called_once_with(0)
 
 
 @pytest.mark.parametrize(
@@ -259,3 +260,14 @@ def test_call_when_files_from_dip_cant_be_retrieved(db, mocker, params):
     upload_archivesspace.call([job])
     job.set_status.assert_called_once_with(params["expected_job_status"])
     assert not upload_to_archivesspace.called
+
+
+def test_call_when_not_all_files_can_be_paired(db, mocker):
+    mocker.patch("upload_archivesspace.get_parser")
+    mocker.patch("upload_archivesspace.ArchivesSpaceClient")
+    mocker.patch("upload_archivesspace.get_files_from_dip")
+    mocker.patch("upload_archivesspace.upload_to_archivesspace", return_value=False)
+    job = mocker.Mock(args=[])
+    job.JobContext = mocker.MagicMock()
+    upload_archivesspace.call([job])
+    job.set_status.assert_called_once_with(2)

--- a/src/MCPClient/tests/test_upload_archivesspace.py
+++ b/src/MCPClient/tests/test_upload_archivesspace.py
@@ -31,8 +31,7 @@ def test_get_files_from_dip_finds_files(tmpdir):
     object2.write("object 2")
     # TODO:
     # - use os.path.join in the function and make trailing slash optional
-    # - remove last two parameters, they're not used in the function
-    result = upload_archivesspace.get_files_from_dip(str(dip) + "/", None, None)
+    result = upload_archivesspace.get_files_from_dip(str(dip) + "/")
     assert sorted(result) == [str(object1), str(object2)]
 
 
@@ -40,7 +39,7 @@ def test_get_files_from_dip_with_empty_dip_location(tmpdir, mocker):
     logger = mocker.patch("upload_archivesspace.logger")
     dip = tmpdir.mkdir("mydip")
     with pytest.raises(ValueError) as excinfo:
-        upload_archivesspace.get_files_from_dip(str(dip) + "/", None, None)
+        upload_archivesspace.get_files_from_dip(str(dip) + "/")
     assert excinfo.value.message == "cannot find dip"
     logger.error.assert_called_once_with("no files in {}/objects/".format(str(dip)))
 
@@ -227,7 +226,7 @@ def test_call(db, mocker):
         host="some_base_url", user="some_user", passwd="some_passwd"
     )
     get_files_from_dip_mock.assert_called_once_with(
-        "some_dip_location", "some_dip_name", "some_dip_uuid"
+        "some_dip_location"
     )
     upload_to_archivesspace.assert_called_once_with(
         [],

--- a/src/MCPClient/tests/test_upload_archivesspace.py
+++ b/src/MCPClient/tests/test_upload_archivesspace.py
@@ -1,0 +1,70 @@
+"""Tests for the upload_archivesspace.py client script."""
+
+import os
+import sys
+
+import pytest
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(THIS_DIR, "../lib/clientScripts")))
+
+import upload_archivesspace
+
+
+def test_recursive_file_gen(tmpdir):
+    mydir = tmpdir.mkdir("mydir")
+    hello = mydir.join("hello.txt")
+    hello.write("hello!")
+    bye = mydir.mkdir("sub").join("bye.txt")
+    bye.write("bye!")
+    result = list(upload_archivesspace.recursive_file_gen(str(mydir)))
+    assert sorted(result) == [str(hello), str(bye)]
+
+
+def test_get_files_from_dip_finds_files(tmpdir):
+    dip = tmpdir.mkdir("mydip")
+    objects = dip.mkdir("objects")
+    object1 = objects.join("object1.txt")
+    object1.write("object 1")
+    object2 = objects.mkdir("subdir").join("object2.txt")
+    object2.write("object 2")
+    # TODO:
+    # - use os.path.join in the function and make trailing slash optional
+    # - remove last two parameters, they're not used in the function
+    result = upload_archivesspace.get_files_from_dip(str(dip) + "/", None, None)
+    assert sorted(result) == [str(object1), str(object2)]
+
+
+def test_get_files_from_dip_with_empty_dip_location(tmpdir, mocker):
+    logger = mocker.patch("upload_archivesspace.logger")
+    dip = tmpdir.mkdir("mydip")
+    with pytest.raises(ValueError) as excinfo:
+        upload_archivesspace.get_files_from_dip(str(dip) + "/", None, None)
+    assert excinfo.value.message == "cannot find dip"
+    logger.error.assert_called_once_with("no files in {}/objects/".format(str(dip)))
+
+
+def test_get_pairs(mocker):
+    dip_uuid = "somedipuuid"
+    filter_mock = mocker.patch(
+        "upload_archivesspace.ArchivesSpaceDIPObjectResourcePairing.objects.filter",
+        return_value=[
+            mocker.Mock(fileuuid="1", resourceid="myresource"),
+            mocker.Mock(fileuuid="2", resourceid="myresource"),
+        ],
+    )
+    result = upload_archivesspace.get_pairs(dip_uuid)
+    assert result == {"1": "myresource", "2": "myresource"}
+    filter_mock.assert_called_once_with(dipuuid=dip_uuid)
+
+
+def test_delete_pairs(mocker):
+    dip_uuid = "somedipuuid"
+    queryset_mock = mocker.Mock()
+    filter_mock = mocker.patch(
+        "upload_archivesspace.ArchivesSpaceDIPObjectResourcePairing.objects.filter",
+        return_value=queryset_mock,
+    )
+    upload_archivesspace.delete_pairs(dip_uuid)
+    filter_mock.assert_called_once_with(dipuuid=dip_uuid)
+    queryset_mock.delete.assert_called_once()

--- a/src/MCPClient/tests/test_upload_archivesspace.py
+++ b/src/MCPClient/tests/test_upload_archivesspace.py
@@ -81,12 +81,8 @@ def test_upload_to_archivespace_adds_trailing_slash_to_uri(db, mocker, uri):
         "upload_archivesspace.get_pairs", return_value={file_uuid: "myresource"}
     )
     files = ["file/{}-path".format(file_uuid)]
-    # TODO: initialize restriction_apply = None/False before determining restrictions
-    #       to avoid referenced before assignment error if restrictions is no in the
-    #       expected values
-    restrictions = "no"
     upload_archivesspace.upload_to_archivesspace(
-        files, client_mock, "", "", "", "", uri, "", "", "", restrictions, "", ""
+        files, client_mock, "", "", "", "", uri, "", "", "", "", "", ""
     )
     client_mock.add_digital_object.assert_called_once_with(
         **{
@@ -173,9 +169,8 @@ def test_upload_to_archivespace_logs_files_with_no_pairs(db, mocker):
         "/path/to/{}-video.avi".format(file2_uuid),
         "/path/to/{}-audio.mp3".format(file3_uuid),
     ]
-    restrictions = "no"
     upload_archivesspace.upload_to_archivesspace(
-        files, client_mock, "", "", "", "", "", "", "", "", restrictions, "", ""
+        files, client_mock, "", "", "", "", "", "", "", "", "", "", ""
     )
     logger.warning.assert_called_once_with(
         "Skipping file {} ({}) - no pairing found".format(files[1], file2_uuid)

--- a/src/MCPClient/tests/test_upload_archivesspace.py
+++ b/src/MCPClient/tests/test_upload_archivesspace.py
@@ -73,7 +73,7 @@ def test_delete_pairs(mocker):
     ["http://some/uri/", "http://some/uri"],
     ids=["uri_with_trailing_slash", "uri_with_no_trailing_slash"],
 )
-def test_upload_to_archivespace_adds_trailing_slash_to_uri(db, mocker, uri):
+def test_upload_to_archivesspace_adds_trailing_slash_to_uri(db, mocker, uri):
     file_uuid = str(uuid.uuid4())
     client_mock = mocker.Mock()
     mocker.patch("upload_archivesspace.mets_file")
@@ -81,7 +81,7 @@ def test_upload_to_archivespace_adds_trailing_slash_to_uri(db, mocker, uri):
         "upload_archivesspace.get_pairs", return_value={file_uuid: "myresource"}
     )
     files = ["file/{}-path".format(file_uuid)]
-    upload_archivesspace.upload_to_archivesspace(
+    success = upload_archivesspace.upload_to_archivesspace(
         files, client_mock, "", "", "", "", uri, "", "", "", "", "", ""
     )
     client_mock.add_digital_object.assert_called_once_with(
@@ -105,6 +105,7 @@ def test_upload_to_archivespace_adds_trailing_slash_to_uri(db, mocker, uri):
             "xlink_show": "",
         }
     )
+    assert success
 
 
 @pytest.mark.parametrize(
@@ -124,7 +125,7 @@ def test_upload_to_archivespace_adds_trailing_slash_to_uri(db, mocker, uri):
     ],
     ids=["with_restrictions", "with_access_conditions", "with_use_conditions"],
 )
-def test_upload_to_archivespace_gets_mets_if_needed(mocker, params):
+def test_upload_to_archivesspace_gets_mets_if_needed(mocker, params):
     mocker.patch("upload_archivesspace.get_pairs")
     logger = mocker.patch("upload_archivesspace.logger")
     mets_file_mock = mocker.patch("upload_archivesspace.mets_file")
@@ -152,7 +153,7 @@ def test_upload_to_archivespace_gets_mets_if_needed(mocker, params):
     )
 
 
-def test_upload_to_archivespace_logs_files_with_no_pairs(db, mocker):
+def test_upload_to_archivesspace_logs_files_with_no_pairs(db, mocker):
     file1_uuid = uuid.uuid4()
     file2_uuid = uuid.uuid4()
     file3_uuid = uuid.uuid4()
@@ -168,12 +169,13 @@ def test_upload_to_archivespace_logs_files_with_no_pairs(db, mocker):
         "/path/to/{}-video.avi".format(file2_uuid),
         "/path/to/{}-audio.mp3".format(file3_uuid),
     ]
-    upload_archivesspace.upload_to_archivesspace(
+    success = upload_archivesspace.upload_to_archivesspace(
         files, client_mock, "", "", "", "", "", "", "", "", "", "", ""
     )
     logger.warning.assert_called_once_with(
         "Skipping file {} ({}) - no pairing found".format(files[1], file2_uuid)
     )
+    assert not success
 
 
 def test_call(db, mocker):

--- a/src/MCPClient/tests/test_upload_archivesspace.py
+++ b/src/MCPClient/tests/test_upload_archivesspace.py
@@ -29,9 +29,7 @@ def test_get_files_from_dip_finds_files(tmpdir):
     object1.write("object 1")
     object2 = objects.mkdir("subdir").join("object2.txt")
     object2.write("object 2")
-    # TODO:
-    # - use os.path.join in the function and make trailing slash optional
-    result = upload_archivesspace.get_files_from_dip(str(dip) + "/")
+    result = upload_archivesspace.get_files_from_dip(str(dip))
     assert sorted(result) == [str(object1), str(object2)]
 
 
@@ -39,9 +37,9 @@ def test_get_files_from_dip_with_empty_dip_location(tmpdir, mocker):
     logger = mocker.patch("upload_archivesspace.logger")
     dip = tmpdir.mkdir("mydip")
     with pytest.raises(ValueError) as excinfo:
-        upload_archivesspace.get_files_from_dip(str(dip) + "/")
+        upload_archivesspace.get_files_from_dip(str(dip))
     assert excinfo.value.message == "cannot find dip"
-    logger.error.assert_called_once_with("no files in {}/objects/".format(str(dip)))
+    logger.error.assert_called_once_with("no files in {}/objects".format(str(dip)))
 
 
 def test_get_pairs(mocker):
@@ -225,9 +223,7 @@ def test_call(db, mocker):
     client_factory_mock.assert_called_once_with(
         host="some_base_url", user="some_user", passwd="some_passwd"
     )
-    get_files_from_dip_mock.assert_called_once_with(
-        "some_dip_location"
-    )
+    get_files_from_dip_mock.assert_called_once_with("some_dip_location")
     upload_to_archivesspace.assert_called_once_with(
         [],
         client_mock,

--- a/src/MCPClient/tests/test_upload_archivesspace.py
+++ b/src/MCPClient/tests/test_upload_archivesspace.py
@@ -22,13 +22,11 @@ def test_recursive_file_gen(tmpdir):
 
 
 def test_get_files_from_dip_finds_files(tmpdir):
-    dip = tmpdir.mkdir("mydip")
-    objects = dip.mkdir("objects")
-    object1 = objects.join("object1.txt")
-    object1.write("object 1")
-    object2 = objects.mkdir("subdir").join("object2.txt")
-    object2.write("object 2")
-    result = upload_archivesspace.get_files_from_dip(str(dip))
+    object1 = tmpdir.join("mydip", "objects", "object1.txt")
+    object1.write("object 1", ensure=True)
+    object2 = tmpdir.join("mydip", "objects", "subdir", "object2.txt")
+    object2.write("object 2", ensure=True)
+    result = upload_archivesspace.get_files_from_dip(str(tmpdir / "mydip"))
     assert sorted(result) == [str(object1), str(object2)]
 
 

--- a/src/MCPClient/tests/test_upload_archivesspace.py
+++ b/src/MCPClient/tests/test_upload_archivesspace.py
@@ -13,12 +13,11 @@ import upload_archivesspace
 
 
 def test_recursive_file_gen(tmpdir):
-    mydir = tmpdir.mkdir("mydir")
-    hello = mydir.join("hello.txt")
-    hello.write("hello!")
-    bye = mydir.mkdir("sub").join("bye.txt")
-    bye.write("bye!")
-    result = list(upload_archivesspace.recursive_file_gen(str(mydir)))
+    hello = tmpdir.join("mydir", "hello.txt")
+    hello.write("hello!", ensure=True)
+    bye = tmpdir.join("mydir", "sub", "bye.txt")
+    bye.write("bye!", ensure=True)
+    result = list(upload_archivesspace.recursive_file_gen(str(tmpdir / "mydir")))
     assert sorted(result) == [str(hello), str(bye)]
 
 


### PR DESCRIPTION
This PR makes the `Upload to ArchivesSpace` job to fail if any file cannot be paired or uploaded. It also cleans some path handling and adds a unit test for the client script.

Connected to https://github.com/archivematica/Issues/issues/258