### PR TITLE
Create dmdSec for non-ascii filenames

### DIFF
--- a/src/MCPClient/lib/archivematicaClient.py
+++ b/src/MCPClient/lib/archivematicaClient.py
@@ -68,6 +68,7 @@ from django.conf import settings as django_settings
 import gearman
 
 from main.models import Task
+from archivematicaFunctions import unicodeToStr
 from databaseFunctions import getUTCDate, retryOnFailure
 
 from django.db import transaction
@@ -83,9 +84,9 @@ from job import Job
 logger = logging.getLogger("archivematica.mcp.client")
 
 replacement_dict = {
-    "%sharedPath%": django_settings.SHARED_DIRECTORY,
-    "%clientScriptsDirectory%": django_settings.CLIENT_SCRIPTS_DIRECTORY,
-    "%clientAssetsDirectory%": django_settings.CLIENT_ASSETS_DIRECTORY,
+    r"%sharedPath%": django_settings.SHARED_DIRECTORY,
+    r"%clientScriptsDirectory%": django_settings.CLIENT_SCRIPTS_DIRECTORY,
+    r"%clientAssetsDirectory%": django_settings.CLIENT_ASSETS_DIRECTORY,
 }
 
 
@@ -119,14 +120,14 @@ def handle_batch_task(gearman_job, supported_modules):
         replacements = (
             replacement_dict.items()
             + {
-                "%date%": utc_date.isoformat(),
-                "%taskUUID%": task_uuid,
-                "%jobCreatedDate%": task_data["createdDate"],
+                r"%date%": utc_date.isoformat(),
+                r"%taskUUID%": task_uuid,
+                r"%jobCreatedDate%": task_data["createdDate"],
             }.items()
         )
 
         for var, val in replacements:
-            arguments = arguments.replace(var, val)
+            arguments = arguments.replace(var, unicodeToStr(val))
 
         job = Job(
             gearman_job.task,

--- a/src/MCPClient/lib/clientScripts/create_mets_v2.py
+++ b/src/MCPClient/lib/clientScripts/create_mets_v2.py
@@ -66,8 +66,9 @@ from archivematicaCreateMETSTrim import getTrimFileAmdSec
 
 # archivematicaCommon
 from archivematicaFunctions import escape
-from archivematicaFunctions import strToUnicode
 from archivematicaFunctions import normalizeNonDcElementName
+from archivematicaFunctions import strToUnicode
+from archivematicaFunctions import unicodeToStr
 from create_mets_dataverse_v2 import (
     create_dataverse_sip_dmdsec,
     create_dataverse_tabfile_dmdsec,
@@ -273,7 +274,7 @@ def createDMDIDsFromCSVMetadata(job, path, state):
     :param path: Path relative to the SIP to find CSV metadata on
     :return: Space-separated list of DMDIDs or empty string
     """
-    metadata = state.CSV_METADATA.get(path, {})
+    metadata = state.CSV_METADATA.get(unicodeToStr(path), {})
     dmdsecs = createDmdSecsFromCSVParsedMetadata(job, metadata, state)
     return " ".join([d.get("ID") for d in dmdsecs])
 

--- a/src/MCPClient/tests/test_archivematicaClient.py
+++ b/src/MCPClient/tests/test_archivematicaClient.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from archivematicaClient import handle_batch_task
+
+
+def test_handle_batch_task_replaces_non_ascii_arguments(mocker):
+    # We are only interested in verifying the string replacement logic
+    # for task arguments and mock the remaining functionality
+    mocker.patch("archivematicaClient.auto_close_db")
+    mocker.patch("archivematicaClient.Job")
+    mocker.patch("archivematicaClient.Task")
+    mocker.patch("archivematicaClient.retryOnFailure")
+    mocker.patch(
+        "cPickle.loads",
+        return_value={
+            "tasks": {
+                "some_task_uuid": {
+                    "uuid": "some_task_uuid",
+                    "arguments": "montréal %taskUUID% %jobCreatedDate%",
+                    "createdDate": "some montréal datetime",
+                    "wants_output": False,
+                }
+            }
+        },
+    )
+
+    # The mocked module will not have a `concurrent_instances` attribute
+    mocker.patch(
+        "importlib.import_module", return_value=mocker.MagicMock(spec=["call"])
+    )
+
+    # This is the only function that uses the arguments after the replacements
+    _parse_command_line = mocker.patch("archivematicaClient._parse_command_line")
+
+    # Mock the two parameters sent to handle_batch_task
+    gearman_job_mock = mocker.Mock()
+    supported_modules_mock = mocker.Mock(**{"get.side_effect": "some_module_name"})
+    handle_batch_task(gearman_job_mock, supported_modules_mock)
+
+    # Check that string replacement were successful
+    _parse_command_line.assert_called_once_with(
+        "montréal some_task_uuid some montréal datetime".encode("utf8")
+    )

--- a/src/MCPClient/tests/test_archivematicaClient.py
+++ b/src/MCPClient/tests/test_archivematicaClient.py
@@ -2,13 +2,15 @@
 
 from __future__ import unicode_literals
 
+import pytest
+
 from archivematicaClient import handle_batch_task
 
 
+@pytest.mark.django_db
 def test_handle_batch_task_replaces_non_ascii_arguments(mocker):
     # We are only interested in verifying the string replacement logic
     # for task arguments and mock the remaining functionality
-    mocker.patch("archivematicaClient.auto_close_db")
     mocker.patch("archivematicaClient.Job")
     mocker.patch("archivematicaClient.Task")
     mocker.patch("archivematicaClient.retryOnFailure")

--- a/src/MCPClient/tests/test_create_mets_v2.py
+++ b/src/MCPClient/tests/test_create_mets_v2.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import os
+import sys
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(THIS_DIR, "../lib/clientScripts")))
+
+from create_mets_v2 import createDMDIDsFromCSVMetadata
+
+
+def test_createDMDIDsFromCSVMetadata_finds_non_ascii_paths(mocker):
+    dmd_secs_creator_mock = mocker.patch(
+        "create_mets_v2.createDmdSecsFromCSVParsedMetadata", return_value=[]
+    )
+    state_mock = mocker.Mock(
+        **{
+            "CSV_METADATA": {
+                "montréal".encode("utf8"): "montreal metadata",
+                "dvořák".encode("utf8"): "dvorak metadata",
+            }
+        }
+    )
+
+    createDMDIDsFromCSVMetadata(None, "montréal", state_mock)
+    createDMDIDsFromCSVMetadata(None, "toronto", state_mock)
+    createDMDIDsFromCSVMetadata(None, "dvořák", state_mock)
+
+    dmd_secs_creator_mock.assert_has_calls(
+        [
+            mocker.call(None, "montreal metadata", state_mock),
+            mocker.call(None, {}, state_mock),
+            mocker.call(None, "dvorak metadata", state_mock),
+        ]
+    )

--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -652,9 +652,9 @@ class Package(object):
                 filter_path = "".join([self.REPLACEMENT_PATH_STRING, filter_subdir])
                 queryset = queryset.filter(currentlocation__startswith=filter_path)
 
-            start_path = self.current_path.encode("utf-8")  # use bytes to return bytes
+            start_path = self.current_path
             if filter_subdir:
-                start_path = start_path + filter_subdir.encode("utf-8")
+                start_path = start_path + filter_subdir
 
             files_returned_already = set()
             if queryset.exists():

--- a/src/MCPServer/tests/test_package.py
+++ b/src/MCPServer/tests/test_package.py
@@ -269,7 +269,13 @@ def test_package_files_with_non_ascii_names(tmp_path):
     models.File.objects.create(**kwargs)
 
     # Assert only one file is returned
-    assert len(list(transfer.files(None, None, "/objects"))) == 1
+    result = list(transfer.files(None, None, "/objects"))
+    assert len(result) == 1
+
+    # And it is the file we just created
+    assert result[0]["%fileUUID%"] == str(kwargs["uuid"])
+    assert result[0]["%currentLocation%"] == kwargs["currentlocation"]
+    assert result[0]["%fileGrpUse%"] == kwargs["filegrpuse"]
 
 
 class TestPadDestinationFilePath:

--- a/src/dashboard/src/settings/test.py
+++ b/src/dashboard/src/settings/test.py
@@ -71,3 +71,8 @@ AUTH_LDAP_USER_SEARCH = LDAPSearch(
 )
 AUTH_LDAP_USER_FLAGS_BY_GROUP = {}
 AUTH_LDAP_USERNAME_SUFFIX = "_ldap"
+
+# These are MCPClient specific settings because
+# tox uses this module instead of MCPClient settings.test
+CLIENT_SCRIPTS_DIRECTORY = ""
+CLIENT_ASSETS_DIRECTORY = ""


### PR DESCRIPTION
This PR handles non-ascii filenames in a `metadata/metadata.csv` import. The specific fix for that problem is in https://github.com/artefactual/archivematica/commit/9ec86dc8b7ac9dd2f63d18d29ccd3329ddd086e8

However, two fixes were required first (apologies for mixing them here):

1. Currently, if a transfer contains files with non-ascii names, the MCPServer will crash without starting the transfer. The problem was that the generator introduced in https://github.com/artefactual/archivematica/pull/1535 considered non-ascii filenames retrieved from the filesystem to be different from the same name retrieved from the database. This is the same problem in Helen's https://github.com/wellcometrust/platform/issues/4175#issuecomment-578136053. This has been fixed and tested in https://github.com/artefactual/archivematica/commit/b6c26eb987e83085f03541a1902c39a7d33a2c5d

1.  Then the helper that creates MCPClient jobs needed to be updated to accept the decoded non-ascii arguments. This has been fixed and tested in https://github.com/artefactual/archivematica/commit/deeb9fe9d1c9a00e597c2f0343a5762982700de5

Finally I realized `tox` is using the `settings.test` module from the dashboard for the MCPClient tests. I worked around this in https://github.com/artefactual/archivematica/commit/2acad6baaeb9dce13ac8e930555c4d196d478e76 by adding the MCPClient specific settings there. Maybe a way to handle this would be to create a separate tox environment only for the MCPClient.

Connected to https://github.com/archivematica/Issues/issues/1073