### PR TITLE
Use uncompressed StaticFilesStorage for local dev

### DIFF
--- a/src/dashboard/src/settings/local.py
+++ b/src/dashboard/src/settings/local.py
@@ -30,6 +30,12 @@ from .base import *
 DEBUG = True
 TEMPLATES[0]["OPTIONS"]["debug"] = True
 
+# Use Django uncompressed StaticFilesStorage rather than compressed Whitenoise
+# storage in local development so that tests run correctly.
+# See: https://docs.djangoproject.com/en/1.11/ref/contrib/staticfiles/
+# #django.contrib.staticfiles.storage.ManifestStaticFilesStorage.manifest_strict
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+
 # Fixture directories are only configured in local and test environments.
 # In Django 1.8, if you create a fixture named initial_data.[xml/yaml/json],
 # that fixture will be loaded every time you run migrate, which is something we


### PR DESCRIPTION
Fixes https://github.com/archivematica/Issues/issues/1218 in local Docker development environment

Results of running `make test-dashboard` before change: `24 failed, 111 passed, 6 skipped, 32 warnings in 28.35 seconds`

After change: `8 failed, 134 passed, 6 skipped, 32 warnings in 16.59 seconds`

Some of the tests that are still failing seem to be known issues (e.g. with running `test_rights.py` tests in Docker), but there may still be some other tests that need to be modified following the Django 1.11 upgrade (e.g. `tests/test_transfer.py::TestTransferViews::test_metadata_edit`).