### PR TITLE
Update error path for "Check transfer directory for objects"

### DIFF
--- a/src/MCPClient/lib/clientScripts/check_transfer_directory_for_objects.py
+++ b/src/MCPClient/lib/clientScripts/check_transfer_directory_for_objects.py
@@ -25,17 +25,17 @@ import os
 import scandir
 
 
-exitInidcatingThereAreObjects = 179
-
-
 def call(jobs):
+    """
+    Check the given directory and it's subdirectories for files.
+    Returns job status 0 if there are files.
+    Returns job status 1 if the directories are empty.
+    """
     for job in jobs:
         with job.JobContext():
-            objectsDir = job.args[1]
-            os.path.isdir(objectsDir)
-            ret = 0
-            for dirs, subDirs, files in scandir.walk(objectsDir):
-                if files is not None and files != []:
-                    ret = exitInidcatingThereAreObjects
-                    break
-            job.set_status(ret)
+            objects_dir = job.args[1]
+            os.path.isdir(objects_dir)
+            for _, _, files in scandir.walk(objects_dir):
+                if files:
+                    return
+            job.set_status(1)

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -1061,15 +1061,11 @@
             "exit_codes": {
                 "0": {
                     "job_status": "Completed successfully",
-                    "link_id": null
-                },
-                "179": {
-                    "job_status": "Completed successfully",
                     "link_id": "b04e9232-2aea-49fc-9560-27349c8eba4e"
                 }
             },
             "fallback_job_status": "Failed",
-            "fallback_link_id": null,
+            "fallback_link_id": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
             "group": {
                 "en": "Create SIP from Transfer",
                 "es": "Crear SIP a partir de la transferencia",

--- a/src/MCPServer/lib/server/queues.py
+++ b/src/MCPServer/lib/server/queues.py
@@ -72,8 +72,6 @@ class PackageQueue(object):
             "377f8ebb-7989-4a68-9361-658079ff8138",
             # Move transfer to backlog
             "abd6d60c-d50f-4660-a189-ac1b34fafe85",
-            # Check transfer directory for objects
-            "032cdc54-0b9b-4caf-86e8-10d63efbaec0",
             # Move to the rejected directory
             "0d7f5dc2-b9af-43bf-b698-10fdcc5b014d",
             "333532b9-b7c2-4478-9415-28a3056d58df",


### PR DESCRIPTION
This PR solves the two problems that are discussed in [#1108](https://github.com/archivematica/Issues/issues/1108):
- e51ca85 removes the "Check transfer directory for objects" as a terminal link. This should resolve the reported `RuntimeError` from showing up in the logs. 
- 2745bf8 configures links the "Check transfer directory for objects" to the failure path for the Transfer. This means that in case of failure an e-mail is sent to the user and the transfer is cleaned. Besides that, I have changed the error codes and code style. For a full explanation please check the commit message.

Using the Images transfer from the samples I have verified that I can Transfer/Ingest without the `RuntimeError` showing up in the logs.

![image](https://user-images.githubusercontent.com/7934339/75094749-5fd91280-558e-11ea-8310-1b36c7628c52.png)

When I run the same transfer, but make sure to clear the objects directory before hitting "Check transfer directory for objects", I get a failed transfer and a failure report:

![image](https://user-images.githubusercontent.com/7934339/75094830-fd344680-558e-11ea-8fd8-076ba6b79854.png)

![image](https://user-images.githubusercontent.com/7934339/75094838-0cb38f80-558f-11ea-8924-d62176a85ddd.png)
 

