### PR TITLE
Fix non DC metadata import on reingest

### DIFF
--- a/src/MCPClient/tests/fixtures/metadata_csv_nondc/objects/metadata/metadata.csv
+++ b/src/MCPClient/tests/fixtures/metadata_csv_nondc/objects/metadata/metadata.csv
@@ -1,0 +1,2 @@
+filename,nondc,dc.title,custom.field,dc.description
+objects/evelyn's photo.jpg,Non DC metadata,Mountain Tents,A custom field,Tents on a mountain


### PR DESCRIPTION
This makes the [`archivematicaCreateMETSReingest.update_metadata_csv`](https://github.com/artefactual/archivematica/blob/e804cc1cc3130c276390b6a0ed63c115c8191576/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py#L534) function to work with non Dublin Core columns in the metadata.csv file during re-ingest.

Currently the function parses the metadata `dmdSec`s correctly but then looks for `dcterm:dublincore` elements in each of them. If a `dmdSec` doesn't contain such an element `None` is added through the `FSEntry.add_dublin_core` method which breaks serialization later in the process raising the exception described in the connected issue. This has been fixed by [simply checking for `None` before adding the section](https://github.com/artefactual/archivematica/blob/6406b9cc4a24f025ce6ac12969fa6773b10c659a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py#L593-L594) to the `FSEntry`.

When the new `dmdSec` represents non Dublin Core metadata instead the `FSEntry.add_dmdsec` is used.

I also added a `TODO` comment on a bit of logic that seems arbitrary regarding marking the reingested DC `dmdSec` as the updated version of existing `dmdSec`s. It seems like https://github.com/artefactual/archivematica/pull/391 replaced this [bit of logic](https://github.com/artefactual/archivematica/blob/c43aa5716c1eab407fdf3f237e81638beff1ab68/src/MCPClient/lib/clientScripts/archivematicaCreateMETSReingest.py#L376-L405) which considered the `STATUS` of the existing entries and looks more correct. I'll leave this out of the scope of this PR though.

**Note:** This implementation depends on the `https://github.com/artefactual/archivematica/tree/dev/issue-1136-directory-metadata-reingest` branch being merged first, so I used it as the base to make code review easier.

Connected to https://github.com/archivematica/Issues/issues/1139