### PR TITLE
SIP Arrangement: stop using completedTransfers

### DIFF
--- a/src/MCPClient/lib/clientScripts/copy_transfer_submission_documentation.py
+++ b/src/MCPClient/lib/clientScripts/copy_transfer_submission_documentation.py
@@ -32,6 +32,8 @@ django.setup()
 from bag import is_bag
 from main.models import File, SIP
 
+from archivematicaFunctions import find_transfer_path_from_ingest
+
 
 def call(jobs):
     for job in jobs:
@@ -54,8 +56,12 @@ def call(jobs):
             aip_mets_name = "METS." + sipUUID + ".xml"
 
             for transferLocation in transfer_locations:
-                transferLocation = transferLocation.replace("%sharedPath%", sharedPath)
                 transferNameUUID = os.path.basename(os.path.abspath(transferLocation))
+                transferLocation = find_transfer_path_from_ingest(
+                    transferLocation, sharedPath
+                )
+                job.pyprint("Transfer found in", transferLocation)
+
                 src = os.path.join(
                     transferLocation, "metadata", "submissionDocumentation"
                 )

--- a/src/MCPClient/lib/clientScripts/copy_transfers_metadata_and_logs.py
+++ b/src/MCPClient/lib/clientScripts/copy_transfers_metadata_and_logs.py
@@ -34,6 +34,8 @@ django.setup()
 from bag import is_bag
 from main.models import File, SIP
 
+from archivematicaFunctions import find_transfer_path_from_ingest
+
 
 def main(
     job, sipUUID, transfersMetadataDirectory, transfersLogsDirectory, sharedPath=""
@@ -54,8 +56,8 @@ def main(
     )
     for transferPath in transfer_paths:
         try:
-            if sharedPath != "":
-                transferPath = transferPath.replace("%sharedPath%", sharedPath, 1)
+            transferPath = find_transfer_path_from_ingest(transferPath, sharedPath)
+            job.pyprint("Transfer found in", transferPath)
 
             if is_bag(transferPath):
                 transfer_logs_dir = os.path.join(transferPath, "data", "logs")

--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -365,3 +365,26 @@ def reconstruct_empty_directories(mets_file_path, objects_path, logger=None):
         path = os.path.join(objects_path, path)
         if not os.path.isdir(path):
             os.makedirs(path)
+
+
+def find_transfer_path_from_ingest(transfer_path, shared_path):
+    """Find path of a transfer arranged or coming straight from processing.
+
+    In Ingest, access to the original transfers is needed in order to copy
+    submission docs, metadata and logs. Transfers can be found under
+    ``currentlyProcessing`` unless they come from SIP Arrangement, in which case
+    they're found under the temporary shared directory.
+
+    TODO: use ``Transfer.currentlocation`` or a model method?
+    """
+    transfer_uuid = transfer_path.rstrip("/")[-36:]
+
+    path = transfer_path.replace("%sharedPath%", shared_path, 1)
+    if os.path.isdir(path):
+        return path
+
+    path = os.path.join(shared_path, "tmp", "transfer-{}".format(transfer_uuid))
+    if os.path.isdir(path):
+        return path
+
+    raise Exception("Transfer directory not physically found")

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -550,7 +550,7 @@ def copy_from_arrange_to_completed_common(filepath, sip_uuid, sip_name):
             transfer_name = transfer_parts[0]
             # Determine if the transfer is a BagIt package
             is_bagit = True if transfer_parts[1].startswith(u"data/objects") else False
-            # Copy metadata & logs to completedTransfers, where later scripts expect
+            # Copy metadata & logs to tmp/, where later scripts expect
             for directory in ("logs", "metadata"):
                 source = [DEFAULT_BACKLOG_PATH, transfer_name, directory]
                 if is_bagit:
@@ -558,10 +558,8 @@ def copy_from_arrange_to_completed_common(filepath, sip_uuid, sip_name):
                 file_ = {
                     "source": os.path.join(os.path.sep.join(source), "."),
                     "destination": os.path.join(
-                        "watchedDirectories",
-                        "SIPCreation",
-                        "completedTransfers",
-                        transfer_name,
+                        "tmp",
+                        "transfer-{}".format(arranged_file.transfer_uuid),
                         directory,
                         ".",
                     ),


### PR DESCRIPTION
This commit updates our haphazardly structured SIP Arrangement functionality
so the transfer(s) extracted from Backlog are located in `sharedDir/tmp` instead
of using `completedTransfers`. The latter approach was problematic because it's
a watched directory triggering workflow chains inadvertently.

Connects to https://github.com/archivematica/Issues/issues/1157.