### PR TITLE
ArchivesSpace: relation: use parent_obj display_string when there is no title

### DIFF
--- a/src/dashboard/src/components/access/views.py
+++ b/src/dashboard/src/components/access/views.py
@@ -464,7 +464,8 @@ def access_arrange_start_sip(client, request, mapping):
     parent = archival_object.get("parent", {}).get("ref")
     while parent:
         parent_obj = client.get_record(parent)
-        relation = [parent_obj["title"]] + relation
+        parent_title = parent_obj["title"] if parent_obj.get("title") else parent_obj["display_string"]
+        relation = [parent_title] + relation
         parent = parent_obj.get("parent", {}).get("ref")
     relation = " - ".join(relation)
 

--- a/src/dashboard/src/components/access/views.py
+++ b/src/dashboard/src/components/access/views.py
@@ -464,7 +464,11 @@ def access_arrange_start_sip(client, request, mapping):
     parent = archival_object.get("parent", {}).get("ref")
     while parent:
         parent_obj = client.get_record(parent)
-        parent_title = parent_obj["title"] if parent_obj.get("title") else parent_obj["display_string"]
+        parent_title = (
+            parent_obj["title"]
+            if parent_obj.get("title")
+            else parent_obj["display_string"]
+        )
         relation = [parent_title] + relation
         parent = parent_obj.get("parent", {}).get("ref")
     relation = " - ".join(relation)


### PR DESCRIPTION
This PR checks if a `parent_obj` has a `title` when constructing the `relation` element to ensure that SIPs can be created with an intellectual arrangement consisting of `titles` and/or `dates`, not just `titles`. If a `title` exists, it is used as the parent_title and, if a `title` does not exist, then the `parent_obj` `display_string` is used instead.


Fixes archivematica/Issues#799
Replaces #1456 