### PR TITLE
Use unit variable for copying processing config

### DIFF
--- a/src/MCPClient/lib/clientScripts/file_to_folder.py
+++ b/src/MCPClient/lib/clientScripts/file_to_folder.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import sys
 
 import django
 
@@ -32,6 +33,17 @@ def main(job, transfer_path, transfer_uuid, shared_path):
     # If file, move into directory and update transfer
     dirpath = os.path.splitext(transfer_path)[0]
     basename = os.path.basename(transfer_path)
+    if os.path.exists(dirpath):
+        job.pyprint(
+            "Cannot move file",
+            transfer_path,
+            "to folder",
+            dirpath,
+            "because it already exists",
+            file=sys.stderr,
+        )
+        return 1
+    os.mkdir(dirpath)
     new_path = os.path.join(dirpath, basename)
     job.pyprint("Moving", transfer_path, "to", new_path)
     os.rename(transfer_path, new_path)

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -1493,7 +1493,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -2658,7 +2658,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -4397,7 +4397,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -10076,7 +10076,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -10588,7 +10588,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -10735,7 +10735,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -11862,7 +11862,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -12089,7 +12089,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -10076,7 +10076,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -10588,7 +10588,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -12089,7 +12089,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -1493,7 +1493,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -2658,7 +2658,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -4397,7 +4397,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -10076,7 +10076,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -10588,7 +10588,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -10735,7 +10735,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -11862,7 +11862,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,
@@ -12089,7 +12089,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\" -n",
+                "arguments": "\"%sharedPath%sharedMicroServiceTasksConfigs/processingMCPConfigs/%processingConfiguration%ProcessingMCP.xml\" \"%SIPDirectory%processingMCP.xml\"",
                 "execute": "copy_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,

--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -809,9 +809,13 @@ class Transfer(Package):
                 transfer_obj.currentpath = path
                 transfer_obj.save()
         else:
-            transfer_obj = models.Transfer.objects.create(
-                uuid=uuid4(), currentlocation=path
-            )
+            try:
+                transfer_obj = models.Transfer.objects.get(currentlocation=path)
+                created = False
+            except models.Transfer.DoesNotExist:
+                transfer_obj = models.Transfer.objects.create(
+                    uuid=uuid4(), currentlocation=path
+                )
         logger.info(
             "Transfer %s %s (%s)",
             transfer_obj.uuid,

--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -18,7 +18,6 @@ from django.utils import six
 import storageService as storage_service
 from archivematicaFunctions import strToUnicode
 from archivematicaFunctions import unicodeToStr
-from fileOperations import get_extract_dir_name
 from main import models
 
 from server.db import auto_close_old_connections
@@ -285,8 +284,6 @@ def _move_to_internal_shared_dir(filepath, dest, transfer):
     filepath = Path(filepath)
     dest = Path(dest)
 
-    is_dir = filepath.is_dir()
-
     # Confine destination to subdir of originals.
     basename = filepath.name
     dest = _pad_destination_filepath_if_it_already_exists(dest / basename)
@@ -300,26 +297,6 @@ def _move_to_internal_shared_dir(filepath, dest, transfer):
             _get_setting("SHARED_DIRECTORY"), r"%sharedPath%", 1
         )
         transfer.save()
-
-    if not is_dir:
-        # Transfer is not a directory so it is an uploaded zipfile.
-        # Precreate the extraction directory for the uploaded zipfile
-        extract_dir = Path(get_extract_dir_name(dest))
-        try:
-            extract_dir.mkdir()
-        except OSError as e:
-            raise Exception("Error creating extraction dir %s (%s)", extract_dir, e)
-
-        # Move the processing config into the extraction directory so that it
-        # is preserved and used in the workflow
-        files_to_preserve = {"processingMCP.xml"}
-        for filename in files_to_preserve:
-            path = filepath.parent / filename
-            if path.exists():
-                try:
-                    path.rename(extract_dir / filename)
-                except OSError as e:
-                    raise Exception("Error moving %s to %s (%s)", path, extract_dir, e)
 
 
 @auto_close_old_connections()

--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -359,7 +359,7 @@ def create_package(
     logger.debug(
         "Package %s: starting transfer (%s)", transfer.pk, (name, type_, path, tmpdir)
     )
-    params = (transfer, name, path, tmpdir, starting_point, processing_config)
+    params = (transfer, name, path, tmpdir, starting_point)
     if auto_approve:
         params = params + (workflow, package_queue)
         result = executor.submit(_start_package_transfer_with_auto_approval, *params)
@@ -405,14 +405,7 @@ def _determine_transfer_paths(name, path, tmpdir):
 
 @_capture_transfer_failure
 def _start_package_transfer_with_auto_approval(
-    transfer,
-    name,
-    path,
-    tmpdir,
-    starting_point,
-    processing_config,
-    workflow,
-    package_queue,
+    transfer, name, path, tmpdir, starting_point, workflow, package_queue
 ):
     """Start a new transfer the new way.
 
@@ -454,9 +447,7 @@ def _start_package_transfer_with_auto_approval(
 
 
 @_capture_transfer_failure
-def _start_package_transfer(
-    transfer, name, path, tmpdir, starting_point, processing_config
-):
+def _start_package_transfer(transfer, name, path, tmpdir, starting_point):
     """Start a new transfer the old way.
 
     This means copying the transfer into one of the standard watched dirs.

--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -23,7 +23,6 @@ from main import models
 
 from server.db import auto_close_old_connections
 from server.jobs import JobChain
-from server.processing_config import copy_processing_config
 from server.utils import uuid_from_path
 
 try:
@@ -461,10 +460,6 @@ def _start_package_transfer_with_auto_approval(
     )
     _copy_from_transfer_sources([path], transfer_rel)
 
-    copy_processing_config(
-        processing_config, os.path.join(_get_setting("SHARED_DIRECTORY"), transfer_rel)
-    )
-
     logger.debug("Package %s: moving package to processing directory", transfer.pk)
     _move_to_internal_shared_dir(
         filepath, _get_setting("PROCESSING_DIRECTORY"), transfer
@@ -508,10 +503,6 @@ def _start_package_transfer(
         transfer_rel,
     )
     _copy_from_transfer_sources([path], transfer_rel)
-
-    copy_processing_config(
-        processing_config, os.path.join(_get_setting("SHARED_DIRECTORY"), transfer_rel)
-    )
 
     logger.debug(
         "Package %s: moving package to activeTransfers dir (from=%s," " to=%s)",

--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -373,6 +373,7 @@ def create_package(
         except models.TransferMetadataSet.DoesNotExist:
             pass
     transfer = models.Transfer.objects.create(**kwargs)
+    transfer.set_processing_configuration(processing_config)
     transfer.update_active_agent(user_id)
     logger.debug("Transfer object created: %s", transfer.pk)
 
@@ -834,6 +835,7 @@ class Transfer(Package):
     def reload(self):
         transfer = models.Transfer.objects.get(uuid=self.uuid)
         self.current_path = transfer.currentlocation
+        self.processing_configuration = transfer.processing_configuration
 
     def get_replacement_mapping(self, filter_subdir_path=None):
         mapping = super(Transfer, self).get_replacement_mapping(
@@ -841,7 +843,11 @@ class Transfer(Package):
         )
 
         mapping.update(
-            {self.REPLACEMENT_PATH_STRING: self.current_path, r"%unitType%": "Transfer"}
+            {
+                self.REPLACEMENT_PATH_STRING: self.current_path,
+                r"%unitType%": "Transfer",
+                r"%processingConfiguration%": self.processing_configuration,
+            }
         )
 
         return mapping

--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -22,6 +22,7 @@ from main import models
 
 from server.db import auto_close_old_connections
 from server.jobs import JobChain
+from server.processing_config import processing_configuration_file_exists
 from server.utils import uuid_from_path
 
 try:
@@ -349,6 +350,8 @@ def create_package(
         except models.TransferMetadataSet.DoesNotExist:
             pass
     transfer = models.Transfer.objects.create(**kwargs)
+    if not processing_configuration_file_exists(processing_config):
+        processing_config = "default"
     transfer.set_processing_configuration(processing_config)
     transfer.update_active_agent(user_id)
     logger.debug("Transfer object created: %s", transfer.pk)

--- a/src/MCPServer/lib/server/processing_config.py
+++ b/src/MCPServer/lib/server/processing_config.py
@@ -302,3 +302,21 @@ def load_preconfigured_choice(package_path, workflow_link_id):
                 choice = preconfigured_choice.find("goToChain").text
 
     return choice
+
+
+def processing_configuration_file_exists(processing_configuration_name):
+    if not processing_configuration_name:
+        return False
+    result = os.path.isfile(
+        os.path.join(
+            settings.SHARED_DIRECTORY,
+            "sharedMicroServiceTasksConfigs/processingMCPConfigs",
+            "%sProcessingMCP.xml" % processing_configuration_name,
+        )
+    )
+    if not result:
+        logger.debug(
+            "Processing configuration file for %s does not exist",
+            processing_configuration_name,
+        )
+    return result

--- a/src/MCPServer/tests/test_mcp.py
+++ b/src/MCPServer/tests/test_mcp.py
@@ -3,10 +3,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import threading
 import uuid
 
+import pytest
+
 from server.mcp import main
 from server.mcp import watched_dir_handler
 
 
+@pytest.mark.django_db(transaction=True)
 def test_watched_dir_handler_creates_transfer_if_it_does_not_exist(mocker, tmpdir):
     """Test that a models.Transfer object exists for an unknown path.
 
@@ -49,6 +52,7 @@ def test_watched_dir_handler_creates_transfer_if_it_does_not_exist(mocker, tmpdi
     )
 
 
+@pytest.mark.django_db(transaction=True)
 def test_watched_dir_handler_creates_transfer_for_file(mocker, tmpdir):
     """Test that a models.Transfer object exists for a file path.
     """

--- a/src/MCPServer/tests/test_package.py
+++ b/src/MCPServer/tests/test_package.py
@@ -335,21 +335,6 @@ class TestMoveToInternalSharedDir:
 
         dest_path = processing_dir / "transfer.zip"
         assert dest_path.is_file()
-        assert (processing_dir / "transfer").is_dir()
 
         transfer.refresh_from_db()
         assert Path(transfer.currentlocation) == dest_path
-
-    def test_move_processing_config_with_zipfile(
-        self, tmp_path, processing_dir, transfer
-    ):
-        filepath = tmp_path / "transfer.zip"
-        filepath.touch()
-
-        config = tmp_path / "processingMCP.xml"
-        config.touch()
-
-        _move_to_internal_shared_dir(str(filepath), str(processing_dir), transfer)
-
-        config_dest = processing_dir / "transfer/processingMCP.xml"
-        assert config_dest.is_file()

--- a/src/MCPServer/tests/test_processing_config.py
+++ b/src/MCPServer/tests/test_processing_config.py
@@ -6,6 +6,7 @@ from server.processing_config import (
     _get_options_for_chain_choice,
     _populate_duplicates_chain_choice,
     get_processing_fields,
+    processing_configuration_file_exists,
     processing_fields,
 )
 from server.workflow import load
@@ -38,3 +39,21 @@ def test__populate_duplicates_chain_choice(_workflow):
     _populate_duplicates_chain_choice(_workflow, link, config)
     duplicates = config["duplicates"]
     assert len(duplicates) > 0
+
+
+def test_processing_configuration_file_exists_with_None():
+    assert not processing_configuration_file_exists(None)
+
+
+def test_processing_configuration_file_exists_with_existent_file(mocker):
+    mocker.patch("os.path.isfile", return_value=True)
+    assert processing_configuration_file_exists("defaultProcessingMCP.xml")
+
+
+def test_processing_configuration_file_exists_with_nonexistent_file(mocker):
+    mocker.patch("os.path.isfile", return_value=False)
+    logger = mocker.patch("server.processing_config.logger")
+    assert not processing_configuration_file_exists("bogus.xml")
+    logger.debug.assert_called_once_with(
+        "Processing configuration file for %s does not exist", "bogus.xml"
+    )

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -489,6 +489,25 @@ class Transfer(models.Model):
 
         return Agent.objects.filter(agent_lookups)
 
+    def set_processing_configuration(self, processing_configuration):
+        UnitVariable.objects.update_processing_configuration(
+            "Transfer", self.uuid, processing_configuration
+        )
+
+    @property
+    def processing_configuration(self):
+        try:
+            unit_variable = UnitVariable.objects.get(
+                unittype="Transfer",
+                unituuid=self.uuid,
+                variable="processingConfiguration",
+            )
+        except UnitVariable.DoesNotExist:
+            result = None
+        else:
+            result = unit_variable.variablevalue
+        return result or "default"
+
 
 class SIPArrange(models.Model):
     """ Information about arranged files: original and arranged location, current status. """
@@ -1392,6 +1411,13 @@ class UnitVariableManager(models.Manager):
             .userprofile.agent_id
         )
         return self.update_variable(unit_type, unit_id, "activeAgent", agent_id)
+
+    def update_processing_configuration(
+        self, unit_type, unit_uuid, processing_configuration
+    ):
+        return self.update_variable(
+            unit_type, unit_uuid, "processingConfiguration", processing_configuration
+        )
 
 
 class UnitVariable(models.Model):


### PR DESCRIPTION
This PR saves the processing configuration name of the transfer in a unit variable (also accessible from the `Transfer` model) in the database and retrieve later to copy it to the processing directory. More context for the change can be found in this https://github.com/archivematica/Issues/issues/1092#issuecomment-585313063 

Additionally the changes made in https://github.com/artefactual/archivematica/pull/1561 have been reverted.

Connected to https://github.com/archivematica/Issues/issues/1092
Connected to https://github.com/archivematica/Issues/issues/1063