### PR TITLE
Fix parameters of copy_metadata_files view

### DIFF
--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -676,9 +676,7 @@ def copy_metadata_files_api(request):
     """
     Endpoint for adding metadata files to a SIP if using an API key.
     """
-    sip_uuid = request.POST.get("sip_uuid")
-    paths = request.POST.getlist("source_paths[]")
-    return filesystem_ajax_views.copy_metadata_files(sip_uuid, paths)
+    return filesystem_ajax_views.copy_metadata_files(request)
 
 
 @_api_endpoint(expected_methods=["GET"])

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -925,7 +925,7 @@ def copy_to_arrange(request, sources=None, destinations=None, fetch_children=Fal
     return helpers.json_response(response, status_code=status_code)
 
 
-def copy_metadata_files(request, sip_uuid, paths):
+def copy_metadata_files(request):
     """
     Copy files from list `source_paths` to sip_uuid's metadata folder.
 


### PR DESCRIPTION
This PR fixes the parameters sent to the `filesystem_ajax.views.copy_metadata_files` view.

I believe the view parameters broke during https://github.com/artefactual/archivematica/pull/1362 and affect two things:

- Metadata files upload through the file explorer during ingest (as described in the issue)
- [The `/api/ingest/copy_metadata_files/` endpoint](https://wiki.archivematica.org/Archivematica_API#Copy_Metadata) which [relies entirely on the same view](https://github.com/artefactual/archivematica/blob/f50d86e1835644e1492c97984b1270879a5c70e6/src/dashboard/src/components/api/views.py#L681)

Connected to https://github.com/archivematica/Issues/issues/1090