### PR TITLE
Fix Archival Storage Chrome and sorting issues

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -233,6 +233,9 @@ def _get_aips_index_body():
                     },
                     "size": {"type": "double"},
                     "uuid": {"type": "keyword"},
+                    "accessionids": {"type": "keyword"},
+                    "status": {"type": "keyword"},
+                    "file_count": {"type": "integer"},
                 },
             }
         },
@@ -271,6 +274,7 @@ def _get_aipfiles_index_body():
                     "origin": {"type": "text"},
                     "identifiers": {"type": "keyword"},
                     "accessionid": {"type": "keyword"},
+                    "status": {"type": "keyword"},
                 },
             }
         },

--- a/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
+++ b/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
@@ -132,7 +132,6 @@ function renderArchivalStorageSearchForm(search_uri, on_success, on_error) {
 }
 
 $(document).ready(function() {
-
   set_create_aic_visibility();
 
   var search = renderArchivalStorageSearchForm(null, null, null);
@@ -231,7 +230,9 @@ $(document).ready(function() {
   }
 
   function get_datatable() {
-    if ($('#id_show_files').prop('checked')) {
+    var showFiles = $('#id_show_files').prop('checked');
+
+    if (showFiles) {
       var cols = [
         {sTitle: gettext('Thumbnail'), mData: 'FILEUUID', mRender: render_thumbnail },
         {sTitle: gettext('File'), mData: 'filePath', mRender: render_filepath },
@@ -341,7 +342,7 @@ $(document).ready(function() {
       'sAjaxSource': '/archival-storage/search?' + search.toUrlParams(),
       'aoColumns': cols,
       'fnServerData': function(sSource, aoData, fnCallback) {
-        aoData.push({ 'name': 'file_mode', 'value': $('#id_show_files').prop('checked') });
+        aoData.push({ 'name': 'file_mode', 'value': showFiles });
         $.getJSON(sSource, aoData, function(json) {
           fnCallback(json);
         });

--- a/src/dashboard/src/media/js/misc.js
+++ b/src/dashboard/src/media/js/misc.js
@@ -139,3 +139,23 @@ $(document).ready(
                 $(this).closest('.preview-help-text').children('.preview').show();
               });
 });
+
+// Return true if user navigated to page via browser back/forward button.
+// Return false if user navigated directly or if browser doesn't support Navigation Timing API.
+function navigatedFromBackOrForwardButton() {
+  if (window.performance) {
+    // Navigation Timing v2 spec
+    var navEntries = window.performance.getEntriesByType('navigation');
+    if (navEntries.length > 0 && navEntries[0].type === 'back_forward') {
+      return true;
+    // Navigation Timing v1 spec (deprecated but widely supported)
+    } else if (window.performance.navigation
+        && window.performance.navigation.type == window.performance.navigation.TYPE_BACK_FORWARD) {
+      return true;
+    } else {
+      return false;
+    }
+  } else {
+    return false;
+  }
+}

--- a/src/dashboard/src/templates/archival_storage/_archival_storage_search_form.html
+++ b/src/dashboard/src/templates/archival_storage/_archival_storage_search_form.html
@@ -5,7 +5,7 @@
     <div id="search_form_container" class="clearfix"></div>
     <div id="search_form_submit_container" class="clearfix">
       <span style="margin-left: 10px">{% trans "Show files?" %}</span>
-      <span style="margin-left: 5px"><input id="id_show_files" type="checkbox" /></span>
+      <span style="margin-left: 5px"><input id="id_show_files" type="checkbox" autocomplete="off"/></span>
       <input class="btn btn-primary" type="button" id="search_submit" value="{% trans 'Search archival storage' %}" style="margin-left: 10px">
     </div>
   </div>

--- a/src/dashboard/src/templates/archival_storage/archival_storage.html
+++ b/src/dashboard/src/templates/archival_storage/archival_storage.html
@@ -12,7 +12,6 @@
   <script type="text/javascript" src="{% static 'vendor/datatables/js/dataTables.buttons.min.js' %}"></script>
   <script type="text/javascript" src="{% static 'vendor/datatables/js/buttons.bootstrap.min.js' %}"></script>
   <script type="text/javascript" src="{% static 'vendor/datatables/js/buttons.colVis.min.js' %}"></script>
-  <script type="text/javascript" src="{% static 'js/misc.js' %}"></script>
   <script type="text/javascript" src="{% static 'js/advanced-search-query-creator.js' %}"></script>
   <script type="text/javascript" src="{% static 'js/archival_storage/archival_storage_search.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Fixes a Chrome issue and sorting issues discovered in internal QA for https://github.com/archivematica/Issues/issues/1168.

**Chrome issue**
Clicking the browser's back button in Chrome to return to the Archival Storage table directly after clicking a link to the AIP detail page from the Show files page was causing a cryptic DataTables error, due to mismatches between the cached DOM and the JSON returned from the AJAX call to the Archival Storage search endpoint. Due to differences in browser functionality, there was no such error in Firefox.

This PR fixes the issue by using the browser's Navigation Timing API to check if a user arrived to the current page via their browser's back or forward buttons when the page first loads, and triggering a page refresh immediately after the document is ready if so.

With this approach, in Chrome if a user goes from the "files" view in the Archival Storage tab to an AIP detail page and then hits back, they will be brought back to the Archival Storage tab's default display (listing all of the AIPs in storage) rather than exactly where they were before clicking on the link to the AIP page.

This does introduce a difference in behavior between browsers when a user takes the particular series of steps as outlined above, but consensus on the project team was that this is an acceptable trade-off, especially given that another solution was not readily apparent after a few hours of research and investigation.

**Sorting issues**
This PR also updates the ES mappings for the `aip` and `aipfiles` indices to explicitly define the mappings for new fields in the indices and ensure that all string fields used for sorting are type "keyword", not "text" (in the case of the `aipfiles` index's `filePath` field, a new raw "keyword" subfield was added so as not to break fulltext searching on the filepath).

In new Archivematica 1.12 installations where there is no extant Elasticsearch mapping, this will entirely solve the problem.

In upgraded instances with existing mappings, the mappings will need to be updated via Put Mapping immediately following the upgrade to 1.12. See https://github.com/archivematica/Issues/issues/1228 for more details, and the associated PR for a new Django dashboard management command to perform the index mapping updates via Put Mapping.

Connected to archivematica/Issues#1168.