### PR TITLE
MCPServer: fix update logic in package initializer

### DIFF
--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -721,6 +721,11 @@ class SIPDIP(Package):
                     "diruuids": False,
                 },
             )
+            # TODO: we thought this path was unused but some tests have proved
+            # us wrong (see issue #1141) - needs to be investigated.
+            if not created and sip_obj.currentpath != path:
+                sip_obj.currentpath = path
+                sip_obj.save()
         else:
             try:
                 sip_obj = models.SIP.objects.get(currentpath=path)
@@ -783,8 +788,10 @@ class Transfer(Package):
             transfer_obj, created = models.Transfer.objects.get_or_create(
                 uuid=transfer_uuid, defaults={"currentlocation": path}
             )
+            # TODO: we thought this path was unused but some tests have proved
+            # us wrong (see issue #1141) - needs to be investigated.
             if not created and transfer_obj.currentlocation != path:
-                transfer_obj.currentpath = path
+                transfer_obj.currentlocation = path
                 transfer_obj.save()
         else:
             try:


### PR DESCRIPTION
It turns out that the update logic in the get_or_create_from_db_path method is
needed in some rare situations. We've seen low rate of errors in test
environments where the db location attribute is out of sync - while this commit
has shown zero error rates during testing hundreds of transfers.

Connects to https://github.com/archivematica/Issues/issues/1141.
Connects to https://github.com/archivematica/Issues/issues/1111.