### PR TITLE
Restructure bag: check for pre-existing metadata dir

### DIFF
--- a/src/MCPClient/lib/clientScripts/verify_and_restructure_transfer_bag.py
+++ b/src/MCPClient/lib/clientScripts/verify_and_restructure_transfer_bag.py
@@ -36,6 +36,8 @@ import bag
 import fileOperations
 from databaseFunctions import insertIntoEvents
 
+from move_or_merge import move_or_merge
+
 
 def restructureBagForComplianceFileUUIDsAssigned(
     job,
@@ -55,6 +57,15 @@ def restructureBagForComplianceFileUUIDsAssigned(
         dirPath = os.path.join(unitPath, dir)
         dirDataPath = os.path.join(unitPath, "data", dir)
         if os.path.isdir(dirDataPath):
+            if dir == "metadata" and os.path.isdir(dirPath):
+                # We move the existing top-level metadata folder, or merge it
+                # with what is currently there, before the next set of
+                # directory operations to move everything up a level below.
+                job.pyprint(
+                    "{}: moving/merging {} to {}".format(dir, dirPath, dirDataPath)
+                )
+                move_or_merge(dirPath, dirDataPath)
+
             # move to the top level
             src = dirDataPath
             dst = dirPath
@@ -67,6 +78,7 @@ def restructureBagForComplianceFileUUIDsAssigned(
                 unitPathReplaceWith,
             )
             job.pyprint("moving directory ", dir)
+
         else:
             if not os.path.isdir(dirPath):
                 job.pyprint("creating: ", dir)


### PR DESCRIPTION
Check for pre-existing metadata directory at the top level of the
transfer before moving bag metadata, merge contents if so.

Connected to archivematica/Issues#1022