### PR TITLE
Match Zipped directory api calls to the UI

### DIFF
--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -64,7 +64,7 @@ PACKAGE_TYPE_STARTING_POINTS = {
         chain="6953950b-c101-4f4c-a0c3-0cd0684afe5e",
         link="045c43ae-d6cf-44f7-97d6-c8a602748565",
     ),
-    "zipfile": StartingPoint(
+    "zipped directory": StartingPoint(
         watched_dir=os.path.join(
             settings.WATCH_DIRECTORY, "activeTransfers/zippedDirectory"
         ),


### PR DESCRIPTION
As discussed in AM releases last week, the more alignment we have in UI terminology and API terminology, the better for the end user, so this commit makes sure that the API call for `Zipped Directory` aligns with the user-interface. 

This enables the following API call to be made:
```
http --pretty=format \
    POST 127.0.0.1:62080/api/v2beta/package \
    "Authorization: ApiKey test:test" \
    type="zipped directory" \
    processing_config=automated \
    path=$(echo -n '/home/archivematica/archivematica-sampledata/SampleTransfers/ZippedDIrectoryTransfers/ZippedDirectoryTransferWithProcessing.zip' | base64 -w 0) \
    name=v2_beta_endpoint_example
```

Where:
```
    type="zipped directory" \
    processing_config=automated \
```
Matches the user interface, and the current:
```
    type="zipfile" \
    processing_config=automated \
```
Does not. `zipfile` I think might be leftover from the original development work here and may have been caught during CR another time. 

**NB.** If this gets merged we should notify Alex at Wellcome, and update the [Wiki](https://wiki.archivematica.org/index.php?title=Archivematica_API&action=edit&section=26 ).

Connected to archivematica/issues#682 