### PR TITLE
Include UUID in SIP path created by dashboard

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -386,7 +386,7 @@ def _create_arranged_sip(staging_sip_path, files, sip_uuid):
         "watchedDirectories",
         "SIPCreation",
         "SIPsUnderConstruction",
-        sip_name,
+        "%s-%s" % (sip_name, sip_uuid),
     )
     currentpath = sip_path.replace(shared_dir, "%sharedPath%", 1) + "/"
     sip_path = helpers.pad_destination_filepath_if_it_already_exists(sip_path)


### PR DESCRIPTION
This ensures the SIP UUID generated by the dashboard sip creation process and linked to the files in the SIP, is preserved when MCP Server picks it up - otherwise MCP Server will try to create its own SIP object with a new UUID and the files are not linked to it.

Fixes https://github.com/archivematica/Issues/issues/1031