### PR TITLE
Handle failures explicitly in find_mets_path()

### DIFF
--- a/src/MCPClient/lib/clientScripts/assign_file_uuids.py
+++ b/src/MCPClient/lib/clientScripts/assign_file_uuids.py
@@ -32,8 +32,8 @@ the path to the file.
 """
 
 import argparse
+import glob
 import os
-import re
 import uuid
 
 from django.db import transaction
@@ -58,12 +58,15 @@ def find_mets_file(unit_path):
     """
     Return the location of the original METS in a Archivematica AIP transfer.
     """
-    p = re.compile(r"^METS\..*\.xml$", re.IGNORECASE)
     src = os.path.join(unit_path, "metadata")
-    for item in os.listdir(src):
-        m = p.match(item)
-        if m:
-            return os.path.join(src, m.group())
+    mets_paths = glob.glob(os.path.join(src, "METS.*.xml"))
+
+    if len(mets_paths) == 1:
+        return mets_paths[0]
+    elif len(mets_paths) == 0:
+        raise Exception("No METS file found in %s" % src)
+    else:
+        raise Exception("Multiple METS files found in %s: %r" % (src, mets_paths))
 
 
 def get_file_info_from_mets(job, sip_directory, file_path_relative_to_sip):

--- a/src/MCPClient/tests/test_assign_file_uuids.py
+++ b/src/MCPClient/tests/test_assign_file_uuids.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+from py.error import EEXIST
+import pytest
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(THIS_DIR, "../lib/clientScripts")))
+
+from assign_file_uuids import find_mets_file
+
+
+def touch(path):
+    """
+    Create a file at a given path (a ``py._path.local.LocalPath``).
+
+    Mimics the Unix command touch: https://en.wikipedia.org/wiki/Touch_(command)
+    """
+    try:
+        path.dirpath().mkdir()
+    except EEXIST:
+        if path.dirpath().isdir():
+            pass
+        else:
+            raise
+
+    path.write_text(u"Test file created by %s" % __file__, encoding="utf-8")
+
+
+def test_finds_matching_mets_file(tmpdir):
+    touch(tmpdir / "metadata" / "METS.1.xml")
+    assert find_mets_file(str(tmpdir)) == str(tmpdir / "metadata" / "METS.1.xml")
+
+
+def test_ambiguous_mets_file_is_error(tmpdir):
+    for i in range(3):
+        touch(tmpdir / "metadata" / ("METS.%d.xml" % i))
+
+    with pytest.raises(
+        Exception, match="Multiple METS files found in %s/metadata" % tmpdir
+    ):
+        find_mets_file(str(tmpdir))
+
+
+def test_no_mets_file_is_error(tmpdir):
+    with pytest.raises(Exception, match="No METS file found in %s/metadata" % tmpdir):
+        find_mets_file(str(tmpdir))


### PR DESCRIPTION
* If there are multiple METS files in a `metadata` folder, something has gone wrong – how do we know which METS file we should choose?

* If there aren't any METS files in a `metadata` folder, this function returns `None` to the calling code, which will give a more confusing error later.  There's no way the calling code can do anything sensible if it gets an unexpected `None`, so throw the exception here.

This is for https://github.com/archivematica/Issues/issues/1102