### PR TITLE
Change name of sanitize names microservices/jobs

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -2894,7 +2894,7 @@
                 "stdout_file": "%SIPLogsDirectory%filenameCleanup.log"
             },
             "description": {
-                "en": "Sanitize object's file and directory names",
+                "en": "Change object and directory filenames",
                 "pt_BR": "Limpar os nomes de arquivos e diretórios do objeto",
                 "sv": "Sanera objekts fil- och katalognamn"
             },
@@ -2907,7 +2907,7 @@
             "fallback_job_status": "Failed",
             "fallback_link_id": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
             "group": {
-                "en": "Clean up names",
+                "en": "Change transfer filenames",
                 "es": "Limpiar nombres",
                 "fr": "Nettoyer les noms",
                 "pt_BR": "Limpe nomes",
@@ -7731,7 +7731,7 @@
             "fallback_job_status": "Failed",
             "fallback_link_id": "7d728c39-395f-4892-8193-92f086c0546f",
             "group": {
-                "en": "Clean up names",
+                "en": "Change SIP filenames",
                 "es": "Limpiar nombres",
                 "fr": "Nettoyer les noms",
                 "pt_BR": "Limpe nomes",
@@ -8027,7 +8027,7 @@
                 "stdout_file": null
             },
             "description": {
-                "en": "Sanitize Transfer name",
+                "en": "Change transfer name",
                 "pt_BR": "Limpar o nome da transferência",
                 "sv": "Sanera överföringspaketets namn"
             },
@@ -8040,7 +8040,7 @@
             "fallback_job_status": "Failed",
             "fallback_link_id": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
             "group": {
-                "en": "Clean up names",
+                "en": "Change transfer filenames",
                 "es": "Limpiar nombres",
                 "fr": "Nettoyer les noms",
                 "pt_BR": "Limpe nomes",
@@ -8060,7 +8060,7 @@
                 "stdout_file": null
             },
             "description": {
-                "en": "Sanitize SIP name",
+                "en": "Change SIP name",
                 "pt_BR": "Limpar o nome SIP",
                 "sv": "Sanera SIP-namn"
             },
@@ -8073,7 +8073,7 @@
             "fallback_job_status": "Failed",
             "fallback_link_id": "7d728c39-395f-4892-8193-92f086c0546f",
             "group": {
-                "en": "Clean up names",
+                "en": "Change SIP filenames",
                 "es": "Limpiar nombres",
                 "fr": "Nettoyer les noms",
                 "pt_BR": "Limpe nomes",
@@ -9533,7 +9533,7 @@
                 "stdout_file": "%SIPLogsDirectory%filenameCleanup.log"
             },
             "description": {
-                "en": "Sanitize object's file and directory names",
+                "en": "Change object and directory filenames",
                 "pt_BR": "Limpar os nomes de arquivos e diretórios do objeto",
                 "sv": "Sanera objekts fil- och katalognamn"
             },
@@ -9546,7 +9546,7 @@
             "fallback_job_status": "Failed",
             "fallback_link_id": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
             "group": {
-                "en": "Clean up names",
+                "en": "Change transfer filenames",
                 "es": "Limpiar nombres",
                 "fr": "Nettoyer les noms",
                 "pt_BR": "Limpe nomes",

--- a/src/dashboard/tests/fixtures/jobs-processing.json
+++ b/src/dashboard/tests/fixtures/jobs-processing.json
@@ -324,7 +324,7 @@
     },
     {
         "fields": {
-            "microservicegroup": "Clean up names",
+            "microservicegroup": "Change transfer filenames",
             "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
             "microservicechainlink": null,
             "currentstep": 2,
@@ -334,7 +334,7 @@
             "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
             "hidden": false,
             "createdtimedec": "0.8298590000",
-            "jobtype": "Sanitize object's file and directory names"
+            "jobtype": "Change object and directory filenames"
         },
         "model": "main.job",
         "pk": "8c66a191-3d5d-4f60-9179-7200f4f04000"
@@ -392,7 +392,7 @@
     },
     {
         "fields": {
-            "microservicegroup": "Clean up names",
+            "microservicegroup": "Change transfer filenames",
             "sipuuid": "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e",
             "microservicechainlink": null,
             "currentstep": 2,
@@ -402,7 +402,7 @@
             "directory": "%sharedPath%currentlyProcessing/test-3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e/",
             "hidden": false,
             "createdtimedec": "0.1601980000",
-            "jobtype": "Sanitize Transfer name"
+            "jobtype": "Change filename of transfer"
         },
         "model": "main.job",
         "pk": "9483fb19-42b6-4997-a285-50ec51040475"

--- a/src/dashboard/tests/fixtures/jobs-sip-complete-clean-up-last.json
+++ b/src/dashboard/tests/fixtures/jobs-sip-complete-clean-up-last.json
@@ -103,7 +103,7 @@
     },
     {
         "fields": {
-            "microservicegroup": "Clean up names",
+            "microservicegroup": "Change SIP filenames",
             "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
             "microservicechainlink": null,
             "currentstep": 2,
@@ -120,7 +120,7 @@
     },
     {
         "fields": {
-            "microservicegroup": "Clean up names",
+            "microservicegroup": "Change SIP filenames",
             "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
             "microservicechainlink": null,
             "currentstep": 2,
@@ -171,7 +171,7 @@
     },
     {
         "fields": {
-            "microservicegroup": "Clean up names",
+            "microservicegroup": "Change SIP filenames",
             "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
             "microservicechainlink": null,
             "currentstep": 2,
@@ -181,7 +181,7 @@
             "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
             "hidden": false,
             "createdtimedec": "0.6769300000",
-            "jobtype": "Sanitize SIP name"
+            "jobtype": "Change SIP filename"
         },
         "model": "main.job",
         "pk": "ef9498c1-418d-4c28-9b73-30c38f0c3476"

--- a/src/dashboard/tests/fixtures/jobs-sip-complete.json
+++ b/src/dashboard/tests/fixtures/jobs-sip-complete.json
@@ -103,7 +103,7 @@
     },
     {
         "fields": {
-            "microservicegroup": "Clean up names",
+            "microservicegroup": "Change SIP filenames",
             "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
             "microservicechainlink": null,
             "currentstep": 2,
@@ -120,7 +120,7 @@
     },
     {
         "fields": {
-            "microservicegroup": "Clean up names",
+            "microservicegroup": "Change SIP filenames",
             "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
             "microservicechainlink": null,
             "currentstep": 2,
@@ -171,7 +171,7 @@
     },
     {
         "fields": {
-            "microservicegroup": "Clean up names",
+            "microservicegroup": "Change SIP filenames",
             "sipuuid": "4060ee97-9c3f-4822-afaf-ebdf838284c3",
             "microservicechainlink": null,
             "currentstep": 2,
@@ -181,7 +181,7 @@
             "directory": "%sharedPath%currentlyProcessing/test-4060ee97-9c3f-4822-afaf-ebdf838284c3/",
             "hidden": false,
             "createdtimedec": "0.6769300000",
-            "jobtype": "Sanitize SIP name"
+            "jobtype": "Change SIP filenames"
         },
         "model": "main.job",
         "pk": "ef9498c1-418d-4c28-9b73-30c38f0c3476"


### PR DESCRIPTION
See the [issue](https://github.com/archivematica/Issues/issues/230) for rationale for this change.

**Transfer tab**

In 1.10 and earlier, the microservice and job names were:

```
Microservice: Clean up names
   Job: Sanitize Transfer name
   Job: Sanitize object's file and directory names
```

They have been changed to:

```
Microservice: Change transfer filenames
   Job: Change transfer name
   Job: Change object and directory filenames
```

**Ingest tab**

In 1.10 and earlier, the microservice and job names were:

```
Microservice: Clean up names
   Job: Load Dublin Core metadata from disk
   Job: Sanitize SIP name
```

They have been changed to:

```
Microservice: Change SIP filenames
   Job: Load Dublin Core metadata from disk
   Job: Change SIP name
```

I have also changed the names where they appear in `tests/fixtures`.

Connected to archivematica/Issues#230