### PR TITLE
Add dependency gcc and gcc++ for pip

### DIFF
--- a/src/archivematicaCommon/osdeps/CentOS-7.json
+++ b/src/archivematicaCommon/osdeps/CentOS-7.json
@@ -15,7 +15,6 @@
    { "name": "epel-release", "state": "latest"}
   ],
   "osdeps_packages_2": [
-   { "name": "gcc", "state": "latest"}
   ]
 
 }

--- a/src/archivematicaCommon/osdeps/RedHat-7.json
+++ b/src/archivematicaCommon/osdeps/RedHat-7.json
@@ -15,7 +15,6 @@
    { "name": "epel-release", "state": "latest"}
   ],
   "osdeps_packages_2": [
-   { "name": "gcc", "state": "latest"}
   ]
 
 }

--- a/src/dashboard/osdeps/CentOS-7.json
+++ b/src/dashboard/osdeps/CentOS-7.json
@@ -10,6 +10,8 @@
   "osdeps_repos": [
   ],
   "osdeps_packages": [
+  { "name": "gcc", "state": "latest"},
+  { "name": "gcc-c++", "state": "latest"},
   { "name": "gettext", "state": "latest"},
   { "name": "nginx", "state": "latest"},
   { "name": "policycoreutils-python", "state": "latest"},

--- a/src/dashboard/osdeps/RedHat-7.json
+++ b/src/dashboard/osdeps/RedHat-7.json
@@ -10,6 +10,8 @@
   "osdeps_repos": [
   ],
   "osdeps_packages": [
+  { "name": "gcc", "state": "latest"},
+  { "name": "gcc-c++", "state": "latest"},
   { "name": "gettext", "state": "latest"},
   { "name": "nginx", "state": "latest"},
   { "name": "policycoreutils-python", "state": "latest"},

--- a/src/dashboard/osdeps/Ubuntu-16.json
+++ b/src/dashboard/osdeps/Ubuntu-16.json
@@ -8,6 +8,18 @@
   "osdeps_repos": [],
   "osdeps_packages": [
     {
+      "name": "gcc",
+      "state": "latest"
+    },
+    {
+      "name": "g++",
+      "state": "latest"
+    },
+    {
+      "name": "make",
+      "state": "latest"
+    },
+    {
       "name": "gettext",
       "state": "latest"
     },

--- a/src/dashboard/osdeps/Ubuntu-18.json
+++ b/src/dashboard/osdeps/Ubuntu-18.json
@@ -8,6 +8,14 @@
   "osdeps_repos": [],
   "osdeps_packages": [
     {
+      "name": "gcc",
+      "state": "latest"
+    },
+    {
+      "name": "g++",
+      "state": "latest"
+    },
+    {
       "name": "gettext",
       "state": "latest"
     },


### PR DESCRIPTION
When installing Dashboard service in a seperate VM, "virtualenv | Install requirements" fails with "gcc: error trying to exec 'cc1plus': execvp: No such file or directory\n  error: command 'gcc' failed with exit status 1"

This PR will add gcc and gcc-c++ as dependency for the Dashboard installer.

Connected to https://github.com/archivematica/Issues/issues/1093 