### PR TITLE
Use render in confirm_required decorator

### DIFF
--- a/src/dashboard/src/components/decorators.py
+++ b/src/dashboard/src/components/decorators.py
@@ -17,7 +17,7 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import
 
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.http import Http404
 from django.utils.functional import wraps
 
@@ -49,7 +49,7 @@ def confirm_required(template_name, context_creator, key="__confirm__"):
                 context = (
                     context_creator and context_creator(request, *args, **kwargs) or {}
                 )
-                return render_to_response(template_name, context)
+                return render(request, template_name, context)
 
         return wraps(func)(inner)
 


### PR DESCRIPTION
This replaces `render_to_response` in the `confirm_required` decorator
that is used in delete views. `render` uses the request so it applies
the `context_processors` of the `TEMPLATES` setting to the process.

`render_to_response` has also been deprecated in Django 2.0.

Connected to https://github.com/artefactual/archivematica/issues/1016