### PR TITLE
Proposal: limit package flooding

### DIFF
--- a/src/MCPServer/install/README.md
+++ b/src/MCPServer/install/README.md
@@ -173,11 +173,18 @@ This is the full list of variables supported by MCPServer:
     - **Default:** `"128"`
 
 - **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_CONCURRENT_PACKAGES`**:
-    - **Description:** the number of packages to process concurrently. Should typically correspond
-    to the number of running MCPClients.
+    - **Description:** the number of packages to process concurrently. Should typically correspond to the number of running MCPClients.
     - **Config file example:** `MCPServer.concurrent_packages`
     - **Type:** `int`
     - **Default:** 1/2 the number of CPU cores available to MCPServer, rounded up.
+
+- **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_MAX_QUEUED_TRANSFERS`**:
+    - **Description:** the total number of transfers that can be waiting to be
+    processed in Archivematica. The ideal number depends on the available disk
+    space and the size of the packages.
+    - **Config file example:** `MCPServer.max_queued_transfers`
+    - **Type:** `int`
+    - **Default:** 128
 
 - **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_RPC_THREADS`**:
     - **Description:** the number of threads used to process RPC requests from the dashboard.

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -88,6 +88,11 @@ CONFIG_MAPPING = {
         "option": "concurrent_packages",
         "type": "int",
     },
+    "max_queued_transfers": {
+        "section": "MCPServer",
+        "option": "max_queued_transfers",
+        "type": "int",
+    },
     "rpc_threads": {"section": "MCPServer", "option": "rpc_threads", "type": "int"},
     "worker_threads": {
         "section": "MCPServer",
@@ -143,6 +148,7 @@ storage_service_client_timeout = 86400
 storage_service_client_quick_timeout = 5
 prometheus_bind_address =
 prometheus_bind_port =
+max_queued_transfers = 128
 
 [client]
 user = archivematica
@@ -265,6 +271,7 @@ BATCH_SIZE = config.get("batch_size")
 CONCURRENT_PACKAGES = config.get(
     "concurrent_packages", default=concurrent_packages_default()
 )
+MAX_QUEUED_TRANSFERS = config.get("max_queued_transfers")
 RPC_THREADS = config.get("rpc_threads")
 WORKER_THREADS = config.get("worker_threads", default=multiprocessing.cpu_count() + 1)
 

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -845,9 +845,9 @@ def _package_create(request):
         client = MCPClient(request.user)
         id_ = client.create_package(*args, **kwargs)
     except Exception as err:
-        msg = "Package cannot be created"
-        LOGGER.error("{}: {}".format(msg, err))
-        return helpers.json_response({"error": True, "message": msg}, 500)
+        messsage = "Package cannot be created: {}".format(err.message)
+        LOGGER.error(messsage)
+        return helpers.json_response({"error": True, "message": messsage}, 500)
     return helpers.json_response({"id": id_}, 202)
 
 


### PR DESCRIPTION
This is proof of concept for limiting the number of transfers that are waiting to be processed by Archivematica. For some background on this problem please check [this issue](https://github.com/archivematica/Issues/issues/1010). This PR is not done yet, but I would like to know what you guys think of the approach, before spending time on polishing it. 

### General idea
In earlier work @cole  introduced a way to limit the number of packages that are running concurrently on Archivematica. This allows transfers/ingests to move through Archivematica swiftly without being held up by resource constraints.  The problem with this is that a user can still start many transfers with all related problems. Two notable examples are blocking RPC threads for a long time and running out of space on the shared directory. This is especially a problem if transfers are created via the API.

To make sure that a user cannot create too many *waiting* transfers this PR introduces the concept of Transfer slots. Each Transfer that is waiting to be processed takes 1 slot. When all slots are taken it is not possible to submit new Transfers until a slot becomes available.   

### Implementation details
e34b31b adds the transfer slots to the Archivematica's queuing logic. By default, the number of transfer slots is set to a high value. This way users will not see any change in the general behaviour. Two new methods are of importance: `acquire_transfer_slot` and `release_transfer_slot`. The purpose of these methods should be clear. They can be used by any Archivematica component to request a transfer slot, and release one when they don't need the slot anymore. 

cc60b6a shows how the new transfer slot concept can be used by an Archivematica component. During the creation of the transfer we request a new slot. If there are no slots available we raise an error. If successfully acquired a slot we continue to create the transfer. One thing I would like to point out is the `_release_transfer_slot_on_failure` callback. This callback ensures that a transfer slot is released if for some reason the creation of the transfer fails.

8a74e03 is an attempt to expose some of the feedback to the API users. Currently, it only communicates missing parameters or too many transfers requests errors. But I think we can use this to make the API way more intuitive and useful for the user. 

### What will the user see?

I have done some tests in the frontend and via the API. For the frontend users, nothing will change. You can just create your transfers the same way you are used to. If you create too many transfers, this will be logged in the logs. You won't get any feedback in the frontend, but that is the case now anyway. Also, the default of 128 waiting should not be reached in a default scenario.

API users will see some small changes. If you try to create a transfer without a name, you get the following response:

```json
{
  "message": "Package cannot be created: No transfer name provided.",
  "error": true
}
```

With the limit set to a lower number (i.e. 2) and sending a couple of new package requests you will get something like this:

```json
{
  "id": "a40d21a8-faba-4fce-9ba7-6cbb90ee80ca"
}
{
  "id": "bb13caf2-7a70-4c57-a7fa-0b16627c0b67"
}
{
  "id": "f6f6441b-dfac-4772-a724-f565d5498b1e"
}
{
  "message": "Package cannot be created: Cannot acquire transfer slot for transfer Images",
  "error": true
}
```

After waiting for a bit, you can create packages again:

```json
{
  "id": "91526cd2-f6b2-482b-84f4-cdd20c8c8b0a"
}
```

### Known issues
When the MCP Server is restarted all program state in the queues is lost. This includes the packages that are active. If after the restart, the watched directory handlers detect a transfer in their directory and continue processing they will queue a transfer without acquiring a slot [here](https://github.com/artefactual/archivematica/blob/53781c95b251121ef92d0d9f56c474aff23be08e/src/MCPServer/lib/server/mcp.py#L65). This means that right after MCP Server restart there might be some errors in the logs ("The number of releases exceeds the number of transfer slots"). IMHO we have two options here. 1) Accepting this small problem. 2) Changing this method to check if a package is active or not, and depending on that request a slot or not.

### Todo
Before this can be considered for a full review we need to do the following:
- [ ] Fix the queues tests.
- [ ] Fix the API tests.
- [ ] Implement the queuing logic in the Transfer endpoint.

@sevein, @cole since you guys have been involved in most of the queueing work I would appreciate it if you can have a look. Thanks! 


