### PR TITLE
Make sure the ability is printed into this log

### DIFF
--- a/src/dashboard/src/contrib/mcp/client.py
+++ b/src/dashboard/src/contrib/mcp/client.py
@@ -121,7 +121,7 @@ class MCPClient(object):
         if response.state == gearman.JOB_CREATED:
             raise TimeoutError(timeout)
         elif response.state != gearman.JOB_COMPLETE:
-            raise RPCError("%s failed (check the logs)".format(ability))
+            raise RPCError("%s failed (check the logs)" % ability)
         payload = cPickle.loads(response.result)
         if isinstance(payload, dict) and payload.get("error", False):
             raise RPCServerError(payload)


### PR DESCRIPTION
As currently written, this will be shown in the log as

> %s failed (check the logs)

which is less than informative!

Spotted while trying to debug something in our dashboard logs; I got the following error line:

```
ERROR     2019-12-20 10:26:01  archivematica.dashboard:views:_package_create:831:  Package cannot be created: %s failed (check the logs)
```

I haven't created a ticket in archivematica/issues because it's such a small thing, but I can create one if you need it.

Connects to https://github.com/archivematica/Issues/issues/1038