### PR TITLE
Makes user email a required field in UserCreationForm

### DIFF
--- a/src/dashboard/src/components/accounts/forms.py
+++ b/src/dashboard/src/components/accounts/forms.py
@@ -32,6 +32,7 @@ from main.models import UserProfile
 
 
 class UserCreationForm(UserCreationForm):
+    email = forms.EmailField(required=True)
     is_superuser = forms.BooleanField(label="Administrator", required=False)
 
     def save(self, commit=True):


### PR DESCRIPTION
Adds a field specification to `UserCreationForm` so that email is always required.

Fixes archivematica/Issues#1067