### PR TITLE
Do not update SIP model path through DIP packages

### DIFF
--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -723,7 +723,7 @@ class SIPDIP(Package):
             )
             # TODO: we thought this path was unused but some tests have proved
             # us wrong (see issue #1141) - needs to be investigated.
-            if not created and sip_obj.currentpath != path:
+            if package_type == "SIP" and (not created and sip_obj.currentpath != path):
                 sip_obj.currentpath = path
                 sip_obj.save()
         else:


### PR DESCRIPTION
The `aip-encrypt` tag of the AMAUATs has been failing intermittently in the matrix-qa of Jenkins. It seems related to a race condition between the SIP and DIP packages updating the path of the SIP model instance.

Thanks to @sevein for the workflow picture and explanation:

![image (3)](https://user-images.githubusercontent.com/560781/76800234-d8e81600-6798-11ea-8360-33edb5bd4712.png)

The `Generate DIP` job is linked to `Prepare AIP` but at the same time it triggers a new chain from the `uploadDIP` watched directory.

This PR changes the base class of both packages to only update the current path of the SIP model instance through SIP packages. I think it's also worth mentioning that [originally DIP packages didn't have this update logic](https://github.com/artefactual/archivematica/blob/3f8c746c69f6d8b30ba79f13d85f4e1a3690e065/src/MCPServer/lib/server/packages.py#L718-L725).

Connected to https://github.com/archivematica/Issues/issues/1141