### PR TITLE
Reorder reingest dropdown options

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -8345,8 +8345,8 @@
                 "@manager": "linkTaskManagerChoice",
                 "@model": "MicroServiceChainChoice",
                 "chain_choices": [
-                    "a6ed697e-6189-4b4e-9f80-29209abc7937",
-                    "2eae85d6-da2f-4f1c-8c33-3810b55e23aa"
+                    "2eae85d6-da2f-4f1c-8c33-3810b55e23aa",
+                    "a6ed697e-6189-4b4e-9f80-29209abc7937"
                 ]
             },
             "description": {

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -7702,8 +7702,8 @@
                 "@manager": "linkTaskManagerChoice",
                 "@model": "MicroServiceChainChoice",
                 "chain_choices": [
-                    "a6ed697e-6189-4b4e-9f80-29209abc7937",
-                    "260ef4ea-f87d-4acf-830d-d0de41e6d2af"
+                    "260ef4ea-f87d-4acf-830d-d0de41e6d2af",
+                    "a6ed697e-6189-4b4e-9f80-29209abc7937"
                 ]
             },
             "description": {


### PR DESCRIPTION
This was missed in the original PR, since I was using the processing
config for guidance. I've just switched the order of these two options
so that "Approve" is first, followed by "Reject", to be consistent with
all of the other dropdowns.

Connected to archivematica/Issues#819