### PR TITLE
Upgrade dependencies

### DIFF
--- a/src/MCPClient/requirements/base.in
+++ b/src/MCPClient/requirements/base.in
@@ -1,4 +1,4 @@
--e git+https://github.com/artefactual-labs/ammcpc@v0.1.1#egg=ammcpc
+ammcpc==0.1.3
 bagit==1.7.0
 clamd==1.0.2
 Django>=1.8,<1.9
@@ -6,7 +6,7 @@ django-extensions==1.1.1
 mysqlclient==1.3.9
 gearman==2.0.2
 lxml==3.5.0
-metsrw==0.3.14
+metsrw==0.3.15
 requests==2.21.0
 unidecode==0.04.19
 opf-fido==1.4.1

--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=base.txt base.in
 #
--e git+https://github.com/artefactual-labs/ammcpc@v0.1.1#egg=ammcpc
+ammcpc==0.1.3
 bagit==1.7.0
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
@@ -15,7 +15,7 @@ future==0.18.2            # via metsrw
 gearman==2.0.2
 idna==2.8                 # via requests
 lxml==3.5.0
-metsrw==0.3.14
+metsrw==0.3.15
 mysqlclient==1.3.9
 olefile==0.46             # via opf-fido
 opf-fido==1.4.1
@@ -27,4 +27,4 @@ unidecode==0.04.19
 urllib3==1.24.3           # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via opf-fido
+# setuptools

--- a/src/MCPClient/requirements/dev.in
+++ b/src/MCPClient/requirements/dev.in
@@ -1,3 +1,3 @@
 -r test.txt
 
-pip-tools==4.3.0
+pip-tools==5.1.2

--- a/src/MCPClient/requirements/dev.txt
+++ b/src/MCPClient/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=dev.txt dev.in
 #
--e git+https://github.com/artefactual-labs/ammcpc@v0.1.1#egg=ammcpc
+ammcpc==0.1.3
 atomicwrites==1.3.0
 attrs==19.3.0
 bagit==1.7.0
@@ -23,7 +23,7 @@ gearman==2.0.2
 idna==2.8
 importlib-metadata==1.3.0
 lxml==3.5.0
-metsrw==0.3.14
+metsrw==0.3.15
 mock==3.0.5
 more-itertools==5.0.0
 mysqlclient==1.3.9
@@ -31,7 +31,7 @@ olefile==0.46
 opf-fido==1.4.1
 packaging==19.2
 pathlib2==2.3.5
-pip-tools==4.3.0
+pip-tools==5.1.2
 pluggy==0.13.1
 prometheus_client==0.7.1
 py==1.8.0
@@ -52,4 +52,5 @@ wcwidth==0.1.7
 zipp==0.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/src/MCPClient/requirements/production.txt
+++ b/src/MCPClient/requirements/production.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=production.txt production.in
 #
--e git+https://github.com/artefactual-labs/ammcpc@v0.1.1#egg=ammcpc
+ammcpc==0.1.3
 bagit==1.7.0
 certifi==2019.11.28
 chardet==3.0.4
@@ -15,7 +15,7 @@ future==0.18.2
 gearman==2.0.2
 idna==2.8
 lxml==3.5.0
-metsrw==0.3.14
+metsrw==0.3.15
 mysqlclient==1.3.9
 olefile==0.46
 opf-fido==1.4.1
@@ -27,4 +27,4 @@ unidecode==0.04.19
 urllib3==1.24.3
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via opf-fido
+# setuptools

--- a/src/MCPClient/requirements/test.txt
+++ b/src/MCPClient/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=test.txt test.in
 #
--e git+https://github.com/artefactual-labs/ammcpc@v0.1.1#egg=ammcpc
+ammcpc==0.1.3
 atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
 bagit==1.7.0
@@ -22,7 +22,7 @@ gearman==2.0.2
 idna==2.8
 importlib-metadata==1.3.0  # via pluggy, pytest, tox
 lxml==3.5.0
-metsrw==0.3.14
+metsrw==0.3.15
 mock==3.0.5               # via pytest-mock
 more-itertools==5.0.0     # via pytest, zipp
 mysqlclient==1.3.9
@@ -50,4 +50,4 @@ wcwidth==0.1.7            # via pytest
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via opf-fido, pytest, tox
+# setuptools

--- a/src/MCPServer/requirements/dev.in
+++ b/src/MCPServer/requirements/dev.in
@@ -1,3 +1,3 @@
 -r test.txt
 
-pip-tools==4.3.0
+pip-tools==5.1.2

--- a/src/MCPServer/requirements/dev.txt
+++ b/src/MCPServer/requirements/dev.txt
@@ -27,7 +27,7 @@ more-itertools==5.0.0
 mysqlclient==1.3.7
 packaging==19.2
 pathlib2==2.3.4 ; python_version < "3"
-pip-tools==4.3.0
+pip-tools==5.1.2
 pluggy==0.13.1
 prometheus_client==0.7.1
 py==1.8.0
@@ -43,3 +43,6 @@ tox==3.14.2
 virtualenv==16.7.9
 wcwidth==0.1.7
 zipp==0.6.0
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/src/archivematicaCommon/requirements/base.in
+++ b/src/archivematicaCommon/requirements/base.in
@@ -1,4 +1,4 @@
-agentarchives==0.5.0
+agentarchives==0.6.0
 bagit==1.7.0
 Django>=1.8,<1.9
 elasticsearch>=6.0.0,<7.0.0

--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=base.txt base.in
 #
-agentarchives==0.5.0
+agentarchives==0.6.0
 bagit==1.7.0
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests

--- a/src/archivematicaCommon/requirements/dev.in
+++ b/src/archivematicaCommon/requirements/dev.in
@@ -1,3 +1,3 @@
 -r test.txt
 
-pip-tools==4.3.0
+pip-tools==5.1.2

--- a/src/archivematicaCommon/requirements/dev.txt
+++ b/src/archivematicaCommon/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=dev.txt dev.in
 #
-agentarchives==0.5.0
+agentarchives==0.6.0
 atomicwrites==1.3.0
 attrs==19.1.0
 bagit==1.7.0
@@ -22,7 +22,7 @@ more-itertools==5.0.0
 mysqlclient==1.4.2.post1
 pathlib2==2.3.4 ; python_version < "3"
 pbr==5.1.3
-pip-tools==4.3.0
+pip-tools==5.1.2
 pluggy==0.9.0
 prometheus_client==0.7.1
 py==1.8.0
@@ -42,4 +42,5 @@ virtualenv==16.4.3
 wrapt==1.11.1
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/src/archivematicaCommon/requirements/production.txt
+++ b/src/archivematicaCommon/requirements/production.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=production.txt production.in
 #
-agentarchives==0.5.0
+agentarchives==0.6.0
 bagit==1.7.0
 certifi==2019.3.9
 chardet==3.0.4

--- a/src/archivematicaCommon/requirements/test.txt
+++ b/src/archivematicaCommon/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=test.txt test.in
 #
-agentarchives==0.5.0
+agentarchives==0.6.0
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 bagit==1.7.0

--- a/src/dashboard/src/requirements/base.in
+++ b/src/dashboard/src/requirements/base.in
@@ -1,6 +1,6 @@
 # Base requirements - for all installations
 amclient==1.1.1
-agentarchives==0.5.0
+agentarchives==0.6.0
 bagit==1.7.0
 brotli==0.5.2  # Better compression library for WhiteNoise
 Django>=1.8,<1.9
@@ -18,7 +18,7 @@ gunicorn==19.9.0
 futures==3.2.0; python_version < '3.0'  # used by gunicorn's async workers
 lazy-paged-sequence
 lxml==3.5.0
-metsrw==0.3.14
+metsrw==0.3.15
 mysqlclient==1.3.7
 pytz
 pyopenssl

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
 -e git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
-agentarchives==0.5.0
+agentarchives==0.6.0
 amclient==1.1.1
 asn1crypto==0.24.0        # via cryptography
 bagit==1.7.0
@@ -37,7 +37,7 @@ ipaddress==1.0.22         # via cryptography
 lazy-paged-sequence==0.3
 logutils==0.3.3
 lxml==3.5.0
-metsrw==0.3.14
+metsrw==0.3.15
 mysqlclient==1.3.7
 ndg-httpsclient==0.5.1
 pathlib2==2.3.3

--- a/src/dashboard/src/requirements/dev.in
+++ b/src/dashboard/src/requirements/dev.in
@@ -2,6 +2,6 @@
 
 ipython
 ipdb
-pip-tools==4.3.0
+pip-tools==5.1.2
 pytest
 pytest-mock

--- a/src/dashboard/src/requirements/dev.txt
+++ b/src/dashboard/src/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
 -e git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
-agentarchives==0.5.0
+agentarchives==0.6.0
 amclient==1.1.1
 asn1crypto==0.24.0
 atomicwrites==1.3.0
@@ -50,7 +50,7 @@ ipython==5.8.0
 lazy-paged-sequence==0.3
 logutils==0.3.3
 lxml==3.5.0
-metsrw==0.3.14
+metsrw==0.3.15
 mock==2.0.0
 mockldap==0.2.8
 more-itertools==5.0.0
@@ -60,7 +60,7 @@ pathlib2==2.3.3
 pbr==5.1.3
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pip-tools==4.3.0
+pip-tools==5.1.2
 pluggy==0.9.0
 prometheus-client==0.7.1
 prompt-toolkit==1.0.15    # via ipython
@@ -96,4 +96,5 @@ whitenoise==3.3.0
 wrapt==1.11.1
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/src/dashboard/src/requirements/production.txt
+++ b/src/dashboard/src/requirements/production.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
 -e git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
-agentarchives==0.5.0
+agentarchives==0.6.0
 amclient==1.1.1
 asn1crypto==0.24.0
 bagit==1.7.0
@@ -37,7 +37,7 @@ ipaddress==1.0.22
 lazy-paged-sequence==0.3
 logutils==0.3.3
 lxml==3.5.0
-metsrw==0.3.14
+metsrw==0.3.15
 mysqlclient==1.3.7
 ndg-httpsclient==0.5.1
 pathlib2==2.3.3

--- a/src/dashboard/src/requirements/test.txt
+++ b/src/dashboard/src/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser
 -e git+https://github.com/seatme/django-longer-username.git@seatme#egg=longerusername
-agentarchives==0.5.0
+agentarchives==0.6.0
 amclient==1.1.1
 asn1crypto==0.24.0
 atomicwrites==1.3.0       # via pytest
@@ -44,7 +44,7 @@ ipaddress==1.0.22
 lazy-paged-sequence==0.3
 logutils==0.3.3
 lxml==3.5.0
-metsrw==0.3.14
+metsrw==0.3.15
 mock==2.0.0               # via mockldap, vcrpy
 mockldap==0.2.8
 more-itertools==5.0.0     # via pytest


### PR DESCRIPTION
- Use the latest versions of metsrw, ammcpc and agentarchives.
- Upgrade pip-tools to be able to compile those upgrades.

Refs https://github.com/archivematica/Issues/issues/811, https://github.com/archivematica/Issues/issues/812, https://github.com/archivematica/Issues/issues/813.