### PR TITLE
WIP: Demonstrate specific changes are to start transfer endpoints

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -12250,7 +12250,7 @@
         {
             "chain_id": "a10b0088-b038-4ea2-91cc-b7761f07fe5a",
             "only_dirs": false,
-            "path": "/activeTransfers/zippedDirectory",
+            "path": "/activeTransfers/zippedPackage",
             "unit_type": "Transfer"
         },
         {

--- a/src/MCPServer/lib/server/shared_dirs.py
+++ b/src/MCPServer/lib/server/shared_dirs.py
@@ -9,6 +9,7 @@ import os
 
 from django.conf import settings
 
+import archivematica_transfer_types as amtypes
 
 logger = logging.getLogger("archivematica.mcp.server.shareddirs")
 
@@ -243,6 +244,22 @@ def install_builtin_config(name):
     return config
 
 
+WATCHED_DIRS = "watchedDirectories"
+ACTIVE_TRANSFERS_DIR = os.path.join(WATCHED_DIRS, "activeTransfers")
+
+
+def generate_transfer_watched_dirs():
+    """Create a tuple of watched directories specifically related to transfers
+    based on the transfer profiles in amtypes.
+    """
+    transfer_dirs = ()
+    for _, watched_directory in amtypes.retrieve_watched_dirs():
+        transfer_dirs = transfer_dirs + (
+            os.path.join(ACTIVE_TRANSFERS_DIR, watched_directory),
+        )
+    return transfer_dirs
+
+
 def create():
     dirs = (
         "arrange",
@@ -261,16 +278,8 @@ def create():
         "sharedMicroServiceTasksConfigs/transcoder/defaultIcons",
         "SIPbackups",
         "tmp",
-        "watchedDirectories",
-        "watchedDirectories/activeTransfers",
-        "watchedDirectories/activeTransfers/baggitDirectory",
-        "watchedDirectories/activeTransfers/baggitZippedDirectory",
-        "watchedDirectories/activeTransfers/dataverseTransfer",
-        "watchedDirectories/activeTransfers/Dspace",
-        "watchedDirectories/activeTransfers/maildir",
-        "watchedDirectories/activeTransfers/standardTransfer",
-        "watchedDirectories/activeTransfers/TRIM",
-        "watchedDirectories/activeTransfers/zippedDirectory",
+        WATCHED_DIRS,
+        ACTIVE_TRANSFERS_DIR,
         "watchedDirectories/approveNormalization",
         "watchedDirectories/approveSubmissionDocumentationIngest",
         "watchedDirectories/SIPCreation",
@@ -300,6 +309,7 @@ def create():
         "www/AIPsStore/transferBacklog/originals",
         "www/DIPsStore",
     )
+    dirs = dirs + generate_transfer_watched_dirs()
     for dirname in dirs:
         dirname = os.path.join(settings.SHARED_DIRECTORY, dirname)
         if os.path.isdir(dirname):

--- a/src/archivematicaCommon/lib/archivematica_transfer_types.py
+++ b/src/archivematicaCommon/lib/archivematica_transfer_types.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+
+"""
+Archivematica transfer types.
+
+Module collects together information related to the validation and initiation
+of Archivematica transfers.
+
+Where feasible this module can be imported to be used in different classes
+calling it in Python. Places where this isn't feasible are as follows:
+
+ - Listing of transfer types plus file-type transfer control:
+     * src/dashboard/frontend/app/browse/browse.controller.js
+
+ - Enable the transfer type to be selected in the browser drop-down:
+     * src/dashboard/frontend/app/front_page/transfer_browser.html
+
+ - Disable the visibility for a transfer name in the browser:
+     * src/dashboard/frontend/app/header/header.controller.js
+
+ - A dummy name is generated for a transfer in the UI:
+     * src/dashboard/frontend/app/services/transfer_browser_transfer.service.js
+
+ - References to watched directories also exist in Workflow.json and MCP
+   server's shared_dirs.py
+     * src/MCPServer/lib/assets/workflow.json
+
+Transfers have different characteristics such as whether a transfer can be
+selected by directory, or by file, e.g. standard transfer vs. zipped bags.
+
+This module should try and capture these characteristics where possible.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import collections
+
+TRANSFER_TYPE_STANDARD = "standard"
+TRANSFER_TYPE_ZIPPED_PACKAGE = "zipped package"
+TRANSFER_TYPE_UNZIPPED_BAG = "unzipped bag"
+TRANSFER_TYPE_ZIPPED_BAG = "zipped bag"
+TRANSFER_TYPE_DSPACE = "dspace"
+TRANSFER_TYPE_MAILDIR = "maildir"
+TRANSFER_TYPE_TRIM = "TRIM"
+TRANSFER_TYPE_DATAVERSE = "dataverse"
+
+TRANSFER_TYPE_DISK_IMAGE = "disk image"
+
+WATCHED_DIRECTORY_STANDARD = "standardTransfer"
+WATCHED_DIRECTORY_ZIPPED_PACKAGE = "zippedPackage"
+WATCHED_DIRECTORY_UNZIPPED_BAG = "baggitDirectory"
+WATCHED_DIRECTORY_ZIPPED_BAG = "baggitZippedDirectory"
+WATCHED_DIRECTORY_DSPACE = "Dspace"
+WATCHED_DIRECTORY_MAILDIR = "maildir"
+WATCHED_DIRECTORY_TRIM = "TRIM"
+WATCHED_DIRECTORY_DATAVERSE = "dataverseTransfer"
+
+ARCHIVE_ZIP = ".zip"
+ARCHIVE_TGZ = ".tgz"
+ARCHIVE_TAR_GZ = ".tar.gz"
+
+ARCHIVE_TYPES = (ARCHIVE_ZIP, ARCHIVE_TGZ, ARCHIVE_TAR_GZ)
+ZIP_TYPE_TRANSFERS = (
+    TRANSFER_TYPE_ZIPPED_PACKAGE,
+    TRANSFER_TYPE_ZIPPED_BAG,
+    TRANSFER_TYPE_DSPACE,
+)
+
+# Manual approval jobs associated with a transfer.
+APPROVE_STANDARD = "Approve standard transfer"
+APPROVE_ZIPPED = "Approve zipped transfer"
+APPROVE_DSPACE = "Approve DSpace transfer"
+APPROVE_UNZIPPED_BAG = "Approve bagit transfer"
+APPROVE_ZIPPED_BAG = "Approve zipped bagit transfer"
+
+APPROVE_TRANSFER_JOB_NAMES = (
+    APPROVE_STANDARD,
+    APPROVE_ZIPPED,
+    APPROVE_DSPACE,
+    APPROVE_UNZIPPED_BAG,
+    APPROVE_ZIPPED_BAG,
+)
+
+# Archivematica transfer profiles that describe a transfer's properties.
+TransferProfile = collections.namedtuple(
+    "TransferProfile", "transfer_type watched_directory"
+)
+TRANSFER_TYPES = {
+    TRANSFER_TYPE_STANDARD: TransferProfile(
+        TRANSFER_TYPE_STANDARD, WATCHED_DIRECTORY_STANDARD
+    ),
+    TRANSFER_TYPE_ZIPPED_PACKAGE: TransferProfile(
+        TRANSFER_TYPE_ZIPPED_PACKAGE, WATCHED_DIRECTORY_ZIPPED_PACKAGE
+    ),
+    TRANSFER_TYPE_UNZIPPED_BAG: TransferProfile(
+        TRANSFER_TYPE_UNZIPPED_BAG, WATCHED_DIRECTORY_UNZIPPED_BAG
+    ),
+    TRANSFER_TYPE_ZIPPED_BAG: TransferProfile(
+        TRANSFER_TYPE_ZIPPED_BAG, WATCHED_DIRECTORY_ZIPPED_BAG
+    ),
+    TRANSFER_TYPE_DSPACE: TransferProfile(
+        TRANSFER_TYPE_DSPACE, WATCHED_DIRECTORY_DSPACE
+    ),
+    TRANSFER_TYPE_MAILDIR: TransferProfile(
+        TRANSFER_TYPE_MAILDIR, WATCHED_DIRECTORY_MAILDIR
+    ),
+    TRANSFER_TYPE_TRIM: TransferProfile(TRANSFER_TYPE_TRIM, WATCHED_DIRECTORY_TRIM),
+    TRANSFER_TYPE_DATAVERSE: TransferProfile(
+        TRANSFER_TYPE_DATAVERSE, WATCHED_DIRECTORY_DATAVERSE
+    ),
+}
+
+
+def retrieve_watched_dirs():
+    """Return a generator of tuples of Archivematica Transfer Types, which
+    contains the transfer type, and suffix that will form part of the
+    transfer's watched directory.
+    """
+    for type_ in TRANSFER_TYPES:
+        yield TRANSFER_TYPES[type_].transfer_type, TRANSFER_TYPES[
+            type_
+        ].watched_directory
+
+
+def retrieve_watched_directory(transfer_type):
+    if transfer_type not in TRANSFER_TYPES:
+        return None
+    return TRANSFER_TYPES[transfer_type].watched_directory

--- a/src/dashboard/frontend/app/browse/browse.controller.js
+++ b/src/dashboard/frontend/app/browse/browse.controller.js
@@ -78,7 +78,7 @@ class BrowseController {
   // Determines whether a given file can be added to the transfer,
   // depending on the transfer type.
   file_can_be_added(file) {
-    if (this.transfer.type === 'zipped bag' || this.transfer.type === 'zipfile') {
+    if (this.transfer.type === 'zipped bag' || this.transfer.type === 'zipped package') {
       return !file.directory && this.zip_filter(file);
     } else if (this.transfer.type === 'dspace') {
       return file.directory || this.zip_filter(file);

--- a/src/dashboard/frontend/app/front_page/transfer_browser.html
+++ b/src/dashboard/frontend/app/front_page/transfer_browser.html
@@ -4,7 +4,7 @@
   <div class="col-xs-2">
   <select class="form-control" ng-model="vm.transfer.type" ng-disabled="vm.transfer.components.length > 0">
     <option value="standard" selected>{{ "Standard" | translate }}</option>
-    <option value="zipfile" selected>{{ "Zipped directory" | translate }}</option>
+    <option value="zipped package" selected>{{ "Zipped package" | translate }}</option>
     <option value="unzipped bag">{{ "Unzipped bag" | translate }}</option>
     <option value="zipped bag">{{ "Zipped bag" | translate }}</option>
     <option value="dspace">{{ "DSpace" | translate }}</option>
@@ -14,7 +14,7 @@
   <div class="help-block">{{ "Transfer type" | translate }}</div>
   </div>
 
-  <div class="col-xs-2" ng-if="vm.transfer.type !== 'zipped bag' && vm.transfer.type !== 'zipfile'">
+  <div class="col-xs-2" ng-if="vm.transfer.type !== 'zipped bag' && vm.transfer.type !== 'zipped package'">
   <input class="form-control" ng-model="vm.transfer.name"/>
   <div class="help-block">{{ "Transfer name" | translate }}</div>
   </div>

--- a/src/dashboard/frontend/app/header/header.controller.js
+++ b/src/dashboard/frontend/app/header/header.controller.js
@@ -31,7 +31,7 @@ class HeaderController {
   enable_submit_button() {
     // It's legal for "zipped bag" transfers to have no title,
     // since the final title is based on the name of the bag itself.
-    if (this.transfer.type !== 'zipped bag' && this.transfer.type !== 'zipfile' && !this.transfer.name) {
+    if (this.transfer.type !== 'zipped bag' && this.transfer.type !== 'zipped package' && !this.transfer.name) {
       return false;
     }
 

--- a/src/dashboard/frontend/app/services/transfer_browser_transfer.service.js
+++ b/src/dashboard/frontend/app/services/transfer_browser_transfer.service.js
@@ -49,8 +49,8 @@ class TransferBrowserTransfer {
     let name = this.name;
     if (this.type === 'zipped bag') {
       name = 'ZippedBag';
-    } else if (this.type === 'zipfile') {
-      name = 'ZipFile';
+    } else if (this.type === 'zipped package') {
+      name = 'ZippedPackage';
     }
 
     let _self = this;

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -811,6 +811,7 @@ def package(request):
 
 def _package_create(request):
     """Create a package."""
+    MESSAGE = "Package cannot be created"
     try:
         payload = json.loads(request.body)
         path = base64.b64decode(payload.get("path"))
@@ -818,9 +819,22 @@ def _package_create(request):
         return helpers.json_response(
             {"error": True, "message": 'Parameter "path" cannot be decoded.'}, 400
         )
+    transfer_type = payload.get("type")
+    try:
+        if transfer_type not in amtypes.TRANSFER_TYPES and transfer_type is not None:
+            raise (
+                ValueError(
+                    "Unexpected type of package provided '{}'".format(transfer_type)
+                )
+            )
+    except ValueError as err:
+        LOGGER.error("{}: {}".format(MESSAGE, err))
+        return helpers.json_response(
+            {"error": True, "message": "{}: {}".format(MESSAGE, err)}, 500
+        )
     args = (
         payload.get("name"),
-        payload.get("type"),
+        transfer_type,
         payload.get("accession"),
         payload.get("access_system_id"),
         path,
@@ -837,9 +851,8 @@ def _package_create(request):
         client = MCPClient(request.user)
         id_ = client.create_package(*args, **kwargs)
     except Exception as err:
-        msg = "Package cannot be created"
-        LOGGER.error("{}: {}".format(msg, err))
-        return helpers.json_response({"error": True, "message": msg}, 500)
+        LOGGER.error("{}: {}".format(MESSAGE, err))
+        return helpers.json_response({"error": True, "message": MESSAGE}, 500)
     return helpers.json_response({"id": id_}, 202)
 
 


### PR DESCRIPTION
This commit is exactly, the same as [dev/issue-682-zipped-package-type](https://github.com/artefactual/archivematica/pull/1580) and contains two commits:

* [Commit 1](https://github.com/artefactual/archivematica/pull/1581/commits/3d9176576a312ef64b7aadf4b4945ed2b7fad9d7): Changes required to simplify changing a transfer name in Archivematica/API.
* [Commit 2](https://github.com/artefactual/archivematica/pull/1581/commits/2c49263eae5a60ae47cd30389d4600e768a272a9): Proposed novel change to packages endpoint to perform early validation.

In comparison to [dev/issue-682-zipped-package-type](https://github.com/artefactual/archivematica/pull/1580) all tests and fixtures have been removed to demonstrate where the bulk of the code changes are in code. 