### PR TITLE
Remove mutable default argument

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -1058,7 +1058,10 @@ def _list_bulk_extractor_reports(transfer_path, file_uuid):
     return reports
 
 
-def _list_files_in_dir(path, filepaths=[]):
+def _list_files_in_dir(path, filepaths=None):
+    if filepaths is None:
+        filepaths = []
+
     # Define entries
     for file in os.listdir(path):
         child_path = os.path.join(path, file)


### PR DESCRIPTION
When reindexing, `_list_files_in_dir()` is run once for each item. If
the `filepaths` argument is left set to `[]`, then each item will
erroneously include all previously indexed files.

By setting it to `None` and initing the `[]` default inside the function
body, we avoid this undesirable behavior because the list is inited anew
each time the function runs.

Duplicate of https://github.com/artefactual/archivematica/pull/1500 to avoid more complicated rebase/merge effort (and because I thought it was going to be possible via the GH UI but was wrong!). 