### PR TITLE
Query current location before creating SIP

### DIFF
--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -699,38 +699,53 @@ class Package(object):
         logger.info(message, key, self.uuid, value, chain_link_id)
 
 
-class DIP(Package):
-    REPLACEMENT_PATH_STRING = r"%SIPDirectory%"
-    UNIT_VARIABLE_TYPE = "DIP"
-    JOB_UNIT_TYPE = "unitDIP"
+class SIPDIP(Package):
+    """SIPDIP captures behavior shared between SIP- and DIP-type packages that
+    share the same model in Archivematica.
+    """
 
     @classmethod
     @auto_close_old_connections()
     def get_or_create_from_db_by_path(cls, path):
-        """Matches a directory to a database DIP by its appended UUID, or path.
-
-        Note that DIPs are represented using the SIP model in the database.
-        """
+        """Matches a directory to a database SIP by its appended UUID, or path."""
         path = path.replace(_get_setting("SHARED_DIRECTORY"), r"%sharedPath%", 1)
-
+        package_type = cls.UNIT_VARIABLE_TYPE
         sip_uuid = uuid_from_path(path)
         created = True
         if sip_uuid:
             sip_obj, created = models.SIP.objects.get_or_create(
-                uuid=sip_uuid, defaults={"currentpath": path, "diruuids": False}
+                uuid=sip_uuid,
+                defaults={
+                    "sip_type": package_type,
+                    "currentpath": path,
+                    "diruuids": False,
+                },
             )
         else:
-            sip_obj = models.SIP.objects.create(
-                uuid=uuid4(), currentpath=path, diruuids=False
-            )
+            try:
+                sip_obj = models.SIP.objects.get(currentpath=path)
+                created = False
+            except models.SIP.DoesNotExist:
+                sip_obj = models.SIP.objects.create(
+                    uuid=uuid4(),
+                    currentpath=path,
+                    sip_type=package_type,
+                    diruuids=False,
+                )
         logger.info(
-            "SIP (for DIP) %s %s (%s)",
+            "%s %s %s (%s)",
+            package_type,
             sip_obj.uuid,
             "created" if created else "updated",
             path,
         )
-
         return cls(path, sip_obj.uuid)
+
+
+class DIP(SIPDIP):
+    REPLACEMENT_PATH_STRING = r"%SIPDirectory%"
+    UNIT_VARIABLE_TYPE = "DIP"
+    JOB_UNIT_TYPE = "unitDIP"
 
     def reload(self):
         # reload is a no-op for DIPs
@@ -815,7 +830,7 @@ class Transfer(Package):
         return mapping
 
 
-class SIP(Package):
+class SIP(SIPDIP):
     REPLACEMENT_PATH_STRING = r"%SIPDirectory%"
     UNIT_VARIABLE_TYPE = "SIP"
     JOB_UNIT_TYPE = "unitSIP"
@@ -825,32 +840,6 @@ class SIP(Package):
 
         self.aip_filename = None
         self.sip_type = None
-
-    @classmethod
-    @auto_close_old_connections()
-    def get_or_create_from_db_by_path(cls, path):
-        """Matches a directory to a database SIP by its appended UUID, or path."""
-        path = path.replace(_get_setting("SHARED_DIRECTORY"), r"%sharedPath%", 1)
-
-        sip_uuid = uuid_from_path(path)
-        created = True
-        if sip_uuid:
-            sip_obj, created = models.SIP.objects.get_or_create(
-                uuid=sip_uuid,
-                defaults={"sip_type": "SIP", "currentpath": path, "diruuids": False},
-            )
-            if not created and sip_obj.currentpath != path:
-                sip_obj.currentpath = path
-                sip_obj.save()
-        else:
-            sip_obj = models.SIP.objects.create(
-                uuid=uuid4(), currentpath=path, sip_type="SIP", diruuids=False
-            )
-        logger.info(
-            "SIP %s %s (%s)", sip_obj.uuid, "created" if created else "updated", path
-        )
-
-        return cls(path, sip_obj.uuid)
 
     @auto_close_old_connections()
     def reload(self):


### PR DESCRIPTION
This is the corollary to Douglas' excellent work in https://github.com/artefactual/archivematica/pull/1570/commits/f750532b30eb5896aa8c12de423fefec128aaeea which seeks to resolve archivematica/issues#1031 where this logic was taken out during https://github.com/artefactual/archivematica/pull/1570/commits/c1e7468ca30794504e8b2f09c352a1b216b1f880 and forced a new SIP to be created if items were taken from the backlog. 

**CR notes** 

We combine the DB lookup and creation for SIPs and DIPs so that we reduce any repetition of code. Douglas noted [here](  https://github.com/artefactual/archivematica/pull/1572#commitcomment-37306108) that DIPs were left out of a logic whereby a path is updated in the model if it has changed. I've worked through this as a thought experiment, and I do not think it is ever triggered. 

1. we can grab a uuid fro the path and look up the path from the UUID. 
2. if we don't have a uuid then we can look up the SIP from the path.
3. If we have neither, we create a new SIP. 

The path would only ever be updated if 1. was triggered above. I tried this pathway in Archivematica by asking it to fail:

```
            if not created and sip_obj.currentpath != path:
                assert False, "because I am in this strange pathway..."
                sip_obj.currentpath = path
                sip_obj.save()
```
I then did the following:
  
  * ran the black-box tests.
  * performed full- and partial-reingest.
  * ran my own transfer through arrangement creating a subset of the original
    transfer along the way.

Nothing triggered this pathway when looking at the logs and monitoring the successful creation of AIPs.

I registered this line of thinking with Douglas in Slack too. And I think it looks like an odd piece of code, and my testing seems to confirm it somewhat. Perhaps an artifact of the migration to the new style package code created by Cole? I think if one looks up the original function [here](https://github.com/artefactual/archivematica/blob/862c4cdd780f1a235f20716d8472d34d9b56094f/src/MCPServer/lib/archivematicaMCP.py#L95-L146), you'll see a lot of strange pathways that one would never hope triggered by Archivematica at present. This seems to be one. 

In favor of keeping the new package code lean, and some amount of workings showing that it isn't needed, I'd like to propose in this piece of code we remove what's there and don't try to add SIP specific logic, i.e. make sure the current path doesn't change for DIPs. 

Connected to https://github.com/archivematica/Issues/issues/1031
Resolves https://github.com/archivematica/Issues/issues/1031
Replaces https://github.com/artefactual/archivematica/pull/1534  
