### PR TITLE
Add CSRF middleware

### DIFF
--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -29,6 +29,7 @@ import re
 from django.db.models import Q
 import django.http
 from django.conf import settings as django_settings
+from django.views.decorators.csrf import csrf_exempt
 import six
 
 from tastypie.authentication import (
@@ -74,6 +75,7 @@ def _api_endpoint(expected_methods):
     def decorator(func):
         """The decorator applied to the endpoint."""
 
+        @csrf_exempt
         def wrapper(request, *args, **kwargs):
             """Wrapper for custom endpoints with boilerplate code."""
             # Check HTTP verb

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -313,7 +313,7 @@ MIDDLEWARE = [
     "middleware.locale.ForceDefaultLanguageMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
-    # 'django.middleware.csrf.CsrfViewMiddleware',
+    "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "middleware.common.AJAXSimpleExceptionResponseMiddleware",

--- a/src/dashboard/src/templates/administration/api.html
+++ b/src/dashboard/src/templates/administration/api.html
@@ -31,6 +31,7 @@
 
       <div style='width: 500px; height: 300px;'>
       <form method='POST'>
+        {% csrf_token %}
         <textarea name='whitelist' class='form-control' style='margin-bottom: 1em;'>{{ whitelist }}</textarea>
         <div>
           <input type='submit' value='{% trans "Save" %}' class='btn btn-primary' />

--- a/src/dashboard/src/templates/administration/atom_levels_of_description.html
+++ b/src/dashboard/src/templates/administration/atom_levels_of_description.html
@@ -29,6 +29,7 @@
 
       {% if levels %}
         <form id="level_form" method="POST">
+        {% csrf_token %}
         <input id="level_operation" name="operation" type="hidden" />
         <input id="level_id" name="id" type="hidden" />
         <table class="table">

--- a/src/dashboard/src/templates/administration/dips_as_edit.html
+++ b/src/dashboard/src/templates/administration/dips_as_edit.html
@@ -24,6 +24,7 @@
   <div class="col-md-10">
     <h3>{% trans "ArchivesSpace DIP upload" %}</h3>
     <form class="form-stacked" method="post" action="{% url 'administration:dips_as' %}">
+      {% csrf_token %}
       {% include "_form.html" %}
       <div class="actions">
         <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>

--- a/src/dashboard/src/templates/administration/dips_atom_edit.html
+++ b/src/dashboard/src/templates/administration/dips_atom_edit.html
@@ -33,6 +33,7 @@
       </div>
 
       <form class="form-stacked" method="post" action="{% url 'administration:dips_atom_index' %}">
+        {% csrf_token %}
 
         <h3>{% trans "AtoM/Binder DIP upload" %}</h3>
 

--- a/src/dashboard/src/templates/administration/general.html
+++ b/src/dashboard/src/templates/administration/general.html
@@ -33,6 +33,7 @@
       <h3>{% trans "General configuration" %}</h3>
 
       <form method='POST'>
+        {% csrf_token %}
 
         {% include "_form.html" with form=general_form %}
 

--- a/src/dashboard/src/templates/administration/handle_config.html
+++ b/src/dashboard/src/templates/administration/handle_config.html
@@ -19,6 +19,7 @@
       <h3>{% trans "Handle Configuration for Persistent Identifier (PID) Binding" %}</h3>
 
       <form method='POST'>
+      {% csrf_token %}
       {% include "_form.html" %}
         <div>
           <input type='submit' value='{% trans "Save" %}' class='btn btn-primary' />

--- a/src/dashboard/src/templates/administration/premis_agent.html
+++ b/src/dashboard/src/templates/administration/premis_agent.html
@@ -19,6 +19,7 @@
       <h3>{% trans "PREMIS agent" %}</h3>
 
       <form method='POST'>
+      {% csrf_token %}
       {% include "_form.html" %}
         <div>
           <input type='submit' value='{% trans "Save" %}' class='btn btn-primary' />

--- a/src/dashboard/src/templates/administration/reports/failure_detail.html
+++ b/src/dashboard/src/templates/administration/reports/failure_detail.html
@@ -28,6 +28,7 @@
 
       <div>
         <form action="{% url 'administration:failure_report_delete' report_id %}" method='POST'>
+          {% csrf_token %}
           <input type="submit" value="{% trans 'Delete' %}" class="btn btn-danger">
         </form>
       </div>

--- a/src/dashboard/src/templates/administration/term_detail.html
+++ b/src/dashboard/src/templates/administration/term_detail.html
@@ -28,6 +28,7 @@
       <h3>Term</h3>
 
       <form method='POST'>
+      {% csrf_token %}
       {% include "_form.html" %}
 
       <div style='float: right'>

--- a/src/dashboard/src/templates/archival_storage/search.html
+++ b/src/dashboard/src/templates/archival_storage/search.html
@@ -38,6 +38,7 @@
     {% if not file_mode %}
     <div>
       <form action="{% url 'archival_storage:create_aic' %}" method="post">
+        {% csrf_token %}
         {{ aic_creation_form }}
         <input type='submit' class='btn btn-primary' id='create_aic' value='{% trans "Create an AIC" %}'>
       </form>

--- a/src/dashboard/src/templates/delete_request.html
+++ b/src/dashboard/src/templates/delete_request.html
@@ -9,6 +9,7 @@
 <br/>
 
 <form method="POST" action="">
+  {% csrf_token %}
   <input type="hidden" name="__confirm__" value="1" />
   <p>
     <strong>{% trans "Reason for deletion:" %}</strong>

--- a/src/dashboard/src/templates/ingest/as/review_matches.html
+++ b/src/dashboard/src/templates/ingest/as/review_matches.html
@@ -17,6 +17,7 @@
   </ul>
 
   <form method="POST" action="{% url 'ingest:complete_matching' uuid %}">
+    {% csrf_token %}
     <a class="btn btn-submit" href="{% url 'ingest:ingest_upload_as_reset' uuid %}">{% trans "Restart matching" %}</a>
     <button class="btn btn-primary">{% trans "Finish matching" %}</button>
   </form>

--- a/src/dashboard/src/templates/ingest/metadata_edit.html
+++ b/src/dashboard/src/templates/ingest/metadata_edit.html
@@ -55,6 +55,7 @@ $(document).ready(function() {
         <form class="form-stacked" method="post" action="{% url 'ingest:ingest_metadata_add' uuid %}">
       {% endif %}
 
+        {% csrf_token %}
         {% include "_form.html" %}
 
         <div class="actions">

--- a/src/dashboard/src/templates/ingest/metadata_event_detail.html
+++ b/src/dashboard/src/templates/ingest/metadata_event_detail.html
@@ -13,6 +13,7 @@
 
       <h1>Normalization Event Detail<br /><small>{{ name }}</small></h1>
       <form method="post" action="">
+        {% csrf_token %}
         {{ formset.management_form }}
         {{ formset.non_form_errors.as_ul }}
 

--- a/src/dashboard/src/templates/installer/storagesetup.html
+++ b/src/dashboard/src/templates/installer/storagesetup.html
@@ -21,6 +21,7 @@
     <img src="{% static 'images/logo_welcome.gif' %}" style="margin-bottom: 20px;" />
 
     <form action="#" method="POST">
+      {% csrf_token %}
 
       <h4>{% trans "Register this pipeline in the Storage Service" %}</h4>
 

--- a/src/dashboard/src/templates/installer/welcome.html
+++ b/src/dashboard/src/templates/installer/welcome.html
@@ -42,6 +42,7 @@
       </div>
 
       <form class="form-stacked" method="post" action="{% url 'installer:welcome' %}">
+        {% csrf_token %}
 
         {% include "_form.html" %}
 

--- a/src/dashboard/src/templates/rights/rights_edit.html
+++ b/src/dashboard/src/templates/rights/rights_edit.html
@@ -81,6 +81,7 @@
         {% endif %}
       {% endif %}
 
+        {% csrf_token %}
         {% include "_form.html" %}
 
         <div id='copyright_formset' class='non-repeating-formset'>

--- a/src/dashboard/src/templates/rights/rights_grants_edit.html
+++ b/src/dashboard/src/templates/rights/rights_grants_edit.html
@@ -61,6 +61,7 @@
         <form class="form-stacked" method="post" action="{% url 'rights_transfer:grants_edit' uuid id %}">
       {% endif %}
 
+        {% csrf_token %}
         {{ grantFormset.management_form }}
         {{ grantFormset.non_form_errors.as_ul }}
 

--- a/src/dashboard/src/templates/simple_confirm.html
+++ b/src/dashboard/src/templates/simple_confirm.html
@@ -6,6 +6,7 @@
 <h1>{{ prompt }}</h1>
 
 <form method="POST" action="">
+  {% csrf_token %}
   <input type="hidden" name="__confirm__" value="1" />
   <input type="submit" value="{{ action }}" class='btn btn-primary' /> <a href="{{ cancel_url }}" class='btn btn-default'>{% trans "Cancel" %}</a>
 </form>

--- a/src/dashboard/src/templates/transfer/component.html
+++ b/src/dashboard/src/templates/transfer/component.html
@@ -16,6 +16,7 @@
       </ul>
 
       <form method='POST'>
+      {% csrf_token %}
       <input name='path' type='hidden' value='{{ path }}'/>
       <table class="table">
       {% for field in fields %}

--- a/src/dashboard/src/templates/transfer/metadata_edit.html
+++ b/src/dashboard/src/templates/transfer/metadata_edit.html
@@ -54,6 +54,7 @@ $(document).ready(function() {
         <form class="form-stacked" method="post" action="{% url 'transfer:transfer_metadata_add' uuid %}">
       {% endif %}
 
+        {% csrf_token %}
         {% include "_form.html" %}
 
         <div class="actions">


### PR DESCRIPTION
This adds Django's `CsrfViewMiddleware` to the dashboard settings and
the `{% csrf_token %}` tag to the form templates.

The wrapper for the API endpoints has been marked as CSRF exempt to
allow API calls to reach authentication, but the CSRF checks are still
performed by the Tastypie's authentication backends when needed.

Connected to https://github.com/archivematica/Issues/issues/1235