### PR TITLE
Ensure workflow endpoints are captured to reduce active package count as reliably as possible

### DIFF
--- a/src/MCPServer/lib/server/queues.py
+++ b/src/MCPServer/lib/server/queues.py
@@ -70,6 +70,18 @@ class PackageQueue(object):
             "828528c2-2eb9-4514-b5ca-dfd1f7cb5b8c",
             # Move Transfer to failed directory
             "377f8ebb-7989-4a68-9361-658079ff8138",
+            # Move transfer to backlog
+            "abd6d60c-d50f-4660-a189-ac1b34fafe85",
+            # Check transfer directory for objects
+            "032cdc54-0b9b-4caf-86e8-10d63efbaec0",
+            # Move to the rejected directory
+            "0d7f5dc2-b9af-43bf-b698-10fdcc5b014d",
+            "333532b9-b7c2-4478-9415-28a3056d58df",
+            "3467d003-1603-49e3-b085-e58aa693afed",
+            # Failed compliance. See output in dashboard. SIP moved back to SIPsUnderConstruction
+            "f025f58c-d48c-4ba1-8904-a56d2a67b42f",
+            # Failed compliance. See output in dashboard. Transfer moved back to activeTransfers
+            "61af079f-46a2-48ff-9b8a-0c78ba3a456d",
         ]
     )
     # An arbitrary, large value, so we don't accept infinite packages.


### PR DESCRIPTION
This commit ensures that workflow endpoints are identified that when
reached should reduce the number of active packages in the
Archivematica workflow. This becomes critical when Archivematica
only recognizes one core available to be used on a machine. If the
count is 1 and the cores are 1 then no new packages can be generated.
We need to increment and decrement our internal counters as reliably
as possible.

Connected to archivematica/issues#1052
Connected to archivematica/issues#1055

See analysis [here](https://github.com/archivematica/Issues/issues/1055#issuecomment-574429288) for more information.