### PR TITLE
Exclude non-default agents

### DIFF
--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -29,7 +29,6 @@ import time
 import uuid
 
 from django.db import close_old_connections
-from django.db.models import Q
 from django.utils import six, timezone
 from main.models import Agent, Derivation, Event, File, FPCommandOutput, SIP
 
@@ -147,9 +146,9 @@ def getAMAgentsForFile(fileUUID):
     elif f.transfer:
         return f.transfer.agents.values_list("pk", flat=True)
 
-    # Fetch other Archivematica Agents
+    # Fetch the default Agents
     return Agent.objects.filter(
-        Q(identifiertype="repository code") | Q(identifiertype="preservation system")
+        Agent.objects.default_agents_query_keywords()
     ).values_list("pk", flat=True)
 
 

--- a/src/archivematicaCommon/tests/fixtures/agents.json
+++ b/src/archivematicaCommon/tests/fixtures/agents.json
@@ -48,5 +48,25 @@
     },
     "model": "main.agent",
     "pk": 10
+},
+{
+    "fields": {
+        "agenttype": "software",
+        "identifiervalue": "Other-Software-1.0",
+        "name": "Other Software",
+        "identifiertype": "preservation system"
+    },
+    "model": "main.agent",
+    "pk": 11
+},
+{
+    "fields": {
+        "agenttype": "organization",
+        "identifiervalue": "other-repository",
+        "name": "Other repository",
+        "identifiertype": "repository code"
+    },
+    "model": "main.agent",
+    "pk": 12
 }
 ]


### PR DESCRIPTION
This PR introduces a model manager for the `Agent` model that knows the primary keys of the default `preservation system` and `repository code` agents and uses it when retrieving File, Transfer or SIP agents.

We've been already assuming these keys in a few places which I didn't update in the scope in this PR:

* [In the `PREMIS agent` administration view](https://github.com/artefactual/archivematica/blob/7ac6501fde87eae13e18dc877962a8bf3a4fb347/src/dashboard/src/components/administration/views.py#L467)
* [The Version view assumes only one `preservation system` agent exists](https://github.com/artefactual/archivematica/blob/7ac6501fde87eae13e18dc877962a8bf3a4fb347/src/dashboard/src/components/administration/views.py#L619-L621)
* [The installer steps](https://github.com/artefactual/archivematica/blob/7ac6501fde87eae13e18dc877962a8bf3a4fb347/src/dashboard/src/installer/steps.py#L65)

Connected to https://github.com/archivematica/Issues/issues/1072