### PR TITLE
Add CSRF header to $.ajax calls

### DIFF
--- a/src/dashboard/src/media/js/ingest/as_matcher.js
+++ b/src/dashboard/src/media/js/ingest/as_matcher.js
@@ -119,6 +119,7 @@ var ATKMatcherView = Backbone.View.extend({
               'file_uuid': uuid
       }),
       dataType: 'json',
+      headers: {'X-CSRFToken': getCookie('csrftoken')},
       success: function(result) {
         // TODO: make the display of the "delete" button conditional on success
       }
@@ -140,6 +141,7 @@ var ATKMatcherView = Backbone.View.extend({
               'file_uuid': uuid,
       }),
       dataType: 'json',
+      headers: {'X-CSRFToken': getCookie('csrftoken')},
       success: function(result) {
         // TODO: delete the pair from the UI, and reactivate the elements?
         //       Or leave that to happen independent of the request?
@@ -596,6 +598,7 @@ var ATKMatcherView = Backbone.View.extend({
       context: this,
       type: 'POST',
       dataType: 'json',
+      headers: {'X-CSRFToken': getCookie('csrftoken')},
       data: {pairs: self.pairCollection.toJSON()},
       success: function(result)
         {

--- a/src/dashboard/src/media/js/ingest/metadata_form.js
+++ b/src/dashboard/src/media/js/ingest/metadata_form.js
@@ -59,6 +59,7 @@ var MetadataFormView = Backbone.View.extend({
         sip_uuid: this.sipUUID,
         source_paths: sourcePaths,
       },
+      headers: {'X-CSRFToken': getCookie('csrftoken')},
       success: function(results) {
         if (results['error']) {
           alert(results['error'])

--- a/src/dashboard/src/media/js/repeating-ajax-data.js
+++ b/src/dashboard/src/media/js/repeating-ajax-data.js
@@ -92,6 +92,7 @@ var RepeatingDataRecordView = Backbone.View.extend({
             url: self.url,
             type: 'POST',
             data: data,
+            headers: {'X-CSRFToken': getCookie('csrftoken')},
             success: function(result) {
               $input.hide();
               $input.fadeIn();
@@ -188,6 +189,7 @@ var RepeatingDataView = Backbone.View.extend({
           url: self.url,
           type: 'POST',
           data: field.getValues(),
+          headers: {'X-CSRFToken': getCookie('csrftoken')},
           success: function(result) {
             $(self).attr('disabled', 'false');
             self.waitingForInput = false;
@@ -218,6 +220,7 @@ var RepeatingDataView = Backbone.View.extend({
           url: self.url + '/' + id,
           type: 'DELETE',
           data: {'id': id},
+          headers: {'X-CSRFToken': getCookie('csrftoken')},
           success: function(result) {
             self.render();
           }


### PR DESCRIPTION
Started as a fix for the ArchivesSpace issue reported by @sallain in https://github.com/archivematica/Issues/issues/1229#issuecomment-640867542, but I also noted a couple of related problems in the metadata CSV upload and rights edit forms.

Connected to https://github.com/archivematica/Issues/issues/1229