### PR TITLE
Create or reuse database transfers for watched directories

### DIFF
--- a/src/MCPServer/lib/server/mcp.py
+++ b/src/MCPServer/lib/server/mcp.py
@@ -42,7 +42,6 @@ from server.jobs import Job, JobChain
 from server.packages import DIP, Transfer, SIP
 from server.queues import PackageQueue
 from server.tasks import Task
-from server.utils import uuid_from_path
 from server.watch_dirs import watch_directories
 from server.workflow import load_default_workflow
 
@@ -64,10 +63,9 @@ def watched_dir_handler(package_queue, path, watched_dir):
     elif package_type == "DIP" and is_dir:
         package = DIP.get_or_create_from_db_by_path(path)
     elif package_type == "Transfer" and is_dir:
-        uuid = uuid_from_path(path)
-        package = Transfer(path, uuid)
+        package = Transfer.get_or_create_from_db_by_path(path)
     elif package_type == "Transfer" and not is_dir:
-        package = Transfer(path, None)
+        package = Transfer.get_or_create_from_db_by_path(path)
     else:
         raise ValueError("Unexpected unit type given for file {}".format(path))
 

--- a/src/MCPServer/tests/test_mcp.py
+++ b/src/MCPServer/tests/test_mcp.py
@@ -1,9 +1,85 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import threading
-
+import uuid
 
 from server.mcp import main
+from server.mcp import watched_dir_handler
+
+
+def test_watched_dir_handler_creates_transfer_if_it_does_not_exist(mocker, tmpdir):
+    """Test that a models.Transfer object exists for an unknown path.
+
+    This for example simulates the case when a user drops a directory
+    in `watchedDirectories/activeTransfers/standardTransfer`, and a
+    transfer UUID cannot be infered from the path because the transfer
+    does not exist yet in the database.
+
+    The database transfer is created with a new UUID and the path as
+    its current location.
+    """
+    # We're not interested in the package queue or the link chaining logics here,
+    # so we mock very limited implementations for those.
+    job_chain_mock = mocker.MagicMock()
+    job_chain_mock.return_value = iter(["some_chain_link"])
+    mocker.patch("server.mcp.JobChain", job_chain_mock)
+    package_queue = mocker.Mock()
+    watched_dir = mocker.MagicMock(**{"__getitem__.return_value": "Transfer"})
+
+    # Mock a known UUID for the new transfer.
+    transfer_uuid = uuid.uuid4()
+    mocker.patch("server.packages.uuid4", return_value=transfer_uuid)
+
+    # Mock the Django manager for the Transfer model. This is mocked from the
+    # `server.packages` module since its path from the Dashboard is not available.
+    transfer_mock = mocker.Mock(uuid=transfer_uuid)
+    create_mock = mocker.patch(
+        "server.packages.models.Transfer.objects.create", return_value=transfer_mock
+    )
+
+    # The new/unknown path for creating the transfer.
+    path = tmpdir.mkdir("some_transfer")
+
+    # Call the function under test.
+    watched_dir_handler(package_queue, str(path), watched_dir)
+
+    # The Transfer manager should have been called with the right arguments.
+    create_mock.assert_called_once_with(
+        uuid=transfer_uuid, currentlocation="{}/".format(path)
+    )
+
+
+def test_watched_dir_handler_creates_transfer_for_file(mocker, tmpdir):
+    """Test that a models.Transfer object exists for a file path.
+    """
+    # We're not interested in the package queue or the link chaining logics here,
+    # so we mock very limited implementations for those.
+    job_chain_mock = mocker.MagicMock()
+    job_chain_mock.return_value = iter(["some_chain_link"])
+    mocker.patch("server.mcp.JobChain", job_chain_mock)
+    package_queue = mocker.Mock()
+    watched_dir = mocker.MagicMock(**{"__getitem__.return_value": "Transfer"})
+
+    # Mock a known UUID for the new transfer.
+    transfer_uuid = uuid.uuid4()
+    mocker.patch("server.packages.uuid4", return_value=transfer_uuid)
+
+    # Mock the Django manager for the Transfer model. This is mocked from the
+    # `server.packages` module since its path from the Dashboard is not available.
+    transfer_mock = mocker.Mock(uuid=transfer_uuid)
+    create_mock = mocker.patch(
+        "server.packages.models.Transfer.objects.create", return_value=transfer_mock
+    )
+
+    # The new/unknown path of a file for creating the transfer.
+    path = tmpdir.join("file.txt")
+    path.write("a file!")
+
+    # Call the function under test.
+    watched_dir_handler(package_queue, str(path), watched_dir)
+
+    # The Transfer manager should have been called with the right arguments.
+    create_mock.assert_called_once_with(uuid=transfer_uuid, currentlocation=str(path))
 
 
 def test_mcp_main(mocker, settings):


### PR DESCRIPTION
For a bit of more context see my https://github.com/archivematica/Issues/issues/1032#issuecomment-567768052 explaining the scenarios where this issue appears.

When a watched directory containing `Transfer` units is polled, its
contents must have `models.Transfer` objects associated. Otherwise,
the package queue machinery fails.

This checks if the transfer exists based on the directory or file name and
reuses it, or creates it when needed.

It might be useful to check how [the previous logic](https://github.com/artefactual/archivematica/blob/f4cae3165434d92af6a0bb8fdddf2e0656fb2231/src/MCPServer/lib/unitTransfer.py#L46-L64) for `finding or creating` transfers worked in 1.10.1.

Connected to https://github.com/archivematica/Issues/issues/1032