### PR TITLE
PoC: Create new dirs in watched dirs as hidden

### DIFF
--- a/src/MCPServer/lib/server/mcp.py
+++ b/src/MCPServer/lib/server/mcp.py
@@ -50,7 +50,12 @@ logger = logging.getLogger("archivematica.mcp.server")
 
 
 def watched_dir_handler(package_queue, path, watched_dir):
-    if os.path.isdir(path):
+
+    is_hidden = os.path.basename(path).startswith(".")
+    if is_hidden:
+        return
+
+    if os.path.isdir(path) and not is_hidden:
         path = path + "/"
     logger.debug("Starting chain for %s", path)
 

--- a/src/MCPServer/tests/test_package.py
+++ b/src/MCPServer/tests/test_package.py
@@ -335,7 +335,7 @@ class TestMoveToInternalSharedDir:
 
         dest_path = processing_dir / "transfer.zip"
         assert dest_path.is_file()
-        assert (processing_dir / "transfer").is_dir()
+        assert (processing_dir / ".transfer").is_dir()
 
         transfer.refresh_from_db()
         assert Path(transfer.currentlocation) == dest_path
@@ -351,5 +351,5 @@ class TestMoveToInternalSharedDir:
 
         _move_to_internal_shared_dir(str(filepath), str(processing_dir), transfer)
 
-        config_dest = processing_dir / "transfer/processingMCP.xml"
+        config_dest = processing_dir / ".transfer/processingMCP.xml"
         assert config_dest.is_file()

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -422,7 +422,7 @@ def get_extract_dir_name(filename):
     if not filename.suffix:
         raise ValueError("Filename '%s' must have an extension", filename)
 
-    extract_dir = filename.parent / filename.stem
+    extract_dir = filename.parent / ".{}".format(str(filename.stem))
 
     # trim off '.tar' if present
     if extract_dir.suffix in (".tar", ".TAR"):

--- a/src/archivematicaCommon/tests/test_file_operations.py
+++ b/src/archivematicaCommon/tests/test_file_operations.py
@@ -6,13 +6,13 @@ from fileOperations import get_extract_dir_name
 @pytest.mark.parametrize(
     "filename,dirname",
     [
-        ("/parent/test.zip", "/parent/test"),
-        ("/parent/test.tar.gz", "/parent/test"),
-        ("/parent/test.TAR.GZ", "/parent/test"),
-        ("/parent/test.TAR.GZ", "/parent/test"),
+        ("/parent/test.zip", "/parent/.test"),
+        ("/parent/test.tar.gz", "/parent/.test"),
+        ("/parent/test.TAR.GZ", "/parent/.test"),
+        ("/parent/test.TAR.GZ", "/parent/.test"),
         (
             "/parent/test.target.tar.gz",
-            "/parent/test.target",
+            "/parent/.test.target",
         ),  # something beginning with "tar"
     ],
 )


### PR DESCRIPTION
Teach the watched directory not to pick up on everything added so
that if something needs to be added over-time, its signal to the
handler is that when it is renamed it is no-longer hidden.

This is an incomplete solution to 1092 with a better approach in the works from Douglas. 