### PR TITLE
Add csrftoken to frontend submissions

### DIFF
--- a/src/dashboard/frontend/app/services/archivesspace.service.js
+++ b/src/dashboard/frontend/app/services/archivesspace.service.js
@@ -4,12 +4,12 @@ import {decode_browse_response, format_entries} from 'archivematica-browse-helpe
 import 'lodash';
 import 'restangular';
 
-angular.module('archivesSpaceService', ['restangular']).
+angular.module('archivesSpaceService', ['restangular', require('angular-cookies')]).
 
 // This service allows access to ArchivesSpace, as proxied via Archivematica.
 // The data format used is documented in agentarchives:
 // https://github.com/artefactual-labs/agentarchives
-factory('ArchivesSpace', ['Restangular', function(Restangular) {
+factory('ArchivesSpace', ['Restangular', '$cookies', function(Restangular, $cookies) {
     var id_to_urlsafe = id => {
       return id.replace(/\//g, '-');
     };
@@ -44,13 +44,13 @@ factory('ArchivesSpace', ['Restangular', function(Restangular) {
       // `get` methods.
       edit: function(id, record) {
         var url_fragment = id_to_urlsafe(id);
-        return ArchivesSpace.one(url_fragment).customPUT(record);
+        return ArchivesSpace.one(url_fragment).customPUT(record, undefined, undefined, {'X-CSRFToken': $cookies.get('csrftoken')});
       },
       // Creates a new archival object as a child to the given record.
       // `record` uses a similar format to the record returned by the `get` methods.
       add_child: function(id, record) {
         var url_fragment = id_to_urlsafe(id);
-        return ArchivesSpace.one(url_fragment).one('children').customPOST(record);
+        return ArchivesSpace.one(url_fragment).one('children').customPOST(record, undefined, undefined, {'X-CSRFToken': $cookies.get('csrftoken')});
       },
       // Lists all of the digital object components associated with a given record.
       // This returns digital object components tracked by Archivematica in its
@@ -65,7 +65,7 @@ factory('ArchivesSpace', ['Restangular', function(Restangular) {
       // `record` uses the same format returned by `digital_object_components`.
       create_digital_object_component: function(id, record) {
         var url_fragment = id_to_urlsafe(id);
-        return ArchivesSpace.one(url_fragment).one('digital_object_components').customPOST(record);
+        return ArchivesSpace.one(url_fragment).one('digital_object_components').customPOST(record, undefined, undefined, {'X-CSRFToken': $cookies.get('csrftoken')});
       },
       // Lists the files inside a digital object component, given the ID of both
       // the digital object component and its parent record.
@@ -78,7 +78,7 @@ factory('ArchivesSpace', ['Restangular', function(Restangular) {
       // The deletion occurs immediately on the remote ArchivesSpace server.
       remove: function(id) {
         var url_fragment = id_to_urlsafe(id);
-        return ArchivesSpace.one(url_fragment).remove();
+        return ArchivesSpace.one(url_fragment).remove(undefined, {'X-CSRFToken': $cookies.get('csrftoken')});
       },
       // Starts a new SIP from the ArchivesSpace record with the given ID.
       // The contents of the SIP will use all of the digital object components
@@ -86,7 +86,7 @@ factory('ArchivesSpace', ['Restangular', function(Restangular) {
       // as a directory within the new SIP.
       start_sip: function(node) {
         var url_fragment = id_to_urlsafe(node.id);
-        return ArchivesSpace.one(url_fragment).one('copy_from_arrange').customPOST({ sip_name: node.display_title });
+        return ArchivesSpace.one(url_fragment).one('copy_from_arrange').customPOST({ sip_name: node.display_title }, undefined, undefined, {'X-CSRFToken': $cookies.get('csrftoken')});
       },
     };
 }]);

--- a/src/dashboard/frontend/app/services/sip_arrange.service.js
+++ b/src/dashboard/frontend/app/services/sip_arrange.service.js
@@ -5,9 +5,9 @@ import Base64 from 'base64-helpers';
 import 'lodash';
 import 'restangular';
 
-angular.module('sipArrangeService', ['restangular']).
+angular.module('sipArrangeService', ['restangular', require('angular-cookies')]).
 
-factory('SipArrange', ['Restangular', function(Restangular) {
+factory('SipArrange', ['Restangular', '$cookies', function(Restangular, $cookies) {
   var SipArrange = Restangular.one('filesystem');
   var Api = Restangular.one('api');
 
@@ -128,8 +128,11 @@ factory('SipArrange', ['Restangular', function(Restangular) {
       jQuery.param(body),
       path,
       {}, // URL parameters - always empty
-      {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
-    )
+      {
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        'X-CSRFToken': $cookies.get('csrftoken')
+      }
+    );
   };
 
   return {

--- a/src/dashboard/src/media/js/ingest.js
+++ b/src/dashboard/src/media/js/ingest.js
@@ -268,6 +268,7 @@ $(function()
               $.ajax({
                 context: self,
                 data: { uuid: self.model.get('uuid'), choice: value, uid: self.uid},
+                headers: {'X-CSRFToken': getCookie('csrftoken')},
                 type: 'POST',
                 success: function(data)
                   {
@@ -363,8 +364,11 @@ $(function()
                     if (input.filter(':text').val())
                     {
                       // get AtoM destination URL (so we can confirm it's up)
-                      var xhr = $.ajax(url, { type: 'POST', data: {
-                        'target': input.filter(':text').val() }})
+                      var xhr = $.ajax(url, {
+                        type: 'POST',
+                        data: {'target': input.filter(':text').val()},
+                        headers: {'X-CSRFToken': getCookie('csrftoken')}
+                      })
                       .done(function(data)
                         {
                           if (data.ready)
@@ -400,10 +404,11 @@ $(function()
               // is to Binder, i.e., the 'ar:' prefix for an artwork record and
               // the 'tr:' prefix for a technical record. This is explained in
               // the modal dialog help text. See templates/ingest/grid.html.
-              var xhr = $.ajax(url, { type: 'POST', data: {
-                'target': this.model.sip.attributes.access_system_id }})
-
-                .done(function(data)
+              var xhr = $.ajax(url, {
+                type: 'POST',
+                data: {'target': this.model.sip.attributes.access_system_id},
+                headers: {'X-CSRFToken': getCookie('csrftoken')}
+              }).done(function(data)
                   {
                     if (data.ready)
                     {

--- a/src/dashboard/src/media/js/jobs.js
+++ b/src/dashboard/src/media/js/jobs.js
@@ -654,8 +654,11 @@ BaseAppView = Backbone.View.extend({
                 text: gettext('Confirm'),
                 click: function() {
                   var self = this;
-                  $.ajax({url: url, method: 'DELETE'})
-                    .done(function(data) {
+                  $.ajax({
+                      url: url,
+                      method: 'DELETE',
+                      headers: {'X-CSRFToken': getCookie('csrftoken')}
+                  }).done(function(data) {
                       if (data.removed.length == 0) {
                           alert(interpolate(gettext(
                             'There were no completed %ss to remove'),

--- a/src/dashboard/src/media/js/transfer.js
+++ b/src/dashboard/src/media/js/transfer.js
@@ -183,6 +183,7 @@ $(function()
           $.ajax({
             context: this,
             data: { uuid: this.model.get('uuid'), choice: value, uid: this.uid },
+            headers: {'X-CSRFToken': getCookie('csrftoken')},
             type: 'POST',
             success: function(data)
               {


### PR DESCRIPTION
The `metadata-only-aip-reingest` AMAUAT currently breaks because the step to approve the reingest fails. Changing the dropdown from `None` to `Approve` makes a `POST` submission to the `/mcp/execute` view without the `'X-CSRFToken'` header.

This updates all the `jQuery.ajax/Restangular` submissions (`POST`, `PUT` and  `DELETE`) that I missed during https://github.com/artefactual/archivematica/pull/1606

Connected to https://github.com/archivematica/Issues/issues/1235