### PR TITLE
Fix user attributes encoding on agent creation

### DIFF
--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -81,8 +81,10 @@ def create_user_agent(sender, instance, **kwargs):
         defaults={
             "identifiertype": "Archivematica user pk",
             "identifiervalue": str(instance.id),
-            "name": 'username="{u.username}", first_name="{u.first_name}", last_name="{u.last_name}"'.format(
-                u=instance
+            "name": 'username="{}", first_name="{}", last_name="{}"'.format(
+                instance.username.encode("utf8"),
+                instance.first_name.encode("utf8"),
+                instance.last_name.encode("utf8"),
             ),
             "agenttype": "Archivematica user",
         },

--- a/src/dashboard/tests/test_models.py
+++ b/src/dashboard/tests/test_models.py
@@ -1,16 +1,19 @@
-from django.test import TestCase
+# -*- coding: utf-8 -*-
 
-from main.models import SIP, Transfer, UnitVariable, User
+from django.test import TestCase
+import mock
+
+from main import models
 
 
 class TestActiveAgent(TestCase):
     fixtures = ["test_user"]
 
     def test_transfer_update_active_agent(self):
-        user = User.objects.get(id=1)
-        transfer = Transfer.objects.create()
+        user = models.User.objects.get(id=1)
+        transfer = models.Transfer.objects.create()
         transfer.update_active_agent(user.id)
-        assert UnitVariable.objects.get(
+        assert models.UnitVariable.objects.get(
             unittype="Transfer",
             unituuid=transfer.uuid,
             variable="activeAgent",
@@ -18,10 +21,10 @@ class TestActiveAgent(TestCase):
         )
 
     def test_sip_update_active_agent(self):
-        user = User.objects.get(id=1)
-        sip = SIP.objects.create()
+        user = models.User.objects.get(id=1)
+        sip = models.SIP.objects.create()
         sip.update_active_agent(user.id)
-        assert UnitVariable.objects.get(
+        assert models.UnitVariable.objects.get(
             unittype="SIP",
             unituuid=sip.uuid,
             variable="activeAgent",
@@ -29,12 +32,12 @@ class TestActiveAgent(TestCase):
         )
 
     def test_unitvariable_update_variable(self):
-        obj, created = UnitVariable.objects.update_variable(
+        obj, created = models.UnitVariable.objects.update_variable(
             "UNIT_TYPE", "UNIT_ID", "VARIABLE", "VALUE", "LINK_ID"
         )
         assert created is True
-        assert isinstance(obj, UnitVariable)
-        UnitVariable.objects.get(
+        assert isinstance(obj, models.UnitVariable)
+        models.UnitVariable.objects.get(
             unittype="UNIT_TYPE",
             unituuid="UNIT_ID",
             variable="VARIABLE",
@@ -42,15 +45,33 @@ class TestActiveAgent(TestCase):
             microservicechainlink="LINK_ID",
         )
 
-        obj, created = UnitVariable.objects.update_variable(
+        obj, created = models.UnitVariable.objects.update_variable(
             "UNIT_TYPE", "UNIT_ID", "VARIABLE", "NEW_VALUE", "NEW_LINK_ID"
         )
         assert created is False
-        assert isinstance(obj, UnitVariable)
-        UnitVariable.objects.get(
+        assert isinstance(obj, models.UnitVariable)
+        models.UnitVariable.objects.get(
             unittype="UNIT_TYPE",
             unituuid="UNIT_ID",
             variable="VARIABLE",
             variablevalue="NEW_VALUE",
             microservicechainlink="NEW_LINK_ID",
         )
+
+
+@mock.patch("main.models.Agent")
+def test_create_user_agent(agent_mock):
+    agent_mock.objects.update_or_create.return_value = (None, False)
+    user_mock = mock.Mock(
+        id=1234, username=u"maría", first_name=u"María", last_name=u"Martínez"
+    )
+    models.create_user_agent(None, user_mock)
+    agent_mock.objects.update_or_create.assert_called_once_with(
+        userprofile__user=user_mock,
+        defaults={
+            "identifiertype": "Archivematica user pk",
+            "identifiervalue": "1234",
+            "name": 'username="maría", first_name="María", last_name="Martínez"',
+            "agenttype": "Archivematica user",
+        },
+    )


### PR DESCRIPTION
This fixes an `UnicodeEncodeError` thrown by the add and edit user forms when non-ascii values are used in the First name and Last name fields.

Connected to https://github.com/archivematica/Issues/issues/261