### PR TITLE
Add support for Open ID Connect (OIDC) authentication.

### DIFF
--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -180,6 +180,12 @@ variables or in the gunicorn configuration file.
     - **Type:** `boolean`
     - **Default:** `false`
 
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_OIDC_AUTHENTICATION`**:
+    - **Description:** enables the OIDC authentication system.
+    - **Config file example:** `Dashboard.oidc_authentication`
+    - **Type:** `boolean`
+    - **Default:** `false`
+
 - **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_STORAGE_SERVICE_CLIENT_TIMEOUT`**:
     - **Description:** configures the Storage Service client to stop waiting for a response after a given number of seconds.
     - **Config file example:** `Dashboard.storage_service_client_timeout`
@@ -575,6 +581,50 @@ These variables specify the behaviour of CAS authentication. Only applicable if 
     - **Description:** Domain to use for auto-configured email addresses, if `AUTH_CAS_AUTOCONFIGURE_EMAIL` is True.
     - **Type:** `string`
     - **Default:** `None`
+
+### OIDC variables
+
+These variables specify the behaviour of OpenID Connect (OIDC) authentication. Only applicable if `ARCHIVEMATICA_DASHBOARD_DASHBOARD_OIDC_AUTHENTICATION` is set.
+
+- **`OIDC_RP_CLIENT_ID`**:
+    - **Description:** OIDC client ID
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`OIDC_RP_CLIENT_SECRET`**:
+    - **Description:** OIDC client secret
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`AZURE_TENANT_ID`**:
+    - **Description:** Azure Active Directory Tenant ID - if this is provided, the endpoint URLs will be automatically generated from this.
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`OIDC_OP_AUTHORIZATION_ENDPOINT`**:
+    - **Description:** URL of OIDC provider authorization endpoint
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`OIDC_OP_TOKEN_ENDPOINT`**:
+    - **Description:** URL of OIDC provider token endpoint
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`OIDC_OP_USER_ENDPOINT`**:
+    - **Description:** URL of OIDC provider userinfo endpoint
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`OIDC_OP_JWKS_ENDPOINT`**:
+    - **Description:** URL of OIDC provider JWKS endpoint
+    - **Type:** `string`
+    - **Default:** ``
+
+- **`OIDC_RP_SIGN_ALGO`**:
+    - **Description:** Algorithm used by the ID provider to sign ID tokens
+    - **Type:** `string`
+    - **Default:** `HS256`
 
 ## Logging configuration
 

--- a/src/dashboard/src/components/accounts/backends.py
+++ b/src/dashboard/src/components/accounts/backends.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import json
 
 from django.conf import settings
 
 from django_auth_ldap.backend import LDAPBackend
 from django_cas_ng.backends import CASBackend
+from josepy.jws import JWS
+from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 from shibboleth.backends import ShibbolethRemoteUserBackend
 
 from components.helpers import generate_api_key
@@ -36,3 +39,31 @@ class CustomLDAPBackend(LDAPBackend):
 
     def django_to_ldap_username(self, username):
         return username + settings.AUTH_LDAP_USERNAME_SUFFIX
+
+
+class CustomOIDCBackend(OIDCAuthenticationBackend):
+    """
+    Provide OpenID Connect authentication
+    """
+
+    def get_userinfo(self, access_token, id_token, verified_id):
+        """
+        Extract user details from JSON web tokens
+        These map to fields on the user field.
+        """
+        user_info = json.loads(JWS.from_compact(id_token).payload.decode("utf-8"))
+        access_info = json.loads(JWS.from_compact(access_token).payload.decode("utf-8"))
+
+        return {
+            "email": user_info["email"],
+            "first_name": access_info["given_name"],
+            "last_name": access_info["family_name"],
+        }
+
+    def create_user(self, user_info):
+        user = super(CustomOIDCBackend, self).create_user(user_info)
+        user.first_name = user_info["first_name"]
+        user.last_name = user_info["last_name"]
+        user.save()
+        generate_api_key(user)
+        return user

--- a/src/dashboard/src/components/accounts/backends.py
+++ b/src/dashboard/src/components/accounts/backends.py
@@ -2,12 +2,16 @@
 from __future__ import absolute_import
 import json
 
+import requests
 from django.conf import settings
+from django.core.exceptions import SuspiciousOperation
+from django.utils.encoding import smart_text
 
 from django_auth_ldap.backend import LDAPBackend
 from django_cas_ng.backends import CASBackend
-from josepy.jws import JWS
+from josepy.jws import JWS, Header
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+from mozilla_django_oidc.utils import import_from_settings
 from shibboleth.backends import ShibbolethRemoteUserBackend
 
 from components.helpers import generate_api_key
@@ -45,6 +49,40 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
     """
     Provide OpenID Connect authentication
     """
+
+    def retrieve_matching_jwk(self, token):
+        """Get the signing key by exploring the JWKS endpoint of the OP."""
+
+        # This method is overridden to provide a fix for "alg" potentially not
+        # being present in the response (it is optional in the spec, and not
+        # provided by Azure)
+
+        # The latest version of mozilla-django-oidc provides this fix, but we
+        # cannot currently use it due to being on Django 1.8. Once we are on a
+        # recent Django version and using mozilla_django_oidc>=1.1.0 then we
+        # can discard this override.
+        response_jwks = requests.get(
+            self.OIDC_OP_JWKS_ENDPOINT,
+            verify=import_from_settings("OIDC_VERIFY_SSL", True),
+        )
+        response_jwks.raise_for_status()
+        jwks = response_jwks.json()
+
+        # Compute the current header from the given token to find a match
+        jws = JWS.from_compact(token)
+        json_header = jws.signature.protected
+        header = Header.json_loads(json_header)
+
+        key = None
+        for jwk in jwks["keys"]:
+            if jwk["kid"] != smart_text(header.kid):
+                continue
+            if "alg" in jwk and jwk["alg"] != smart_text(header.alg):
+                raise SuspiciousOperation("alg values do not match.")
+            key = jwk
+        if key is None:
+            raise SuspiciousOperation("Could not find a valid JWKS.")
+        return key
 
     def get_userinfo(self, access_token, id_token, verified_id):
         """

--- a/src/dashboard/src/components/accounts/backends.py
+++ b/src/dashboard/src/components/accounts/backends.py
@@ -2,16 +2,11 @@
 from __future__ import absolute_import
 import json
 
-import requests
 from django.conf import settings
-from django.core.exceptions import SuspiciousOperation
-from django.utils.encoding import smart_text
-
 from django_auth_ldap.backend import LDAPBackend
 from django_cas_ng.backends import CASBackend
-from josepy.jws import JWS, Header
+from josepy.jws import JWS
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
-from mozilla_django_oidc.utils import import_from_settings
 from shibboleth.backends import ShibbolethRemoteUserBackend
 
 from components.helpers import generate_api_key
@@ -49,40 +44,6 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
     """
     Provide OpenID Connect authentication
     """
-
-    def retrieve_matching_jwk(self, token):
-        """Get the signing key by exploring the JWKS endpoint of the OP."""
-
-        # This method is overridden to provide a fix for "alg" potentially not
-        # being present in the response (it is optional in the spec, and not
-        # provided by Azure)
-
-        # The latest version of mozilla-django-oidc provides this fix, but we
-        # cannot currently use it due to being on Django 1.8. Once we are on a
-        # recent Django version and using mozilla_django_oidc>=1.1.0 then we
-        # can discard this override.
-        response_jwks = requests.get(
-            self.OIDC_OP_JWKS_ENDPOINT,
-            verify=import_from_settings("OIDC_VERIFY_SSL", True),
-        )
-        response_jwks.raise_for_status()
-        jwks = response_jwks.json()
-
-        # Compute the current header from the given token to find a match
-        jws = JWS.from_compact(token)
-        json_header = jws.signature.protected
-        header = Header.json_loads(json_header)
-
-        key = None
-        for jwk in jwks["keys"]:
-            if jwk["kid"] != smart_text(header.kid):
-                continue
-            if "alg" in jwk and jwk["alg"] != smart_text(header.alg):
-                raise SuspiciousOperation("alg values do not match.")
-            key = jwk
-        if key is None:
-            raise SuspiciousOperation("Could not find a valid JWKS.")
-        return key
 
     def get_userinfo(self, access_token, id_token, verified_id):
         """

--- a/src/dashboard/src/main/context_processors.py
+++ b/src/dashboard/src/main/context_processors.py
@@ -9,3 +9,7 @@ def search_enabled(request):
         "search_transfers_enabled": "transfers" in settings.SEARCH_ENABLED,
         "search_aips_enabled": "aips" in settings.SEARCH_ENABLED,
     }
+
+
+def auth_methods(request):
+    return {"oidc_enabled": settings.OIDC_AUTHENTICATION}

--- a/src/dashboard/src/requirements/base.in
+++ b/src/dashboard/src/requirements/base.in
@@ -44,3 +44,6 @@ python-ldap==3.2.0
 
 # Required by CAS authentication
 django-cas-ng==3.6.0
+
+# Required for OpenID Connect authentication and pinned to a version that supports Django 1.8
+mozilla-django-oidc==1.0.0

--- a/src/dashboard/src/requirements/base.in
+++ b/src/dashboard/src/requirements/base.in
@@ -45,5 +45,5 @@ python-ldap==3.2.0
 # Required by CAS authentication
 django-cas-ng==3.6.0
 
-# Required for OpenID Connect authentication and pinned to a version that supports Django 1.8
-mozilla-django-oidc==1.0.0
+# Required for OpenID Connect authentication
+mozilla-django-oidc

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -13,7 +13,7 @@ brotli==0.5.2             # via -r base.in
 certifi==2020.6.20        # via requests
 cffi==1.14.1              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==3.0         # via pyopenssl
+cryptography==3.0         # via josepy, mozilla-django-oidc, pyopenssl
 django-auth-ldap==1.3.0   # via -r base.in
 django-autoslug==1.9.3    # via -r base.in
 django-braces==1.0.0      # via -r base.in
@@ -23,7 +23,7 @@ django-forms-bootstrap==3.1.0  # via -r base.in
 django-model-utils==1.3.1  # via -r base.in
 django-prometheus==1.0.15  # via -r base.in
 django-tastypie==0.13.2   # via -r base.in
-django==1.11.29           # via -r base.in, django-auth-ldap, django-cas-ng
+django==1.11.29           # via -r base.in, django-auth-ldap, django-cas-ng, mozilla-django-oidc
 elasticsearch==6.8.1      # via -r base.in
 enum34==1.1.10            # via cryptography
 future==0.18.2            # via metsrw
@@ -34,10 +34,12 @@ greenlet==0.4.16          # via gevent
 gunicorn==19.9.0          # via -r base.in
 idna==2.8                 # via requests
 ipaddress==1.0.23         # via cryptography
+josepy==1.2.0             # via mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r base.in
 logutils==0.3.3           # via -r base.in
 lxml==3.5.0               # via -r base.in, metsrw, python-cas
 metsrw==0.3.15            # via -r base.in
+mozilla-django-oidc==1.0.0  # via -r base.in
 mysqlclient==1.4.6        # via -r base.in, agentarchives
 ndg-httpsclient==0.5.1    # via -r base.in
 numpy==1.16.6             # via pandas
@@ -47,14 +49,14 @@ prometheus-client==0.7.1  # via -r base.in, django-prometheus
 pyasn1-modules==0.2.8     # via python-ldap
 pyasn1==0.4.8             # via -r base.in, ndg-httpsclient, pyasn1-modules, python-ldap
 pycparser==2.20           # via cffi
-pyopenssl==19.1.0         # via -r base.in, ndg-httpsclient
+pyopenssl==19.1.0         # via -r base.in, josepy, ndg-httpsclient
 python-cas==1.5.0         # via django-cas-ng
 python-dateutil==2.6.0    # via -r base.in, django-tastypie, pandas
 python-ldap==3.2.0        # via -r base.in, django-auth-ldap
 python-mimeparse==1.6.0   # via django-tastypie
 pytz==2020.1              # via -r base.in, django, pandas
-requests==2.21.0          # via -r base.in, agentarchives, amclient, python-cas
+requests==2.21.0          # via -r base.in, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r base.in, pathlib2
-six==1.15.0               # via amclient, cryptography, django-extensions, metsrw, pathlib2, pyopenssl, python-cas, python-dateutil
+six==1.15.0               # via amclient, cryptography, django-extensions, josepy, metsrw, pathlib2, pyopenssl, python-cas, python-dateutil
 urllib3==1.24.3           # via amclient, elasticsearch, requests
 whitenoise==3.3.0         # via -r base.in

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -34,12 +34,12 @@ greenlet==0.4.16          # via gevent
 gunicorn==19.9.0          # via -r base.in
 idna==2.8                 # via requests
 ipaddress==1.0.23         # via cryptography
-josepy==1.2.0             # via mozilla-django-oidc
+josepy==1.3.0             # via mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r base.in
 logutils==0.3.3           # via -r base.in
 lxml==3.5.0               # via -r base.in, metsrw, python-cas
 metsrw==0.3.15            # via -r base.in
-mozilla-django-oidc==1.0.0  # via -r base.in
+mozilla-django-oidc==1.2.3  # via -r base.in
 mysqlclient==1.4.6        # via -r base.in, agentarchives
 ndg-httpsclient==0.5.1    # via -r base.in
 numpy==1.16.6             # via pandas
@@ -57,6 +57,6 @@ python-mimeparse==1.6.0   # via django-tastypie
 pytz==2020.1              # via -r base.in, django, pandas
 requests==2.21.0          # via -r base.in, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r base.in, pathlib2
-six==1.15.0               # via amclient, cryptography, django-extensions, josepy, metsrw, pathlib2, pyopenssl, python-cas, python-dateutil
+six==1.15.0               # via amclient, cryptography, django-extensions, josepy, metsrw, mozilla-django-oidc, pathlib2, pyopenssl, python-cas, python-dateutil
 urllib3==1.24.3           # via amclient, elasticsearch, requests
 whitenoise==3.3.0         # via -r base.in

--- a/src/dashboard/src/requirements/dev.txt
+++ b/src/dashboard/src/requirements/dev.txt
@@ -54,7 +54,7 @@ ipaddress==1.0.23         # via -r test.txt, cryptography
 ipdb==0.13.3              # via -r dev.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==5.10.0           # via -r dev.in, ipdb
-josepy==1.2.0             # via -r test.txt, mozilla-django-oidc
+josepy==1.3.0             # via -r test.txt, mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r test.txt
 logutils==0.3.3           # via -r test.txt
 lxml==3.5.0               # via -r test.txt, metsrw, python-cas
@@ -62,7 +62,7 @@ metsrw==0.3.15            # via -r test.txt
 mock==3.0.5               # via -r test.txt, mockldap, pytest-mock, vcrpy
 mockldap==0.2.8           # via -r test.txt
 more-itertools==5.0.0     # via -r test.txt, pytest
-mozilla-django-oidc==1.0.0  # via -r test.txt
+mozilla-django-oidc==1.2.3  # via -r test.txt
 mysqlclient==1.4.6        # via -r test.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r test.txt
 numpy==1.16.6             # via -r test.txt, pandas
@@ -98,7 +98,7 @@ requests==2.21.0          # via -r test.txt, agentarchives, amclient, mozilla-dj
 scandir==1.10.0           # via -r test.txt, pathlib2
 simplegeneric==0.8.1      # via ipython
 singledispatch==3.4.0.3   # via -r test.txt, importlib-resources
-six==1.15.0               # via -r test.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, packaging, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pytest, python-cas, python-dateutil, singledispatch, tox, traitlets, vcrpy, virtualenv
+six==1.15.0               # via -r test.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, mozilla-django-oidc, packaging, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pytest, python-cas, python-dateutil, singledispatch, tox, traitlets, vcrpy, virtualenv
 toml==0.10.1              # via -r test.txt, tox
 tox==3.18.1               # via -r test.txt
 traitlets==4.3.3          # via ipython

--- a/src/dashboard/src/requirements/dev.txt
+++ b/src/dashboard/src/requirements/dev.txt
@@ -9,6 +9,7 @@
 agentarchives==0.6.0      # via -r test.txt
 amclient==1.1.1           # via -r test.txt
 appdirs==1.4.4            # via -r test.txt, virtualenv
+appnope==0.1.0            # via ipython
 atomicwrites==1.4.0       # via -r test.txt, pytest
 attrs==19.3.0             # via -r test.txt, pytest
 backports.functools-lru-cache==1.6.1  # via -r test.txt, wcwidth
@@ -22,7 +23,7 @@ click==7.1.2              # via pip-tools
 configparser==4.0.2       # via -r test.txt, importlib-metadata
 contextlib2==0.6.0.post1  # via -r test.txt, importlib-metadata, importlib-resources, vcrpy, zipp
 coverage==4.2             # via -r test.txt, pytest-cov
-cryptography==3.0         # via -r test.txt, pyopenssl
+cryptography==3.0         # via -r test.txt, josepy, mozilla-django-oidc, pyopenssl
 decorator==4.4.2          # via ipython, traitlets
 distlib==0.3.1            # via -r test.txt, virtualenv
 django-auth-ldap==1.3.0   # via -r test.txt
@@ -34,7 +35,7 @@ django-forms-bootstrap==3.1.0  # via -r test.txt
 django-model-utils==1.3.1  # via -r test.txt
 django-prometheus==1.0.15  # via -r test.txt
 django-tastypie==0.13.2   # via -r test.txt
-django==1.11.29           # via -r test.txt, django-auth-ldap, django-cas-ng
+django==1.11.29           # via -r test.txt, django-auth-ldap, django-cas-ng, mozilla-django-oidc
 elasticsearch==6.8.1      # via -r test.txt
 enum34==1.1.10            # via -r test.txt, cryptography, traitlets
 filelock==3.0.12          # via -r test.txt, tox, virtualenv
@@ -53,6 +54,7 @@ ipaddress==1.0.23         # via -r test.txt, cryptography
 ipdb==0.13.3              # via -r dev.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==5.10.0           # via -r dev.in, ipdb
+josepy==1.2.0             # via -r test.txt, mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r test.txt
 logutils==0.3.3           # via -r test.txt
 lxml==3.5.0               # via -r test.txt, metsrw, python-cas
@@ -60,6 +62,7 @@ metsrw==0.3.15            # via -r test.txt
 mock==3.0.5               # via -r test.txt, mockldap, pytest-mock, vcrpy
 mockldap==0.2.8           # via -r test.txt
 more-itertools==5.0.0     # via -r test.txt, pytest
+mozilla-django-oidc==1.0.0  # via -r test.txt
 mysqlclient==1.4.6        # via -r test.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r test.txt
 numpy==1.16.6             # via -r test.txt, pandas
@@ -78,7 +81,7 @@ pyasn1-modules==0.2.8     # via -r test.txt, python-ldap
 pyasn1==0.4.8             # via -r test.txt, ndg-httpsclient, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r test.txt, cffi
 pygments==2.5.2           # via ipython
-pyopenssl==19.1.0         # via -r test.txt, ndg-httpsclient
+pyopenssl==19.1.0         # via -r test.txt, josepy, ndg-httpsclient
 pyparsing==2.4.7          # via -r test.txt, packaging
 pytest-cov==2.4.0         # via -r test.txt
 pytest-django==3.9.0      # via -r test.txt
@@ -91,11 +94,11 @@ python-ldap==3.2.0        # via -r test.txt, django-auth-ldap, mockldap
 python-mimeparse==1.6.0   # via -r test.txt, django-tastypie
 pytz==2020.1              # via -r test.txt, django, pandas
 pyyaml==5.3.1             # via -r test.txt, vcrpy
-requests==2.21.0          # via -r test.txt, agentarchives, amclient, python-cas
+requests==2.21.0          # via -r test.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r test.txt, pathlib2
 simplegeneric==0.8.1      # via ipython
 singledispatch==3.4.0.3   # via -r test.txt, importlib-resources
-six==1.15.0               # via -r test.txt, amclient, cryptography, django-extensions, metsrw, mock, more-itertools, packaging, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pytest, python-cas, python-dateutil, singledispatch, tox, traitlets, vcrpy, virtualenv
+six==1.15.0               # via -r test.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, packaging, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pytest, python-cas, python-dateutil, singledispatch, tox, traitlets, vcrpy, virtualenv
 toml==0.10.1              # via -r test.txt, tox
 tox==3.18.1               # via -r test.txt
 traitlets==4.3.3          # via ipython

--- a/src/dashboard/src/requirements/production.txt
+++ b/src/dashboard/src/requirements/production.txt
@@ -13,7 +13,7 @@ brotli==0.5.2             # via -r base.txt
 certifi==2020.6.20        # via -r base.txt, requests
 cffi==1.14.1              # via -r base.txt, cryptography
 chardet==3.0.4            # via -r base.txt, requests
-cryptography==3.0         # via -r base.txt, pyopenssl
+cryptography==3.0         # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
 django-auth-ldap==1.3.0   # via -r base.txt
 django-autoslug==1.9.3    # via -r base.txt
 django-braces==1.0.0      # via -r base.txt
@@ -23,7 +23,7 @@ django-forms-bootstrap==3.1.0  # via -r base.txt
 django-model-utils==1.3.1  # via -r base.txt
 django-prometheus==1.0.15  # via -r base.txt
 django-tastypie==0.13.2   # via -r base.txt
-django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng
+django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, mozilla-django-oidc
 elasticsearch==6.8.1      # via -r base.txt
 enum34==1.1.10            # via -r base.txt, cryptography
 future==0.18.2            # via -r base.txt, metsrw
@@ -34,10 +34,12 @@ greenlet==0.4.16          # via -r base.txt, gevent
 gunicorn==19.9.0          # via -r base.txt
 idna==2.8                 # via -r base.txt, requests
 ipaddress==1.0.23         # via -r base.txt, cryptography
+josepy==1.2.0             # via -r base.txt, mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r base.txt
 logutils==0.3.3           # via -r base.txt
 lxml==3.5.0               # via -r base.txt, metsrw, python-cas
 metsrw==0.3.15            # via -r base.txt
+mozilla-django-oidc==1.0.0  # via -r base.txt
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r base.txt
 numpy==1.16.6             # via -r base.txt, pandas
@@ -47,14 +49,14 @@ prometheus-client==0.7.1  # via -r base.txt, django-prometheus
 pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
 pyasn1==0.4.8             # via -r base.txt, ndg-httpsclient, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r base.txt, cffi
-pyopenssl==19.1.0         # via -r base.txt, ndg-httpsclient
+pyopenssl==19.1.0         # via -r base.txt, josepy, ndg-httpsclient
 python-cas==1.5.0         # via -r base.txt, django-cas-ng
 python-dateutil==2.6.0    # via -r base.txt, django-tastypie, pandas
 python-ldap==3.2.0        # via -r base.txt, django-auth-ldap
 python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
 pytz==2020.1              # via -r base.txt, django, pandas
-requests==2.21.0          # via -r base.txt, agentarchives, amclient, python-cas
+requests==2.21.0          # via -r base.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r base.txt, pathlib2
-six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, metsrw, pathlib2, pyopenssl, python-cas, python-dateutil
+six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, josepy, metsrw, pathlib2, pyopenssl, python-cas, python-dateutil
 urllib3==1.24.3           # via -r base.txt, amclient, elasticsearch, requests
 whitenoise==3.3.0         # via -r base.txt

--- a/src/dashboard/src/requirements/production.txt
+++ b/src/dashboard/src/requirements/production.txt
@@ -34,12 +34,12 @@ greenlet==0.4.16          # via -r base.txt, gevent
 gunicorn==19.9.0          # via -r base.txt
 idna==2.8                 # via -r base.txt, requests
 ipaddress==1.0.23         # via -r base.txt, cryptography
-josepy==1.2.0             # via -r base.txt, mozilla-django-oidc
+josepy==1.3.0             # via -r base.txt, mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r base.txt
 logutils==0.3.3           # via -r base.txt
 lxml==3.5.0               # via -r base.txt, metsrw, python-cas
 metsrw==0.3.15            # via -r base.txt
-mozilla-django-oidc==1.0.0  # via -r base.txt
+mozilla-django-oidc==1.2.3  # via -r base.txt
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r base.txt
 numpy==1.16.6             # via -r base.txt, pandas
@@ -57,6 +57,6 @@ python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
 pytz==2020.1              # via -r base.txt, django, pandas
 requests==2.21.0          # via -r base.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r base.txt, pathlib2
-six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, josepy, metsrw, pathlib2, pyopenssl, python-cas, python-dateutil
+six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, josepy, metsrw, mozilla-django-oidc, pathlib2, pyopenssl, python-cas, python-dateutil
 urllib3==1.24.3           # via -r base.txt, amclient, elasticsearch, requests
 whitenoise==3.3.0         # via -r base.txt

--- a/src/dashboard/src/requirements/test.txt
+++ b/src/dashboard/src/requirements/test.txt
@@ -47,7 +47,7 @@ idna==2.8                 # via -r base.txt, requests
 importlib-metadata==1.7.0  # via pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 ipaddress==1.0.23         # via -r base.txt, cryptography
-josepy==1.2.0             # via -r base.txt, mozilla-django-oidc
+josepy==1.3.0             # via -r base.txt, mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r base.txt
 logutils==0.3.3           # via -r base.txt
 lxml==3.5.0               # via -r base.txt, metsrw, python-cas
@@ -55,7 +55,7 @@ metsrw==0.3.15            # via -r base.txt
 mock==3.0.5               # via mockldap, pytest-mock, vcrpy
 mockldap==0.2.8           # via -r test.in
 more-itertools==5.0.0     # via pytest
-mozilla-django-oidc==1.0.0  # via -r base.txt
+mozilla-django-oidc==1.2.3  # via -r base.txt
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r base.txt
 numpy==1.16.6             # via -r base.txt, pandas
@@ -84,7 +84,7 @@ pyyaml==5.3.1             # via vcrpy
 requests==2.21.0          # via -r base.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r base.txt, pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
-six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, packaging, pathlib2, pyopenssl, pytest, python-cas, python-dateutil, tox, vcrpy, virtualenv
+six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, mozilla-django-oidc, packaging, pathlib2, pyopenssl, pytest, python-cas, python-dateutil, tox, vcrpy, virtualenv
 toml==0.10.1              # via tox
 tox==3.18.1               # via -r test.in
 typing==3.7.4.3           # via importlib-resources

--- a/src/dashboard/src/requirements/test.txt
+++ b/src/dashboard/src/requirements/test.txt
@@ -20,7 +20,7 @@ chardet==3.0.4            # via -r base.txt, requests
 configparser==4.0.2       # via importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, vcrpy, zipp
 coverage==4.2             # via -r test.in, pytest-cov
-cryptography==3.0         # via -r base.txt, pyopenssl
+cryptography==3.0         # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
 distlib==0.3.1            # via virtualenv
 django-auth-ldap==1.3.0   # via -r base.txt
 django-autoslug==1.9.3    # via -r base.txt
@@ -31,7 +31,7 @@ django-forms-bootstrap==3.1.0  # via -r base.txt
 django-model-utils==1.3.1  # via -r base.txt
 django-prometheus==1.0.15  # via -r base.txt
 django-tastypie==0.13.2   # via -r base.txt
-django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng
+django==1.11.29           # via -r base.txt, django-auth-ldap, django-cas-ng, mozilla-django-oidc
 elasticsearch==6.8.1      # via -r base.txt
 enum34==1.1.10            # via -r base.txt, cryptography
 filelock==3.0.12          # via tox, virtualenv
@@ -47,6 +47,7 @@ idna==2.8                 # via -r base.txt, requests
 importlib-metadata==1.7.0  # via pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 ipaddress==1.0.23         # via -r base.txt, cryptography
+josepy==1.2.0             # via -r base.txt, mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r base.txt
 logutils==0.3.3           # via -r base.txt
 lxml==3.5.0               # via -r base.txt, metsrw, python-cas
@@ -54,6 +55,7 @@ metsrw==0.3.15            # via -r base.txt
 mock==3.0.5               # via mockldap, pytest-mock, vcrpy
 mockldap==0.2.8           # via -r test.in
 more-itertools==5.0.0     # via pytest
+mozilla-django-oidc==1.0.0  # via -r base.txt
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r base.txt
 numpy==1.16.6             # via -r base.txt, pandas
@@ -66,7 +68,7 @@ py==1.9.0                 # via pytest, tox
 pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
 pyasn1==0.4.8             # via -r base.txt, ndg-httpsclient, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r base.txt, cffi
-pyopenssl==19.1.0         # via -r base.txt, ndg-httpsclient
+pyopenssl==19.1.0         # via -r base.txt, josepy, ndg-httpsclient
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.4.0         # via -r test.in
 pytest-django==3.9.0      # via -r test.in
@@ -79,10 +81,10 @@ python-ldap==3.2.0        # via -r base.txt, django-auth-ldap, mockldap
 python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
 pytz==2020.1              # via -r base.txt, django, pandas
 pyyaml==5.3.1             # via vcrpy
-requests==2.21.0          # via -r base.txt, agentarchives, amclient, python-cas
+requests==2.21.0          # via -r base.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r base.txt, pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
-six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, metsrw, mock, more-itertools, packaging, pathlib2, pyopenssl, pytest, python-cas, python-dateutil, tox, vcrpy, virtualenv
+six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, packaging, pathlib2, pyopenssl, pytest, python-cas, python-dateutil, tox, vcrpy, virtualenv
 toml==0.10.1              # via tox
 tox==3.18.1               # via -r test.in
 typing==3.7.4.3           # via importlib-resources

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -310,6 +310,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.messages.context_processors.messages",
                 "main.context_processors.search_enabled",
+                "main.context_processors.auth_methods",
             ],
             "debug": DEBUG,
         },

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -78,6 +78,11 @@ CONFIG_MAPPING = {
         "option": "ldap_authentication",
         "type": "boolean",
     },
+    "oidc_authentication": {
+        "section": "Dashboard",
+        "option": "oidc_authentication",
+        "type": "boolean",
+    },
     "storage_service_client_timeout": {
         "section": "Dashboard",
         "option": "storage_service_client_timeout",
@@ -133,6 +138,7 @@ gearman_server = 127.0.0.1:4730
 shibboleth_authentication = False
 cas_authentication = False
 ldap_authentication = False
+oidc_authentication = False
 storage_service_client_timeout = 86400
 storage_service_client_quick_timeout = 5
 agentarchives_client_timeout = 300
@@ -539,6 +545,16 @@ if CAS_AUTHENTICATION:
     )
 
     from .components.cas_auth import *  # noqa
+
+OIDC_AUTHENTICATION = config.get("oidc_authentication")
+if OIDC_AUTHENTICATION:
+    ALLOW_USER_EDITS = False
+
+    AUTHENTICATION_BACKENDS += ["components.accounts.backends.CustomOIDCBackend"]
+    LOGIN_EXEMPT_URLS.append(r"^oidc")
+    INSTALLED_APPS += ["mozilla_django_oidc"]
+
+    from .components.oidc_auth import *  # noqa
 
 PROMETHEUS_ENABLED = config.get("prometheus_enabled")
 if PROMETHEUS_ENABLED:

--- a/src/dashboard/src/settings/components/oidc_auth.py
+++ b/src/dashboard/src/settings/components/oidc_auth.py
@@ -23,9 +23,9 @@ if AZURE_TENANT_ID:
         "https://login.microsoftonline.com/%s/discovery/v2.0/keys" % AZURE_TENANT_ID
     )
 else:
-    OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("OIDC_OP_AUTHORIZATION_ENDPOINT", "")
-    OIDC_OP_TOKEN_ENDPOINT = os.environ.get("OIDC_OP_TOKEN_ENDPOINT", "")
-    OIDC_OP_USER_ENDPOINT = os.environ.get("OIDC_OP_USER_ENDPOINT", "")
+    OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ["OIDC_OP_AUTHORIZATION_ENDPOINT"]
+    OIDC_OP_TOKEN_ENDPOINT = os.environ["OIDC_OP_TOKEN_ENDPOINT"]
+    OIDC_OP_USER_ENDPOINT = os.environ["OIDC_OP_USER_ENDPOINT"]
     OIDC_OP_JWKS_ENDPOINT = os.environ.get("OIDC_OP_JWKS_ENDPOINT", "")
 
 OIDC_RP_SIGN_ALGO = os.environ.get("OIDC_RP_SIGN_ALGO", "HS256")

--- a/src/dashboard/src/settings/components/oidc_auth.py
+++ b/src/dashboard/src/settings/components/oidc_auth.py
@@ -1,0 +1,31 @@
+import os
+
+
+# AUTH_SERVER = 'https://login.microsoftonline.com/common/v2.0/'
+OIDC_RP_CLIENT_ID = os.environ.get("OIDC_RP_CLIENT_ID", "")
+OIDC_RP_CLIENT_SECRET = os.environ.get("OIDC_RP_CLIENT_SECRET", "")
+
+OIDC_OP_AUTHORIZATION_ENDPOINT = ""
+OIDC_OP_TOKEN_ENDPOINT = ""
+OIDC_OP_USER_ENDPOINT = ""
+OIDC_OP_JWKS_ENDPOINT = ""
+
+AZURE_TENANT_ID = os.environ.get("AZURE_TENANT_ID", "")
+if AZURE_TENANT_ID:
+    OIDC_OP_AUTHORIZATION_ENDPOINT = (
+        "https://login.microsoftonline.com/%s/oauth2/v2.0/authorize" % AZURE_TENANT_ID
+    )
+    OIDC_OP_TOKEN_ENDPOINT = (
+        "https://login.microsoftonline.com/%s/oauth2/v2.0/token" % AZURE_TENANT_ID
+    )
+    OIDC_OP_USER_ENDPOINT = (
+        "https://login.microsoftonline.com/%s/openid/userinfo" % AZURE_TENANT_ID
+    )
+    OIDC_OP_JWKS_ENDPOINT = (
+        "https://login.microsoftonline.com/%s/discovery/v2.0/keys" % AZURE_TENANT_ID
+    )
+
+OIDC_RP_SIGN_ALGO = os.environ.get("OIDC_RP_SIGN_ALGO", "HS256")
+
+# Username is email address
+OIDC_USERNAME_ALGO = lambda email: email

--- a/src/dashboard/src/settings/components/oidc_auth.py
+++ b/src/dashboard/src/settings/components/oidc_auth.py
@@ -26,4 +26,10 @@ if AZURE_TENANT_ID:
 OIDC_RP_SIGN_ALGO = os.environ.get("OIDC_RP_SIGN_ALGO", "HS256")
 
 # Username is email address
-OIDC_USERNAME_ALGO = lambda email: email
+OIDC_USERNAME_ALGO = lambda email: email  # noqa
+
+# map attributes from access token
+OIDC_ACCESS_ATTRIBUTE_MAP = {"given_name": "first_name", "family_name": "last_name"}
+
+# map attributes from id token
+OIDC_ID_ATTRIBUTE_MAP = {"email": "email"}

--- a/src/dashboard/src/settings/components/oidc_auth.py
+++ b/src/dashboard/src/settings/components/oidc_auth.py
@@ -1,7 +1,5 @@
 import os
 
-
-# AUTH_SERVER = 'https://login.microsoftonline.com/common/v2.0/'
 OIDC_RP_CLIENT_ID = os.environ.get("OIDC_RP_CLIENT_ID", "")
 OIDC_RP_CLIENT_SECRET = os.environ.get("OIDC_RP_CLIENT_SECRET", "")
 

--- a/src/dashboard/src/settings/components/oidc_auth.py
+++ b/src/dashboard/src/settings/components/oidc_auth.py
@@ -22,6 +22,11 @@ if AZURE_TENANT_ID:
     OIDC_OP_JWKS_ENDPOINT = (
         "https://login.microsoftonline.com/%s/discovery/v2.0/keys" % AZURE_TENANT_ID
     )
+else:
+    OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("OIDC_OP_AUTHORIZATION_ENDPOINT", "")
+    OIDC_OP_TOKEN_ENDPOINT = os.environ.get("OIDC_OP_TOKEN_ENDPOINT", "")
+    OIDC_OP_USER_ENDPOINT = os.environ.get("OIDC_OP_USER_ENDPOINT", "")
+    OIDC_OP_JWKS_ENDPOINT = os.environ.get("OIDC_OP_JWKS_ENDPOINT", "")
 
 OIDC_RP_SIGN_ALGO = os.environ.get("OIDC_RP_SIGN_ALGO", "HS256")
 

--- a/src/dashboard/src/templates/accounts/login.html
+++ b/src/dashboard/src/templates/accounts/login.html
@@ -24,6 +24,11 @@
 
     </form>
 
+    {% if oidc_enabled %}
+      <p>
+        <a href="{% url 'oidc_authentication_init' %}">Log in with OpenID Connect</a>
+      </p>
+    {% endif %}
   </div>
 
 {% endblock %}

--- a/src/dashboard/src/templates/layout.html
+++ b/src/dashboard/src/templates/layout.html
@@ -80,9 +80,6 @@
                 </li>
               {% endif %}
 
-               <a href="{% url 'oidc_authentication_init' %}">Login</a>
-
-
             </ul>
 
           </div>

--- a/src/dashboard/src/templates/layout.html
+++ b/src/dashboard/src/templates/layout.html
@@ -80,6 +80,9 @@
                 </li>
               {% endif %}
 
+               <a href="{% url 'oidc_authentication_init' %}">Login</a>
+
+
             </ul>
 
           </div>

--- a/src/dashboard/src/urls.py
+++ b/src/dashboard/src/urls.py
@@ -47,7 +47,9 @@ urlpatterns = [
     url(r"^file/", include("components.file.urls")),
     url(r"^access/", include("components.access.urls")),
     url(r"^backlog/", include("components.backlog.urls")),
+    url(r'^oidc/', include('mozilla_django_oidc.urls')),
     url(r"", include("main.urls")),
+
 ]
 
 if settings.PROMETHEUS_ENABLED:

--- a/src/dashboard/src/urls.py
+++ b/src/dashboard/src/urls.py
@@ -47,11 +47,12 @@ urlpatterns = [
     url(r"^file/", include("components.file.urls")),
     url(r"^access/", include("components.access.urls")),
     url(r"^backlog/", include("components.backlog.urls")),
-    url(r'^oidc/', include('mozilla_django_oidc.urls')),
     url(r"", include("main.urls")),
-
 ]
 
 if settings.PROMETHEUS_ENABLED:
     # Include prometheus metrics at /metrics
     urlpatterns.append(url("", include("django_prometheus.urls")))
+
+if settings.OIDC_AUTHENTICATION:
+    urlpatterns.append(url(r"^oidc/", include("mozilla_django_oidc.urls")))

--- a/src/dashboard/tests/test_oidc.py
+++ b/src/dashboard/tests/test_oidc.py
@@ -1,0 +1,38 @@
+import pytest
+from django.conf import settings
+from django.test import TestCase
+
+from components.accounts.backends import CustomOIDCBackend
+
+
+@pytest.mark.skipif(
+    not settings.OIDC_AUTHENTICATION, reason="tests will only pass if OIDC is enabled"
+)
+class TestOIDC(TestCase):
+    def test_create_user(self):
+        backend = CustomOIDCBackend()
+        user = backend.create_user(
+            {"email": "test@example.com", "first_name": "Test", "last_name": "User"}
+        )
+
+        user.refresh_from_db()
+        assert user.first_name == "Test"
+        assert user.last_name == "User"
+        assert user.email == "test@example.com"
+        assert user.username == "test@example.com"
+        assert user.api_key
+
+    def test_get_userinfo(self):
+        # Encoded at https://www.jsonwebtoken.io/
+        # {"email": "test@example.com"}
+        id_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJqdGkiOiI1M2QyMzUzMy04NDk0LTQyZWQtYTJiZC03Mzc2MjNmMjUzZjciLCJpYXQiOjE1NzMwMzE4NDQsImV4cCI6MTU3MzAzNTQ0NH0.m3nHgvj_DyVJMcW5eyYuUss1Y0PNzJV2O3bX0b_DCmI"
+        # {"given_name": "Test", "family_name": "User"}
+        access_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJnaXZlbl9uYW1lIjoiVGVzdCIsImZhbWlseV9uYW1lIjoiVXNlciIsImp0aSI6ImRhZjIwNTNiLWE4MTgtNDE1Yy1hM2Y1LTkxYWVhMTMxYjljZCIsImlhdCI6MTU3MzAzMTk3OSwiZXhwIjoxNTczMDM1NTc5fQ.cGcmt7d9IuKndvrqPpAH3Dvb3KyCOMqixUWgS7sg8r4"
+
+        backend = CustomOIDCBackend()
+        info = backend.get_userinfo(
+            access_token=access_token, id_token=id_token, verified_id=None
+        )
+        assert info["email"] == "test@example.com"
+        assert info["first_name"] == "Test"
+        assert info["last_name"] == "User"


### PR DESCRIPTION
Follows similar pattern to existing Shibboleth and LDAP support. Also supports automatic setup of OIDC URLs for Azure providers by supplying just the tenant ID.

Using an older version of the OIDC library because of the older version of Django currently used in Archivematica. It's been necessary to port a fix from more recent versions of the library, and I've included notes in the code about this.

Based on work from the Wellcome fork: https://github.com/wellcometrust/archivematica/pull/10
Connected to archivematica/Issues#1053
PR for Storage service: https://github.com/artefactual/archivematica-storage-service/pull/517