### PR TITLE
Re-enable package.py to update its file list

### DIFF
--- a/src/MCPServer/tests/test_package.py
+++ b/src/MCPServer/tests/test_package.py
@@ -123,6 +123,123 @@ def test_transfer_get_or_create_from_db_path_with_uuid(tmp_path):
         )
 
 
+@pytest.mark.django_db(transaction=True)
+def test_reload_file_list(tmp_path):
+
+    # Create a transfer that will be updated through time to simulate
+    # Archivematica's processing.
+    transfer_uuid = uuid.uuid4()
+    transfer_path = tmp_path / "test-transfer-{}".format(transfer_uuid)
+    transfer = Transfer.get_or_create_from_db_by_path(str(transfer_path))
+
+    # Add files to the transfer to simulate a transfer existing on disk.
+    transfer_path.mkdir()
+    objects_path = transfer_path / "objects"
+    objects_path.mkdir()
+    first_file = objects_path / "file.txt"
+    first_file.touch()
+
+    kwargs = {
+        "uuid": uuid.uuid4(),
+        "currentlocation": "".join(
+            [transfer.REPLACEMENT_PATH_STRING, str(Path("/objects/file.txt"))]
+        ),
+        "filegrpuse": "original",
+        "transfer_id": transfer_uuid,
+    }
+    models.File.objects.create(**kwargs)
+    assert models.File.objects.filter(transfer_id=str(transfer_uuid)).count() == 1
+
+    # Add a new file to the file-system, e.g. to simulate normalization for
+    # preservation adding a new object.
+    new_file = objects_path / "new_file.txt"
+    new_file.touch()
+
+    # One file will be returned from the database  with a UUID, another from
+    # the filesystem without a UUID.
+    for file_count, file_info in enumerate(transfer.files(None, None, "/objects"), 1):
+        assert "%fileUUID%" in file_info
+        assert "%fileGrpUse%" in file_info
+        assert "%relativeLocation%" in file_info
+        if file_info.get("%fileUUID%") != "None":
+            continue
+        assert file_info.get("%relativeLocation%") == str(new_file)
+        file_path = "".join(
+            [
+                transfer.REPLACEMENT_PATH_STRING,
+                "/objects",
+                file_info.get("%relativeLocation%").split("objects")[1],
+            ]
+        )
+        kwargs = {
+            "uuid": uuid.uuid4(),
+            "currentlocation": file_path,
+            "filegrpuse": "original",
+            "transfer_id": transfer_uuid,
+        }
+        models.File.objects.create(**kwargs)
+    assert (
+        file_count == 2
+    ), "Database and file objects were not returned by the generator"
+    assert models.File.objects.filter(transfer_id=str(transfer_uuid)).count() == 2
+
+    # Simulate an additional file object being added later on in the transfer
+    # in a sub directory of the objects folder, e.g. transcribe contents.
+    sub_dir = objects_path / "subdir"
+    sub_dir.mkdir()
+    new_file = sub_dir / "another_new_file.txt"
+    new_file.touch()
+    for file_count, file_info in enumerate(transfer.files(None, None, "/objects"), 1):
+        file_path = "".join(
+            [
+                transfer.REPLACEMENT_PATH_STRING,
+                "/objects",
+                file_info.get("%relativeLocation%").split("objects")[1],
+            ]
+        )
+        if file_info.get("%fileUUID%") != "None":
+            continue
+        kwargs = {
+            "uuid": uuid.uuid4(),
+            "currentlocation": file_path,
+            "filegrpuse": "original",
+            "transfer_id": transfer_uuid,
+        }
+        models.File.objects.create(**kwargs)
+    assert (
+        file_count == 3
+    ), "Database and file objects were not returned by the generator"
+    assert models.File.objects.filter(transfer_id=str(transfer_uuid)).count() == 3
+
+    # Now the database is updated, we will still have the same file count, but
+    # all objects will be returned from the database and we will have uuids.
+    for file_count, file_info in enumerate(transfer.files(None, None, "/objects"), 1):
+        if file_info.get("%fileUUID%") == "None":
+            assert (
+                False
+            ), "Non-database entries returned from package.files(): {}".format(
+                file_info
+            )
+    assert file_count == 3
+
+    # Finally, let's just see if the scan works for a slightly larger no.
+    # files, i.e. a number with an increment slightly larger than one.
+    files = ["f1", "f2", "f3", "f4", "f5"]
+    for file_ in files:
+        new_file = objects_path / file_
+        new_file.touch()
+    new_count = 0
+    for file_count, file_info in enumerate(transfer.files(None, None, "/objects"), 1):
+        if file_info.get("%fileUUID%") == "None":
+            new_count += 1
+    assert new_count == 5
+    assert file_count == 8
+
+    # Clean up state and ensure test doesn't interfere with other transfers
+    # expected to be in the database, e.g. in test_queues.py.
+    models.File.objects.filter(transfer_id=str(transfer_uuid)).delete()
+
+
 class TestPadDestinationFilePath:
     def test_zipfile_is_not_padded_if_does_not_exist(self, tmp_path):
         transfer_path = tmp_path / "transfer.zip"


### PR DESCRIPTION
Before c1e7468 Archivematica package objects were able to be updated
with new file information. c1e7468 removed this asking the files
associated with a package to be returned from either the database
when objects were known to be in the database, or the file system
when no database objects existed.

Archivematica currently relies on being able to update a package
object's associated files with those on disk as well as in the
database where microservices are interacting e.g. creating or
updating file information in contrasting and potentially
inconsistent ways.

Black box testing results (**nb.** my test server was running slow for a few things):
```
6 features passed, 0 failed, 20 skipped
13 scenarios passed, 0 failed, 58 skipped
76 steps passed, 0 failed, 607 skipped, 0 undefined
Took 16m5.002s
```

Connected to archivematica/issues#955
Connected to archivematica/issues#973
Connected to archivematica/issues#1060

Once merged we will need to create a follow-up ticket for the suggestions in #955 [comment](https://github.com/archivematica/Issues/issues/955#issuecomment-571126909)