### PR TITLE
Fix enhanced decision point selector

### DIFF
--- a/src/dashboard/src/media/js/jobs.js
+++ b/src/dashboard/src/media/js/jobs.js
@@ -567,18 +567,27 @@ var BaseJobView = Backbone.View.extend({
       return UNKNOWN_COLOR;
     },
 
+  destroyEnhacedActionSelectContainer: function(statusObject)
+    {
+      $('.modal-backdrop.in').remove();
+      $('body').removeClass('modal-open');
+      $('#big-choice-select-modal').remove();
+      statusObject.bigSelectShowing = false;
+    },
+
   // augment dashboard action select by using a pop-up with an enhanced select widget
   activateEnhancedActionSelect: function($select, statusObject)
     {
+      var self = this;
       $select.hover(function() {
         // if not showing proxy selector and modal window
         if (!statusObject.bigSelectShowing)
         {
           // clone action selector
-          var $proxySelect = $select.clone();
+          var $proxySelect = $select.clone().css({'width': '100%'});
 
           // display action selector in modal window
-          $('<div class="modal hide" id="big-choice-select-modal"><div class="modal-header"><button type="button" class="close" id="big-choice-select-close" data-dismiss="modal">×</button><h3>' + gettext('Select an action...') + '</h3></div><div class="modal-body" id="big-choice-select-body"></div><div class="modal-footer"><a href="#" class="btn btn-default" data-dismiss="modal" id="big-choice-select-cancel">' + gettext('Cancel') + '</a></div></div>').modal({show: true});
+          $('<div class="modal" id="big-choice-select-modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="close" id="big-choice-select-close" data-dismiss="modal">×</button><h3>' + gettext('Select an action...') + '</h3></div><div class="modal-body" id="big-choice-select-body"></div><div class="modal-footer"><a href="#" class="btn btn-default" data-dismiss="modal" id="big-choice-select-cancel">' + gettext('Cancel') + '</a></div></div></div></div>').modal({show: true, backdrop: 'static'});
           $('#big-choice-select-body').append($proxySelect);
 
           // style clone as Select2
@@ -587,16 +596,21 @@ var BaseJobView = Backbone.View.extend({
           // proxy selections to action selector
           $proxySelect.change(function()
                   {
+            // TODO: revise this approach
+            // Once the UI is refreshed/repainted by Angular triggering the change
+            // on the $select element has no effect since it's "expired".
+            // An alternative could be to assign a unique identifier to the
+            // $select element when its created and look it up before triggering its
+            // change event.
             $select.val($(this).val());
             $select.trigger('change');
-            $('#big-choice-select-modal').remove();
+            self.destroyEnhacedActionSelectContainer(statusObject);
           });
 
           // allow another instance to show if modal is closed
           $('#big-choice-select-close, #big-choice-select-cancel').click(function()
           {
-            statusObject.bigSelectShowing = false;
-            $('#big-choice-select-modal').remove();
+            self.destroyEnhacedActionSelectContainer(statusObject);
           });
 
           // prevent multiple instances of this from displaying at once


### PR DESCRIPTION
This PR fixes the modal dialog shown when a decision point has more than 10 options.

I started reviewing https://github.com/artefactual/archivematica/pull/1475 but found the same [issues Ross reported](https://github.com/artefactual/archivematica/pull/1475#pullrequestreview-316284704).

I consider this fix a bit more robust because:

1. It doesn't require changes to the style sheets: to make the `Select2` dropdown in the modal responsive I followed this suggestion in its documentation (see the `**Responsive Design - Percent Width** section in http://select2.github.io/select2/):

> The best way to ensure that Select2 is using a percent based width is to inline the style declaration into the tag.

2. It completes the HTML structure of the modal element as explained in the [Bootstrap documentation](https://getbootstrap.com/docs/3.3/javascript/#modals). I also set the `backdrop` option of the modal as [`static`](https://getbootstrap.com/docs/3.3/javascript/#modals-options) to have the user destroy the modal container either trhough the `x` icon or the `Cancel` button. 

The modal seems to work similarly in Firefox and Chrome and it looks like this:

![Captura de pantalla de 2020-02-25 23-27-51](https://user-images.githubusercontent.com/560781/75315430-608cd580-5828-11ea-8cf5-397ae6990f6a.png)

**Note**: I also found a limitation in the whole approach that we'll need to revise in the future: once Angular repaints the UI, triggering the `change` event of the original decision point dropdown doesn't work anymore. I commented the code accordingly.

Connected to https://github.com/archivematica/Issues/issues/850