### PR TITLE
Fix .tar handling in get_extract_dir_name helper

### DIFF
--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -426,6 +426,6 @@ def get_extract_dir_name(filename):
 
     # trim off '.tar' if present
     if extract_dir.suffix in (".tar", ".TAR"):
-        extract_dir = extract_dir.stem
+        extract_dir = extract_dir.parent / extract_dir.stem
 
     return str(extract_dir)

--- a/src/archivematicaCommon/tests/test_file_operations.py
+++ b/src/archivematicaCommon/tests/test_file_operations.py
@@ -6,11 +6,14 @@ from fileOperations import get_extract_dir_name
 @pytest.mark.parametrize(
     "filename,dirname",
     [
-        ("test.zip", "test"),
-        ("test.tar.gz", "test"),
-        ("test.TAR.GZ", "test"),
-        ("test.TAR.GZ", "test"),
-        ("test.target.tar.gz", "test.target"),  # something beginning with "tar"
+        ("/parent/test.zip", "/parent/test"),
+        ("/parent/test.tar.gz", "/parent/test"),
+        ("/parent/test.TAR.GZ", "/parent/test"),
+        ("/parent/test.TAR.GZ", "/parent/test"),
+        (
+            "/parent/test.target.tar.gz",
+            "/parent/test.target",
+        ),  # something beginning with "tar"
     ],
 )
 def test_get_extract_dir_name(filename, dirname):


### PR DESCRIPTION
This PR fixes the `get_extract_dir_name` helper by returning an absolute path when the file path contains a `.tar` suffix.

Connected to https://github.com/archivematica/Issues/issues/1091