### PR TITLE
Set CSRF header when destroying Backbone models

### DIFF
--- a/src/dashboard/src/media/js/ingest.js
+++ b/src/dashboard/src/media/js/ingest.js
@@ -114,7 +114,8 @@ $(function()
                           {
                             $dialog.dialog('close');
                             $(self.el).removeClass('sip-removing');
-                          }
+                          },
+                        headers: {'X-CSRFToken': getCookie('csrftoken')}
 
                       });
                     }

--- a/src/dashboard/src/media/js/transfer.js
+++ b/src/dashboard/src/media/js/transfer.js
@@ -114,7 +114,8 @@ $(function()
                           {
                             $dialog.dialog('close');
                             $(self.el).removeClass('sip-removing');
-                          }
+                          },
+                        headers: {'X-CSRFToken': getCookie('csrftoken')}
 
                       });
                     }


### PR DESCRIPTION
This fixes the `Remove` icon for transfer and ingest units in the
dashboard by setting the CSRF header before calling
[`Backbone.sync`][0].

Connected to https://github.com/archivematica/Issues/issues/1227

[0]: https://backbonejs.org/#Sync