### PR TITLE
Enable download of complete Archival Storage Elasticsearch results as CSV and enables display of storage location

### DIFF
--- a/src/MCPClient/lib/clientScripts/index_aip.py
+++ b/src/MCPClient/lib/clientScripts/index_aip.py
@@ -48,9 +48,15 @@ def index_aip(job):
     sip_name = job.args[2]  # %SIPName%
     sip_staging_path = job.args[3]  # %SIPDirectory%
     sip_type = job.args[4]  # %SIPType%
+    aip_location = job.args[5]  # %AIPsStore%%
+
     if "aips" not in mcpclient_settings.SEARCH_ENABLED:
         logger.info("Skipping indexing: AIPs indexing is currently disabled.")
         return 0
+
+    location_description = storage_service.retrieve_storage_location_description(
+        aip_location, logger
+    )
     elasticSearchFunctions.setup_reading_from_conf(mcpclient_settings)
     client = elasticSearchFunctions.get_client()
     aip_info = storage_service.get_file_info(uuid=sip_uuid)
@@ -91,6 +97,7 @@ def index_aip(job):
         aips_in_aic=aips_in_aic,
         identifiers=identifiers,
         encrypted=aip_info["encrypted"],
+        location=location_description,
         printfn=job.pyprint,
     )
     if ret == 1:

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -4503,7 +4503,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%SIPUUID%\" \"%SIPName%\" \"%SIPDirectory%\" \"%SIPType%\"",
+                "arguments": "\"%SIPUUID%\" \"%SIPName%\" \"%SIPDirectory%\" \"%SIPType%\" \"%AIPsStore%\" ",
                 "execute": "indexAIP_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,

--- a/src/archivematicaCommon/tests/test_storage_service.py
+++ b/src/archivematicaCommon/tests/test_storage_service.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+"""Test Storage Service
+
+Tests for the Archivematica Common Storage Service helpers.
+"""
+
+import json
+
+import pytest
+from requests import Response
+
+from storageService import (
+    location_description_from_slug,
+    retrieve_storage_location_description,
+)
+
+
+def mock_response(status_code, content_type, content):
+    response = Response()
+    response.status_code = status_code
+    response.headers["content-type"] = content_type
+    response.status = "Mocked status value"
+    response._content = json.dumps(content)
+    return response
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status_code,content_type,expected_result",
+    [
+        (200, "application/json", {"description": "a description", "path": "/a/path/"}),
+        (200, "application/gzip", {}),
+        (204, "x-application/mocked", {}),
+        (400, "x-application/mocked", {}),
+        (500, "x-application/mocked", {}),
+        (None, "", {}),
+    ],
+)
+def test_location_desc_from_slug(status_code, content_type, expected_result, mocker):
+    """Test location description from slug
+
+    Rudimentary test to ensure that we're returning something that
+    implements .get() for any potential return from this function. And
+    that we get something sensible for unexpected status codes.
+    """
+    mocker.patch("storageService._storage_service_url")
+    mocker.patch(
+        "requests.Session.get",
+        return_value=mock_response(status_code, content_type, expected_result),
+    )
+    res = location_description_from_slug("mock_uri")
+    assert res == expected_result, "Unexpected result for status test: {}".format(
+        status_code
+    )
+
+
+@pytest.mark.parametrize(
+    "slug,return_value,expected_result",
+    [
+        (
+            "/api/v2/location/3e796bef-0d56-4471-8700-eeb256859811/",
+            {"description": "a description"},
+            "a description",
+        ),
+        (
+            "/api/v2/location/default/AS/",
+            {"description": None, "path": "/path/one/"},
+            "/path/one/",
+        ),
+        (
+            "/api/v2/location/e0a9558c-ae00-4e39-886d-2a38bba98c72/",
+            {"path": "/path/two"},
+            "/path/two",
+        ),
+        (
+            "/api/v2/location/e0a9558c-ae00-4e39-886d-2a38bba98c72/",
+            {"description": "a description", "path": "/path/three"},
+            "a description",
+        ),
+        ("/api/v2/location/fd46760b-567f-4c17-a2f4-a05e79074932/", {}, ""),
+    ],
+)
+def test_retrieve_storage_location(slug, return_value, expected_result, mocker):
+    """Test retrieve storage location
+
+    Ensure that we're able to retrieve the resource description for the
+    storage service from our request to the storage service. We should
+    be able to retrieve a 'description' or "path" or "" (blank string)
+    in that order, depending on the response, i.e. if a user hasn't
+    specified a description, we should be able to fall-back on something
+    else. Likewise if we receive something unexpected.
+    """
+    mocker.patch(
+        "storageService.location_description_from_slug", return_value=return_value
+    )
+    res = retrieve_storage_location_description(slug)
+    assert res == expected_result

--- a/src/dashboard/src/locale/en/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 11:52-0400\n"
+"POT-Creation-Date: 2020-07-27 22:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,12 +17,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: components/accounts/views.py:62 components/accounts/views.py:150
-#: components/administration/views.py:459
-#: components/administration/views.py:474
-#: components/administration/views.py:486
-#: components/administration/views.py:513
-#: components/administration/views.py:564
+#: components/accounts/views.py:61 components/accounts/views.py:149
+#: components/administration/views.py:454
+#: components/administration/views.py:469
+#: components/administration/views.py:481
+#: components/administration/views.py:508
+#: components/administration/views.py:555
 #: components/administration/views_dip_upload.py:25
 #: components/administration/views_dip_upload.py:39 fpr/views.py:106
 #: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
@@ -31,7 +31,7 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: components/accounts/views.py:82
+#: components/accounts/views.py:81
 #, python-format
 msgid "Your profile (%s)"
 msgstr ""
@@ -364,7 +364,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:973
+#: components/administration/forms_dip_upload.py:21 main/models.py:1021
 msgid "Other"
 msgstr ""
 
@@ -547,93 +547,93 @@ msgstr ""
 msgid "Used in metadata-only DIP upload."
 msgstr ""
 
-#: components/administration/views.py:92 components/administration/views.py:125
-#: components/ingest/views.py:293 fpr/views.py:261 main/views.py:310
+#: components/administration/views.py:89 components/administration/views.py:122
+#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
 msgid "Deleted."
 msgstr ""
 
-#: components/administration/views.py:109
+#: components/administration/views.py:106
 msgid "Promoted."
 msgstr ""
 
-#: components/administration/views.py:112
+#: components/administration/views.py:109
 msgid "Error attempting to promote level of description."
 msgstr ""
 
-#: components/administration/views.py:116
+#: components/administration/views.py:113
 msgid "Demoted."
 msgstr ""
 
-#: components/administration/views.py:119
+#: components/administration/views.py:116
 msgid "Error attempting to demote level of description."
 msgstr ""
 
-#: components/administration/views.py:127
+#: components/administration/views.py:124
 msgid "Level of description not found."
 msgstr ""
 
-#: components/administration/views.py:193
+#: components/administration/views.py:190
 msgid ""
 "Error retrieving locations: is the storage server running? Please contact an "
 "administrator."
 msgstr ""
 
-#: components/administration/views.py:202
+#: components/administration/views.py:199
 msgid "AIP Storage"
 msgstr ""
 
-#: components/administration/views.py:203
+#: components/administration/views.py:200
 msgid "DIP Storage"
 msgstr ""
 
-#: components/administration/views.py:204
+#: components/administration/views.py:201
 msgid "FEDORA Deposits"
 msgstr ""
 
-#: components/administration/views.py:205
+#: components/administration/views.py:202
 msgid "Transfer Backlog"
 msgstr ""
 
-#: components/administration/views.py:206
+#: components/administration/views.py:203
 msgid "Transfer Source"
 msgstr ""
 
-#: components/administration/views.py:207
+#: components/administration/views.py:204
 msgid "Replicator"
 msgstr ""
 
-#: components/administration/views.py:224
+#: components/administration/views.py:221
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:407
+#: components/administration/views.py:404
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:410
+#: components/administration/views.py:406
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr ""
 
-#: components/administration/views.py:436
+#: components/administration/views.py:431
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:439
+#: components/administration/views.py:434
 #, python-format
 msgid "No such file or directory: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:580
+#: components/administration/views.py:571
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
 "Storage Sevice URL below.<hr />%(error)s"
 msgstr ""
 
-#: components/administration/views.py:597
+#: components/administration/views.py:588
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -641,7 +641,7 @@ msgid ""
 "%(error)s"
 msgstr ""
 
-#: components/administration/views.py:609
+#: components/administration/views.py:600
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -710,6 +710,7 @@ msgid "Please type in the UUID to confirm"
 msgstr ""
 
 #: components/archival_storage/forms.py:89
+#: components/archival_storage/views.py:210
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -739,35 +740,92 @@ msgstr ""
 msgid "UUID mismatch"
 msgstr ""
 
-#: components/archival_storage/views.py:49
+#: components/archival_storage/views.py:54
 msgid "Stored"
 msgstr ""
 
-#: components/archival_storage/views.py:50
+#: components/archival_storage/views.py:55
 msgid "Deletion requested"
 msgstr ""
 
-#: components/archival_storage/views.py:464
+#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: templates/accounts/profile.html:31
+#: templates/administration/atom_levels_of_description.html:37
+#: templates/administration/reports/failures.html:26
+msgid "Name"
+msgstr ""
+
+#: components/archival_storage/views.py:211
+msgid "AICID"
+msgstr ""
+
+#: components/archival_storage/views.py:212
+msgid "Count AIPs in AIC"
+msgstr ""
+
+#: components/archival_storage/views.py:213
+#: templates/administration/usage.html:90
+#: templates/archival_storage/view.html:67
+msgid "Size"
+msgstr ""
+
+#: components/archival_storage/views.py:214
+msgid "File count"
+msgstr ""
+
+#: components/archival_storage/views.py:215
+msgid "Accession IDs"
+msgstr ""
+
+#: components/archival_storage/views.py:216
+msgid "Created date (UTC)"
+msgstr ""
+
+#: components/archival_storage/views.py:217
+#: templates/archival_storage/view.html:75
+msgid "Status"
+msgstr ""
+
+#: components/archival_storage/views.py:218
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: templates/administration/reports/failures.html:25
+#: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
+#: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
+msgid "Type"
+msgstr ""
+
+#: components/archival_storage/views.py:219
+#: templates/archival_storage/view.html:79
+msgid "Encrypted"
+msgstr ""
+
+#: components/archival_storage/views.py:220
+#: templates/archival_storage/view.html:83
+#: templates/ingest/normalization_report.html:31
+msgid "Location"
+msgstr ""
+
+#: components/archival_storage/views.py:600
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:593
+#: components/archival_storage/views.py:729
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 
-#: components/archival_storage/views.py:605
+#: components/archival_storage/views.py:741
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
 "slug: %(slug)s"
 msgstr ""
 
-#: components/archival_storage/views.py:628
+#: components/archival_storage/views.py:764
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr ""
 
-#: components/backlog/views.py:291
+#: components/backlog/views.py:282
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 
@@ -920,40 +978,40 @@ msgstr ""
 msgid "Unable to fetch levels of description from AtoM!"
 msgstr ""
 
-#: components/ingest/views.py:87
+#: components/ingest/views.py:86
 msgid ""
 "Error retrieving originals/arrange directory locations: is the storage "
 "server running? Please contact an administrator."
 msgstr ""
 
-#: components/ingest/views.py:182
+#: components/ingest/views.py:181
 msgid ""
 "Error retrieving source directories: is the storage server running? Please "
 "contact an administrator."
 msgstr ""
 
-#: components/ingest/views.py:191
+#: components/ingest/views.py:190
 msgid ""
 "No transfer source locations are available. Please contact an administrator."
 msgstr ""
 
-#: components/ingest/views.py:283
+#: components/ingest/views.py:278
 msgid "Are you sure you want to delete this metadata?"
 msgstr ""
 
-#: components/ingest/views.py:418
+#: components/ingest/views.py:412
 msgid "Review normalization"
 msgstr ""
 
-#: components/ingest/views.py:421
+#: components/ingest/views.py:415
 msgid "Review AIP"
 msgstr ""
 
-#: components/ingest/views.py:424
+#: components/ingest/views.py:418
 msgid "Review DIP"
 msgstr ""
 
-#: components/ingest/views_as.py:327
+#: components/ingest/views_as.py:325
 msgid "Operation failed, please try again later or contact your administrator."
 msgstr ""
 
@@ -1066,20 +1124,20 @@ msgid ""
 "content."
 msgstr ""
 
-#: components/rights/views.py:277 components/rights/views.py:311
+#: components/rights/views.py:272 components/rights/views.py:306
 msgid "copyright"
 msgstr ""
 
-#: components/rights/views.py:345 components/rights/views.py:379
+#: components/rights/views.py:340 components/rights/views.py:374
 msgid "license"
 msgstr ""
 
-#: components/rights/views.py:391 components/rights/views.py:426
-#: components/rights/views.py:466 components/rights/views.py:497
+#: components/rights/views.py:386 components/rights/views.py:421
+#: components/rights/views.py:461 components/rights/views.py:492
 msgid "statute"
 msgstr ""
 
-#: components/rights/views.py:483
+#: components/rights/views.py:478
 msgid "statue"
 msgstr ""
 
@@ -1087,11 +1145,11 @@ msgstr ""
 msgid "Error retrieving source directories"
 msgstr ""
 
-#: components/transfer/views.py:210
+#: components/transfer/views.py:208
 msgid "Updated path was not provided."
 msgstr ""
 
-#: components/transfer/views.py:212
+#: components/transfer/views.py:210
 msgid "Unable to update transfer metadata set, contact administrator:"
 msgstr ""
 
@@ -1124,393 +1182,393 @@ msgstr ""
 msgid "the related model"
 msgstr ""
 
-#: fpr/models.py:51 fpr/models.py:362 fpr/models.py:560 fpr/models.py:603
-#: fpr/models.py:643 fpr/models.py:659 fpr/models.py:677 fpr/models.py:705
-#: fpr/models.py:730 fpr/models.py:749 fpr/models.py:770
+#: fpr/models.py:52 fpr/models.py:378 fpr/models.py:586 fpr/models.py:629
+#: fpr/models.py:669 fpr/models.py:685 fpr/models.py:703 fpr/models.py:731
+#: fpr/models.py:757 fpr/models.py:776 fpr/models.py:797
 msgid "enabled"
 msgstr ""
 
-#: fpr/models.py:52 fpr/models.py:601 fpr/models.py:640 fpr/models.py:657
-#: fpr/models.py:675 fpr/models.py:703 fpr/models.py:728 fpr/models.py:747
-#: fpr/models.py:768
+#: fpr/models.py:53 fpr/models.py:627 fpr/models.py:666 fpr/models.py:683
+#: fpr/models.py:701 fpr/models.py:729 fpr/models.py:755 fpr/models.py:774
+#: fpr/models.py:795
 msgid "last modified"
 msgstr ""
 
-#: fpr/models.py:141 fpr/models.py:165 fpr/models.py:182 fpr/models.py:251
-#: fpr/models.py:306 fpr/models.py:356 fpr/models.py:388 fpr/models.py:484
-#: fpr/models.py:554
+#: fpr/models.py:142 fpr/models.py:170 fpr/models.py:187 fpr/models.py:257
+#: fpr/models.py:316 fpr/models.py:372 fpr/models.py:404 fpr/models.py:506
+#: fpr/models.py:580
 msgid "Unique identifier"
 msgstr ""
 
-#: fpr/models.py:144 fpr/models.py:167 fpr/models.py:194 fpr/models.py:254
-#: fpr/models.py:359 fpr/models.py:494 fpr/models.py:557 fpr/models.py:631
-#: fpr/models.py:652 fpr/models.py:671 fpr/models.py:686
+#: fpr/models.py:145 fpr/models.py:172 fpr/models.py:200 fpr/models.py:260
+#: fpr/models.py:375 fpr/models.py:517 fpr/models.py:583 fpr/models.py:657
+#: fpr/models.py:678 fpr/models.py:697 fpr/models.py:712
 msgid "description"
 msgstr ""
 
-#: fpr/models.py:144
+#: fpr/models.py:145
 msgid "Common name of format"
 msgstr ""
 
-#: fpr/models.py:147
+#: fpr/models.py:151
 msgid "the related group"
 msgstr ""
 
-#: fpr/models.py:149 fpr/models.py:168 fpr/models.py:364 fpr/models.py:561
+#: fpr/models.py:154 fpr/models.py:173 fpr/models.py:380 fpr/models.py:587
 msgid "slug"
 msgstr ""
 
-#: fpr/models.py:154 fpr/templates/fpr/format/version/detail.html:31
+#: fpr/models.py:159 fpr/templates/fpr/format/version/detail.html:31
 #: fpr/templates/fpr/fprule/detail.html:30
 #: fpr/templates/fpr/fprule/list.html:30 fpr/templates/fpr/idrule/list.html:28
 #: templates/ingest/normalization_report.html:32
 msgid "Format"
 msgstr ""
 
-#: fpr/models.py:171
+#: fpr/models.py:176
 msgid "Format group"
 msgstr ""
 
-#: fpr/models.py:189 fpr/models.py:312 fpr/models.py:444 fpr/models.py:713
+#: fpr/models.py:194 fpr/models.py:327 fpr/models.py:465 fpr/models.py:739
 msgid "the related format"
 msgstr ""
 
-#: fpr/models.py:191 fpr/models.py:361 fpr/models.py:559
+#: fpr/models.py:197 fpr/models.py:377 fpr/models.py:585
 msgid "version"
 msgstr ""
 
-#: fpr/models.py:192
+#: fpr/models.py:198
 msgid "pronom id"
 msgstr ""
 
-#: fpr/models.py:198
+#: fpr/models.py:204
 msgid "Formal name to go in the METS file."
 msgstr ""
 
-#: fpr/models.py:200
+#: fpr/models.py:206
 msgid "access format"
 msgstr ""
 
-#: fpr/models.py:201
+#: fpr/models.py:207
 msgid "preservation format"
 msgstr ""
 
-#: fpr/models.py:208 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
 msgid "Format version"
 msgstr ""
 
-#: fpr/models.py:227
+#: fpr/models.py:233
 msgid ""
 "Unable to save, an active Format Version  with this pronom id already exists."
 msgstr ""
 
-#: fpr/models.py:234
+#: fpr/models.py:240
 #, python-format
 msgid "%(format)s: %(description)s (%(pronom_id)s)"
 msgstr ""
 
-#: fpr/models.py:254
+#: fpr/models.py:260
 msgid "Name to identify script"
 msgstr ""
 
-#: fpr/models.py:257
+#: fpr/models.py:263
 msgid "PUID"
 msgstr ""
 
-#: fpr/models.py:258
+#: fpr/models.py:264
 msgid "MIME type"
 msgstr ""
 
-#: fpr/models.py:259
+#: fpr/models.py:265
 msgid "File extension"
 msgstr ""
 
-#: fpr/models.py:261
+#: fpr/models.py:267
 msgid "configuration"
 msgstr ""
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 msgid "script"
 msgstr ""
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 msgid "Script to be executed."
 msgstr ""
 
-#: fpr/models.py:265 fpr/models.py:497
+#: fpr/models.py:271 fpr/models.py:520
 msgid "Bash script"
 msgstr ""
 
-#: fpr/models.py:266 fpr/models.py:498
+#: fpr/models.py:272 fpr/models.py:521
 msgid "Python script"
 msgstr ""
 
-#: fpr/models.py:267 fpr/models.py:499
+#: fpr/models.py:273 fpr/models.py:522
 msgid "Command line"
 msgstr ""
 
-#: fpr/models.py:268 fpr/models.py:500
+#: fpr/models.py:274 fpr/models.py:523
 msgid "No shebang needed"
 msgstr ""
 
-#: fpr/models.py:271 fpr/models.py:503
+#: fpr/models.py:277 fpr/models.py:526
 msgid "script type"
 msgstr ""
 
-#: fpr/models.py:274 fpr/models.py:492
+#: fpr/models.py:283 fpr/models.py:514
 msgid "the related tool"
 msgstr ""
 
-#: fpr/models.py:278
+#: fpr/models.py:288
 msgid "Format identification command"
 msgstr ""
 
-#: fpr/models.py:282
+#: fpr/models.py:292
 #, python-format
 msgid "%(tool)s %(config)s runs %(command)s"
 msgstr ""
 
-#: fpr/models.py:309 fpr/models.py:441
+#: fpr/models.py:321 fpr/models.py:459
 msgid "the related command"
 msgstr ""
 
-#: fpr/models.py:315
+#: fpr/models.py:331
 msgid "command output"
 msgstr ""
 
-#: fpr/models.py:318
+#: fpr/models.py:334
 msgid "Format identification rule"
 msgstr ""
 
-#: fpr/models.py:335
+#: fpr/models.py:351
 msgid ""
 "Unable to save, a rule with this output already exists for this command."
 msgstr ""
 
-#: fpr/models.py:342
+#: fpr/models.py:358
 #, python-format
 msgid "Format identification rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:345
+#: fpr/models.py:361
 #, python-format
 msgid "%(command)s with %(output)s is %(format)s"
 msgstr ""
 
-#: fpr/models.py:359 fpr/models.py:557
+#: fpr/models.py:375 fpr/models.py:583
 msgid "Name of tool"
 msgstr ""
 
-#: fpr/models.py:368
+#: fpr/models.py:384
 msgid "Format identification tool"
 msgstr ""
 
-#: fpr/models.py:374 fpr/models.py:568
+#: fpr/models.py:390 fpr/models.py:594
 #, python-format
 msgid "%(description)s"
 msgstr ""
 
-#: fpr/models.py:416 templates/layout.html:65 templates/main/access.html:4
+#: fpr/models.py:432 templates/layout.html:67 templates/main/access.html:4
 #: templates/main/access.html:5
 msgid "Access"
 msgstr ""
 
-#: fpr/models.py:417 fpr/models.py:514
+#: fpr/models.py:433 fpr/models.py:538
 msgid "Characterization"
 msgstr ""
 
-#: fpr/models.py:418
+#: fpr/models.py:434
 msgid "Extract"
 msgstr ""
 
-#: fpr/models.py:419 fpr/templates/fpr/format/version/detail.html:33
+#: fpr/models.py:435 fpr/templates/fpr/format/version/detail.html:33
 msgid "Preservation"
 msgstr ""
 
-#: fpr/models.py:420
+#: fpr/models.py:436
 msgid "Thumbnail"
 msgstr ""
 
-#: fpr/models.py:421 fpr/models.py:518
+#: fpr/models.py:437 fpr/models.py:542
 msgid "Transcription"
 msgstr ""
 
-#: fpr/models.py:422 fpr/models.py:519
+#: fpr/models.py:438 fpr/models.py:543
 msgid "Validation"
 msgstr ""
 
-#: fpr/models.py:423
+#: fpr/models.py:439
 msgid "Validation against a policy"
 msgstr ""
 
-#: fpr/models.py:426
+#: fpr/models.py:442
 msgid "Default access"
 msgstr ""
 
-#: fpr/models.py:427
+#: fpr/models.py:443
 msgid "Default characterization"
 msgstr ""
 
-#: fpr/models.py:428
+#: fpr/models.py:444
 msgid "Default thumbnail"
 msgstr ""
 
-#: fpr/models.py:439
+#: fpr/models.py:455
 msgid "purpose"
 msgstr ""
 
-#: fpr/models.py:447
+#: fpr/models.py:469
 msgid "count attempts"
 msgstr ""
 
-#: fpr/models.py:448
+#: fpr/models.py:470
 msgid "count okay"
 msgstr ""
 
-#: fpr/models.py:449
+#: fpr/models.py:471
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:452 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:732
 msgid "Format policy rule"
 msgstr ""
 
-#: fpr/models.py:472
+#: fpr/models.py:494
 #, python-format
 msgid "Format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:475
+#: fpr/models.py:497
 #, python-format
 msgid "Normalize %(format)s for %(purpose)s via %(command)s"
 msgstr ""
 
-#: fpr/models.py:495 fpr/models.py:627 fpr/models.py:744
+#: fpr/models.py:518 fpr/models.py:653 fpr/models.py:771
 msgid "command"
 msgstr ""
 
-#: fpr/models.py:505 fpr/models.py:629
+#: fpr/models.py:528 fpr/models.py:655
 msgid "output location"
 msgstr ""
 
-#: fpr/models.py:511
+#: fpr/models.py:534
 msgid "the related output format"
 msgstr ""
 
-#: fpr/models.py:515
+#: fpr/models.py:539
 msgid "Event Detail"
 msgstr ""
 
-#: fpr/models.py:516
+#: fpr/models.py:540
 msgid "Extraction"
 msgstr ""
 
-#: fpr/models.py:517
+#: fpr/models.py:541
 msgid "Normalization"
 msgstr ""
 
-#: fpr/models.py:520
+#: fpr/models.py:544
 msgid "Verification"
 msgstr ""
 
-#: fpr/models.py:523 fpr/models.py:613
+#: fpr/models.py:547 fpr/models.py:639
 msgid "command usage"
 msgstr ""
 
-#: fpr/models.py:531
+#: fpr/models.py:555
 msgid "the related verification command"
 msgstr ""
 
-#: fpr/models.py:539
+#: fpr/models.py:564
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:543 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:731
 msgid "Format policy command"
 msgstr ""
 
-#: fpr/models.py:565
+#: fpr/models.py:591
 msgid "Normalization tool"
 msgstr ""
 
-#: fpr/models.py:582
+#: fpr/models.py:608
 msgid "agent identifier type"
 msgstr ""
 
-#: fpr/models.py:583
+#: fpr/models.py:609
 msgid "agent identifier value"
 msgstr ""
 
-#: fpr/models.py:584
+#: fpr/models.py:610
 msgid "agent name"
 msgstr ""
 
-#: fpr/models.py:585
+#: fpr/models.py:611
 msgid "agent type"
 msgstr ""
 
-#: fpr/models.py:586
+#: fpr/models.py:612
 msgid "client IP address"
 msgstr ""
 
-#: fpr/models.py:598 fpr/models.py:637 fpr/models.py:655 fpr/models.py:673
-#: fpr/models.py:701 fpr/models.py:726 fpr/models.py:746 fpr/models.py:766
+#: fpr/models.py:624 fpr/models.py:663 fpr/models.py:681 fpr/models.py:699
+#: fpr/models.py:727 fpr/models.py:753 fpr/models.py:773 fpr/models.py:793
 msgid "replaces"
 msgstr ""
 
-#: fpr/models.py:600
+#: fpr/models.py:626
 msgid "type"
 msgstr ""
 
-#: fpr/models.py:614
+#: fpr/models.py:640
 msgid "command type"
 msgstr ""
 
-#: fpr/models.py:617
+#: fpr/models.py:643
 msgid "verification command"
 msgstr ""
 
-#: fpr/models.py:621
+#: fpr/models.py:647
 msgid "event detail command"
 msgstr ""
 
-#: fpr/models.py:625
+#: fpr/models.py:651
 msgid "supported by"
 msgstr ""
 
-#: fpr/models.py:633
+#: fpr/models.py:659
 msgid "output file format"
 msgstr ""
 
-#: fpr/models.py:688
+#: fpr/models.py:714
 msgid "valid preservation format"
 msgstr ""
 
-#: fpr/models.py:694
+#: fpr/models.py:720
 msgid "valid access format"
 msgstr ""
 
-#: fpr/models.py:698
+#: fpr/models.py:724
 msgid "file ID type"
 msgstr ""
 
-#: fpr/models.py:723
+#: fpr/models.py:750
 msgid "classification"
 msgstr ""
 
-#: fpr/models.py:740
+#: fpr/models.py:767
 msgid "command clasification"
 msgstr ""
 
-#: fpr/models.py:745 fpr/models.py:759
+#: fpr/models.py:772 fpr/models.py:786
 msgid "file ID"
 msgstr ""
 
-#: fpr/models.py:761
+#: fpr/models.py:788
 msgid "tool"
 msgstr ""
 
-#: fpr/models.py:763
+#: fpr/models.py:790
 msgid "tool version"
 msgstr ""
 
@@ -1675,12 +1733,12 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:50 templates/accounts/add.html:36
 #: templates/accounts/edit.html:40 templates/accounts/profile.html:49
 #: templates/administration/processing_edit.html:40
-#: templates/delete_request.html:19 templates/ingest/as/match.html:129
-#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:66
-#: templates/rights/rights_edit.html:290 templates/rights/rights_edit.html:292
-#: templates/rights/rights_grants_edit.html:111
-#: templates/rights/rights_grants_edit.html:113
-#: templates/simple_confirm.html:10 templates/transfer/metadata_edit.html:65
+#: templates/delete_request.html:20 templates/ingest/as/match.html:129
+#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:67
+#: templates/rights/rights_edit.html:291 templates/rights/rights_edit.html:293
+#: templates/rights/rights_grants_edit.html:112
+#: templates/rights/rights_grants_edit.html:114
+#: templates/simple_confirm.html:11 templates/transfer/metadata_edit.html:66
 msgid "Cancel"
 msgstr ""
 
@@ -1857,18 +1915,18 @@ msgstr ""
 #: fpr/templates/fpr/idcommand/form.html:32
 #: fpr/templates/fpr/idrule/form.html:29 fpr/templates/fpr/idtool/form.html:30
 #: templates/accounts/edit.html:39 templates/accounts/profile.html:48
-#: templates/administration/api.html:36
-#: templates/administration/dips_as_edit.html:29
-#: templates/administration/dips_atom_edit.html:44
-#: templates/administration/general.html:67
-#: templates/administration/handle_config.html:24
-#: templates/administration/premis_agent.html:24
+#: templates/administration/api.html:37
+#: templates/administration/dips_as_edit.html:30
+#: templates/administration/dips_atom_edit.html:45
+#: templates/administration/general.html:68
+#: templates/administration/handle_config.html:25
+#: templates/administration/premis_agent.html:25
 #: templates/administration/processing_edit.html:39
-#: templates/administration/term_detail.html:34
-#: templates/ingest/metadata_edit.html:62 templates/rights/rights_edit.html:285
-#: templates/rights/rights_grants_edit.html:106
-#: templates/transfer/component.html:54
-#: templates/transfer/metadata_edit.html:61
+#: templates/administration/term_detail.html:35
+#: templates/ingest/metadata_edit.html:63 templates/rights/rights_edit.html:286
+#: templates/rights/rights_grants_edit.html:107
+#: templates/transfer/component.html:55
+#: templates/transfer/metadata_edit.html:62
 msgid "Save"
 msgstr ""
 
@@ -1881,11 +1939,11 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:12
 #: fpr/templates/fpr/format/group/delete.html:49
 #: fpr/templates/fpr/format/group/list.html:51 templates/accounts/list.html:42
-#: templates/administration/atom_levels_of_description.html:44
+#: templates/administration/atom_levels_of_description.html:45
 #: templates/administration/processing.html:33
-#: templates/administration/reports/failure_detail.html:31
+#: templates/administration/reports/failure_detail.html:32
 #: templates/administration/reports/failures.html:39
-#: templates/administration/term_detail.html:35
+#: templates/administration/term_detail.html:36
 #: templates/archival_storage/view.html:111
 #: templates/archival_storage/view.html:154 templates/main/access.html:25
 #: templates/rights/rights_list.html:55 templates/rights/rights_list.html:58
@@ -2155,13 +2213,6 @@ msgstr ""
 msgid "Script"
 msgstr ""
 
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:959
-#: templates/administration/reports/failures.html:25
-#: templates/rights/rights_edit.html:101 templates/rights/rights_edit.html:153
-#: templates/rights/rights_edit.html:203 templates/rights/rights_edit.html:251
-msgid "Type"
-msgstr ""
-
 #: fpr/templates/fpr/idcommand/list.html:56
 msgid "No identification commands exist."
 msgstr ""
@@ -2211,7 +2262,7 @@ msgstr ""
 #: fpr/templates/fpr/idtool/detail.html:49
 #: templates/ingest/as/_search_form.html:5 templates/ingest/as/match.html:102
 #: templates/ingest/as/match.html:120
-#: templates/ingest/as/review_matches.html:30 templates/ingest/grid.html:165
+#: templates/ingest/as/review_matches.html:31 templates/ingest/grid.html:165
 msgid "Identifier"
 msgstr ""
 
@@ -2412,462 +2463,462 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: main/models.py:243
+#: main/models.py:245
 msgid "Part of AIC"
 msgstr ""
 
-#: main/models.py:244
+#: main/models.py:246
 msgid "Optional: leave blank if unsure"
 msgstr ""
 
-#: main/models.py:253
+#: main/models.py:255
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:263
+#: main/models.py:265
 msgid "Use ISO 639"
 msgstr ""
 
-#: main/models.py:281
+#: main/models.py:283
 msgid "Untitled"
 msgstr ""
 
-#: main/models.py:329
+#: main/models.py:336
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr ""
 
-#: main/models.py:371
+#: main/models.py:381
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr ""
 
-#: main/models.py:399
+#: main/models.py:409
 msgid "SIP"
 msgstr ""
 
-#: main/models.py:400
+#: main/models.py:410
 msgid "AIC"
 msgstr ""
 
-#: main/models.py:401
+#: main/models.py:411
 msgid "Reingested AIP"
 msgstr ""
 
-#: main/models.py:402
+#: main/models.py:412
 msgid "Reingested AIC"
 msgstr ""
 
-#: main/models.py:416
+#: main/models.py:426
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr ""
 
-#: main/models.py:529
+#: main/models.py:547
 msgid "Arranged SIPs"
 msgstr ""
 
-#: main/models.py:533
+#: main/models.py:551
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr ""
 
-#: main/models.py:578
+#: main/models.py:596
 msgid "Identifier Type"
 msgstr ""
 
-#: main/models.py:580
+#: main/models.py:598
 msgid "Identifier Value"
 msgstr ""
 
-#: main/models.py:582
+#: main/models.py:600
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
 msgstr ""
 
-#: main/models.py:645
+#: main/models.py:673
 #, python-format
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:681
+#: main/models.py:719
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:740
+#: main/models.py:783
 #, python-format
 msgid "%(file)s is %(format)s"
 msgstr ""
 
-#: main/models.py:758
+#: main/models.py:801
 msgid "(Unnamed)"
 msgstr ""
 
-#: main/models.py:780
+#: main/models.py:823
 msgid "Unknown"
 msgstr ""
 
-#: main/models.py:781
+#: main/models.py:824
 msgid "Awaiting decision"
 msgstr ""
 
-#: main/models.py:782
+#: main/models.py:825
 msgid "Completed successfully"
 msgstr ""
 
-#: main/models.py:783
+#: main/models.py:826
 msgid "Executing command(s)"
 msgstr ""
 
-#: main/models.py:784
+#: main/models.py:827
 msgid "Failed"
 msgstr ""
 
-#: main/models.py:879
+#: main/models.py:924
 msgid "Agent Identifier Type"
 msgstr ""
 
-#: main/models.py:884
+#: main/models.py:929
 msgid "Agent Identifier Value"
 msgstr ""
 
-#: main/models.py:886
+#: main/models.py:931
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
 msgstr ""
 
-#: main/models.py:893
+#: main/models.py:938
 msgid "Agent Name"
 msgstr ""
 
-#: main/models.py:894
+#: main/models.py:939
 msgid "Used for premis:agentName in the METS file."
 msgstr ""
 
-#: main/models.py:900
+#: main/models.py:945
 msgid "Agent Type"
 msgstr ""
 
-#: main/models.py:901
+#: main/models.py:946
 msgid "Used for premis:agentType in the METS file."
 msgstr ""
 
-#: main/models.py:925
+#: main/models.py:970
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:927
+#: main/models.py:972
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:962 templates/rights/rights_edit.html:105
-#: templates/rights/rights_edit.html:157 templates/rights/rights_edit.html:207
-#: templates/rights/rights_edit.html:255
+#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
+#: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr ""
 
-#: main/models.py:965
+#: main/models.py:1013
 msgid "Rights holder"
 msgstr ""
 
-#: main/models.py:968
+#: main/models.py:1016
 msgid "Copyright"
 msgstr ""
 
-#: main/models.py:969
+#: main/models.py:1017
 msgid "Statute"
 msgstr ""
 
-#: main/models.py:970
+#: main/models.py:1018
 msgid "License"
 msgstr ""
 
-#: main/models.py:971
+#: main/models.py:1019
 msgid "Donor"
 msgstr ""
 
-#: main/models.py:972
+#: main/models.py:1020
 msgid "Policy"
 msgstr ""
 
-#: main/models.py:979 templates/rights/rights_list.html:34
+#: main/models.py:1027 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr ""
 
-#: main/models.py:991
+#: main/models.py:1039
 msgid "Rights Statement"
 msgstr ""
 
-#: main/models.py:995
+#: main/models.py:1043
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr ""
 
-#: main/models.py:1008
+#: main/models.py:1058
 msgid "copyrighted"
 msgstr ""
 
-#: main/models.py:1009
+#: main/models.py:1059
 msgid "public domain"
 msgstr ""
 
-#: main/models.py:1010
+#: main/models.py:1060
 msgid "unknown"
 msgstr ""
 
-#: main/models.py:1015
+#: main/models.py:1065
 msgid "Copyright status"
 msgstr ""
 
-#: main/models.py:1020
+#: main/models.py:1070
 msgid "Copyright jurisdiction"
 msgstr ""
 
-#: main/models.py:1026
+#: main/models.py:1076
 msgid "Copyright determination date"
 msgstr ""
 
-#: main/models.py:1027 main/models.py:1034 main/models.py:1041
-#: main/models.py:1105 main/models.py:1112 main/models.py:1172
-#: main/models.py:1179 main/models.py:1237 main/models.py:1246
-#: main/models.py:1253 main/models.py:1321 main/models.py:1328
+#: main/models.py:1077 main/models.py:1084 main/models.py:1091
+#: main/models.py:1161 main/models.py:1168 main/models.py:1234
+#: main/models.py:1241 main/models.py:1303 main/models.py:1312
+#: main/models.py:1319 main/models.py:1391 main/models.py:1398
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:1033
+#: main/models.py:1083
 msgid "Copyright start date"
 msgstr ""
 
-#: main/models.py:1040
+#: main/models.py:1090
 msgid "Copyright end date"
 msgstr ""
 
-#: main/models.py:1046 main/models.py:1117 main/models.py:1186
-#: main/models.py:1258 main/models.py:1333
+#: main/models.py:1096 main/models.py:1173 main/models.py:1248
+#: main/models.py:1324 main/models.py:1403
 msgid "Open End Date"
 msgstr ""
 
-#: main/models.py:1047 main/models.py:1118 main/models.py:1187
-#: main/models.py:1259 main/models.py:1334
+#: main/models.py:1097 main/models.py:1174 main/models.py:1249
+#: main/models.py:1325 main/models.py:1404
 msgid "Indicate end date is open"
 msgstr ""
 
-#: main/models.py:1052
+#: main/models.py:1102
 msgid "Rights: Copyright"
 msgstr ""
 
-#: main/models.py:1062
+#: main/models.py:1114
 msgid "Copyright document identification type"
 msgstr ""
 
-#: main/models.py:1066
+#: main/models.py:1118
 msgid "Copyright document identification value"
 msgstr ""
 
-#: main/models.py:1072
+#: main/models.py:1124
 msgid "Copyright document identification role"
 msgstr ""
 
-#: main/models.py:1077
+#: main/models.py:1129
 msgid "Rights: Copyright: Docs ID"
 msgstr ""
 
-#: main/models.py:1086 templates/rights/rights_edit.html:116
+#: main/models.py:1140 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr ""
 
-#: main/models.py:1091
+#: main/models.py:1145
 msgid "Rights: Copyright: Note"
 msgstr ""
 
-#: main/models.py:1098
+#: main/models.py:1154
 msgid "License terms"
 msgstr ""
 
-#: main/models.py:1104
+#: main/models.py:1160
 msgid "License start date"
 msgstr ""
 
-#: main/models.py:1111
+#: main/models.py:1167
 msgid "License end date"
 msgstr ""
 
-#: main/models.py:1123
+#: main/models.py:1179
 msgid "Rights: License"
 msgstr ""
 
-#: main/models.py:1133
+#: main/models.py:1191
 msgid "License documentation identification type"
 msgstr ""
 
-#: main/models.py:1137
+#: main/models.py:1195
 msgid "License documentation identification value"
 msgstr ""
 
-#: main/models.py:1143
+#: main/models.py:1201
 msgid "License document identification role"
 msgstr ""
 
-#: main/models.py:1148
+#: main/models.py:1206
 msgid "Rights: License: Docs ID"
 msgstr ""
 
-#: main/models.py:1157 templates/rights/rights_edit.html:218
+#: main/models.py:1217 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr ""
 
-#: main/models.py:1162
+#: main/models.py:1222
 msgid "Rights: License: Note"
 msgstr ""
 
-#: main/models.py:1171 templates/rights/rights_list.html:36
+#: main/models.py:1233 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr ""
 
-#: main/models.py:1178 templates/rights/rights_list.html:37
+#: main/models.py:1240 templates/rights/rights_list.html:37
 msgid "End"
 msgstr ""
 
-#: main/models.py:1192
+#: main/models.py:1254
 msgid "Rights: Granted"
 msgstr ""
 
-#: main/models.py:1203
+#: main/models.py:1266
 msgid "Rights note"
 msgstr ""
 
-#: main/models.py:1208
+#: main/models.py:1271
 msgid "Rights: Granted: Note"
 msgstr ""
 
-#: main/models.py:1222
+#: main/models.py:1286
 msgid "Rights: Granted: Restriction"
 msgstr ""
 
-#: main/models.py:1229
+#: main/models.py:1295
 msgid "Statute jurisdiction"
 msgstr ""
 
-#: main/models.py:1232
+#: main/models.py:1298
 msgid "Statute citation"
 msgstr ""
 
-#: main/models.py:1236
+#: main/models.py:1302
 msgid "Statute determination date"
 msgstr ""
 
-#: main/models.py:1245
+#: main/models.py:1311
 msgid "Statute start date"
 msgstr ""
 
-#: main/models.py:1252
+#: main/models.py:1318
 msgid "Statute end date"
 msgstr ""
 
-#: main/models.py:1264
+#: main/models.py:1330
 msgid "Rights: Statute"
 msgstr ""
 
-#: main/models.py:1274 templates/rights/rights_edit.html:168
+#: main/models.py:1341 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr ""
 
-#: main/models.py:1279
+#: main/models.py:1346
 msgid "Rights: Statute: Note"
 msgstr ""
 
-#: main/models.py:1290
+#: main/models.py:1358
 msgid "Statute document identification type"
 msgstr ""
 
-#: main/models.py:1294
+#: main/models.py:1362
 msgid "Statute document identification value"
 msgstr ""
 
-#: main/models.py:1300
+#: main/models.py:1368
 msgid "Statute document identification role"
 msgstr ""
 
-#: main/models.py:1305
+#: main/models.py:1373
 msgid "Rights: Statute: Docs ID"
 msgstr ""
 
-#: main/models.py:1313
+#: main/models.py:1383
 msgid "Other rights basis"
 msgstr ""
 
-#: main/models.py:1320
+#: main/models.py:1390
 msgid "Other rights start date"
 msgstr ""
 
-#: main/models.py:1327
+#: main/models.py:1397
 msgid "Other rights end date"
 msgstr ""
 
-#: main/models.py:1339
+#: main/models.py:1409
 msgid "Rights: Other"
 msgstr ""
 
-#: main/models.py:1350
+#: main/models.py:1421
 msgid "Other rights document identification type"
 msgstr ""
 
-#: main/models.py:1354
+#: main/models.py:1425
 msgid "Other right document identification value"
 msgstr ""
 
-#: main/models.py:1360
+#: main/models.py:1431
 msgid "Other rights document identification role"
 msgstr ""
 
-#: main/models.py:1365
+#: main/models.py:1436
 msgid "Rights: Other: Docs ID"
 msgstr ""
 
-#: main/models.py:1375
+#: main/models.py:1447
 msgid "Other rights note"
 msgstr ""
 
-#: main/models.py:1380
+#: main/models.py:1452
 msgid "Rights: Other: Note"
 msgstr ""
 
-#: main/models.py:1388
+#: main/models.py:1462
 msgid "Linking Agent"
 msgstr ""
 
-#: main/models.py:1393
+#: main/models.py:1467
 msgid "Linking Agent Value"
 msgstr ""
 
-#: main/models.py:1399
+#: main/models.py:1473
 msgid "Rights: Agent"
 msgstr ""
 
-#: main/models.py:1435
+#: main/models.py:1509
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr ""
 
-#: main/models.py:1473
+#: main/models.py:1547
 msgid "ASDIPObjectResourcePairing"
 msgstr ""
 
-#: main/models.py:1488
+#: main/models.py:1562
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr ""
 
-#: main/models.py:1495
+#: main/models.py:1569
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 
-#: main/models.py:1615
+#: main/models.py:1709
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr ""
@@ -2876,15 +2927,15 @@ msgstr ""
 msgid "<no API key generated>"
 msgstr ""
 
-#: main/views.py:302
+#: main/views.py:299
 msgid "Added."
 msgstr ""
 
-#: main/views.py:307
+#: main/views.py:304
 msgid "Error: no delete ID supplied."
 msgstr ""
 
-#: main/views.py:322
+#: main/views.py:319
 msgid "Incorrect type."
 msgstr ""
 
@@ -2916,38 +2967,38 @@ msgstr ""
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:436
+#: settings/base.py:435
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
 msgstr ""
 
-#: settings/base.py:439
+#: settings/base.py:438
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
 "has been moved into storage."
 msgstr ""
 
-#: settings/base.py:441
+#: settings/base.py:440
 msgid "Create a SIP from the transfer."
 msgstr ""
 
-#: settings/base.py:443
+#: settings/base.py:442
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
 "start ingest micro-services."
 msgstr ""
 
-#: settings/base.py:446
+#: settings/base.py:445
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
 "system."
 msgstr ""
 
-#: settings/base.py:449
+#: settings/base.py:448
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -2956,13 +3007,13 @@ msgid ""
 "view the tool output and error message."
 msgstr ""
 
-#: settings/base.py:452
+#: settings/base.py:451
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
 msgstr ""
 
-#: settings/base.py:455
+#: settings/base.py:454
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -2997,7 +3048,7 @@ msgid "Previous"
 msgstr ""
 
 #: templates/_pager.html:35 templates/ingest/normalization_report.html:121
-#: templates/rights/rights_edit.html:287
+#: templates/rights/rights_edit.html:288
 msgid "Next"
 msgstr ""
 
@@ -3031,8 +3082,8 @@ msgstr ""
 msgid "Add new user"
 msgstr ""
 
-#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:64
-#: templates/installer/welcome.html:49 templates/transfer/metadata_edit.html:63
+#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:65
+#: templates/installer/welcome.html:50 templates/transfer/metadata_edit.html:64
 msgid "Create"
 msgstr ""
 
@@ -3043,12 +3094,6 @@ msgstr ""
 
 #: templates/accounts/list.html:23 templates/accounts/profile.html:29
 msgid "Username"
-msgstr ""
-
-#: templates/accounts/list.html:24 templates/accounts/profile.html:31
-#: templates/administration/atom_levels_of_description.html:36
-#: templates/administration/reports/failures.html:26
-msgid "Name"
 msgstr ""
 
 #: templates/accounts/list.html:25 templates/accounts/profile.html:33
@@ -3112,14 +3157,12 @@ msgstr ""
 #: templates/administration/reports/failure_detail.html:6
 #: templates/administration/reports/failures.html:5
 #: templates/administration/reports/failures.html:6
-#: templates/administration/search.html:5
-#: templates/administration/search.html:6
 #: templates/administration/taxonomy.html:5
 #: templates/administration/taxonomy.html:6
 #: templates/administration/term_detail.html:5
 #: templates/administration/term_detail.html:6
 #: templates/administration/terms.html:5 templates/administration/terms.html:6
-#: templates/layout.html:66
+#: templates/layout.html:68
 msgid "Administration"
 msgstr ""
 
@@ -3149,15 +3192,15 @@ msgstr ""
 msgid "AtoM Levels of Description"
 msgstr ""
 
-#: templates/administration/atom_levels_of_description.html:45
+#: templates/administration/atom_levels_of_description.html:46
 msgid "Promote"
 msgstr ""
 
-#: templates/administration/atom_levels_of_description.html:46
+#: templates/administration/atom_levels_of_description.html:47
 msgid "Demote"
 msgstr ""
 
-#: templates/administration/atom_levels_of_description.html:54
+#: templates/administration/atom_levels_of_description.html:55
 msgid "No levels found."
 msgstr ""
 
@@ -3169,11 +3212,11 @@ msgstr ""
 msgid "Levels of Description"
 msgstr ""
 
-#: templates/administration/dips_atom_edit.html:37
+#: templates/administration/dips_atom_edit.html:38
 msgid "AtoM/Binder DIP upload"
 msgstr ""
 
-#: templates/administration/dips_atom_edit.html:39
+#: templates/administration/dips_atom_edit.html:40
 msgid "The settings below configure DIP uploading to AtoM/Binder."
 msgstr ""
 
@@ -3189,31 +3232,31 @@ msgstr ""
 msgid "General configuration"
 msgstr ""
 
-#: templates/administration/general.html:39
+#: templates/administration/general.html:40
 msgid "Storage Service options"
 msgstr ""
 
-#: templates/administration/general.html:43
+#: templates/administration/general.html:44
 msgid "Checksum algorithm"
 msgstr ""
 
-#: templates/administration/general.html:47
+#: templates/administration/general.html:48
 msgid "Elasticsearch Indexing"
 msgstr ""
 
-#: templates/administration/general.html:52
+#: templates/administration/general.html:53
 msgid "Transfers related indexes enabled."
 msgstr ""
 
-#: templates/administration/general.html:54
+#: templates/administration/general.html:55
 msgid "Transfers related indexes disabled."
 msgstr ""
 
-#: templates/administration/general.html:59
+#: templates/administration/general.html:60
 msgid "AIPs related indexes enabled."
 msgstr ""
 
-#: templates/administration/general.html:61
+#: templates/administration/general.html:62
 msgid "AIPs related indexes disabled."
 msgstr ""
 
@@ -3327,22 +3370,6 @@ msgstr ""
 
 #: templates/administration/reports/failures.html:56
 msgid "No reports found."
-msgstr ""
-
-#: templates/administration/search.html:23
-msgid "Search administration"
-msgstr ""
-
-#: templates/administration/search.html:26
-#, python-format
-msgid ""
-"\n"
-"          %(count)s AIP files indexed.\n"
-"        "
-msgstr ""
-
-#: templates/administration/search.html:33
-msgid "Flush AIP Index"
 msgstr ""
 
 #: templates/administration/sidebar.html:23
@@ -3459,11 +3486,6 @@ msgid ""
 "cleared manually."
 msgstr ""
 
-#: templates/administration/usage.html:90
-#: templates/archival_storage/view.html:67
-msgid "Size"
-msgstr ""
-
 #: templates/administration/version.html:19
 msgid "About Archivematica"
 msgstr ""
@@ -3473,12 +3495,12 @@ msgid "Agent code"
 msgstr ""
 
 #: templates/appraisal/appraisal.html:4 templates/appraisal/appraisal.html:5
-#: templates/layout.html:58
+#: templates/layout.html:60
 msgid "Appraisal"
 msgstr ""
 
 #: templates/appraisal/appraisal.html:30
-#: templates/archival_storage/archival_storage.html:70
+#: templates/archival_storage/archival_storage.html:74
 #: templates/backlog/backlog.html:34
 msgid "Elasticsearch Indexing Disabled"
 msgstr ""
@@ -3501,23 +3523,23 @@ msgstr ""
 
 #: templates/archival_storage/archival_storage.html:6
 #: templates/archival_storage/archival_storage.html:7
-#: templates/archival_storage/archival_storage.html:32
+#: templates/archival_storage/archival_storage.html:31
 #: templates/archival_storage/view.html:6
 #: templates/archival_storage/view.html:7
-#: templates/archival_storage/view.html:50 templates/layout.html:62
+#: templates/archival_storage/view.html:50 templates/layout.html:64
 msgid "Archival storage"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:33
+#: templates/archival_storage/archival_storage.html:32
 #: templates/ingest/as/_search_form.html:6
 msgid "Search"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:41
+#: templates/archival_storage/archival_storage.html:40
 msgid "Browse archival storage"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:44
+#: templates/archival_storage/archival_storage.html:43
 #, python-format
 msgid ""
 "\n"
@@ -3525,7 +3547,7 @@ msgid ""
 "          "
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:50
+#: templates/archival_storage/archival_storage.html:49
 #, python-format
 msgid ""
 "\n"
@@ -3533,15 +3555,25 @@ msgid ""
 "            "
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:61
+#: templates/archival_storage/archival_storage.html:60
 msgid "Create an AIC from current search results"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:62
+#: templates/archival_storage/archival_storage.html:61
 msgid "Create an AIC"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:71
+#: templates/archival_storage/archival_storage.html:65
+msgid ""
+"Download all results from archival storage as a CSV (Comma-separated-values) "
+"table"
+msgstr ""
+
+#: templates/archival_storage/archival_storage.html:66
+msgid "Download CSV"
+msgstr ""
+
+#: templates/archival_storage/archival_storage.html:75
 msgid ""
 "Sorry, Elasticsearch indexing has been disabled for the AIPs related indexes "
 "in this Archivematica installation. The archival storage tab is non-"
@@ -3554,19 +3586,6 @@ msgstr ""
 
 #: templates/archival_storage/view.html:71
 msgid "Date stored"
-msgstr ""
-
-#: templates/archival_storage/view.html:75
-msgid "Status"
-msgstr ""
-
-#: templates/archival_storage/view.html:79
-msgid "Encrypted"
-msgstr ""
-
-#: templates/archival_storage/view.html:83
-#: templates/ingest/normalization_report.html:31
-msgid "Location"
 msgstr ""
 
 #: templates/archival_storage/view.html:90
@@ -3618,7 +3637,7 @@ msgid ""
 "functional when indexing is turned off."
 msgstr ""
 
-#: templates/delete_request.html:14
+#: templates/delete_request.html:15
 msgid "Reason for deletion:"
 msgstr ""
 
@@ -3665,7 +3684,7 @@ msgstr ""
 #: templates/ingest/grid.html:5 templates/ingest/grid.html:6
 #: templates/ingest/metadata_add_files.html:31
 #: templates/ingest/metadata_edit.html:31
-#: templates/ingest/microservices.html:11 templates/layout.html:60
+#: templates/ingest/microservices.html:11 templates/layout.html:62
 #: templates/rights/rights_edit.html:16
 #: templates/rights/rights_grants_edit.html:16
 #: templates/rights/rights_list.html:9
@@ -3682,7 +3701,7 @@ msgstr ""
 #: templates/ingest/as/resource_component.html:52
 #: templates/ingest/as/resource_detail.html:42
 #: templates/ingest/as/resource_list.html:34
-#: templates/ingest/as/review_matches.html:29
+#: templates/ingest/as/review_matches.html:30
 msgid "Title"
 msgstr ""
 
@@ -3726,7 +3745,7 @@ msgstr ""
 #: templates/ingest/as/resource_detail.html:30
 #: templates/ingest/as/resource_list.html:25
 #: templates/ingest/as/resource_list.html:27
-#: templates/ingest/as/review_matches.html:20
+#: templates/ingest/as/review_matches.html:21
 msgid "Restart matching"
 msgstr ""
 
@@ -3752,7 +3771,7 @@ msgid "Resources"
 msgstr ""
 
 #: templates/ingest/as/match.html:100 templates/ingest/as/match.html:118
-#: templates/ingest/as/review_matches.html:28
+#: templates/ingest/as/review_matches.html:29
 msgid "Level"
 msgstr ""
 
@@ -3760,7 +3779,7 @@ msgstr ""
 #: templates/ingest/as/resource_component.html:53
 #: templates/ingest/as/resource_detail.html:43
 #: templates/ingest/as/resource_list.html:35
-#: templates/ingest/as/review_matches.html:31
+#: templates/ingest/as/review_matches.html:32
 msgid "Dates"
 msgstr ""
 
@@ -3769,7 +3788,7 @@ msgid "Pairs"
 msgstr ""
 
 #: templates/ingest/as/match.html:117
-#: templates/ingest/as/review_matches.html:27
+#: templates/ingest/as/review_matches.html:28
 msgid "File"
 msgstr ""
 
@@ -3808,7 +3827,7 @@ msgstr ""
 msgid "Collections"
 msgstr ""
 
-#: templates/ingest/as/review_matches.html:21
+#: templates/ingest/as/review_matches.html:22
 msgid "Finish matching"
 msgstr ""
 
@@ -3912,50 +3931,50 @@ msgstr ""
 msgid "Select a directory"
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:77
-#: templates/transfer/metadata_edit.html:76
+#: templates/ingest/metadata_edit.html:78
+#: templates/transfer/metadata_edit.html:77
 msgid "A name given to the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:81
-#: templates/transfer/metadata_edit.html:80
+#: templates/ingest/metadata_edit.html:82
+#: templates/transfer/metadata_edit.html:81
 msgid "An entity primarily responsible for making the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:85
-#: templates/transfer/metadata_edit.html:84
+#: templates/ingest/metadata_edit.html:86
+#: templates/transfer/metadata_edit.html:85
 msgid "The topic of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:89
-#: templates/transfer/metadata_edit.html:88
+#: templates/ingest/metadata_edit.html:90
+#: templates/transfer/metadata_edit.html:89
 msgid "An account of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:93
-#: templates/transfer/metadata_edit.html:92
+#: templates/ingest/metadata_edit.html:94
+#: templates/transfer/metadata_edit.html:93
 msgid "An entity responsible for making the resource available."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:97
-#: templates/transfer/metadata_edit.html:96
+#: templates/ingest/metadata_edit.html:98
+#: templates/transfer/metadata_edit.html:97
 msgid "An entity responsible for making contributions to the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:101
-#: templates/transfer/metadata_edit.html:100
+#: templates/ingest/metadata_edit.html:102
+#: templates/transfer/metadata_edit.html:101
 msgid ""
 "A point or period of time associated with an event in the lifecycle of the "
 "resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:106
-#: templates/transfer/metadata_edit.html:105
+#: templates/ingest/metadata_edit.html:107
+#: templates/transfer/metadata_edit.html:106
 msgid "The nature or genre of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:108
-#: templates/transfer/metadata_edit.html:107
+#: templates/ingest/metadata_edit.html:109
+#: templates/transfer/metadata_edit.html:108
 msgid ""
 "\n"
 "        You may wish to use the DCMI type vocabulary provided here: <a href="
@@ -3964,13 +3983,13 @@ msgid ""
 "      "
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:116
-#: templates/transfer/metadata_edit.html:115
+#: templates/ingest/metadata_edit.html:117
+#: templates/transfer/metadata_edit.html:116
 msgid "The file format, physical medium, or dimensions of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:118
-#: templates/transfer/metadata_edit.html:117
+#: templates/ingest/metadata_edit.html:119
+#: templates/transfer/metadata_edit.html:118
 msgid ""
 "\n"
 "        Best practice is to use a controlled vocabulary such as the list of "
@@ -3980,35 +3999,35 @@ msgid ""
 "      "
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:125
-#: templates/transfer/metadata_edit.html:124
+#: templates/ingest/metadata_edit.html:126
+#: templates/transfer/metadata_edit.html:125
 msgid "An unambiguous reference to the resource within a given context."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:129
-#: templates/transfer/metadata_edit.html:128
+#: templates/ingest/metadata_edit.html:130
+#: templates/transfer/metadata_edit.html:129
 msgid "A related resource from which the described resource is derived."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:133
-#: templates/transfer/metadata_edit.html:132
+#: templates/ingest/metadata_edit.html:134
+#: templates/transfer/metadata_edit.html:133
 msgid "A related resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:137
-#: templates/transfer/metadata_edit.html:136
+#: templates/ingest/metadata_edit.html:138
+#: templates/transfer/metadata_edit.html:137
 msgid "A language of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:141
-#: templates/transfer/metadata_edit.html:140
+#: templates/ingest/metadata_edit.html:142
+#: templates/transfer/metadata_edit.html:141
 msgid ""
 "The spatial or temporal topic of the resource, the spatial applicability of "
 "the resource, or the jurisdiction under which the resource is relevant."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:145
-#: templates/transfer/metadata_edit.html:144
+#: templates/ingest/metadata_edit.html:146
+#: templates/transfer/metadata_edit.html:145
 msgid "Information about rights held in and over the resource."
 msgstr ""
 
@@ -4067,15 +4086,15 @@ msgid ""
 "    "
 msgstr ""
 
-#: templates/installer/storagesetup.html:25
+#: templates/installer/storagesetup.html:26
 msgid "Register this pipeline in the Storage Service"
 msgstr ""
 
-#: templates/installer/storagesetup.html:30
+#: templates/installer/storagesetup.html:31
 msgid "Dashboard UUID"
 msgstr ""
 
-#: templates/installer/storagesetup.html:39
+#: templates/installer/storagesetup.html:40
 msgid "Register"
 msgstr ""
 
@@ -4097,7 +4116,7 @@ msgstr ""
 msgid "Archivematica Dashboard"
 msgstr ""
 
-#: templates/layout.html:55 templates/rights/rights_edit.html:18
+#: templates/layout.html:57 templates/rights/rights_edit.html:18
 #: templates/rights/rights_grants_edit.html:18
 #: templates/rights/rights_list.html:11 templates/transfer/component.html:10
 #: templates/transfer/detail.html:9 templates/transfer/grid.html:5
@@ -4107,19 +4126,19 @@ msgstr ""
 msgid "Transfer"
 msgstr ""
 
-#: templates/layout.html:57
+#: templates/layout.html:59
 msgid "Backlog"
 msgstr ""
 
-#: templates/layout.html:64
+#: templates/layout.html:66
 msgid "Preservation planning"
 msgstr ""
 
-#: templates/layout.html:74
+#: templates/layout.html:76
 msgid "Your profile"
 msgstr ""
 
-#: templates/layout.html:76
+#: templates/layout.html:78
 msgid "Log out"
 msgstr ""
 
@@ -4228,28 +4247,28 @@ msgid ""
 "                "
 msgstr ""
 
-#: templates/rights/rights_edit.html:96
+#: templates/rights/rights_edit.html:97
 msgid "Copyright documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:109 templates/rights/rights_edit.html:161
-#: templates/rights/rights_edit.html:211 templates/rights/rights_edit.html:259
+#: templates/rights/rights_edit.html:110 templates/rights/rights_edit.html:162
+#: templates/rights/rights_edit.html:212 templates/rights/rights_edit.html:260
 msgid "Role"
 msgstr ""
 
-#: templates/rights/rights_edit.html:147
+#: templates/rights/rights_edit.html:148
 msgid "Statute documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:197
+#: templates/rights/rights_edit.html:198
 msgid "License documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:245
+#: templates/rights/rights_edit.html:246
 msgid "Documentation identifier"
 msgstr ""
 
-#: templates/rights/rights_edit.html:266
+#: templates/rights/rights_edit.html:267
 msgid "Note"
 msgstr ""
 
@@ -4258,23 +4277,23 @@ msgid ""
 "You may now add additional information such as document identifers and notes."
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:79
+#: templates/rights/rights_grants_edit.html:80
 msgid "Allow"
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:80
+#: templates/rights/rights_grants_edit.html:81
 msgid "Disallow"
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:81
+#: templates/rights/rights_grants_edit.html:82
 msgid "Conditional"
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:87
+#: templates/rights/rights_grants_edit.html:88
 msgid "Grant/restriction note"
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:108
+#: templates/rights/rights_grants_edit.html:109
 msgid "Done"
 msgstr ""
 

--- a/src/dashboard/src/locale/en/LC_MESSAGES/djangojs.po
+++ b/src/dashboard/src/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 12:27-0400\n"
+"POT-Creation-Date: 2020-07-27 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgid "Are you sure you want to delete this level of description?"
 msgstr ""
 
 #: media/js/advanced-search-query-creator.js:14 media/js/file_browser.js:59
-#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:209
+#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:211
 msgid "Delete"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Any"
 msgstr ""
 
 #: media/js/archival_storage/archival_storage_search.js:61
-#: media/js/archival_storage/archival_storage_search.js:238
+#: media/js/archival_storage/archival_storage_search.js:242
 msgid "File UUID"
 msgstr ""
 
@@ -104,215 +104,219 @@ msgstr ""
 msgid "Date range"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:148
+#: media/js/archival_storage/archival_storage_search.js:152
 msgid "view raw"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:169
+#: media/js/archival_storage/archival_storage_search.js:173
 #: media/js/backlog/backlog-search.js:6 media/js/backlog/backlog-search.js:12
 msgid "Download"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:184
+#: media/js/archival_storage/archival_storage_search.js:188
 msgid "AIPs in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:185
+#: media/js/archival_storage/archival_storage_search.js:189
 msgid "AIP in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:188
+#: media/js/archival_storage/archival_storage_search.js:192
 msgid "Part of"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:190
+#: media/js/archival_storage/archival_storage_search.js:194
 msgid "None"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:197
+#: media/js/archival_storage/archival_storage_search.js:201
 msgid "View"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "True"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "False"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 msgid "Deletion requested"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 #: media/js/backlog/backlog-search.js:19
 msgid "Stored"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:236
+#: media/js/archival_storage/archival_storage_search.js:240
 msgid "Thumbnail"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:237
+#: media/js/archival_storage/archival_storage_search.js:241
 msgid "File"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:239
+#: media/js/archival_storage/archival_storage_search.js:243
 msgid "AIP"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:240
+#: media/js/archival_storage/archival_storage_search.js:244
 #: media/js/backlog/backlog-search.js:42 media/js/backlog/backlog-search.js:53
 #: media/js/ingest/backlog.js:37
 msgid "Accession number"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:241
-#: media/js/archival_storage/archival_storage_search.js:254
+#: media/js/archival_storage/archival_storage_search.js:245
+#: media/js/archival_storage/archival_storage_search.js:258
 #: media/js/backlog/backlog-search.js:43 media/js/backlog/backlog-search.js:55
 msgid "Status"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:242
-#: media/js/archival_storage/archival_storage_search.js:256
+#: media/js/archival_storage/archival_storage_search.js:246
+#: media/js/archival_storage/archival_storage_search.js:261
 #: media/js/backlog/backlog-search.js:44 media/js/backlog/backlog-search.js:56
-#: media/js/ingest.js:216 media/js/transfer.js:153
+#: media/js/ingest.js:217 media/js/transfer.js:154
 msgid "Actions"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:247
+#: media/js/archival_storage/archival_storage_search.js:251
 #: media/js/backlog/backlog-search.js:49
 msgid "Name"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:248
+#: media/js/archival_storage/archival_storage_search.js:252
 msgid "UUID"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:249
+#: media/js/archival_storage/archival_storage_search.js:253
 msgid "AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:250
+#: media/js/archival_storage/archival_storage_search.js:254
 #: media/js/backlog/backlog-search.js:51
 msgid "Size"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:251
+#: media/js/archival_storage/archival_storage_search.js:255
 #: media/js/backlog/backlog-search.js:52
 msgid "File count"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:252
+#: media/js/archival_storage/archival_storage_search.js:256
 msgid "Accession numbers"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:253
+#: media/js/archival_storage/archival_storage_search.js:257
 msgid "Created"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:255
+#: media/js/archival_storage/archival_storage_search.js:259
 msgid "Encrypted"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:309
-#: media/js/backlog/backlog-search.js:109
+#: media/js/archival_storage/archival_storage_search.js:260
+msgid "Location"
+msgstr ""
+
+#: media/js/archival_storage/archival_storage_search.js:315
+#: media/js/backlog/backlog-search.js:110
 msgid "Select columns"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:313
-#: media/js/backlog/backlog-search.js:113
+#: media/js/archival_storage/archival_storage_search.js:319
+#: media/js/backlog/backlog-search.js:114
 msgctxt "DataTable - sEmptyTable"
 msgid "No data available in table"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:314
-#: media/js/backlog/backlog-search.js:114
+#: media/js/archival_storage/archival_storage_search.js:320
+#: media/js/backlog/backlog-search.js:115
 msgctxt "DataTable - sInfo"
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:315
-#: media/js/backlog/backlog-search.js:115
+#: media/js/archival_storage/archival_storage_search.js:321
+#: media/js/backlog/backlog-search.js:116
 msgctxt "DataTable - sInfoEmpty"
 msgid "Showing 0 to 0 of 0 entries"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:316
-#: media/js/backlog/backlog-search.js:116
+#: media/js/archival_storage/archival_storage_search.js:322
+#: media/js/backlog/backlog-search.js:117
 msgctxt "DataTable - sInfoFiltered"
 msgid "(filtered from _MAX_ total entries)"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:318
-#: media/js/backlog/backlog-search.js:118
+#: media/js/archival_storage/archival_storage_search.js:324
+#: media/js/backlog/backlog-search.js:119
 msgctxt "DataTable - sInfoThousands"
 msgid ","
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:319
-#: media/js/backlog/backlog-search.js:119
+#: media/js/archival_storage/archival_storage_search.js:325
+#: media/js/backlog/backlog-search.js:120
 msgctxt "DataTable - sLengthMenu"
 msgid "Show _MENU_ entries"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:320
-#: media/js/backlog/backlog-search.js:120
+#: media/js/archival_storage/archival_storage_search.js:326
+#: media/js/backlog/backlog-search.js:121
 msgctxt "DataTable - sLoadingRecords"
 msgid "Loading..."
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:321
-#: media/js/backlog/backlog-search.js:121
+#: media/js/archival_storage/archival_storage_search.js:327
+#: media/js/backlog/backlog-search.js:122
 msgctxt "DataTable - sProcessing"
 msgid "Processing..."
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:322
-#: media/js/backlog/backlog-search.js:122
+#: media/js/archival_storage/archival_storage_search.js:328
+#: media/js/backlog/backlog-search.js:123
 msgctxt "DataTable - sSearch"
 msgid "Search:"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:323
-#: media/js/backlog/backlog-search.js:123
+#: media/js/archival_storage/archival_storage_search.js:329
+#: media/js/backlog/backlog-search.js:124
 msgctxt "DataTable - sZeroRecords"
 msgid "No matching records found"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:325
-#: media/js/backlog/backlog-search.js:125
+#: media/js/archival_storage/archival_storage_search.js:331
+#: media/js/backlog/backlog-search.js:126
 msgctxt "DataTable - sFirst"
 msgid "First"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:326
-#: media/js/backlog/backlog-search.js:126
+#: media/js/archival_storage/archival_storage_search.js:332
+#: media/js/backlog/backlog-search.js:127
 msgctxt "DataTable - sLast"
 msgid "Last"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:327
-#: media/js/backlog/backlog-search.js:127
+#: media/js/archival_storage/archival_storage_search.js:333
+#: media/js/backlog/backlog-search.js:128
 msgctxt "DataTable - sNext"
 msgid "Next"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:328
-#: media/js/backlog/backlog-search.js:128
+#: media/js/archival_storage/archival_storage_search.js:334
+#: media/js/backlog/backlog-search.js:129
 msgctxt "DataTable - sPrevious"
 msgid "Previous"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:331
-#: media/js/backlog/backlog-search.js:131
+#: media/js/archival_storage/archival_storage_search.js:337
+#: media/js/backlog/backlog-search.js:132
 msgctxt "DataTable - sSortAscending"
 msgid ": activate to sort column ascending"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:332
-#: media/js/backlog/backlog-search.js:132
+#: media/js/archival_storage/archival_storage_search.js:338
+#: media/js/backlog/backlog-search.js:133
 msgctxt "DataTable - sSortDescending"
 msgid ": activate to sort column descending"
 msgstr ""
@@ -352,7 +356,7 @@ msgid "Yes"
 msgstr ""
 
 #: media/js/directory_picker.js:90 media/js/file_browser.js:178
-#: media/js/ingest.js:123 media/js/jobs.js:590 media/js/jobs.js:683
+#: media/js/ingest.js:124 media/js/jobs.js:590 media/js/jobs.js:686
 msgid "Cancel"
 msgstr ""
 
@@ -400,43 +404,43 @@ msgstr ""
 msgid "Confirm"
 msgstr ""
 
-#: media/js/ingest.js:145
+#: media/js/ingest.js:146
 msgid "Dublin Core metadata editor"
 msgstr ""
 
-#: media/js/ingest.js:152 media/js/jobs.js:535
+#: media/js/ingest.js:153 media/js/jobs.js:535
 msgid "Close"
 msgstr ""
 
-#: media/js/ingest.js:173
+#: media/js/ingest.js:174
 msgid "Error"
 msgstr ""
 
-#: media/js/ingest.js:240
+#: media/js/ingest.js:241
 msgid "Report"
 msgstr ""
 
-#: media/js/ingest.js:243
+#: media/js/ingest.js:244
 msgid "Match DIP objects to resources"
 msgstr ""
 
-#: media/js/ingest.js:301
+#: media/js/ingest.js:303
 msgid "Loading..."
 msgstr ""
 
-#: media/js/ingest/as_matcher.js:551
+#: media/js/ingest/as_matcher.js:553
 msgid "No resource selected."
 msgstr ""
 
-#: media/js/ingest/as_matcher.js:558
+#: media/js/ingest/as_matcher.js:560
 msgid "No objects selected."
 msgstr ""
 
-#: media/js/ingest/as_matcher.js:670
+#: media/js/ingest/as_matcher.js:673
 msgid "Warning"
 msgstr ""
 
-#: media/js/ingest/as_matcher.js:674
+#: media/js/ingest/as_matcher.js:677
 msgid "Dismiss"
 msgstr ""
 
@@ -448,15 +452,15 @@ msgstr ""
 msgid "Ingest date (YYYY-MM-DD)"
 msgstr ""
 
-#: media/js/ingest/metadata_form.js:83
+#: media/js/ingest/metadata_form.js:84
 msgid "Browse"
 msgstr ""
 
-#: media/js/ingest/metadata_form.js:85
+#: media/js/ingest/metadata_form.js:86
 msgid "Add files"
 msgstr ""
 
-#: media/js/ingest/metadata_form.js:124
+#: media/js/ingest/metadata_form.js:125
 msgid "Please select at least one metadata file."
 msgstr ""
 
@@ -483,34 +487,34 @@ msgstr ""
 msgid "Remove All Completed %ss"
 msgstr ""
 
-#: media/js/jobs.js:661
+#: media/js/jobs.js:664
 #, javascript-format
 msgid "There were no completed %ss to remove"
 msgstr ""
 
-#: media/js/jobs.js:665
+#: media/js/jobs.js:668
 #, javascript-format
 msgid "Successfully removed the following %ss: %s"
 msgstr ""
 
-#: media/js/jobs.js:671
+#: media/js/jobs.js:674
 #, javascript-format
 msgid "Failed to remove all completed %ss"
 msgstr ""
 
-#: media/js/jobs.js:797
+#: media/js/jobs.js:800
 msgid "Previous"
 msgstr ""
 
-#: media/js/jobs.js:812
+#: media/js/jobs.js:815
 msgid "Next"
 msgstr ""
 
-#: media/js/jobs.js:850
+#: media/js/jobs.js:853
 msgid "Error trying to connect to database. Trying again..."
 msgstr ""
 
-#: media/js/jobs.js:900
+#: media/js/jobs.js:903
 msgid "Error trying to connect to MCP server. Trying again..."
 msgstr ""
 
@@ -526,7 +530,7 @@ msgstr ""
 msgid "Disconnected"
 msgstr ""
 
-#: media/js/repeating-ajax-data.js:215
+#: media/js/repeating-ajax-data.js:217
 msgid "Are you sure?"
 msgstr ""
 

--- a/src/dashboard/src/locale/es/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 11:52-0400\n"
+"POT-Creation-Date: 2020-07-27 22:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Flores (PhD.) <dfloresbr@gmail.com>, 2017\n"
 "Language-Team: Spanish (https://www.transifex.com/artefactual/teams/1506/"
@@ -19,12 +19,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: components/accounts/views.py:62 components/accounts/views.py:150
-#: components/administration/views.py:459
-#: components/administration/views.py:474
-#: components/administration/views.py:486
-#: components/administration/views.py:513
-#: components/administration/views.py:564
+#: components/accounts/views.py:61 components/accounts/views.py:149
+#: components/administration/views.py:454
+#: components/administration/views.py:469
+#: components/administration/views.py:481
+#: components/administration/views.py:508
+#: components/administration/views.py:555
 #: components/administration/views_dip_upload.py:25
 #: components/administration/views_dip_upload.py:39 fpr/views.py:106
 #: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Saved."
 msgstr "Grabado."
 
-#: components/accounts/views.py:82
+#: components/accounts/views.py:81
 #, python-format
 msgid "Your profile (%s)"
 msgstr ""
@@ -366,7 +366,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:973
+#: components/administration/forms_dip_upload.py:21 main/models.py:1021
 msgid "Other"
 msgstr "Otro"
 
@@ -551,99 +551,99 @@ msgstr "Clave de la REST API"
 msgid "Used in metadata-only DIP upload."
 msgstr ""
 
-#: components/administration/views.py:92 components/administration/views.py:125
-#: components/ingest/views.py:293 fpr/views.py:261 main/views.py:310
+#: components/administration/views.py:89 components/administration/views.py:122
+#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
 msgid "Deleted."
 msgstr "Borrado."
 
-#: components/administration/views.py:109
+#: components/administration/views.py:106
 msgid "Promoted."
 msgstr ""
 
-#: components/administration/views.py:112
+#: components/administration/views.py:109
 msgid "Error attempting to promote level of description."
 msgstr ""
 
-#: components/administration/views.py:116
+#: components/administration/views.py:113
 msgid "Demoted."
 msgstr ""
 
-#: components/administration/views.py:119
+#: components/administration/views.py:116
 msgid "Error attempting to demote level of description."
 msgstr ""
 
-#: components/administration/views.py:127
+#: components/administration/views.py:124
 msgid "Level of description not found."
 msgstr ""
 
-#: components/administration/views.py:193
+#: components/administration/views.py:190
 msgid ""
 "Error retrieving locations: is the storage server running? Please contact an "
 "administrator."
 msgstr ""
 
-#: components/administration/views.py:202
+#: components/administration/views.py:199
 #, fuzzy
 #| msgid "AIP storage locations"
 msgid "AIP Storage"
 msgstr "Ubicaciones de almacenamiento AIP"
 
-#: components/administration/views.py:203
+#: components/administration/views.py:200
 msgid "DIP Storage"
 msgstr ""
 
-#: components/administration/views.py:204
+#: components/administration/views.py:201
 msgid "FEDORA Deposits"
 msgstr ""
 
-#: components/administration/views.py:205
+#: components/administration/views.py:202
 #, fuzzy
 #| msgid "Transfer"
 msgid "Transfer Backlog"
 msgstr "Transferencia"
 
-#: components/administration/views.py:206
+#: components/administration/views.py:203
 #, fuzzy
 #| msgid "Transfer source locations"
 msgid "Transfer Source"
 msgstr "Ubicaciones de orígenes de transferencias"
 
-#: components/administration/views.py:207
+#: components/administration/views.py:204
 msgid "Replicator"
 msgstr ""
 
-#: components/administration/views.py:224
+#: components/administration/views.py:221
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:407
+#: components/administration/views.py:404
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:410
+#: components/administration/views.py:406
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr "Limpiar"
 
-#: components/administration/views.py:436
+#: components/administration/views.py:431
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:439
+#: components/administration/views.py:434
 #, python-format
 msgid "No such file or directory: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:580
+#: components/administration/views.py:571
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
 "Storage Sevice URL below.<hr />%(error)s"
 msgstr ""
 
-#: components/administration/views.py:597
+#: components/administration/views.py:588
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -651,7 +651,7 @@ msgid ""
 "%(error)s"
 msgstr ""
 
-#: components/administration/views.py:609
+#: components/administration/views.py:600
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -720,6 +720,7 @@ msgid "Please type in the UUID to confirm"
 msgstr ""
 
 #: components/archival_storage/forms.py:89
+#: components/archival_storage/views.py:210
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -749,35 +750,98 @@ msgstr ""
 msgid "UUID mismatch"
 msgstr ""
 
-#: components/archival_storage/views.py:49
+#: components/archival_storage/views.py:54
 msgid "Stored"
 msgstr ""
 
-#: components/archival_storage/views.py:50
+#: components/archival_storage/views.py:55
 msgid "Deletion requested"
 msgstr ""
 
-#: components/archival_storage/views.py:464
+#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: templates/accounts/profile.html:31
+#: templates/administration/atom_levels_of_description.html:37
+#: templates/administration/reports/failures.html:26
+msgid "Name"
+msgstr "Nombre"
+
+#: components/archival_storage/views.py:211
+msgid "AICID"
+msgstr ""
+
+#: components/archival_storage/views.py:212
+msgid "Count AIPs in AIC"
+msgstr ""
+
+#: components/archival_storage/views.py:213
+#: templates/administration/usage.html:90
+#: templates/archival_storage/view.html:67
+msgid "Size"
+msgstr "Tamaño"
+
+#: components/archival_storage/views.py:214
+#, fuzzy
+#| msgid "Failures"
+msgid "File count"
+msgstr "Fallos"
+
+#: components/archival_storage/views.py:215
+#, fuzzy
+#| msgid "Access"
+msgid "Accession IDs"
+msgstr "Acceso"
+
+#: components/archival_storage/views.py:216
+#, fuzzy
+#| msgid "Create SIP"
+msgid "Created date (UTC)"
+msgstr "Crear SIP"
+
+#: components/archival_storage/views.py:217
+#: templates/archival_storage/view.html:75
+msgid "Status"
+msgstr "Estado de elaboración"
+
+#: components/archival_storage/views.py:218
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: templates/administration/reports/failures.html:25
+#: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
+#: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
+msgid "Type"
+msgstr "Tipo"
+
+#: components/archival_storage/views.py:219
+#: templates/archival_storage/view.html:79
+msgid "Encrypted"
+msgstr ""
+
+#: components/archival_storage/views.py:220
+#: templates/archival_storage/view.html:83
+#: templates/ingest/normalization_report.html:31
+msgid "Location"
+msgstr "Localización"
+
+#: components/archival_storage/views.py:600
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:593
+#: components/archival_storage/views.py:729
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 
-#: components/archival_storage/views.py:605
+#: components/archival_storage/views.py:741
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
 "slug: %(slug)s"
 msgstr ""
 
-#: components/archival_storage/views.py:628
+#: components/archival_storage/views.py:764
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr ""
 
-#: components/backlog/views.py:291
+#: components/backlog/views.py:282
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 
@@ -930,40 +994,40 @@ msgstr ""
 msgid "Unable to fetch levels of description from AtoM!"
 msgstr ""
 
-#: components/ingest/views.py:87
+#: components/ingest/views.py:86
 msgid ""
 "Error retrieving originals/arrange directory locations: is the storage "
 "server running? Please contact an administrator."
 msgstr ""
 
-#: components/ingest/views.py:182
+#: components/ingest/views.py:181
 msgid ""
 "Error retrieving source directories: is the storage server running? Please "
 "contact an administrator."
 msgstr ""
 
-#: components/ingest/views.py:191
+#: components/ingest/views.py:190
 msgid ""
 "No transfer source locations are available. Please contact an administrator."
 msgstr ""
 
-#: components/ingest/views.py:283
+#: components/ingest/views.py:278
 msgid "Are you sure you want to delete this metadata?"
 msgstr "¿Estás seguro de que quieres eliminar estos metadatos?"
 
-#: components/ingest/views.py:418
+#: components/ingest/views.py:412
 msgid "Review normalization"
 msgstr ""
 
-#: components/ingest/views.py:421
+#: components/ingest/views.py:415
 msgid "Review AIP"
 msgstr ""
 
-#: components/ingest/views.py:424
+#: components/ingest/views.py:418
 msgid "Review DIP"
 msgstr ""
 
-#: components/ingest/views_as.py:327
+#: components/ingest/views_as.py:325
 msgid "Operation failed, please try again later or contact your administrator."
 msgstr ""
 
@@ -1076,20 +1140,20 @@ msgid ""
 "content."
 msgstr ""
 
-#: components/rights/views.py:277 components/rights/views.py:311
+#: components/rights/views.py:272 components/rights/views.py:306
 msgid "copyright"
 msgstr ""
 
-#: components/rights/views.py:345 components/rights/views.py:379
+#: components/rights/views.py:340 components/rights/views.py:374
 msgid "license"
 msgstr ""
 
-#: components/rights/views.py:391 components/rights/views.py:426
-#: components/rights/views.py:466 components/rights/views.py:497
+#: components/rights/views.py:386 components/rights/views.py:421
+#: components/rights/views.py:461 components/rights/views.py:492
 msgid "statute"
 msgstr ""
 
-#: components/rights/views.py:483
+#: components/rights/views.py:478
 msgid "statue"
 msgstr ""
 
@@ -1097,11 +1161,11 @@ msgstr ""
 msgid "Error retrieving source directories"
 msgstr ""
 
-#: components/transfer/views.py:210
+#: components/transfer/views.py:208
 msgid "Updated path was not provided."
 msgstr ""
 
-#: components/transfer/views.py:212
+#: components/transfer/views.py:210
 msgid "Unable to update transfer metadata set, contact administrator:"
 msgstr ""
 
@@ -1136,436 +1200,436 @@ msgstr ""
 msgid "the related model"
 msgstr ""
 
-#: fpr/models.py:51 fpr/models.py:362 fpr/models.py:560 fpr/models.py:603
-#: fpr/models.py:643 fpr/models.py:659 fpr/models.py:677 fpr/models.py:705
-#: fpr/models.py:730 fpr/models.py:749 fpr/models.py:770
+#: fpr/models.py:52 fpr/models.py:378 fpr/models.py:586 fpr/models.py:629
+#: fpr/models.py:669 fpr/models.py:685 fpr/models.py:703 fpr/models.py:731
+#: fpr/models.py:757 fpr/models.py:776 fpr/models.py:797
 msgid "enabled"
 msgstr ""
 
-#: fpr/models.py:52 fpr/models.py:601 fpr/models.py:640 fpr/models.py:657
-#: fpr/models.py:675 fpr/models.py:703 fpr/models.py:728 fpr/models.py:747
-#: fpr/models.py:768
+#: fpr/models.py:53 fpr/models.py:627 fpr/models.py:666 fpr/models.py:683
+#: fpr/models.py:701 fpr/models.py:729 fpr/models.py:755 fpr/models.py:774
+#: fpr/models.py:795
 msgid "last modified"
 msgstr ""
 
-#: fpr/models.py:141 fpr/models.py:165 fpr/models.py:182 fpr/models.py:251
-#: fpr/models.py:306 fpr/models.py:356 fpr/models.py:388 fpr/models.py:484
-#: fpr/models.py:554
+#: fpr/models.py:142 fpr/models.py:170 fpr/models.py:187 fpr/models.py:257
+#: fpr/models.py:316 fpr/models.py:372 fpr/models.py:404 fpr/models.py:506
+#: fpr/models.py:580
 #, fuzzy
 #| msgid "Identifier"
 msgid "Unique identifier"
 msgstr "Identificador"
 
-#: fpr/models.py:144 fpr/models.py:167 fpr/models.py:194 fpr/models.py:254
-#: fpr/models.py:359 fpr/models.py:494 fpr/models.py:557 fpr/models.py:631
-#: fpr/models.py:652 fpr/models.py:671 fpr/models.py:686
+#: fpr/models.py:145 fpr/models.py:172 fpr/models.py:200 fpr/models.py:260
+#: fpr/models.py:375 fpr/models.py:517 fpr/models.py:583 fpr/models.py:657
+#: fpr/models.py:678 fpr/models.py:697 fpr/models.py:712
 #, fuzzy
 #| msgid "Description"
 msgid "description"
 msgstr "Descripción"
 
-#: fpr/models.py:144
+#: fpr/models.py:145
 msgid "Common name of format"
 msgstr ""
 
-#: fpr/models.py:147
+#: fpr/models.py:151
 msgid "the related group"
 msgstr ""
 
-#: fpr/models.py:149 fpr/models.py:168 fpr/models.py:364 fpr/models.py:561
+#: fpr/models.py:154 fpr/models.py:173 fpr/models.py:380 fpr/models.py:587
 msgid "slug"
 msgstr ""
 
-#: fpr/models.py:154 fpr/templates/fpr/format/version/detail.html:31
+#: fpr/models.py:159 fpr/templates/fpr/format/version/detail.html:31
 #: fpr/templates/fpr/fprule/detail.html:30
 #: fpr/templates/fpr/fprule/list.html:30 fpr/templates/fpr/idrule/list.html:28
 #: templates/ingest/normalization_report.html:32
 msgid "Format"
 msgstr "Formato"
 
-#: fpr/models.py:171
+#: fpr/models.py:176
 #, fuzzy
 #| msgid "Format"
 msgid "Format group"
 msgstr "Formato"
 
-#: fpr/models.py:189 fpr/models.py:312 fpr/models.py:444 fpr/models.py:713
+#: fpr/models.py:194 fpr/models.py:327 fpr/models.py:465 fpr/models.py:739
 msgid "the related format"
 msgstr ""
 
-#: fpr/models.py:191 fpr/models.py:361 fpr/models.py:559
+#: fpr/models.py:197 fpr/models.py:377 fpr/models.py:585
 #, fuzzy
 #| msgid "Version"
 msgid "version"
 msgstr "Versión"
 
-#: fpr/models.py:192
+#: fpr/models.py:198
 msgid "pronom id"
 msgstr ""
 
-#: fpr/models.py:198
+#: fpr/models.py:204
 msgid "Formal name to go in the METS file."
 msgstr ""
 
-#: fpr/models.py:200
+#: fpr/models.py:206
 msgid "access format"
 msgstr ""
 
-#: fpr/models.py:201
+#: fpr/models.py:207
 #, fuzzy
 #| msgid "Preservation planning"
 msgid "preservation format"
 msgstr "Planificación de la preservación"
 
-#: fpr/models.py:208 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
 #, fuzzy
 #| msgid "Format"
 msgid "Format version"
 msgstr "Formato"
 
-#: fpr/models.py:227
+#: fpr/models.py:233
 msgid ""
 "Unable to save, an active Format Version  with this pronom id already exists."
 msgstr ""
 
-#: fpr/models.py:234
+#: fpr/models.py:240
 #, python-format
 msgid "%(format)s: %(description)s (%(pronom_id)s)"
 msgstr ""
 
-#: fpr/models.py:254
+#: fpr/models.py:260
 msgid "Name to identify script"
 msgstr ""
 
-#: fpr/models.py:257
+#: fpr/models.py:263
 msgid "PUID"
 msgstr ""
 
-#: fpr/models.py:258
+#: fpr/models.py:264
 msgid "MIME type"
 msgstr ""
 
-#: fpr/models.py:259
+#: fpr/models.py:265
 msgid "File extension"
 msgstr ""
 
-#: fpr/models.py:261
+#: fpr/models.py:267
 #, fuzzy
 #| msgid "Configuration"
 msgid "configuration"
 msgstr "Configuración"
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 #, fuzzy
 #| msgid "Description"
 msgid "script"
 msgstr "Descripción"
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 msgid "Script to be executed."
 msgstr ""
 
-#: fpr/models.py:265 fpr/models.py:497
+#: fpr/models.py:271 fpr/models.py:520
 msgid "Bash script"
 msgstr ""
 
-#: fpr/models.py:266 fpr/models.py:498
+#: fpr/models.py:272 fpr/models.py:521
 msgid "Python script"
 msgstr ""
 
-#: fpr/models.py:267 fpr/models.py:499
+#: fpr/models.py:273 fpr/models.py:522
 msgid "Command line"
 msgstr ""
 
-#: fpr/models.py:268 fpr/models.py:500
+#: fpr/models.py:274 fpr/models.py:523
 msgid "No shebang needed"
 msgstr ""
 
-#: fpr/models.py:271 fpr/models.py:503
+#: fpr/models.py:277 fpr/models.py:526
 #, fuzzy
 #| msgid "Incorrect type."
 msgid "script type"
 msgstr "Tipo incorrecto."
 
-#: fpr/models.py:274 fpr/models.py:492
+#: fpr/models.py:283 fpr/models.py:514
 msgid "the related tool"
 msgstr ""
 
-#: fpr/models.py:278
+#: fpr/models.py:288
 msgid "Format identification command"
 msgstr ""
 
-#: fpr/models.py:282
+#: fpr/models.py:292
 #, python-format
 msgid "%(tool)s %(config)s runs %(command)s"
 msgstr ""
 
-#: fpr/models.py:309 fpr/models.py:441
+#: fpr/models.py:321 fpr/models.py:459
 msgid "the related command"
 msgstr ""
 
-#: fpr/models.py:315
+#: fpr/models.py:331
 msgid "command output"
 msgstr ""
 
-#: fpr/models.py:318
+#: fpr/models.py:334
 msgid "Format identification rule"
 msgstr ""
 
-#: fpr/models.py:335
+#: fpr/models.py:351
 msgid ""
 "Unable to save, a rule with this output already exists for this command."
 msgstr ""
 
-#: fpr/models.py:342
+#: fpr/models.py:358
 #, python-format
 msgid "Format identification rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:345
+#: fpr/models.py:361
 #, python-format
 msgid "%(command)s with %(output)s is %(format)s"
 msgstr ""
 
-#: fpr/models.py:359 fpr/models.py:557
+#: fpr/models.py:375 fpr/models.py:583
 msgid "Name of tool"
 msgstr ""
 
-#: fpr/models.py:368
+#: fpr/models.py:384
 msgid "Format identification tool"
 msgstr ""
 
-#: fpr/models.py:374 fpr/models.py:568
+#: fpr/models.py:390 fpr/models.py:594
 #, fuzzy, python-format
 #| msgid "Description"
 msgid "%(description)s"
 msgstr "Descripción"
 
-#: fpr/models.py:416 templates/layout.html:65 templates/main/access.html:4
+#: fpr/models.py:432 templates/layout.html:67 templates/main/access.html:4
 #: templates/main/access.html:5
 msgid "Access"
 msgstr "Acceso"
 
-#: fpr/models.py:417 fpr/models.py:514
+#: fpr/models.py:433 fpr/models.py:538
 msgid "Characterization"
 msgstr ""
 
-#: fpr/models.py:418
+#: fpr/models.py:434
 #, fuzzy
 #| msgid "Extract packages"
 msgid "Extract"
 msgstr "Extraer paquetes"
 
-#: fpr/models.py:419 fpr/templates/fpr/format/version/detail.html:33
+#: fpr/models.py:435 fpr/templates/fpr/format/version/detail.html:33
 #, fuzzy
 #| msgid "Preservation planning"
 msgid "Preservation"
 msgstr "Planificación de la preservación"
 
-#: fpr/models.py:420
+#: fpr/models.py:436
 msgid "Thumbnail"
 msgstr ""
 
-#: fpr/models.py:421 fpr/models.py:518
+#: fpr/models.py:437 fpr/models.py:542
 #, fuzzy
 #| msgid "Description"
 msgid "Transcription"
 msgstr "Descripción"
 
-#: fpr/models.py:422 fpr/models.py:519
+#: fpr/models.py:438 fpr/models.py:543
 msgid "Validation"
 msgstr ""
 
-#: fpr/models.py:423
+#: fpr/models.py:439
 msgid "Validation against a policy"
 msgstr ""
 
-#: fpr/models.py:426
+#: fpr/models.py:442
 msgid "Default access"
 msgstr ""
 
-#: fpr/models.py:427
+#: fpr/models.py:443
 msgid "Default characterization"
 msgstr ""
 
-#: fpr/models.py:428
+#: fpr/models.py:444
 msgid "Default thumbnail"
 msgstr ""
 
-#: fpr/models.py:439
+#: fpr/models.py:455
 #, fuzzy
 #| msgid "Purpose"
 msgid "purpose"
 msgstr "Objetivo"
 
-#: fpr/models.py:447
+#: fpr/models.py:469
 msgid "count attempts"
 msgstr ""
 
-#: fpr/models.py:448
+#: fpr/models.py:470
 msgid "count okay"
 msgstr ""
 
-#: fpr/models.py:449
+#: fpr/models.py:471
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:452 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:732
 msgid "Format policy rule"
 msgstr ""
 
-#: fpr/models.py:472
+#: fpr/models.py:494
 #, python-format
 msgid "Format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:475
+#: fpr/models.py:497
 #, python-format
 msgid "Normalize %(format)s for %(purpose)s via %(command)s"
 msgstr ""
 
-#: fpr/models.py:495 fpr/models.py:627 fpr/models.py:744
+#: fpr/models.py:518 fpr/models.py:653 fpr/models.py:771
 msgid "command"
 msgstr ""
 
-#: fpr/models.py:505 fpr/models.py:629
+#: fpr/models.py:528 fpr/models.py:655
 #, fuzzy
 #| msgid "Statute citation"
 msgid "output location"
 msgstr "Cita de la normativa"
 
-#: fpr/models.py:511
+#: fpr/models.py:534
 msgid "the related output format"
 msgstr ""
 
-#: fpr/models.py:515
+#: fpr/models.py:539
 msgid "Event Detail"
 msgstr ""
 
-#: fpr/models.py:516
+#: fpr/models.py:540
 msgid "Extraction"
 msgstr ""
 
-#: fpr/models.py:517
+#: fpr/models.py:541
 #, fuzzy
 #| msgid "Normalize"
 msgid "Normalization"
 msgstr "Normalizar"
 
-#: fpr/models.py:520
+#: fpr/models.py:544
 #, fuzzy
 #| msgid "Description"
 msgid "Verification"
 msgstr "Descripción"
 
-#: fpr/models.py:523 fpr/models.py:613
+#: fpr/models.py:547 fpr/models.py:639
 msgid "command usage"
 msgstr ""
 
-#: fpr/models.py:531
+#: fpr/models.py:555
 msgid "the related verification command"
 msgstr ""
 
-#: fpr/models.py:539
+#: fpr/models.py:564
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:543 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:731
 msgid "Format policy command"
 msgstr ""
 
-#: fpr/models.py:565
+#: fpr/models.py:591
 #, fuzzy
 #| msgid "Approve normalization"
 msgid "Normalization tool"
 msgstr "Aprobar normalización"
 
-#: fpr/models.py:582
+#: fpr/models.py:608
 msgid "agent identifier type"
 msgstr ""
 
-#: fpr/models.py:583
+#: fpr/models.py:609
 msgid "agent identifier value"
 msgstr ""
 
-#: fpr/models.py:584
+#: fpr/models.py:610
 #, fuzzy
 #| msgid "File name"
 msgid "agent name"
 msgstr "Nombre de fichero"
 
-#: fpr/models.py:585
+#: fpr/models.py:611
 #, fuzzy
 #| msgid "Agent code"
 msgid "agent type"
 msgstr "Código del agente"
 
-#: fpr/models.py:586
+#: fpr/models.py:612
 msgid "client IP address"
 msgstr ""
 
-#: fpr/models.py:598 fpr/models.py:637 fpr/models.py:655 fpr/models.py:673
-#: fpr/models.py:701 fpr/models.py:726 fpr/models.py:746 fpr/models.py:766
+#: fpr/models.py:624 fpr/models.py:663 fpr/models.py:681 fpr/models.py:699
+#: fpr/models.py:727 fpr/models.py:753 fpr/models.py:773 fpr/models.py:793
 #, fuzzy
 #| msgid "Replace"
 msgid "replaces"
 msgstr "Reemplazar"
 
-#: fpr/models.py:600
+#: fpr/models.py:626
 msgid "type"
 msgstr ""
 
-#: fpr/models.py:614
+#: fpr/models.py:640
 msgid "command type"
 msgstr ""
 
-#: fpr/models.py:617
+#: fpr/models.py:643
 #, fuzzy
 #| msgid "Executing command(s)"
 msgid "verification command"
 msgstr "Ejecutando comando(s)"
 
-#: fpr/models.py:621
+#: fpr/models.py:647
 msgid "event detail command"
 msgstr ""
 
-#: fpr/models.py:625
+#: fpr/models.py:651
 msgid "supported by"
 msgstr ""
 
-#: fpr/models.py:633
+#: fpr/models.py:659
 msgid "output file format"
 msgstr ""
 
-#: fpr/models.py:688
+#: fpr/models.py:714
 msgid "valid preservation format"
 msgstr ""
 
-#: fpr/models.py:694
+#: fpr/models.py:720
 msgid "valid access format"
 msgstr ""
 
-#: fpr/models.py:698
+#: fpr/models.py:724
 msgid "file ID type"
 msgstr ""
 
-#: fpr/models.py:723
+#: fpr/models.py:750
 msgid "classification"
 msgstr ""
 
-#: fpr/models.py:740
+#: fpr/models.py:767
 msgid "command clasification"
 msgstr ""
 
-#: fpr/models.py:745 fpr/models.py:759
+#: fpr/models.py:772 fpr/models.py:786
 msgid "file ID"
 msgstr ""
 
-#: fpr/models.py:761
+#: fpr/models.py:788
 msgid "tool"
 msgstr ""
 
-#: fpr/models.py:763
+#: fpr/models.py:790
 #, fuzzy
 #| msgid "Version"
 msgid "tool version"
@@ -1746,12 +1810,12 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:50 templates/accounts/add.html:36
 #: templates/accounts/edit.html:40 templates/accounts/profile.html:49
 #: templates/administration/processing_edit.html:40
-#: templates/delete_request.html:19 templates/ingest/as/match.html:129
-#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:66
-#: templates/rights/rights_edit.html:290 templates/rights/rights_edit.html:292
-#: templates/rights/rights_grants_edit.html:111
-#: templates/rights/rights_grants_edit.html:113
-#: templates/simple_confirm.html:10 templates/transfer/metadata_edit.html:65
+#: templates/delete_request.html:20 templates/ingest/as/match.html:129
+#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:67
+#: templates/rights/rights_edit.html:291 templates/rights/rights_edit.html:293
+#: templates/rights/rights_grants_edit.html:112
+#: templates/rights/rights_grants_edit.html:114
+#: templates/simple_confirm.html:11 templates/transfer/metadata_edit.html:66
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1933,18 +1997,18 @@ msgstr ""
 #: fpr/templates/fpr/idcommand/form.html:32
 #: fpr/templates/fpr/idrule/form.html:29 fpr/templates/fpr/idtool/form.html:30
 #: templates/accounts/edit.html:39 templates/accounts/profile.html:48
-#: templates/administration/api.html:36
-#: templates/administration/dips_as_edit.html:29
-#: templates/administration/dips_atom_edit.html:44
-#: templates/administration/general.html:67
-#: templates/administration/handle_config.html:24
-#: templates/administration/premis_agent.html:24
+#: templates/administration/api.html:37
+#: templates/administration/dips_as_edit.html:30
+#: templates/administration/dips_atom_edit.html:45
+#: templates/administration/general.html:68
+#: templates/administration/handle_config.html:25
+#: templates/administration/premis_agent.html:25
 #: templates/administration/processing_edit.html:39
-#: templates/administration/term_detail.html:34
-#: templates/ingest/metadata_edit.html:62 templates/rights/rights_edit.html:285
-#: templates/rights/rights_grants_edit.html:106
-#: templates/transfer/component.html:54
-#: templates/transfer/metadata_edit.html:61
+#: templates/administration/term_detail.html:35
+#: templates/ingest/metadata_edit.html:63 templates/rights/rights_edit.html:286
+#: templates/rights/rights_grants_edit.html:107
+#: templates/transfer/component.html:55
+#: templates/transfer/metadata_edit.html:62
 msgid "Save"
 msgstr "Grabar"
 
@@ -1957,11 +2021,11 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:12
 #: fpr/templates/fpr/format/group/delete.html:49
 #: fpr/templates/fpr/format/group/list.html:51 templates/accounts/list.html:42
-#: templates/administration/atom_levels_of_description.html:44
+#: templates/administration/atom_levels_of_description.html:45
 #: templates/administration/processing.html:33
-#: templates/administration/reports/failure_detail.html:31
+#: templates/administration/reports/failure_detail.html:32
 #: templates/administration/reports/failures.html:39
-#: templates/administration/term_detail.html:35
+#: templates/administration/term_detail.html:36
 #: templates/archival_storage/view.html:111
 #: templates/archival_storage/view.html:154 templates/main/access.html:25
 #: templates/rights/rights_list.html:55 templates/rights/rights_list.html:58
@@ -2253,13 +2317,6 @@ msgstr ""
 msgid "Script"
 msgstr ""
 
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:959
-#: templates/administration/reports/failures.html:25
-#: templates/rights/rights_edit.html:101 templates/rights/rights_edit.html:153
-#: templates/rights/rights_edit.html:203 templates/rights/rights_edit.html:251
-msgid "Type"
-msgstr "Tipo"
-
 #: fpr/templates/fpr/idcommand/list.html:56
 msgid "No identification commands exist."
 msgstr ""
@@ -2311,7 +2368,7 @@ msgstr "Configuración"
 #: fpr/templates/fpr/idtool/detail.html:49
 #: templates/ingest/as/_search_form.html:5 templates/ingest/as/match.html:102
 #: templates/ingest/as/match.html:120
-#: templates/ingest/as/review_matches.html:30 templates/ingest/grid.html:165
+#: templates/ingest/as/review_matches.html:31 templates/ingest/grid.html:165
 msgid "Identifier"
 msgstr "Identificador"
 
@@ -2524,462 +2581,462 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: main/models.py:243
+#: main/models.py:245
 msgid "Part of AIC"
 msgstr ""
 
-#: main/models.py:244
+#: main/models.py:246
 msgid "Optional: leave blank if unsure"
 msgstr ""
 
-#: main/models.py:253
+#: main/models.py:255
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:263
+#: main/models.py:265
 msgid "Use ISO 639"
 msgstr ""
 
-#: main/models.py:281
+#: main/models.py:283
 msgid "Untitled"
 msgstr "Sin título"
 
-#: main/models.py:329
+#: main/models.py:336
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr ""
 
-#: main/models.py:371
+#: main/models.py:381
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr ""
 
-#: main/models.py:399
+#: main/models.py:409
 msgid "SIP"
 msgstr ""
 
-#: main/models.py:400
+#: main/models.py:410
 msgid "AIC"
 msgstr ""
 
-#: main/models.py:401
+#: main/models.py:411
 msgid "Reingested AIP"
 msgstr ""
 
-#: main/models.py:402
+#: main/models.py:412
 msgid "Reingested AIC"
 msgstr ""
 
-#: main/models.py:416
+#: main/models.py:426
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr ""
 
-#: main/models.py:529
+#: main/models.py:547
 msgid "Arranged SIPs"
 msgstr ""
 
-#: main/models.py:533
+#: main/models.py:551
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr ""
 
-#: main/models.py:578
+#: main/models.py:596
 msgid "Identifier Type"
 msgstr ""
 
-#: main/models.py:580
+#: main/models.py:598
 msgid "Identifier Value"
 msgstr ""
 
-#: main/models.py:582
+#: main/models.py:600
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
 msgstr ""
 
-#: main/models.py:645
+#: main/models.py:673
 #, python-format
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:681
+#: main/models.py:719
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:740
+#: main/models.py:783
 #, python-format
 msgid "%(file)s is %(format)s"
 msgstr ""
 
-#: main/models.py:758
+#: main/models.py:801
 msgid "(Unnamed)"
 msgstr ""
 
-#: main/models.py:780
+#: main/models.py:823
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: main/models.py:781
+#: main/models.py:824
 msgid "Awaiting decision"
 msgstr "Esperando decisión"
 
-#: main/models.py:782
+#: main/models.py:825
 msgid "Completed successfully"
 msgstr "Completado"
 
-#: main/models.py:783
+#: main/models.py:826
 msgid "Executing command(s)"
 msgstr "Ejecutando comando(s)"
 
-#: main/models.py:784
+#: main/models.py:827
 msgid "Failed"
 msgstr "Fallido"
 
-#: main/models.py:879
+#: main/models.py:924
 msgid "Agent Identifier Type"
 msgstr ""
 
-#: main/models.py:884
+#: main/models.py:929
 msgid "Agent Identifier Value"
 msgstr ""
 
-#: main/models.py:886
+#: main/models.py:931
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
 msgstr ""
 
-#: main/models.py:893
+#: main/models.py:938
 msgid "Agent Name"
 msgstr ""
 
-#: main/models.py:894
+#: main/models.py:939
 msgid "Used for premis:agentName in the METS file."
 msgstr ""
 
-#: main/models.py:900
+#: main/models.py:945
 msgid "Agent Type"
 msgstr ""
 
-#: main/models.py:901
+#: main/models.py:946
 msgid "Used for premis:agentType in the METS file."
 msgstr ""
 
-#: main/models.py:925
+#: main/models.py:970
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:927
+#: main/models.py:972
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:962 templates/rights/rights_edit.html:105
-#: templates/rights/rights_edit.html:157 templates/rights/rights_edit.html:207
-#: templates/rights/rights_edit.html:255
+#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
+#: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr "Valor"
 
-#: main/models.py:965
+#: main/models.py:1013
 msgid "Rights holder"
 msgstr "Titular de derechos"
 
-#: main/models.py:968
+#: main/models.py:1016
 msgid "Copyright"
 msgstr "Derechos de autor"
 
-#: main/models.py:969
+#: main/models.py:1017
 msgid "Statute"
 msgstr "Normativa"
 
-#: main/models.py:970
+#: main/models.py:1018
 msgid "License"
 msgstr "Licencia"
 
-#: main/models.py:971
+#: main/models.py:1019
 msgid "Donor"
 msgstr "Donador"
 
-#: main/models.py:972
+#: main/models.py:1020
 msgid "Policy"
 msgstr "Política"
 
-#: main/models.py:979 templates/rights/rights_list.html:34
+#: main/models.py:1027 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr "Fundamento"
 
-#: main/models.py:991
+#: main/models.py:1039
 msgid "Rights Statement"
 msgstr ""
 
-#: main/models.py:995
+#: main/models.py:1043
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr ""
 
-#: main/models.py:1008
+#: main/models.py:1058
 msgid "copyrighted"
 msgstr ""
 
-#: main/models.py:1009
+#: main/models.py:1059
 msgid "public domain"
 msgstr ""
 
-#: main/models.py:1010
+#: main/models.py:1060
 msgid "unknown"
 msgstr ""
 
-#: main/models.py:1015
+#: main/models.py:1065
 msgid "Copyright status"
 msgstr "Régimen de derechos de autor"
 
-#: main/models.py:1020
+#: main/models.py:1070
 msgid "Copyright jurisdiction"
 msgstr "Ley del estado aplicable"
 
-#: main/models.py:1026
+#: main/models.py:1076
 msgid "Copyright determination date"
 msgstr ""
 
-#: main/models.py:1027 main/models.py:1034 main/models.py:1041
-#: main/models.py:1105 main/models.py:1112 main/models.py:1172
-#: main/models.py:1179 main/models.py:1237 main/models.py:1246
-#: main/models.py:1253 main/models.py:1321 main/models.py:1328
+#: main/models.py:1077 main/models.py:1084 main/models.py:1091
+#: main/models.py:1161 main/models.py:1168 main/models.py:1234
+#: main/models.py:1241 main/models.py:1303 main/models.py:1312
+#: main/models.py:1319 main/models.py:1391 main/models.py:1398
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:1033
+#: main/models.py:1083
 msgid "Copyright start date"
 msgstr ""
 
-#: main/models.py:1040
+#: main/models.py:1090
 msgid "Copyright end date"
 msgstr ""
 
-#: main/models.py:1046 main/models.py:1117 main/models.py:1186
-#: main/models.py:1258 main/models.py:1333
+#: main/models.py:1096 main/models.py:1173 main/models.py:1248
+#: main/models.py:1324 main/models.py:1403
 msgid "Open End Date"
 msgstr ""
 
-#: main/models.py:1047 main/models.py:1118 main/models.py:1187
-#: main/models.py:1259 main/models.py:1334
+#: main/models.py:1097 main/models.py:1174 main/models.py:1249
+#: main/models.py:1325 main/models.py:1404
 msgid "Indicate end date is open"
 msgstr ""
 
-#: main/models.py:1052
+#: main/models.py:1102
 msgid "Rights: Copyright"
 msgstr ""
 
-#: main/models.py:1062
+#: main/models.py:1114
 msgid "Copyright document identification type"
 msgstr ""
 
-#: main/models.py:1066
+#: main/models.py:1118
 msgid "Copyright document identification value"
 msgstr ""
 
-#: main/models.py:1072
+#: main/models.py:1124
 msgid "Copyright document identification role"
 msgstr ""
 
-#: main/models.py:1077
+#: main/models.py:1129
 msgid "Rights: Copyright: Docs ID"
 msgstr ""
 
-#: main/models.py:1086 templates/rights/rights_edit.html:116
+#: main/models.py:1140 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr "Nota sobre los derechos de autor"
 
-#: main/models.py:1091
+#: main/models.py:1145
 msgid "Rights: Copyright: Note"
 msgstr ""
 
-#: main/models.py:1098
+#: main/models.py:1154
 msgid "License terms"
 msgstr "Términos de licencia"
 
-#: main/models.py:1104
+#: main/models.py:1160
 msgid "License start date"
 msgstr ""
 
-#: main/models.py:1111
+#: main/models.py:1167
 msgid "License end date"
 msgstr ""
 
-#: main/models.py:1123
+#: main/models.py:1179
 msgid "Rights: License"
 msgstr ""
 
-#: main/models.py:1133
+#: main/models.py:1191
 msgid "License documentation identification type"
 msgstr ""
 
-#: main/models.py:1137
+#: main/models.py:1195
 msgid "License documentation identification value"
 msgstr ""
 
-#: main/models.py:1143
+#: main/models.py:1201
 msgid "License document identification role"
 msgstr ""
 
-#: main/models.py:1148
+#: main/models.py:1206
 msgid "Rights: License: Docs ID"
 msgstr ""
 
-#: main/models.py:1157 templates/rights/rights_edit.html:218
+#: main/models.py:1217 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr "Nota sobre la licencia"
 
-#: main/models.py:1162
+#: main/models.py:1222
 msgid "Rights: License: Note"
 msgstr ""
 
-#: main/models.py:1171 templates/rights/rights_list.html:36
+#: main/models.py:1233 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr "Inicio"
 
-#: main/models.py:1178 templates/rights/rights_list.html:37
+#: main/models.py:1240 templates/rights/rights_list.html:37
 msgid "End"
 msgstr "Fin"
 
-#: main/models.py:1192
+#: main/models.py:1254
 msgid "Rights: Granted"
 msgstr ""
 
-#: main/models.py:1203
+#: main/models.py:1266
 msgid "Rights note"
 msgstr ""
 
-#: main/models.py:1208
+#: main/models.py:1271
 msgid "Rights: Granted: Note"
 msgstr ""
 
-#: main/models.py:1222
+#: main/models.py:1286
 msgid "Rights: Granted: Restriction"
 msgstr ""
 
-#: main/models.py:1229
+#: main/models.py:1295
 msgid "Statute jurisdiction"
 msgstr "Organismo que ha dictado la norma"
 
-#: main/models.py:1232
+#: main/models.py:1298
 msgid "Statute citation"
 msgstr "Cita de la normativa"
 
-#: main/models.py:1236
+#: main/models.py:1302
 msgid "Statute determination date"
 msgstr "Fecha de entrada en vigor"
 
-#: main/models.py:1245
+#: main/models.py:1311
 msgid "Statute start date"
 msgstr ""
 
-#: main/models.py:1252
+#: main/models.py:1318
 msgid "Statute end date"
 msgstr ""
 
-#: main/models.py:1264
+#: main/models.py:1330
 msgid "Rights: Statute"
 msgstr ""
 
-#: main/models.py:1274 templates/rights/rights_edit.html:168
+#: main/models.py:1341 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr "Nota sobre la normativa"
 
-#: main/models.py:1279
+#: main/models.py:1346
 msgid "Rights: Statute: Note"
 msgstr ""
 
-#: main/models.py:1290
+#: main/models.py:1358
 msgid "Statute document identification type"
 msgstr ""
 
-#: main/models.py:1294
+#: main/models.py:1362
 msgid "Statute document identification value"
 msgstr ""
 
-#: main/models.py:1300
+#: main/models.py:1368
 msgid "Statute document identification role"
 msgstr ""
 
-#: main/models.py:1305
+#: main/models.py:1373
 msgid "Rights: Statute: Docs ID"
 msgstr ""
 
-#: main/models.py:1313
+#: main/models.py:1383
 msgid "Other rights basis"
 msgstr ""
 
-#: main/models.py:1320
+#: main/models.py:1390
 msgid "Other rights start date"
 msgstr ""
 
-#: main/models.py:1327
+#: main/models.py:1397
 msgid "Other rights end date"
 msgstr ""
 
-#: main/models.py:1339
+#: main/models.py:1409
 msgid "Rights: Other"
 msgstr ""
 
-#: main/models.py:1350
+#: main/models.py:1421
 msgid "Other rights document identification type"
 msgstr ""
 
-#: main/models.py:1354
+#: main/models.py:1425
 msgid "Other right document identification value"
 msgstr ""
 
-#: main/models.py:1360
+#: main/models.py:1431
 msgid "Other rights document identification role"
 msgstr ""
 
-#: main/models.py:1365
+#: main/models.py:1436
 msgid "Rights: Other: Docs ID"
 msgstr ""
 
-#: main/models.py:1375
+#: main/models.py:1447
 msgid "Other rights note"
 msgstr ""
 
-#: main/models.py:1380
+#: main/models.py:1452
 msgid "Rights: Other: Note"
 msgstr ""
 
-#: main/models.py:1388
+#: main/models.py:1462
 msgid "Linking Agent"
 msgstr ""
 
-#: main/models.py:1393
+#: main/models.py:1467
 msgid "Linking Agent Value"
 msgstr ""
 
-#: main/models.py:1399
+#: main/models.py:1473
 msgid "Rights: Agent"
 msgstr ""
 
-#: main/models.py:1435
+#: main/models.py:1509
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr ""
 
-#: main/models.py:1473
+#: main/models.py:1547
 msgid "ASDIPObjectResourcePairing"
 msgstr ""
 
-#: main/models.py:1488
+#: main/models.py:1562
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr ""
 
-#: main/models.py:1495
+#: main/models.py:1569
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 
-#: main/models.py:1615
+#: main/models.py:1709
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr ""
@@ -2988,15 +3045,15 @@ msgstr ""
 msgid "<no API key generated>"
 msgstr ""
 
-#: main/views.py:302
+#: main/views.py:299
 msgid "Added."
 msgstr "Añadido."
 
-#: main/views.py:307
+#: main/views.py:304
 msgid "Error: no delete ID supplied."
 msgstr ""
 
-#: main/views.py:322
+#: main/views.py:319
 msgid "Incorrect type."
 msgstr "Tipo incorrecto."
 
@@ -3028,38 +3085,38 @@ msgstr ""
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:436
+#: settings/base.py:435
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
 msgstr ""
 
-#: settings/base.py:439
+#: settings/base.py:438
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
 "has been moved into storage."
 msgstr ""
 
-#: settings/base.py:441
+#: settings/base.py:440
 msgid "Create a SIP from the transfer."
 msgstr ""
 
-#: settings/base.py:443
+#: settings/base.py:442
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
 "start ingest micro-services."
 msgstr ""
 
-#: settings/base.py:446
+#: settings/base.py:445
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
 "system."
 msgstr ""
 
-#: settings/base.py:449
+#: settings/base.py:448
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -3068,13 +3125,13 @@ msgid ""
 "view the tool output and error message."
 msgstr ""
 
-#: settings/base.py:452
+#: settings/base.py:451
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
 msgstr ""
 
-#: settings/base.py:455
+#: settings/base.py:454
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3111,7 +3168,7 @@ msgid "Previous"
 msgstr "Previa"
 
 #: templates/_pager.html:35 templates/ingest/normalization_report.html:121
-#: templates/rights/rights_edit.html:287
+#: templates/rights/rights_edit.html:288
 msgid "Next"
 msgstr "Siguiente"
 
@@ -3145,8 +3202,8 @@ msgstr "Usuarios"
 msgid "Add new user"
 msgstr "Agregar nuevo usuario"
 
-#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:64
-#: templates/installer/welcome.html:49 templates/transfer/metadata_edit.html:63
+#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:65
+#: templates/installer/welcome.html:50 templates/transfer/metadata_edit.html:64
 msgid "Create"
 msgstr "Crear"
 
@@ -3158,12 +3215,6 @@ msgstr "Usuarios - Editar %(user)s"
 #: templates/accounts/list.html:23 templates/accounts/profile.html:29
 msgid "Username"
 msgstr "Nombre de usuario"
-
-#: templates/accounts/list.html:24 templates/accounts/profile.html:31
-#: templates/administration/atom_levels_of_description.html:36
-#: templates/administration/reports/failures.html:26
-msgid "Name"
-msgstr "Nombre"
 
 #: templates/accounts/list.html:25 templates/accounts/profile.html:33
 msgid "E-mail"
@@ -3226,14 +3277,12 @@ msgstr "Administrador"
 #: templates/administration/reports/failure_detail.html:6
 #: templates/administration/reports/failures.html:5
 #: templates/administration/reports/failures.html:6
-#: templates/administration/search.html:5
-#: templates/administration/search.html:6
 #: templates/administration/taxonomy.html:5
 #: templates/administration/taxonomy.html:6
 #: templates/administration/term_detail.html:5
 #: templates/administration/term_detail.html:6
 #: templates/administration/terms.html:5 templates/administration/terms.html:6
-#: templates/layout.html:66
+#: templates/layout.html:68
 msgid "Administration"
 msgstr "Administración"
 
@@ -3263,15 +3312,15 @@ msgstr ""
 msgid "AtoM Levels of Description"
 msgstr ""
 
-#: templates/administration/atom_levels_of_description.html:45
+#: templates/administration/atom_levels_of_description.html:46
 msgid "Promote"
 msgstr "Promover"
 
-#: templates/administration/atom_levels_of_description.html:46
+#: templates/administration/atom_levels_of_description.html:47
 msgid "Demote"
 msgstr "Degradar"
 
-#: templates/administration/atom_levels_of_description.html:54
+#: templates/administration/atom_levels_of_description.html:55
 msgid "No levels found."
 msgstr ""
 
@@ -3283,11 +3332,11 @@ msgstr ""
 msgid "Levels of Description"
 msgstr ""
 
-#: templates/administration/dips_atom_edit.html:37
+#: templates/administration/dips_atom_edit.html:38
 msgid "AtoM/Binder DIP upload"
 msgstr ""
 
-#: templates/administration/dips_atom_edit.html:39
+#: templates/administration/dips_atom_edit.html:40
 msgid "The settings below configure DIP uploading to AtoM/Binder."
 msgstr ""
 
@@ -3303,31 +3352,31 @@ msgstr ""
 msgid "General configuration"
 msgstr "Configuración general"
 
-#: templates/administration/general.html:39
+#: templates/administration/general.html:40
 msgid "Storage Service options"
 msgstr ""
 
-#: templates/administration/general.html:43
+#: templates/administration/general.html:44
 msgid "Checksum algorithm"
 msgstr ""
 
-#: templates/administration/general.html:47
+#: templates/administration/general.html:48
 msgid "Elasticsearch Indexing"
 msgstr ""
 
-#: templates/administration/general.html:52
+#: templates/administration/general.html:53
 msgid "Transfers related indexes enabled."
 msgstr ""
 
-#: templates/administration/general.html:54
+#: templates/administration/general.html:55
 msgid "Transfers related indexes disabled."
 msgstr ""
 
-#: templates/administration/general.html:59
+#: templates/administration/general.html:60
 msgid "AIPs related indexes enabled."
 msgstr ""
 
-#: templates/administration/general.html:61
+#: templates/administration/general.html:62
 msgid "AIPs related indexes disabled."
 msgstr ""
 
@@ -3444,22 +3493,6 @@ msgstr "Fecha"
 #: templates/administration/reports/failures.html:56
 msgid "No reports found."
 msgstr ""
-
-#: templates/administration/search.html:23
-msgid "Search administration"
-msgstr ""
-
-#: templates/administration/search.html:26
-#, python-format
-msgid ""
-"\n"
-"          %(count)s AIP files indexed.\n"
-"        "
-msgstr ""
-
-#: templates/administration/search.html:33
-msgid "Flush AIP Index"
-msgstr "Limpiar el índice de AIPs"
 
 #: templates/administration/sidebar.html:23
 msgid "General"
@@ -3587,11 +3620,6 @@ msgid ""
 "cleared manually."
 msgstr ""
 
-#: templates/administration/usage.html:90
-#: templates/archival_storage/view.html:67
-msgid "Size"
-msgstr "Tamaño"
-
 #: templates/administration/version.html:19
 msgid "About Archivematica"
 msgstr "Sobre Archivematica"
@@ -3601,12 +3629,12 @@ msgid "Agent code"
 msgstr "Código del agente"
 
 #: templates/appraisal/appraisal.html:4 templates/appraisal/appraisal.html:5
-#: templates/layout.html:58
+#: templates/layout.html:60
 msgid "Appraisal"
 msgstr "Evaluación"
 
 #: templates/appraisal/appraisal.html:30
-#: templates/archival_storage/archival_storage.html:70
+#: templates/archival_storage/archival_storage.html:74
 #: templates/backlog/backlog.html:34
 msgid "Elasticsearch Indexing Disabled"
 msgstr ""
@@ -3629,23 +3657,23 @@ msgstr ""
 
 #: templates/archival_storage/archival_storage.html:6
 #: templates/archival_storage/archival_storage.html:7
-#: templates/archival_storage/archival_storage.html:32
+#: templates/archival_storage/archival_storage.html:31
 #: templates/archival_storage/view.html:6
 #: templates/archival_storage/view.html:7
-#: templates/archival_storage/view.html:50 templates/layout.html:62
+#: templates/archival_storage/view.html:50 templates/layout.html:64
 msgid "Archival storage"
 msgstr "Almacén archivístico"
 
-#: templates/archival_storage/archival_storage.html:33
+#: templates/archival_storage/archival_storage.html:32
 #: templates/ingest/as/_search_form.html:6
 msgid "Search"
 msgstr "Búsqueda"
 
-#: templates/archival_storage/archival_storage.html:41
+#: templates/archival_storage/archival_storage.html:40
 msgid "Browse archival storage"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:44
+#: templates/archival_storage/archival_storage.html:43
 #, python-format
 msgid ""
 "\n"
@@ -3653,7 +3681,7 @@ msgid ""
 "          "
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:50
+#: templates/archival_storage/archival_storage.html:49
 #, python-format
 msgid ""
 "\n"
@@ -3661,17 +3689,29 @@ msgid ""
 "            "
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:61
+#: templates/archival_storage/archival_storage.html:60
 msgid "Create an AIC from current search results"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:62
+#: templates/archival_storage/archival_storage.html:61
 #, fuzzy
 #| msgid "Create SIP"
 msgid "Create an AIC"
 msgstr "Crear SIP"
 
-#: templates/archival_storage/archival_storage.html:71
+#: templates/archival_storage/archival_storage.html:65
+msgid ""
+"Download all results from archival storage as a CSV (Comma-separated-values) "
+"table"
+msgstr ""
+
+#: templates/archival_storage/archival_storage.html:66
+#, fuzzy
+#| msgid "Download"
+msgid "Download CSV"
+msgstr "Descargas"
+
+#: templates/archival_storage/archival_storage.html:75
 msgid ""
 "Sorry, Elasticsearch indexing has been disabled for the AIPs related indexes "
 "in this Archivematica installation. The archival storage tab is non-"
@@ -3685,19 +3725,6 @@ msgstr ""
 #: templates/archival_storage/view.html:71
 msgid "Date stored"
 msgstr ""
-
-#: templates/archival_storage/view.html:75
-msgid "Status"
-msgstr "Estado de elaboración"
-
-#: templates/archival_storage/view.html:79
-msgid "Encrypted"
-msgstr ""
-
-#: templates/archival_storage/view.html:83
-#: templates/ingest/normalization_report.html:31
-msgid "Location"
-msgstr "Localización"
 
 #: templates/archival_storage/view.html:90
 #, fuzzy
@@ -3750,7 +3777,7 @@ msgid ""
 "functional when indexing is turned off."
 msgstr ""
 
-#: templates/delete_request.html:14
+#: templates/delete_request.html:15
 msgid "Reason for deletion:"
 msgstr ""
 
@@ -3797,7 +3824,7 @@ msgstr ""
 #: templates/ingest/grid.html:5 templates/ingest/grid.html:6
 #: templates/ingest/metadata_add_files.html:31
 #: templates/ingest/metadata_edit.html:31
-#: templates/ingest/microservices.html:11 templates/layout.html:60
+#: templates/ingest/microservices.html:11 templates/layout.html:62
 #: templates/rights/rights_edit.html:16
 #: templates/rights/rights_grants_edit.html:16
 #: templates/rights/rights_list.html:9
@@ -3814,7 +3841,7 @@ msgstr "Inicializando..."
 #: templates/ingest/as/resource_component.html:52
 #: templates/ingest/as/resource_detail.html:42
 #: templates/ingest/as/resource_list.html:34
-#: templates/ingest/as/review_matches.html:29
+#: templates/ingest/as/review_matches.html:30
 msgid "Title"
 msgstr "Título"
 
@@ -3858,7 +3885,7 @@ msgstr ""
 #: templates/ingest/as/resource_detail.html:30
 #: templates/ingest/as/resource_list.html:25
 #: templates/ingest/as/resource_list.html:27
-#: templates/ingest/as/review_matches.html:20
+#: templates/ingest/as/review_matches.html:21
 msgid "Restart matching"
 msgstr ""
 
@@ -3884,7 +3911,7 @@ msgid "Resources"
 msgstr ""
 
 #: templates/ingest/as/match.html:100 templates/ingest/as/match.html:118
-#: templates/ingest/as/review_matches.html:28
+#: templates/ingest/as/review_matches.html:29
 msgid "Level"
 msgstr "Nivel"
 
@@ -3892,7 +3919,7 @@ msgstr "Nivel"
 #: templates/ingest/as/resource_component.html:53
 #: templates/ingest/as/resource_detail.html:43
 #: templates/ingest/as/resource_list.html:35
-#: templates/ingest/as/review_matches.html:31
+#: templates/ingest/as/review_matches.html:32
 msgid "Dates"
 msgstr "Fechas"
 
@@ -3901,7 +3928,7 @@ msgid "Pairs"
 msgstr ""
 
 #: templates/ingest/as/match.html:117
-#: templates/ingest/as/review_matches.html:27
+#: templates/ingest/as/review_matches.html:28
 msgid "File"
 msgstr "Unidad documental compuesta"
 
@@ -3940,7 +3967,7 @@ msgstr ""
 msgid "Collections"
 msgstr ""
 
-#: templates/ingest/as/review_matches.html:21
+#: templates/ingest/as/review_matches.html:22
 msgid "Finish matching"
 msgstr ""
 
@@ -4044,50 +4071,50 @@ msgstr ""
 msgid "Select a directory"
 msgstr "Seleccionar un directorio"
 
-#: templates/ingest/metadata_edit.html:77
-#: templates/transfer/metadata_edit.html:76
+#: templates/ingest/metadata_edit.html:78
+#: templates/transfer/metadata_edit.html:77
 msgid "A name given to the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:81
-#: templates/transfer/metadata_edit.html:80
+#: templates/ingest/metadata_edit.html:82
+#: templates/transfer/metadata_edit.html:81
 msgid "An entity primarily responsible for making the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:85
-#: templates/transfer/metadata_edit.html:84
+#: templates/ingest/metadata_edit.html:86
+#: templates/transfer/metadata_edit.html:85
 msgid "The topic of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:89
-#: templates/transfer/metadata_edit.html:88
+#: templates/ingest/metadata_edit.html:90
+#: templates/transfer/metadata_edit.html:89
 msgid "An account of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:93
-#: templates/transfer/metadata_edit.html:92
+#: templates/ingest/metadata_edit.html:94
+#: templates/transfer/metadata_edit.html:93
 msgid "An entity responsible for making the resource available."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:97
-#: templates/transfer/metadata_edit.html:96
+#: templates/ingest/metadata_edit.html:98
+#: templates/transfer/metadata_edit.html:97
 msgid "An entity responsible for making contributions to the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:101
-#: templates/transfer/metadata_edit.html:100
+#: templates/ingest/metadata_edit.html:102
+#: templates/transfer/metadata_edit.html:101
 msgid ""
 "A point or period of time associated with an event in the lifecycle of the "
 "resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:106
-#: templates/transfer/metadata_edit.html:105
+#: templates/ingest/metadata_edit.html:107
+#: templates/transfer/metadata_edit.html:106
 msgid "The nature or genre of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:108
-#: templates/transfer/metadata_edit.html:107
+#: templates/ingest/metadata_edit.html:109
+#: templates/transfer/metadata_edit.html:108
 msgid ""
 "\n"
 "        You may wish to use the DCMI type vocabulary provided here: <a href="
@@ -4096,13 +4123,13 @@ msgid ""
 "      "
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:116
-#: templates/transfer/metadata_edit.html:115
+#: templates/ingest/metadata_edit.html:117
+#: templates/transfer/metadata_edit.html:116
 msgid "The file format, physical medium, or dimensions of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:118
-#: templates/transfer/metadata_edit.html:117
+#: templates/ingest/metadata_edit.html:119
+#: templates/transfer/metadata_edit.html:118
 msgid ""
 "\n"
 "        Best practice is to use a controlled vocabulary such as the list of "
@@ -4112,35 +4139,35 @@ msgid ""
 "      "
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:125
-#: templates/transfer/metadata_edit.html:124
+#: templates/ingest/metadata_edit.html:126
+#: templates/transfer/metadata_edit.html:125
 msgid "An unambiguous reference to the resource within a given context."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:129
-#: templates/transfer/metadata_edit.html:128
+#: templates/ingest/metadata_edit.html:130
+#: templates/transfer/metadata_edit.html:129
 msgid "A related resource from which the described resource is derived."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:133
-#: templates/transfer/metadata_edit.html:132
+#: templates/ingest/metadata_edit.html:134
+#: templates/transfer/metadata_edit.html:133
 msgid "A related resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:137
-#: templates/transfer/metadata_edit.html:136
+#: templates/ingest/metadata_edit.html:138
+#: templates/transfer/metadata_edit.html:137
 msgid "A language of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:141
-#: templates/transfer/metadata_edit.html:140
+#: templates/ingest/metadata_edit.html:142
+#: templates/transfer/metadata_edit.html:141
 msgid ""
 "The spatial or temporal topic of the resource, the spatial applicability of "
 "the resource, or the jurisdiction under which the resource is relevant."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:145
-#: templates/transfer/metadata_edit.html:144
+#: templates/ingest/metadata_edit.html:146
+#: templates/transfer/metadata_edit.html:145
 msgid "Information about rights held in and over the resource."
 msgstr ""
 
@@ -4199,15 +4226,15 @@ msgid ""
 "    "
 msgstr ""
 
-#: templates/installer/storagesetup.html:25
+#: templates/installer/storagesetup.html:26
 msgid "Register this pipeline in the Storage Service"
 msgstr ""
 
-#: templates/installer/storagesetup.html:30
+#: templates/installer/storagesetup.html:31
 msgid "Dashboard UUID"
 msgstr ""
 
-#: templates/installer/storagesetup.html:39
+#: templates/installer/storagesetup.html:40
 msgid "Register"
 msgstr ""
 
@@ -4229,7 +4256,7 @@ msgstr ""
 msgid "Archivematica Dashboard"
 msgstr "Archivematica Dashboard"
 
-#: templates/layout.html:55 templates/rights/rights_edit.html:18
+#: templates/layout.html:57 templates/rights/rights_edit.html:18
 #: templates/rights/rights_grants_edit.html:18
 #: templates/rights/rights_list.html:11 templates/transfer/component.html:10
 #: templates/transfer/detail.html:9 templates/transfer/grid.html:5
@@ -4239,19 +4266,19 @@ msgstr "Archivematica Dashboard"
 msgid "Transfer"
 msgstr "Transferencia"
 
-#: templates/layout.html:57
+#: templates/layout.html:59
 msgid "Backlog"
 msgstr "Cola"
 
-#: templates/layout.html:64
+#: templates/layout.html:66
 msgid "Preservation planning"
 msgstr "Planificación de la preservación"
 
-#: templates/layout.html:74
+#: templates/layout.html:76
 msgid "Your profile"
 msgstr "Tu perfil"
 
-#: templates/layout.html:76
+#: templates/layout.html:78
 msgid "Log out"
 msgstr "cerrar sesión"
 
@@ -4360,28 +4387,28 @@ msgid ""
 "                "
 msgstr ""
 
-#: templates/rights/rights_edit.html:96
+#: templates/rights/rights_edit.html:97
 msgid "Copyright documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:109 templates/rights/rights_edit.html:161
-#: templates/rights/rights_edit.html:211 templates/rights/rights_edit.html:259
+#: templates/rights/rights_edit.html:110 templates/rights/rights_edit.html:162
+#: templates/rights/rights_edit.html:212 templates/rights/rights_edit.html:260
 msgid "Role"
 msgstr ""
 
-#: templates/rights/rights_edit.html:147
+#: templates/rights/rights_edit.html:148
 msgid "Statute documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:197
+#: templates/rights/rights_edit.html:198
 msgid "License documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:245
+#: templates/rights/rights_edit.html:246
 msgid "Documentation identifier"
 msgstr ""
 
-#: templates/rights/rights_edit.html:266
+#: templates/rights/rights_edit.html:267
 msgid "Note"
 msgstr "Notas"
 
@@ -4390,23 +4417,23 @@ msgid ""
 "You may now add additional information such as document identifers and notes."
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:79
+#: templates/rights/rights_grants_edit.html:80
 msgid "Allow"
 msgstr "Permitir"
 
-#: templates/rights/rights_grants_edit.html:80
+#: templates/rights/rights_grants_edit.html:81
 msgid "Disallow"
 msgstr "No permitir"
 
-#: templates/rights/rights_grants_edit.html:81
+#: templates/rights/rights_grants_edit.html:82
 msgid "Conditional"
 msgstr "Condicional"
 
-#: templates/rights/rights_grants_edit.html:87
+#: templates/rights/rights_grants_edit.html:88
 msgid "Grant/restriction note"
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:108
+#: templates/rights/rights_grants_edit.html:109
 msgid "Done"
 msgstr "Hecho"
 
@@ -4437,6 +4464,9 @@ msgstr "Metadatos de transferencia"
 #: templates/transfer/grid.html:86
 msgid "Transfer start time"
 msgstr "Fecha de inicio"
+
+#~ msgid "Flush AIP Index"
+#~ msgstr "Limpiar el índice de AIPs"
 
 #~ msgid "Invalid syntax."
 #~ msgstr "Sintaxis incorrecta."

--- a/src/dashboard/src/locale/es/LC_MESSAGES/djangojs.po
+++ b/src/dashboard/src/locale/es/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 12:27-0400\n"
+"POT-Creation-Date: 2020-07-27 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: María Jesús Colmenero <mjcolmenero@gmail.com>, 2018\n"
 "Language-Team: Spanish (https://www.transifex.com/artefactual/teams/1506/"
@@ -28,7 +28,7 @@ msgid "Are you sure you want to delete this level of description?"
 msgstr ""
 
 #: media/js/advanced-search-query-creator.js:14 media/js/file_browser.js:59
-#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:209
+#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:211
 msgid "Delete"
 msgstr "Eliminar"
 
@@ -47,7 +47,7 @@ msgid "Any"
 msgstr ""
 
 #: media/js/archival_storage/archival_storage_search.js:61
-#: media/js/archival_storage/archival_storage_search.js:238
+#: media/js/archival_storage/archival_storage_search.js:242
 msgid "File UUID"
 msgstr ""
 
@@ -106,223 +106,229 @@ msgstr "Frase"
 msgid "Date range"
 msgstr "Rango de fechas"
 
-#: media/js/archival_storage/archival_storage_search.js:148
+#: media/js/archival_storage/archival_storage_search.js:152
 msgid "view raw"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:169
+#: media/js/archival_storage/archival_storage_search.js:173
 #: media/js/backlog/backlog-search.js:6 media/js/backlog/backlog-search.js:12
 msgid "Download"
 msgstr "Descargas"
 
-#: media/js/archival_storage/archival_storage_search.js:184
+#: media/js/archival_storage/archival_storage_search.js:188
 msgid "AIPs in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:185
+#: media/js/archival_storage/archival_storage_search.js:189
 msgid "AIP in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:188
+#: media/js/archival_storage/archival_storage_search.js:192
 msgid "Part of"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:190
+#: media/js/archival_storage/archival_storage_search.js:194
 msgid "None"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:197
+#: media/js/archival_storage/archival_storage_search.js:201
 msgid "View"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "True"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "False"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 msgid "Deletion requested"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 #: media/js/backlog/backlog-search.js:19
 msgid "Stored"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:236
+#: media/js/archival_storage/archival_storage_search.js:240
 msgid "Thumbnail"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:237
+#: media/js/archival_storage/archival_storage_search.js:241
 #, fuzzy
 #| msgid "Filename"
 msgid "File"
 msgstr "Nombre del archivo"
 
-#: media/js/archival_storage/archival_storage_search.js:239
+#: media/js/archival_storage/archival_storage_search.js:243
 msgid "AIP"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:240
+#: media/js/archival_storage/archival_storage_search.js:244
 #: media/js/backlog/backlog-search.js:42 media/js/backlog/backlog-search.js:53
 #: media/js/ingest/backlog.js:37
 msgid "Accession number"
 msgstr "Número de acceso"
 
-#: media/js/archival_storage/archival_storage_search.js:241
-#: media/js/archival_storage/archival_storage_search.js:254
+#: media/js/archival_storage/archival_storage_search.js:245
+#: media/js/archival_storage/archival_storage_search.js:258
 #: media/js/backlog/backlog-search.js:43 media/js/backlog/backlog-search.js:55
 msgid "Status"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:242
-#: media/js/archival_storage/archival_storage_search.js:256
+#: media/js/archival_storage/archival_storage_search.js:246
+#: media/js/archival_storage/archival_storage_search.js:261
 #: media/js/backlog/backlog-search.js:44 media/js/backlog/backlog-search.js:56
-#: media/js/ingest.js:216 media/js/transfer.js:153
+#: media/js/ingest.js:217 media/js/transfer.js:154
 msgid "Actions"
 msgstr "Acciones"
 
-#: media/js/archival_storage/archival_storage_search.js:247
+#: media/js/archival_storage/archival_storage_search.js:251
 #: media/js/backlog/backlog-search.js:49
 msgid "Name"
 msgstr "Nombre"
 
-#: media/js/archival_storage/archival_storage_search.js:248
+#: media/js/archival_storage/archival_storage_search.js:252
 #, fuzzy
 #| msgid "AIP UUID"
 msgid "UUID"
 msgstr "AIP UUID"
 
-#: media/js/archival_storage/archival_storage_search.js:249
+#: media/js/archival_storage/archival_storage_search.js:253
 msgid "AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:250
+#: media/js/archival_storage/archival_storage_search.js:254
 #: media/js/backlog/backlog-search.js:51
 msgid "Size"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:251
+#: media/js/archival_storage/archival_storage_search.js:255
 #: media/js/backlog/backlog-search.js:52
 msgid "File count"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:252
+#: media/js/archival_storage/archival_storage_search.js:256
 #, fuzzy
 #| msgid "Accession number"
 msgid "Accession numbers"
 msgstr "Número de acceso"
 
-#: media/js/archival_storage/archival_storage_search.js:253
+#: media/js/archival_storage/archival_storage_search.js:257
 #, fuzzy
 #| msgid "Create SIP"
 msgid "Created"
 msgstr "Crear SIP"
 
-#: media/js/archival_storage/archival_storage_search.js:255
+#: media/js/archival_storage/archival_storage_search.js:259
 msgid "Encrypted"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:309
-#: media/js/backlog/backlog-search.js:109
+#: media/js/archival_storage/archival_storage_search.js:260
+#, fuzzy
+#| msgid "Actions"
+msgid "Location"
+msgstr "Acciones"
+
+#: media/js/archival_storage/archival_storage_search.js:315
+#: media/js/backlog/backlog-search.js:110
 msgid "Select columns"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:313
-#: media/js/backlog/backlog-search.js:113
+#: media/js/archival_storage/archival_storage_search.js:319
+#: media/js/backlog/backlog-search.js:114
 msgctxt "DataTable - sEmptyTable"
 msgid "No data available in table"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:314
-#: media/js/backlog/backlog-search.js:114
+#: media/js/archival_storage/archival_storage_search.js:320
+#: media/js/backlog/backlog-search.js:115
 msgctxt "DataTable - sInfo"
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:315
-#: media/js/backlog/backlog-search.js:115
+#: media/js/archival_storage/archival_storage_search.js:321
+#: media/js/backlog/backlog-search.js:116
 msgctxt "DataTable - sInfoEmpty"
 msgid "Showing 0 to 0 of 0 entries"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:316
-#: media/js/backlog/backlog-search.js:116
+#: media/js/archival_storage/archival_storage_search.js:322
+#: media/js/backlog/backlog-search.js:117
 msgctxt "DataTable - sInfoFiltered"
 msgid "(filtered from _MAX_ total entries)"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:318
-#: media/js/backlog/backlog-search.js:118
+#: media/js/archival_storage/archival_storage_search.js:324
+#: media/js/backlog/backlog-search.js:119
 msgctxt "DataTable - sInfoThousands"
 msgid ","
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:319
-#: media/js/backlog/backlog-search.js:119
+#: media/js/archival_storage/archival_storage_search.js:325
+#: media/js/backlog/backlog-search.js:120
 msgctxt "DataTable - sLengthMenu"
 msgid "Show _MENU_ entries"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:320
-#: media/js/backlog/backlog-search.js:120
+#: media/js/archival_storage/archival_storage_search.js:326
+#: media/js/backlog/backlog-search.js:121
 msgctxt "DataTable - sLoadingRecords"
 msgid "Loading..."
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:321
-#: media/js/backlog/backlog-search.js:121
+#: media/js/archival_storage/archival_storage_search.js:327
+#: media/js/backlog/backlog-search.js:122
 msgctxt "DataTable - sProcessing"
 msgid "Processing..."
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:322
-#: media/js/backlog/backlog-search.js:122
+#: media/js/archival_storage/archival_storage_search.js:328
+#: media/js/backlog/backlog-search.js:123
 msgctxt "DataTable - sSearch"
 msgid "Search:"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:323
-#: media/js/backlog/backlog-search.js:123
+#: media/js/archival_storage/archival_storage_search.js:329
+#: media/js/backlog/backlog-search.js:124
 msgctxt "DataTable - sZeroRecords"
 msgid "No matching records found"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:325
-#: media/js/backlog/backlog-search.js:125
+#: media/js/archival_storage/archival_storage_search.js:331
+#: media/js/backlog/backlog-search.js:126
 msgctxt "DataTable - sFirst"
 msgid "First"
 msgstr "Primera"
 
-#: media/js/archival_storage/archival_storage_search.js:326
-#: media/js/backlog/backlog-search.js:126
+#: media/js/archival_storage/archival_storage_search.js:332
+#: media/js/backlog/backlog-search.js:127
 msgctxt "DataTable - sLast"
 msgid "Last"
 msgstr "Última"
 
-#: media/js/archival_storage/archival_storage_search.js:327
-#: media/js/backlog/backlog-search.js:127
+#: media/js/archival_storage/archival_storage_search.js:333
+#: media/js/backlog/backlog-search.js:128
 msgctxt "DataTable - sNext"
 msgid "Next"
 msgstr "Siguiente"
 
-#: media/js/archival_storage/archival_storage_search.js:328
-#: media/js/backlog/backlog-search.js:128
+#: media/js/archival_storage/archival_storage_search.js:334
+#: media/js/backlog/backlog-search.js:129
 msgctxt "DataTable - sPrevious"
 msgid "Previous"
 msgstr "Previa"
 
-#: media/js/archival_storage/archival_storage_search.js:331
-#: media/js/backlog/backlog-search.js:131
+#: media/js/archival_storage/archival_storage_search.js:337
+#: media/js/backlog/backlog-search.js:132
 msgctxt "DataTable - sSortAscending"
 msgid ": activate to sort column ascending"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:332
-#: media/js/backlog/backlog-search.js:132
+#: media/js/archival_storage/archival_storage_search.js:338
+#: media/js/backlog/backlog-search.js:133
 msgctxt "DataTable - sSortDescending"
 msgid ": activate to sort column descending"
 msgstr ""
@@ -362,7 +368,7 @@ msgid "Yes"
 msgstr "Sí"
 
 #: media/js/directory_picker.js:90 media/js/file_browser.js:178
-#: media/js/ingest.js:123 media/js/jobs.js:590 media/js/jobs.js:683
+#: media/js/ingest.js:124 media/js/jobs.js:590 media/js/jobs.js:686
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -410,43 +416,43 @@ msgstr ""
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: media/js/ingest.js:145
+#: media/js/ingest.js:146
 msgid "Dublin Core metadata editor"
 msgstr ""
 
-#: media/js/ingest.js:152 media/js/jobs.js:535
+#: media/js/ingest.js:153 media/js/jobs.js:535
 msgid "Close"
 msgstr "Cerrar"
 
-#: media/js/ingest.js:173
+#: media/js/ingest.js:174
 msgid "Error"
 msgstr "Error"
 
-#: media/js/ingest.js:240
+#: media/js/ingest.js:241
 msgid "Report"
 msgstr ""
 
-#: media/js/ingest.js:243
+#: media/js/ingest.js:244
 msgid "Match DIP objects to resources"
 msgstr ""
 
-#: media/js/ingest.js:301
+#: media/js/ingest.js:303
 msgid "Loading..."
 msgstr ""
 
-#: media/js/ingest/as_matcher.js:551
+#: media/js/ingest/as_matcher.js:553
 msgid "No resource selected."
 msgstr ""
 
-#: media/js/ingest/as_matcher.js:558
+#: media/js/ingest/as_matcher.js:560
 msgid "No objects selected."
 msgstr ""
 
-#: media/js/ingest/as_matcher.js:670
+#: media/js/ingest/as_matcher.js:673
 msgid "Warning"
 msgstr ""
 
-#: media/js/ingest/as_matcher.js:674
+#: media/js/ingest/as_matcher.js:677
 msgid "Dismiss"
 msgstr ""
 
@@ -458,15 +464,15 @@ msgstr "Nombre de fichero"
 msgid "Ingest date (YYYY-MM-DD)"
 msgstr ""
 
-#: media/js/ingest/metadata_form.js:83
+#: media/js/ingest/metadata_form.js:84
 msgid "Browse"
 msgstr "Navegar"
 
-#: media/js/ingest/metadata_form.js:85
+#: media/js/ingest/metadata_form.js:86
 msgid "Add files"
 msgstr ""
 
-#: media/js/ingest/metadata_form.js:124
+#: media/js/ingest/metadata_form.js:125
 msgid "Please select at least one metadata file."
 msgstr ""
 
@@ -493,34 +499,34 @@ msgstr ""
 msgid "Remove All Completed %ss"
 msgstr ""
 
-#: media/js/jobs.js:661
+#: media/js/jobs.js:664
 #, javascript-format
 msgid "There were no completed %ss to remove"
 msgstr ""
 
-#: media/js/jobs.js:665
+#: media/js/jobs.js:668
 #, javascript-format
 msgid "Successfully removed the following %ss: %s"
 msgstr ""
 
-#: media/js/jobs.js:671
+#: media/js/jobs.js:674
 #, javascript-format
 msgid "Failed to remove all completed %ss"
 msgstr ""
 
-#: media/js/jobs.js:797
+#: media/js/jobs.js:800
 msgid "Previous"
 msgstr "Previa"
 
-#: media/js/jobs.js:812
+#: media/js/jobs.js:815
 msgid "Next"
 msgstr "Siguiente"
 
-#: media/js/jobs.js:850
+#: media/js/jobs.js:853
 msgid "Error trying to connect to database. Trying again..."
 msgstr ""
 
-#: media/js/jobs.js:900
+#: media/js/jobs.js:903
 msgid "Error trying to connect to MCP server. Trying again..."
 msgstr ""
 
@@ -536,7 +542,7 @@ msgstr ""
 msgid "Disconnected"
 msgstr ""
 
-#: media/js/repeating-ajax-data.js:215
+#: media/js/repeating-ajax-data.js:217
 msgid "Are you sure?"
 msgstr "¿Estás seguro?"
 

--- a/src/dashboard/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 11:52-0400\n"
+"POT-Creation-Date: 2020-07-27 22:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Nicolas Bednarz <nicolas.bednarz@ville.montreal.qc.ca>, "
 "2017\n"
@@ -20,12 +20,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: components/accounts/views.py:62 components/accounts/views.py:150
-#: components/administration/views.py:459
-#: components/administration/views.py:474
-#: components/administration/views.py:486
-#: components/administration/views.py:513
-#: components/administration/views.py:564
+#: components/accounts/views.py:61 components/accounts/views.py:149
+#: components/administration/views.py:454
+#: components/administration/views.py:469
+#: components/administration/views.py:481
+#: components/administration/views.py:508
+#: components/administration/views.py:555
 #: components/administration/views_dip_upload.py:25
 #: components/administration/views_dip_upload.py:39 fpr/views.py:106
 #: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
@@ -34,7 +34,7 @@ msgstr ""
 msgid "Saved."
 msgstr "Sauvé."
 
-#: components/accounts/views.py:82
+#: components/accounts/views.py:81
 #, python-format
 msgid "Your profile (%s)"
 msgstr "Votre profil (%s)"
@@ -393,7 +393,7 @@ msgstr "Intégrer"
 msgid "New"
 msgstr "Nouveau"
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:973
+#: components/administration/forms_dip_upload.py:21 main/models.py:1021
 msgid "Other"
 msgstr "Autre"
 
@@ -589,32 +589,32 @@ msgid "Used in metadata-only DIP upload."
 msgstr ""
 "Utilisé lors d'un téléchargement DIP contenant uniquement des métadonnées."
 
-#: components/administration/views.py:92 components/administration/views.py:125
-#: components/ingest/views.py:293 fpr/views.py:261 main/views.py:310
+#: components/administration/views.py:89 components/administration/views.py:122
+#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
 msgid "Deleted."
 msgstr "Supprimé."
 
-#: components/administration/views.py:109
+#: components/administration/views.py:106
 msgid "Promoted."
 msgstr "Promu."
 
-#: components/administration/views.py:112
+#: components/administration/views.py:109
 msgid "Error attempting to promote level of description."
 msgstr ""
 
-#: components/administration/views.py:116
+#: components/administration/views.py:113
 msgid "Demoted."
 msgstr "Rétrogradé."
 
-#: components/administration/views.py:119
+#: components/administration/views.py:116
 msgid "Error attempting to demote level of description."
 msgstr ""
 
-#: components/administration/views.py:127
+#: components/administration/views.py:124
 msgid "Level of description not found."
 msgstr "Niveau de description introuvable."
 
-#: components/administration/views.py:193
+#: components/administration/views.py:190
 msgid ""
 "Error retrieving locations: is the storage server running? Please contact an "
 "administrator."
@@ -622,69 +622,69 @@ msgstr ""
 "Erreur lors de la récupération des localisations : est-ce que le Service de "
 "stockage fonctionne? Veuillez contacter votre administrateur."
 
-#: components/administration/views.py:202
+#: components/administration/views.py:199
 #, fuzzy
 #| msgid "AIP storage locations"
 msgid "AIP Storage"
 msgstr "Emplacements de stockage d’AIP"
 
-#: components/administration/views.py:203
+#: components/administration/views.py:200
 msgid "DIP Storage"
 msgstr ""
 
-#: components/administration/views.py:204
+#: components/administration/views.py:201
 msgid "FEDORA Deposits"
 msgstr ""
 
-#: components/administration/views.py:205
+#: components/administration/views.py:202
 #, fuzzy
 #| msgid "Search transfer backlog"
 msgid "Transfer Backlog"
 msgstr "Chercher dans le backlog des transferts"
 
-#: components/administration/views.py:206
+#: components/administration/views.py:203
 #, fuzzy
 #| msgid "Transfer source locations"
 msgid "Transfer Source"
 msgstr "Emplacement du transfert source"
 
-#: components/administration/views.py:207
+#: components/administration/views.py:204
 msgid "Replicator"
 msgstr ""
 
-#: components/administration/views.py:224
+#: components/administration/views.py:221
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:407
+#: components/administration/views.py:404
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:410
+#: components/administration/views.py:406
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr "Effacer"
 
-#: components/administration/views.py:436
+#: components/administration/views.py:431
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:439
+#: components/administration/views.py:434
 #, fuzzy, python-format
 #| msgid "No files or directories found under path: %(path)s"
 msgid "No such file or directory: %(path)s"
 msgstr "Aucun fichier ou répertoire trouvé pour le chemin d'accès : %(path)s"
 
-#: components/administration/views.py:580
+#: components/administration/views.py:571
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
 "Storage Sevice URL below.<hr />%(error)s"
 msgstr ""
 
-#: components/administration/views.py:597
+#: components/administration/views.py:588
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -692,7 +692,7 @@ msgid ""
 "%(error)s"
 msgstr ""
 
-#: components/administration/views.py:609
+#: components/administration/views.py:600
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -761,6 +761,7 @@ msgid "Please type in the UUID to confirm"
 msgstr "Encoder l'UUID pour confirmer"
 
 #: components/archival_storage/forms.py:89
+#: components/archival_storage/views.py:210
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -790,25 +791,88 @@ msgstr "L'UUID doit être définie"
 msgid "UUID mismatch"
 msgstr "Disparité d'UUID"
 
-#: components/archival_storage/views.py:49
+#: components/archival_storage/views.py:54
 msgid "Stored"
 msgstr "Stocké"
 
-#: components/archival_storage/views.py:50
+#: components/archival_storage/views.py:55
 msgid "Deletion requested"
 msgstr "Suppression demandée"
 
-#: components/archival_storage/views.py:464
+#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: templates/accounts/profile.html:31
+#: templates/administration/atom_levels_of_description.html:37
+#: templates/administration/reports/failures.html:26
+msgid "Name"
+msgstr "Nom"
+
+#: components/archival_storage/views.py:211
+msgid "AICID"
+msgstr ""
+
+#: components/archival_storage/views.py:212
+msgid "Count AIPs in AIC"
+msgstr ""
+
+#: components/archival_storage/views.py:213
+#: templates/administration/usage.html:90
+#: templates/archival_storage/view.html:67
+msgid "Size"
+msgstr "Taille"
+
+#: components/archival_storage/views.py:214
+#, fuzzy
+#| msgid "Failure report"
+msgid "File count"
+msgstr "Rapport d'échec"
+
+#: components/archival_storage/views.py:215
+#, fuzzy
+#| msgid "Access"
+msgid "Accession IDs"
+msgstr "Accès"
+
+#: components/archival_storage/views.py:216
+#, fuzzy
+#| msgid "Create SIP"
+msgid "Created date (UTC)"
+msgstr "Créer un SIP "
+
+#: components/archival_storage/views.py:217
+#: templates/archival_storage/view.html:75
+msgid "Status"
+msgstr "Statut"
+
+#: components/archival_storage/views.py:218
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: templates/administration/reports/failures.html:25
+#: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
+#: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
+msgid "Type"
+msgstr "Type"
+
+#: components/archival_storage/views.py:219
+#: templates/archival_storage/view.html:79
+msgid "Encrypted"
+msgstr ""
+
+#: components/archival_storage/views.py:220
+#: templates/archival_storage/view.html:83
+#: templates/ingest/normalization_report.html:31
+msgid "Location"
+msgstr "Emplacement"
+
+#: components/archival_storage/views.py:600
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:593
+#: components/archival_storage/views.py:729
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 "Le téléchargement DIP contenant uniquement des métadonnées a échoué, "
 "consulter les journaux pour plus de détails."
 
-#: components/archival_storage/views.py:605
+#: components/archival_storage/views.py:741
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
@@ -817,12 +881,12 @@ msgstr ""
 "Le téléchargement DIP contenant uniquement des métadonnées a été complété "
 "avec succès. Identifiant (slug) de la nouvelle ressource : %(slug)s"
 
-#: components/archival_storage/views.py:628
+#: components/archival_storage/views.py:764
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr "Erreur lors de la réacquisition du paquet : %(message)s"
 
-#: components/backlog/views.py:291
+#: components/backlog/views.py:282
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 "Incapable d'établir la connexion avec le Service de stockage. Veuillez "
@@ -980,7 +1044,7 @@ msgstr "Paramètres d'authentification d'AtoM non définis !"
 msgid "Unable to fetch levels of description from AtoM!"
 msgstr "Incapable de récupérer les niveaux de description venant d'AtoM!"
 
-#: components/ingest/views.py:87
+#: components/ingest/views.py:86
 msgid ""
 "Error retrieving originals/arrange directory locations: is the storage "
 "server running? Please contact an administrator."
@@ -989,7 +1053,7 @@ msgstr ""
 "répertoires originaux/classer : est-ce que le Service de stockage "
 "fonctionne? Veuillez contacter votre administrateur."
 
-#: components/ingest/views.py:182
+#: components/ingest/views.py:181
 msgid ""
 "Error retrieving source directories: is the storage server running? Please "
 "contact an administrator."
@@ -997,30 +1061,30 @@ msgstr ""
 "Erreur lors de la récupération des répertoires source : est-ce que le "
 "Service de stockage fonctionne? Veuillez contacter votre administrateur."
 
-#: components/ingest/views.py:191
+#: components/ingest/views.py:190
 msgid ""
 "No transfer source locations are available. Please contact an administrator."
 msgstr ""
 "Aucun emplacement de transfert source n'est disponible. Veuillez contacter "
 "votre administrateur."
 
-#: components/ingest/views.py:283
+#: components/ingest/views.py:278
 msgid "Are you sure you want to delete this metadata?"
 msgstr "Êtes-vous sûr de vouloir supprimer ces métadonnées?"
 
-#: components/ingest/views.py:418
+#: components/ingest/views.py:412
 msgid "Review normalization"
 msgstr "Examiner la normalisation"
 
-#: components/ingest/views.py:421
+#: components/ingest/views.py:415
 msgid "Review AIP"
 msgstr "Examiner l'AIP"
 
-#: components/ingest/views.py:424
+#: components/ingest/views.py:418
 msgid "Review DIP"
 msgstr "Examiner le DIP"
 
-#: components/ingest/views_as.py:327
+#: components/ingest/views_as.py:325
 msgid "Operation failed, please try again later or contact your administrator."
 msgstr ""
 
@@ -1153,20 +1217,20 @@ msgid ""
 msgstr ""
 "Date à laquelle la licence prend fin ou cesse de s’appliquer au contenu."
 
-#: components/rights/views.py:277 components/rights/views.py:311
+#: components/rights/views.py:272 components/rights/views.py:306
 msgid "copyright"
 msgstr "droit d'auteur"
 
-#: components/rights/views.py:345 components/rights/views.py:379
+#: components/rights/views.py:340 components/rights/views.py:374
 msgid "license"
 msgstr "licence"
 
-#: components/rights/views.py:391 components/rights/views.py:426
-#: components/rights/views.py:466 components/rights/views.py:497
+#: components/rights/views.py:386 components/rights/views.py:421
+#: components/rights/views.py:461 components/rights/views.py:492
 msgid "statute"
 msgstr "réglementation"
 
-#: components/rights/views.py:483
+#: components/rights/views.py:478
 msgid "statue"
 msgstr ""
 
@@ -1174,11 +1238,11 @@ msgstr ""
 msgid "Error retrieving source directories"
 msgstr "Erreur lors de la récupération des répertoires sources"
 
-#: components/transfer/views.py:210
+#: components/transfer/views.py:208
 msgid "Updated path was not provided."
 msgstr ""
 
-#: components/transfer/views.py:212
+#: components/transfer/views.py:210
 #, fuzzy
 #| msgid ""
 #| "Unable to connect to storage server. Please contact your administrator."
@@ -1218,466 +1282,466 @@ msgstr ""
 msgid "the related model"
 msgstr ""
 
-#: fpr/models.py:51 fpr/models.py:362 fpr/models.py:560 fpr/models.py:603
-#: fpr/models.py:643 fpr/models.py:659 fpr/models.py:677 fpr/models.py:705
-#: fpr/models.py:730 fpr/models.py:749 fpr/models.py:770
+#: fpr/models.py:52 fpr/models.py:378 fpr/models.py:586 fpr/models.py:629
+#: fpr/models.py:669 fpr/models.py:685 fpr/models.py:703 fpr/models.py:731
+#: fpr/models.py:757 fpr/models.py:776 fpr/models.py:797
 msgid "enabled"
 msgstr ""
 
-#: fpr/models.py:52 fpr/models.py:601 fpr/models.py:640 fpr/models.py:657
-#: fpr/models.py:675 fpr/models.py:703 fpr/models.py:728 fpr/models.py:747
-#: fpr/models.py:768
+#: fpr/models.py:53 fpr/models.py:627 fpr/models.py:666 fpr/models.py:683
+#: fpr/models.py:701 fpr/models.py:729 fpr/models.py:755 fpr/models.py:774
+#: fpr/models.py:795
 msgid "last modified"
 msgstr ""
 
-#: fpr/models.py:141 fpr/models.py:165 fpr/models.py:182 fpr/models.py:251
-#: fpr/models.py:306 fpr/models.py:356 fpr/models.py:388 fpr/models.py:484
-#: fpr/models.py:554
+#: fpr/models.py:142 fpr/models.py:170 fpr/models.py:187 fpr/models.py:257
+#: fpr/models.py:316 fpr/models.py:372 fpr/models.py:404 fpr/models.py:506
+#: fpr/models.py:580
 #, fuzzy
 #| msgid "Identifier"
 msgid "Unique identifier"
 msgstr "Identifiant"
 
-#: fpr/models.py:144 fpr/models.py:167 fpr/models.py:194 fpr/models.py:254
-#: fpr/models.py:359 fpr/models.py:494 fpr/models.py:557 fpr/models.py:631
-#: fpr/models.py:652 fpr/models.py:671 fpr/models.py:686
+#: fpr/models.py:145 fpr/models.py:172 fpr/models.py:200 fpr/models.py:260
+#: fpr/models.py:375 fpr/models.py:517 fpr/models.py:583 fpr/models.py:657
+#: fpr/models.py:678 fpr/models.py:697 fpr/models.py:712
 #, fuzzy
 #| msgid "Description"
 msgid "description"
 msgstr "Description"
 
-#: fpr/models.py:144
+#: fpr/models.py:145
 msgid "Common name of format"
 msgstr ""
 
-#: fpr/models.py:147
+#: fpr/models.py:151
 msgid "the related group"
 msgstr ""
 
-#: fpr/models.py:149 fpr/models.py:168 fpr/models.py:364 fpr/models.py:561
+#: fpr/models.py:154 fpr/models.py:173 fpr/models.py:380 fpr/models.py:587
 msgid "slug"
 msgstr ""
 
-#: fpr/models.py:154 fpr/templates/fpr/format/version/detail.html:31
+#: fpr/models.py:159 fpr/templates/fpr/format/version/detail.html:31
 #: fpr/templates/fpr/fprule/detail.html:30
 #: fpr/templates/fpr/fprule/list.html:30 fpr/templates/fpr/idrule/list.html:28
 #: templates/ingest/normalization_report.html:32
 msgid "Format"
 msgstr "Format"
 
-#: fpr/models.py:171
+#: fpr/models.py:176
 #, fuzzy
 #| msgid "Format"
 msgid "Format group"
 msgstr "Format"
 
-#: fpr/models.py:189 fpr/models.py:312 fpr/models.py:444 fpr/models.py:713
+#: fpr/models.py:194 fpr/models.py:327 fpr/models.py:465 fpr/models.py:739
 #, fuzzy
 #| msgid "File format"
 msgid "the related format"
 msgstr "Format de fichier"
 
-#: fpr/models.py:191 fpr/models.py:361 fpr/models.py:559
+#: fpr/models.py:197 fpr/models.py:377 fpr/models.py:585
 #, fuzzy
 #| msgid "Version"
 msgid "version"
 msgstr "Version"
 
-#: fpr/models.py:192
+#: fpr/models.py:198
 msgid "pronom id"
 msgstr ""
 
-#: fpr/models.py:198
+#: fpr/models.py:204
 msgid "Formal name to go in the METS file."
 msgstr ""
 
-#: fpr/models.py:200
+#: fpr/models.py:206
 #, fuzzy
 #| msgid "Already in access format"
 msgid "access format"
 msgstr "Déjà dans un format d'accès"
 
-#: fpr/models.py:201
+#: fpr/models.py:207
 #, fuzzy
 #| msgid "Already in preservation format"
 msgid "preservation format"
 msgstr "Déjà dans un format de préservation"
 
-#: fpr/models.py:208 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
 #, fuzzy
 #| msgid "Format"
 msgid "Format version"
 msgstr "Format"
 
-#: fpr/models.py:227
+#: fpr/models.py:233
 msgid ""
 "Unable to save, an active Format Version  with this pronom id already exists."
 msgstr ""
 
-#: fpr/models.py:234
+#: fpr/models.py:240
 #, python-format
 msgid "%(format)s: %(description)s (%(pronom_id)s)"
 msgstr ""
 
-#: fpr/models.py:254
+#: fpr/models.py:260
 msgid "Name to identify script"
 msgstr ""
 
-#: fpr/models.py:257
+#: fpr/models.py:263
 msgid "PUID"
 msgstr ""
 
-#: fpr/models.py:258
+#: fpr/models.py:264
 msgid "MIME type"
 msgstr ""
 
-#: fpr/models.py:259
+#: fpr/models.py:265
 msgid "File extension"
 msgstr ""
 
-#: fpr/models.py:261
+#: fpr/models.py:267
 #, fuzzy
 #| msgid "Configuration"
 msgid "configuration"
 msgstr "Configuration"
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 #, fuzzy
 #| msgid "Description"
 msgid "script"
 msgstr "Description"
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 msgid "Script to be executed."
 msgstr ""
 
-#: fpr/models.py:265 fpr/models.py:497
+#: fpr/models.py:271 fpr/models.py:520
 msgid "Bash script"
 msgstr ""
 
-#: fpr/models.py:266 fpr/models.py:498
+#: fpr/models.py:272 fpr/models.py:521
 msgid "Python script"
 msgstr ""
 
-#: fpr/models.py:267 fpr/models.py:499
+#: fpr/models.py:273 fpr/models.py:522
 msgid "Command line"
 msgstr ""
 
-#: fpr/models.py:268 fpr/models.py:500
+#: fpr/models.py:274 fpr/models.py:523
 msgid "No shebang needed"
 msgstr ""
 
-#: fpr/models.py:271 fpr/models.py:503
+#: fpr/models.py:277 fpr/models.py:526
 #, fuzzy
 #| msgid "Object type"
 msgid "script type"
 msgstr "Type d'objet"
 
-#: fpr/models.py:274 fpr/models.py:492
+#: fpr/models.py:283 fpr/models.py:514
 msgid "the related tool"
 msgstr ""
 
-#: fpr/models.py:278
+#: fpr/models.py:288
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "Format identification command"
 msgstr ""
 "Sélectionner la commande d'identification de format de fichier (Acquisition)"
 
-#: fpr/models.py:282
+#: fpr/models.py:292
 #, python-format
 msgid "%(tool)s %(config)s runs %(command)s"
 msgstr ""
 
-#: fpr/models.py:309 fpr/models.py:441
+#: fpr/models.py:321 fpr/models.py:459
 msgid "the related command"
 msgstr ""
 
-#: fpr/models.py:315
+#: fpr/models.py:331
 msgid "command output"
 msgstr ""
 
-#: fpr/models.py:318
+#: fpr/models.py:334
 msgid "Format identification rule"
 msgstr ""
 
-#: fpr/models.py:335
+#: fpr/models.py:351
 msgid ""
 "Unable to save, a rule with this output already exists for this command."
 msgstr ""
 
-#: fpr/models.py:342
+#: fpr/models.py:358
 #, python-format
 msgid "Format identification rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:345
+#: fpr/models.py:361
 #, python-format
 msgid "%(command)s with %(output)s is %(format)s"
 msgstr ""
 
-#: fpr/models.py:359 fpr/models.py:557
+#: fpr/models.py:375 fpr/models.py:583
 msgid "Name of tool"
 msgstr ""
 
-#: fpr/models.py:368
+#: fpr/models.py:384
 msgid "Format identification tool"
 msgstr ""
 
-#: fpr/models.py:374 fpr/models.py:568
+#: fpr/models.py:390 fpr/models.py:594
 #, fuzzy, python-format
 #| msgid "Description"
 msgid "%(description)s"
 msgstr "Description"
 
-#: fpr/models.py:416 templates/layout.html:65 templates/main/access.html:4
+#: fpr/models.py:432 templates/layout.html:67 templates/main/access.html:4
 #: templates/main/access.html:5
 msgid "Access"
 msgstr "Accès"
 
-#: fpr/models.py:417 fpr/models.py:514
+#: fpr/models.py:433 fpr/models.py:538
 msgid "Characterization"
 msgstr ""
 
-#: fpr/models.py:418
+#: fpr/models.py:434
 #, fuzzy
 #| msgid "Extract packages"
 msgid "Extract"
 msgstr "Extraire les paquets"
 
-#: fpr/models.py:419 fpr/templates/fpr/format/version/detail.html:33
+#: fpr/models.py:435 fpr/templates/fpr/format/version/detail.html:33
 #, fuzzy
 #| msgid "Preservation planning"
 msgid "Preservation"
 msgstr "Planification de la préservation"
 
-#: fpr/models.py:420
+#: fpr/models.py:436
 msgid "Thumbnail"
 msgstr ""
 
-#: fpr/models.py:421 fpr/models.py:518
+#: fpr/models.py:437 fpr/models.py:542
 #, fuzzy
 #| msgid "Description"
 msgid "Transcription"
 msgstr "Description"
 
-#: fpr/models.py:422 fpr/models.py:519
+#: fpr/models.py:438 fpr/models.py:543
 msgid "Validation"
 msgstr ""
 
-#: fpr/models.py:423
+#: fpr/models.py:439
 msgid "Validation against a policy"
 msgstr ""
 
-#: fpr/models.py:426
+#: fpr/models.py:442
 #, fuzzy
 #| msgid "Delete successful."
 msgid "Default access"
 msgstr "Supprimé avec succès."
 
-#: fpr/models.py:427
+#: fpr/models.py:443
 #, fuzzy
 #| msgid "Default location"
 msgid "Default characterization"
 msgstr "Localisation par défaut"
 
-#: fpr/models.py:428
+#: fpr/models.py:444
 #, fuzzy
 #| msgid "Default location"
 msgid "Default thumbnail"
 msgstr "Localisation par défaut"
 
-#: fpr/models.py:439
+#: fpr/models.py:455
 #, fuzzy
 #| msgid "Purpose"
 msgid "purpose"
 msgstr "But"
 
-#: fpr/models.py:447
+#: fpr/models.py:469
 msgid "count attempts"
 msgstr ""
 
-#: fpr/models.py:448
+#: fpr/models.py:470
 msgid "count okay"
 msgstr ""
 
-#: fpr/models.py:449
+#: fpr/models.py:471
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:452 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:732
 msgid "Format policy rule"
 msgstr ""
 
-#: fpr/models.py:472
+#: fpr/models.py:494
 #, python-format
 msgid "Format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:475
+#: fpr/models.py:497
 #, python-format
 msgid "Normalize %(format)s for %(purpose)s via %(command)s"
 msgstr ""
 
-#: fpr/models.py:495 fpr/models.py:627 fpr/models.py:744
+#: fpr/models.py:518 fpr/models.py:653 fpr/models.py:771
 #, fuzzy
 #| msgid "Rsync command"
 msgid "command"
 msgstr "Commande Rsync"
 
-#: fpr/models.py:505 fpr/models.py:629
+#: fpr/models.py:528 fpr/models.py:655
 #, fuzzy
 #| msgid "Default location"
 msgid "output location"
 msgstr "Localisation par défaut"
 
-#: fpr/models.py:511
+#: fpr/models.py:534
 msgid "the related output format"
 msgstr ""
 
-#: fpr/models.py:515
+#: fpr/models.py:539
 msgid "Event Detail"
 msgstr ""
 
-#: fpr/models.py:516
+#: fpr/models.py:540
 #, fuzzy
 #| msgid "Duration"
 msgid "Extraction"
 msgstr "Durée"
 
-#: fpr/models.py:517
+#: fpr/models.py:541
 #, fuzzy
 #| msgid "Review normalization"
 msgid "Normalization"
 msgstr "Examiner la normalisation"
 
-#: fpr/models.py:520
+#: fpr/models.py:544
 #, fuzzy
 #| msgid "Restriction(s)"
 msgid "Verification"
 msgstr "Restriction(s)"
 
-#: fpr/models.py:523 fpr/models.py:613
+#: fpr/models.py:547 fpr/models.py:639
 msgid "command usage"
 msgstr ""
 
-#: fpr/models.py:531
+#: fpr/models.py:555
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "the related verification command"
 msgstr ""
 "Sélectionner la commande d'identification de format de fichier (Acquisition)"
 
-#: fpr/models.py:539
+#: fpr/models.py:564
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:543 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:731
 msgid "Format policy command"
 msgstr ""
 
-#: fpr/models.py:565
+#: fpr/models.py:591
 #, fuzzy
 #| msgid "Review normalization"
 msgid "Normalization tool"
 msgstr "Examiner la normalisation"
 
-#: fpr/models.py:582
+#: fpr/models.py:608
 #, fuzzy
 #| msgid "PREMIS agent identifier"
 msgid "agent identifier type"
 msgstr "Identifiant de l'agent PREMIS"
 
-#: fpr/models.py:583
+#: fpr/models.py:609
 #, fuzzy
 #| msgid "PREMIS agent identifier"
 msgid "agent identifier value"
 msgstr "Identifiant de l'agent PREMIS"
 
-#: fpr/models.py:584
+#: fpr/models.py:610
 #, fuzzy
 #| msgid "PREMIS agent name"
 msgid "agent name"
 msgstr "Nom de l'agent PREMIS"
 
-#: fpr/models.py:585
+#: fpr/models.py:611
 #, fuzzy
 #| msgid "Object type"
 msgid "agent type"
 msgstr "Type d'objet"
 
-#: fpr/models.py:586
+#: fpr/models.py:612
 msgid "client IP address"
 msgstr ""
 
-#: fpr/models.py:598 fpr/models.py:637 fpr/models.py:655 fpr/models.py:673
-#: fpr/models.py:701 fpr/models.py:726 fpr/models.py:746 fpr/models.py:766
+#: fpr/models.py:624 fpr/models.py:663 fpr/models.py:681 fpr/models.py:699
+#: fpr/models.py:727 fpr/models.py:753 fpr/models.py:773 fpr/models.py:793
 #, fuzzy
 #| msgid "Replace"
 msgid "replaces"
 msgstr "Remplacer"
 
-#: fpr/models.py:600
+#: fpr/models.py:626
 msgid "type"
 msgstr ""
 
-#: fpr/models.py:614
+#: fpr/models.py:640
 msgid "command type"
 msgstr ""
 
-#: fpr/models.py:617
+#: fpr/models.py:643
 msgid "verification command"
 msgstr ""
 
-#: fpr/models.py:621
+#: fpr/models.py:647
 msgid "event detail command"
 msgstr ""
 
-#: fpr/models.py:625
+#: fpr/models.py:651
 msgid "supported by"
 msgstr ""
 
-#: fpr/models.py:633
+#: fpr/models.py:659
 #, fuzzy
 #| msgid "File format"
 msgid "output file format"
 msgstr "Format de fichier"
 
-#: fpr/models.py:688
+#: fpr/models.py:714
 #, fuzzy
 #| msgid "Already in preservation format"
 msgid "valid preservation format"
 msgstr "Déjà dans un format de préservation"
 
-#: fpr/models.py:694
+#: fpr/models.py:720
 #, fuzzy
 #| msgid "Already in access format"
 msgid "valid access format"
 msgstr "Déjà dans un format d'accès"
 
-#: fpr/models.py:698
+#: fpr/models.py:724
 msgid "file ID type"
 msgstr ""
 
-#: fpr/models.py:723
+#: fpr/models.py:750
 msgid "classification"
 msgstr ""
 
-#: fpr/models.py:740
+#: fpr/models.py:767
 msgid "command clasification"
 msgstr ""
 
-#: fpr/models.py:745 fpr/models.py:759
+#: fpr/models.py:772 fpr/models.py:786
 #, fuzzy
 #| msgid "File UUID"
 msgid "file ID"
 msgstr "Fichier UUID"
 
-#: fpr/models.py:761
+#: fpr/models.py:788
 msgid "tool"
 msgstr ""
 
-#: fpr/models.py:763
+#: fpr/models.py:790
 #, fuzzy
 #| msgid "Version"
 msgid "tool version"
@@ -1862,12 +1926,12 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:50 templates/accounts/add.html:36
 #: templates/accounts/edit.html:40 templates/accounts/profile.html:49
 #: templates/administration/processing_edit.html:40
-#: templates/delete_request.html:19 templates/ingest/as/match.html:129
-#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:66
-#: templates/rights/rights_edit.html:290 templates/rights/rights_edit.html:292
-#: templates/rights/rights_grants_edit.html:111
-#: templates/rights/rights_grants_edit.html:113
-#: templates/simple_confirm.html:10 templates/transfer/metadata_edit.html:65
+#: templates/delete_request.html:20 templates/ingest/as/match.html:129
+#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:67
+#: templates/rights/rights_edit.html:291 templates/rights/rights_edit.html:293
+#: templates/rights/rights_grants_edit.html:112
+#: templates/rights/rights_grants_edit.html:114
+#: templates/simple_confirm.html:11 templates/transfer/metadata_edit.html:66
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -2055,18 +2119,18 @@ msgstr ""
 #: fpr/templates/fpr/idcommand/form.html:32
 #: fpr/templates/fpr/idrule/form.html:29 fpr/templates/fpr/idtool/form.html:30
 #: templates/accounts/edit.html:39 templates/accounts/profile.html:48
-#: templates/administration/api.html:36
-#: templates/administration/dips_as_edit.html:29
-#: templates/administration/dips_atom_edit.html:44
-#: templates/administration/general.html:67
-#: templates/administration/handle_config.html:24
-#: templates/administration/premis_agent.html:24
+#: templates/administration/api.html:37
+#: templates/administration/dips_as_edit.html:30
+#: templates/administration/dips_atom_edit.html:45
+#: templates/administration/general.html:68
+#: templates/administration/handle_config.html:25
+#: templates/administration/premis_agent.html:25
 #: templates/administration/processing_edit.html:39
-#: templates/administration/term_detail.html:34
-#: templates/ingest/metadata_edit.html:62 templates/rights/rights_edit.html:285
-#: templates/rights/rights_grants_edit.html:106
-#: templates/transfer/component.html:54
-#: templates/transfer/metadata_edit.html:61
+#: templates/administration/term_detail.html:35
+#: templates/ingest/metadata_edit.html:63 templates/rights/rights_edit.html:286
+#: templates/rights/rights_grants_edit.html:107
+#: templates/transfer/component.html:55
+#: templates/transfer/metadata_edit.html:62
 msgid "Save"
 msgstr "Sauvegarder"
 
@@ -2079,11 +2143,11 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:12
 #: fpr/templates/fpr/format/group/delete.html:49
 #: fpr/templates/fpr/format/group/list.html:51 templates/accounts/list.html:42
-#: templates/administration/atom_levels_of_description.html:44
+#: templates/administration/atom_levels_of_description.html:45
 #: templates/administration/processing.html:33
-#: templates/administration/reports/failure_detail.html:31
+#: templates/administration/reports/failure_detail.html:32
 #: templates/administration/reports/failures.html:39
-#: templates/administration/term_detail.html:35
+#: templates/administration/term_detail.html:36
 #: templates/archival_storage/view.html:111
 #: templates/archival_storage/view.html:154 templates/main/access.html:25
 #: templates/rights/rights_list.html:55 templates/rights/rights_list.html:58
@@ -2398,13 +2462,6 @@ msgstr ""
 msgid "Script"
 msgstr ""
 
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:959
-#: templates/administration/reports/failures.html:25
-#: templates/rights/rights_edit.html:101 templates/rights/rights_edit.html:153
-#: templates/rights/rights_edit.html:203 templates/rights/rights_edit.html:251
-msgid "Type"
-msgstr "Type"
-
 #: fpr/templates/fpr/idcommand/list.html:56
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
@@ -2459,7 +2516,7 @@ msgstr "Configuration"
 #: fpr/templates/fpr/idtool/detail.html:49
 #: templates/ingest/as/_search_form.html:5 templates/ingest/as/match.html:102
 #: templates/ingest/as/match.html:120
-#: templates/ingest/as/review_matches.html:30 templates/ingest/grid.html:165
+#: templates/ingest/as/review_matches.html:31 templates/ingest/grid.html:165
 msgid "Identifier"
 msgstr "Identifiant"
 
@@ -2680,463 +2737,463 @@ msgstr ""
 "Une erreur s'est produite en créant le pipeline : est-ce que le Service de "
 "stockage fonctionne? Veuillez contacter votre administrateur."
 
-#: main/models.py:243
+#: main/models.py:245
 msgid "Part of AIC"
 msgstr "Partie d'une AIC"
 
-#: main/models.py:244
+#: main/models.py:246
 msgid "Optional: leave blank if unsure"
 msgstr ""
 
-#: main/models.py:253
+#: main/models.py:255
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:263
+#: main/models.py:265
 msgid "Use ISO 639"
 msgstr ""
 
-#: main/models.py:281
+#: main/models.py:283
 msgid "Untitled"
 msgstr "Sans titre"
 
-#: main/models.py:329
+#: main/models.py:336
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr ""
 
-#: main/models.py:371
+#: main/models.py:381
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr ""
 
-#: main/models.py:399
+#: main/models.py:409
 msgid "SIP"
 msgstr ""
 
-#: main/models.py:400
+#: main/models.py:410
 msgid "AIC"
 msgstr "AIC"
 
-#: main/models.py:401
+#: main/models.py:411
 msgid "Reingested AIP"
 msgstr ""
 
-#: main/models.py:402
+#: main/models.py:412
 msgid "Reingested AIC"
 msgstr ""
 
-#: main/models.py:416
+#: main/models.py:426
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr "SIP: {path}"
 
-#: main/models.py:529
+#: main/models.py:547
 msgid "Arranged SIPs"
 msgstr ""
 
-#: main/models.py:533
+#: main/models.py:551
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr "%(original)s -> %(arrange)s"
 
-#: main/models.py:578
+#: main/models.py:596
 msgid "Identifier Type"
 msgstr ""
 
-#: main/models.py:580
+#: main/models.py:598
 msgid "Identifier Value"
 msgstr ""
 
-#: main/models.py:582
+#: main/models.py:600
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
 msgstr ""
 
-#: main/models.py:645
+#: main/models.py:673
 #, python-format
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:681
+#: main/models.py:719
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:740
+#: main/models.py:783
 #, fuzzy, python-format
 #| msgid "File format"
 msgid "%(file)s is %(format)s"
 msgstr "Format de fichier"
 
-#: main/models.py:758
+#: main/models.py:801
 msgid "(Unnamed)"
 msgstr ""
 
-#: main/models.py:780
+#: main/models.py:823
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: main/models.py:781
+#: main/models.py:824
 msgid "Awaiting decision"
 msgstr ""
 
-#: main/models.py:782
+#: main/models.py:825
 msgid "Completed successfully"
 msgstr ""
 
-#: main/models.py:783
+#: main/models.py:826
 msgid "Executing command(s)"
 msgstr ""
 
-#: main/models.py:784
+#: main/models.py:827
 msgid "Failed"
 msgstr ""
 
-#: main/models.py:879
+#: main/models.py:924
 msgid "Agent Identifier Type"
 msgstr ""
 
-#: main/models.py:884
+#: main/models.py:929
 msgid "Agent Identifier Value"
 msgstr ""
 
-#: main/models.py:886
+#: main/models.py:931
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
 msgstr ""
 
-#: main/models.py:893
+#: main/models.py:938
 msgid "Agent Name"
 msgstr ""
 
-#: main/models.py:894
+#: main/models.py:939
 msgid "Used for premis:agentName in the METS file."
 msgstr ""
 
-#: main/models.py:900
+#: main/models.py:945
 msgid "Agent Type"
 msgstr ""
 
-#: main/models.py:901
+#: main/models.py:946
 msgid "Used for premis:agentType in the METS file."
 msgstr ""
 
-#: main/models.py:925
+#: main/models.py:970
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:927
+#: main/models.py:972
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:962 templates/rights/rights_edit.html:105
-#: templates/rights/rights_edit.html:157 templates/rights/rights_edit.html:207
-#: templates/rights/rights_edit.html:255
+#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
+#: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr "Valeur"
 
-#: main/models.py:965
+#: main/models.py:1013
 msgid "Rights holder"
 msgstr "Détenteur de droits"
 
-#: main/models.py:968
+#: main/models.py:1016
 msgid "Copyright"
 msgstr "Droit d'auteur"
 
-#: main/models.py:969
+#: main/models.py:1017
 msgid "Statute"
 msgstr "Réglementation"
 
-#: main/models.py:970
+#: main/models.py:1018
 msgid "License"
 msgstr "Licence"
 
-#: main/models.py:971
+#: main/models.py:1019
 msgid "Donor"
 msgstr "Donateur"
 
-#: main/models.py:972
+#: main/models.py:1020
 msgid "Policy"
 msgstr "Politique"
 
-#: main/models.py:979 templates/rights/rights_list.html:34
+#: main/models.py:1027 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr "Base"
 
-#: main/models.py:991
+#: main/models.py:1039
 msgid "Rights Statement"
 msgstr ""
 
-#: main/models.py:995
+#: main/models.py:1043
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr "%(basis)s pour %(unit)s (%(id)s)"
 
-#: main/models.py:1008
+#: main/models.py:1058
 msgid "copyrighted"
 msgstr ""
 
-#: main/models.py:1009
+#: main/models.py:1059
 msgid "public domain"
 msgstr ""
 
-#: main/models.py:1010
+#: main/models.py:1060
 msgid "unknown"
 msgstr ""
 
-#: main/models.py:1015
+#: main/models.py:1065
 msgid "Copyright status"
 msgstr "Statut des droits d'auteur"
 
-#: main/models.py:1020
+#: main/models.py:1070
 msgid "Copyright jurisdiction"
 msgstr "Compétence en matière de droit d'auteur"
 
-#: main/models.py:1026
+#: main/models.py:1076
 msgid "Copyright determination date"
 msgstr ""
 
-#: main/models.py:1027 main/models.py:1034 main/models.py:1041
-#: main/models.py:1105 main/models.py:1112 main/models.py:1172
-#: main/models.py:1179 main/models.py:1237 main/models.py:1246
-#: main/models.py:1253 main/models.py:1321 main/models.py:1328
+#: main/models.py:1077 main/models.py:1084 main/models.py:1091
+#: main/models.py:1161 main/models.py:1168 main/models.py:1234
+#: main/models.py:1241 main/models.py:1303 main/models.py:1312
+#: main/models.py:1319 main/models.py:1391 main/models.py:1398
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:1033
+#: main/models.py:1083
 msgid "Copyright start date"
 msgstr ""
 
-#: main/models.py:1040
+#: main/models.py:1090
 msgid "Copyright end date"
 msgstr ""
 
-#: main/models.py:1046 main/models.py:1117 main/models.py:1186
-#: main/models.py:1258 main/models.py:1333
+#: main/models.py:1096 main/models.py:1173 main/models.py:1248
+#: main/models.py:1324 main/models.py:1403
 msgid "Open End Date"
 msgstr ""
 
-#: main/models.py:1047 main/models.py:1118 main/models.py:1187
-#: main/models.py:1259 main/models.py:1334
+#: main/models.py:1097 main/models.py:1174 main/models.py:1249
+#: main/models.py:1325 main/models.py:1404
 msgid "Indicate end date is open"
 msgstr ""
 
-#: main/models.py:1052
+#: main/models.py:1102
 msgid "Rights: Copyright"
 msgstr ""
 
-#: main/models.py:1062
+#: main/models.py:1114
 msgid "Copyright document identification type"
 msgstr ""
 
-#: main/models.py:1066
+#: main/models.py:1118
 msgid "Copyright document identification value"
 msgstr ""
 
-#: main/models.py:1072
+#: main/models.py:1124
 msgid "Copyright document identification role"
 msgstr ""
 
-#: main/models.py:1077
+#: main/models.py:1129
 msgid "Rights: Copyright: Docs ID"
 msgstr ""
 
-#: main/models.py:1086 templates/rights/rights_edit.html:116
+#: main/models.py:1140 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr "Note sur le droit d'auteur"
 
-#: main/models.py:1091
+#: main/models.py:1145
 msgid "Rights: Copyright: Note"
 msgstr ""
 
-#: main/models.py:1098
+#: main/models.py:1154
 msgid "License terms"
 msgstr "Termes de la licence"
 
-#: main/models.py:1104
+#: main/models.py:1160
 msgid "License start date"
 msgstr ""
 
-#: main/models.py:1111
+#: main/models.py:1167
 msgid "License end date"
 msgstr ""
 
-#: main/models.py:1123
+#: main/models.py:1179
 msgid "Rights: License"
 msgstr ""
 
-#: main/models.py:1133
+#: main/models.py:1191
 msgid "License documentation identification type"
 msgstr ""
 
-#: main/models.py:1137
+#: main/models.py:1195
 msgid "License documentation identification value"
 msgstr ""
 
-#: main/models.py:1143
+#: main/models.py:1201
 msgid "License document identification role"
 msgstr ""
 
-#: main/models.py:1148
+#: main/models.py:1206
 msgid "Rights: License: Docs ID"
 msgstr ""
 
-#: main/models.py:1157 templates/rights/rights_edit.html:218
+#: main/models.py:1217 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr "Note sur la licence"
 
-#: main/models.py:1162
+#: main/models.py:1222
 msgid "Rights: License: Note"
 msgstr ""
 
-#: main/models.py:1171 templates/rights/rights_list.html:36
+#: main/models.py:1233 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr "Début"
 
-#: main/models.py:1178 templates/rights/rights_list.html:37
+#: main/models.py:1240 templates/rights/rights_list.html:37
 msgid "End"
 msgstr "Fin"
 
-#: main/models.py:1192
+#: main/models.py:1254
 msgid "Rights: Granted"
 msgstr ""
 
-#: main/models.py:1203
+#: main/models.py:1266
 msgid "Rights note"
 msgstr ""
 
-#: main/models.py:1208
+#: main/models.py:1271
 msgid "Rights: Granted: Note"
 msgstr ""
 
-#: main/models.py:1222
+#: main/models.py:1286
 msgid "Rights: Granted: Restriction"
 msgstr ""
 
-#: main/models.py:1229
+#: main/models.py:1295
 msgid "Statute jurisdiction"
 msgstr "Champ d'application de la réglementation"
 
-#: main/models.py:1232
+#: main/models.py:1298
 msgid "Statute citation"
 msgstr "Mention de la réglementation"
 
-#: main/models.py:1236
+#: main/models.py:1302
 msgid "Statute determination date"
 msgstr "Date d'établissement de la réglementation"
 
-#: main/models.py:1245
+#: main/models.py:1311
 msgid "Statute start date"
 msgstr ""
 
-#: main/models.py:1252
+#: main/models.py:1318
 msgid "Statute end date"
 msgstr ""
 
-#: main/models.py:1264
+#: main/models.py:1330
 msgid "Rights: Statute"
 msgstr ""
 
-#: main/models.py:1274 templates/rights/rights_edit.html:168
+#: main/models.py:1341 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr "Note sur la réglementation"
 
-#: main/models.py:1279
+#: main/models.py:1346
 msgid "Rights: Statute: Note"
 msgstr ""
 
-#: main/models.py:1290
+#: main/models.py:1358
 msgid "Statute document identification type"
 msgstr ""
 
-#: main/models.py:1294
+#: main/models.py:1362
 msgid "Statute document identification value"
 msgstr ""
 
-#: main/models.py:1300
+#: main/models.py:1368
 msgid "Statute document identification role"
 msgstr ""
 
-#: main/models.py:1305
+#: main/models.py:1373
 msgid "Rights: Statute: Docs ID"
 msgstr ""
 
-#: main/models.py:1313
+#: main/models.py:1383
 msgid "Other rights basis"
 msgstr ""
 
-#: main/models.py:1320
+#: main/models.py:1390
 msgid "Other rights start date"
 msgstr ""
 
-#: main/models.py:1327
+#: main/models.py:1397
 msgid "Other rights end date"
 msgstr ""
 
-#: main/models.py:1339
+#: main/models.py:1409
 msgid "Rights: Other"
 msgstr ""
 
-#: main/models.py:1350
+#: main/models.py:1421
 msgid "Other rights document identification type"
 msgstr ""
 
-#: main/models.py:1354
+#: main/models.py:1425
 msgid "Other right document identification value"
 msgstr ""
 
-#: main/models.py:1360
+#: main/models.py:1431
 msgid "Other rights document identification role"
 msgstr ""
 
-#: main/models.py:1365
+#: main/models.py:1436
 msgid "Rights: Other: Docs ID"
 msgstr ""
 
-#: main/models.py:1375
+#: main/models.py:1447
 msgid "Other rights note"
 msgstr ""
 
-#: main/models.py:1380
+#: main/models.py:1452
 msgid "Rights: Other: Note"
 msgstr ""
 
-#: main/models.py:1388
+#: main/models.py:1462
 msgid "Linking Agent"
 msgstr ""
 
-#: main/models.py:1393
+#: main/models.py:1467
 msgid "Linking Agent Value"
 msgstr ""
 
-#: main/models.py:1399
+#: main/models.py:1473
 msgid "Rights: Agent"
 msgstr ""
 
-#: main/models.py:1435
+#: main/models.py:1509
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr ""
 
-#: main/models.py:1473
+#: main/models.py:1547
 msgid "ASDIPObjectResourcePairing"
 msgstr ""
 
-#: main/models.py:1488
+#: main/models.py:1562
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr ""
 
-#: main/models.py:1495
+#: main/models.py:1569
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 
-#: main/models.py:1615
+#: main/models.py:1709
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr "%(sortorder)s: %(name)s"
@@ -3145,15 +3202,15 @@ msgstr "%(sortorder)s: %(name)s"
 msgid "<no API key generated>"
 msgstr "<no API key generated>"
 
-#: main/views.py:302
+#: main/views.py:299
 msgid "Added."
 msgstr "Ajouté."
 
-#: main/views.py:307
+#: main/views.py:304
 msgid "Error: no delete ID supplied."
 msgstr ""
 
-#: main/views.py:322
+#: main/views.py:319
 msgid "Incorrect type."
 msgstr "Type incorrect."
 
@@ -3185,7 +3242,7 @@ msgstr ""
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:436
+#: settings/base.py:435
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
@@ -3193,32 +3250,32 @@ msgstr ""
 "Sélectionnez \"Approuver le transfert\" pour commencer le traitement ou "
 "\"Rejeter le transfert\" pour recommencer."
 
-#: settings/base.py:439
+#: settings/base.py:438
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
 "has been moved into storage."
 msgstr ""
 
-#: settings/base.py:441
+#: settings/base.py:440
 msgid "Create a SIP from the transfer."
 msgstr "Créer un SIP à partir du transfert."
 
-#: settings/base.py:443
+#: settings/base.py:442
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
 "start ingest micro-services."
 msgstr ""
 
-#: settings/base.py:446
+#: settings/base.py:445
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
 "system."
 msgstr ""
 
-#: settings/base.py:449
+#: settings/base.py:448
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -3227,7 +3284,7 @@ msgid ""
 "view the tool output and error message."
 msgstr ""
 
-#: settings/base.py:452
+#: settings/base.py:451
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
@@ -3236,7 +3293,7 @@ msgstr ""
 "Sélectionnez \"Stocker l'AIP\" pour déplacer l'AIP dans le dossier de "
 "stockage des archives."
 
-#: settings/base.py:455
+#: settings/base.py:454
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3274,7 +3331,7 @@ msgid "Previous"
 msgstr "Précédent"
 
 #: templates/_pager.html:35 templates/ingest/normalization_report.html:121
-#: templates/rights/rights_edit.html:287
+#: templates/rights/rights_edit.html:288
 msgid "Next"
 msgstr "Suivant"
 
@@ -3311,8 +3368,8 @@ msgstr "Utilisateurs"
 msgid "Add new user"
 msgstr "Ajouter un nouvel utilisateur"
 
-#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:64
-#: templates/installer/welcome.html:49 templates/transfer/metadata_edit.html:63
+#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:65
+#: templates/installer/welcome.html:50 templates/transfer/metadata_edit.html:64
 msgid "Create"
 msgstr "Ajouter"
 
@@ -3324,12 +3381,6 @@ msgstr "Utilisateurs - Modifier %(user)s"
 #: templates/accounts/list.html:23 templates/accounts/profile.html:29
 msgid "Username"
 msgstr "Nom d'utilisateur"
-
-#: templates/accounts/list.html:24 templates/accounts/profile.html:31
-#: templates/administration/atom_levels_of_description.html:36
-#: templates/administration/reports/failures.html:26
-msgid "Name"
-msgstr "Nom"
 
 #: templates/accounts/list.html:25 templates/accounts/profile.html:33
 msgid "E-mail"
@@ -3392,14 +3443,12 @@ msgstr "Administration"
 #: templates/administration/reports/failure_detail.html:6
 #: templates/administration/reports/failures.html:5
 #: templates/administration/reports/failures.html:6
-#: templates/administration/search.html:5
-#: templates/administration/search.html:6
 #: templates/administration/taxonomy.html:5
 #: templates/administration/taxonomy.html:6
 #: templates/administration/term_detail.html:5
 #: templates/administration/term_detail.html:6
 #: templates/administration/terms.html:5 templates/administration/terms.html:6
-#: templates/layout.html:66
+#: templates/layout.html:68
 msgid "Administration"
 msgstr "Administration"
 
@@ -3429,15 +3478,15 @@ msgstr "Extraire d'AtoM"
 msgid "AtoM Levels of Description"
 msgstr "Niveaux de description AtoM"
 
-#: templates/administration/atom_levels_of_description.html:45
+#: templates/administration/atom_levels_of_description.html:46
 msgid "Promote"
 msgstr ""
 
-#: templates/administration/atom_levels_of_description.html:46
+#: templates/administration/atom_levels_of_description.html:47
 msgid "Demote"
 msgstr ""
 
-#: templates/administration/atom_levels_of_description.html:54
+#: templates/administration/atom_levels_of_description.html:55
 msgid "No levels found."
 msgstr "Pas de niveau trouvé."
 
@@ -3449,11 +3498,11 @@ msgstr "Téléchargement DIP via ArchivesSpace"
 msgid "Levels of Description"
 msgstr "Niveaux de description"
 
-#: templates/administration/dips_atom_edit.html:37
+#: templates/administration/dips_atom_edit.html:38
 msgid "AtoM/Binder DIP upload"
 msgstr ""
 
-#: templates/administration/dips_atom_edit.html:39
+#: templates/administration/dips_atom_edit.html:40
 msgid "The settings below configure DIP uploading to AtoM/Binder."
 msgstr ""
 
@@ -3471,31 +3520,31 @@ msgstr ""
 msgid "General configuration"
 msgstr "Configuration générale"
 
-#: templates/administration/general.html:39
+#: templates/administration/general.html:40
 msgid "Storage Service options"
 msgstr "Options du service de stockage"
 
-#: templates/administration/general.html:43
+#: templates/administration/general.html:44
 msgid "Checksum algorithm"
 msgstr "Algorithme de somme de contrôle"
 
-#: templates/administration/general.html:47
+#: templates/administration/general.html:48
 msgid "Elasticsearch Indexing"
 msgstr ""
 
-#: templates/administration/general.html:52
+#: templates/administration/general.html:53
 msgid "Transfers related indexes enabled."
 msgstr ""
 
-#: templates/administration/general.html:54
+#: templates/administration/general.html:55
 msgid "Transfers related indexes disabled."
 msgstr ""
 
-#: templates/administration/general.html:59
+#: templates/administration/general.html:60
 msgid "AIPs related indexes enabled."
 msgstr ""
 
-#: templates/administration/general.html:61
+#: templates/administration/general.html:62
 msgid "AIPs related indexes disabled."
 msgstr ""
 
@@ -3614,24 +3663,6 @@ msgstr "Date"
 #: templates/administration/reports/failures.html:56
 msgid "No reports found."
 msgstr "Aucun rapport trouvé."
-
-#: templates/administration/search.html:23
-msgid "Search administration"
-msgstr ""
-
-#: templates/administration/search.html:26
-#, python-format
-msgid ""
-"\n"
-"          %(count)s AIP files indexed.\n"
-"        "
-msgstr ""
-"\n"
-" %(count)s Fichiers AIP indexés."
-
-#: templates/administration/search.html:33
-msgid "Flush AIP Index"
-msgstr ""
 
 #: templates/administration/sidebar.html:23
 msgid "General"
@@ -3759,11 +3790,6 @@ msgid ""
 "cleared manually."
 msgstr ""
 
-#: templates/administration/usage.html:90
-#: templates/archival_storage/view.html:67
-msgid "Size"
-msgstr "Taille"
-
 #: templates/administration/version.html:19
 msgid "About Archivematica"
 msgstr "À propos d'Archivematica"
@@ -3773,12 +3799,12 @@ msgid "Agent code"
 msgstr ""
 
 #: templates/appraisal/appraisal.html:4 templates/appraisal/appraisal.html:5
-#: templates/layout.html:58
+#: templates/layout.html:60
 msgid "Appraisal"
 msgstr "Évaluation"
 
 #: templates/appraisal/appraisal.html:30
-#: templates/archival_storage/archival_storage.html:70
+#: templates/archival_storage/archival_storage.html:74
 #: templates/backlog/backlog.html:34
 msgid "Elasticsearch Indexing Disabled"
 msgstr ""
@@ -3801,23 +3827,23 @@ msgstr "Faire une recherche dans le dossier de stockage des archives"
 
 #: templates/archival_storage/archival_storage.html:6
 #: templates/archival_storage/archival_storage.html:7
-#: templates/archival_storage/archival_storage.html:32
+#: templates/archival_storage/archival_storage.html:31
 #: templates/archival_storage/view.html:6
 #: templates/archival_storage/view.html:7
-#: templates/archival_storage/view.html:50 templates/layout.html:62
+#: templates/archival_storage/view.html:50 templates/layout.html:64
 msgid "Archival storage"
 msgstr "Dossier de stockage des archives"
 
-#: templates/archival_storage/archival_storage.html:33
+#: templates/archival_storage/archival_storage.html:32
 #: templates/ingest/as/_search_form.html:6
 msgid "Search"
 msgstr "Rechercher"
 
-#: templates/archival_storage/archival_storage.html:41
+#: templates/archival_storage/archival_storage.html:40
 msgid "Browse archival storage"
 msgstr "Parcourir le dossier de stockage des archives"
 
-#: templates/archival_storage/archival_storage.html:44
+#: templates/archival_storage/archival_storage.html:43
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -3831,7 +3857,7 @@ msgstr ""
 "\n"
 "Module %(module)s"
 
-#: templates/archival_storage/archival_storage.html:50
+#: templates/archival_storage/archival_storage.html:49
 #, python-format
 msgid ""
 "\n"
@@ -3839,17 +3865,29 @@ msgid ""
 "            "
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:61
+#: templates/archival_storage/archival_storage.html:60
 msgid "Create an AIC from current search results"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:62
+#: templates/archival_storage/archival_storage.html:61
 #, fuzzy
 #| msgid "Create SIP"
 msgid "Create an AIC"
 msgstr "Créer un SIP "
 
-#: templates/archival_storage/archival_storage.html:71
+#: templates/archival_storage/archival_storage.html:65
+msgid ""
+"Download all results from archival storage as a CSV (Comma-separated-values) "
+"table"
+msgstr ""
+
+#: templates/archival_storage/archival_storage.html:66
+#, fuzzy
+#| msgid "Download"
+msgid "Download CSV"
+msgstr "Télécharger"
+
+#: templates/archival_storage/archival_storage.html:75
 msgid ""
 "Sorry, Elasticsearch indexing has been disabled for the AIPs related indexes "
 "in this Archivematica installation. The archival storage tab is non-"
@@ -3863,19 +3901,6 @@ msgstr "Paquet d'information archivé (AIP)"
 #: templates/archival_storage/view.html:71
 msgid "Date stored"
 msgstr ""
-
-#: templates/archival_storage/view.html:75
-msgid "Status"
-msgstr "Statut"
-
-#: templates/archival_storage/view.html:79
-msgid "Encrypted"
-msgstr ""
-
-#: templates/archival_storage/view.html:83
-#: templates/ingest/normalization_report.html:31
-msgid "Location"
-msgstr "Emplacement"
 
 #: templates/archival_storage/view.html:90
 #, fuzzy
@@ -3928,7 +3953,7 @@ msgid ""
 "functional when indexing is turned off."
 msgstr ""
 
-#: templates/delete_request.html:14
+#: templates/delete_request.html:15
 msgid "Reason for deletion:"
 msgstr "Justification de la suppression : "
 
@@ -3979,7 +4004,7 @@ msgstr "AIP"
 #: templates/ingest/grid.html:5 templates/ingest/grid.html:6
 #: templates/ingest/metadata_add_files.html:31
 #: templates/ingest/metadata_edit.html:31
-#: templates/ingest/microservices.html:11 templates/layout.html:60
+#: templates/ingest/microservices.html:11 templates/layout.html:62
 #: templates/rights/rights_edit.html:16
 #: templates/rights/rights_grants_edit.html:16
 #: templates/rights/rights_list.html:9
@@ -3996,7 +4021,7 @@ msgstr "Initialisation..."
 #: templates/ingest/as/resource_component.html:52
 #: templates/ingest/as/resource_detail.html:42
 #: templates/ingest/as/resource_list.html:34
-#: templates/ingest/as/review_matches.html:29
+#: templates/ingest/as/review_matches.html:30
 msgid "Title"
 msgstr "Titre"
 
@@ -4040,7 +4065,7 @@ msgstr "Attribuer les objets aux descriptions"
 #: templates/ingest/as/resource_detail.html:30
 #: templates/ingest/as/resource_list.html:25
 #: templates/ingest/as/resource_list.html:27
-#: templates/ingest/as/review_matches.html:20
+#: templates/ingest/as/review_matches.html:21
 msgid "Restart matching"
 msgstr "Réinitialiser le jumelage"
 
@@ -4066,7 +4091,7 @@ msgid "Resources"
 msgstr "Ressources"
 
 #: templates/ingest/as/match.html:100 templates/ingest/as/match.html:118
-#: templates/ingest/as/review_matches.html:28
+#: templates/ingest/as/review_matches.html:29
 msgid "Level"
 msgstr "Niveau"
 
@@ -4074,7 +4099,7 @@ msgstr "Niveau"
 #: templates/ingest/as/resource_component.html:53
 #: templates/ingest/as/resource_detail.html:43
 #: templates/ingest/as/resource_list.html:35
-#: templates/ingest/as/review_matches.html:31
+#: templates/ingest/as/review_matches.html:32
 msgid "Dates"
 msgstr "Dates"
 
@@ -4083,7 +4108,7 @@ msgid "Pairs"
 msgstr "Jumeler"
 
 #: templates/ingest/as/match.html:117
-#: templates/ingest/as/review_matches.html:27
+#: templates/ingest/as/review_matches.html:28
 msgid "File"
 msgstr "Dossier"
 
@@ -4122,7 +4147,7 @@ msgstr "Attribuer les objets DIP à cette ressource"
 msgid "Collections"
 msgstr "Collections"
 
-#: templates/ingest/as/review_matches.html:21
+#: templates/ingest/as/review_matches.html:22
 msgid "Finish matching"
 msgstr "Terminer le jumelage"
 
@@ -4228,50 +4253,50 @@ msgstr ""
 msgid "Select a directory"
 msgstr "Sélectionner un répertoire"
 
-#: templates/ingest/metadata_edit.html:77
-#: templates/transfer/metadata_edit.html:76
+#: templates/ingest/metadata_edit.html:78
+#: templates/transfer/metadata_edit.html:77
 msgid "A name given to the resource."
 msgstr "Nom donné à la ressource"
 
-#: templates/ingest/metadata_edit.html:81
-#: templates/transfer/metadata_edit.html:80
+#: templates/ingest/metadata_edit.html:82
+#: templates/transfer/metadata_edit.html:81
 msgid "An entity primarily responsible for making the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:85
-#: templates/transfer/metadata_edit.html:84
+#: templates/ingest/metadata_edit.html:86
+#: templates/transfer/metadata_edit.html:85
 msgid "The topic of the resource."
 msgstr "Sujet de la ressource"
 
-#: templates/ingest/metadata_edit.html:89
-#: templates/transfer/metadata_edit.html:88
+#: templates/ingest/metadata_edit.html:90
+#: templates/transfer/metadata_edit.html:89
 msgid "An account of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:93
-#: templates/transfer/metadata_edit.html:92
+#: templates/ingest/metadata_edit.html:94
+#: templates/transfer/metadata_edit.html:93
 msgid "An entity responsible for making the resource available."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:97
-#: templates/transfer/metadata_edit.html:96
+#: templates/ingest/metadata_edit.html:98
+#: templates/transfer/metadata_edit.html:97
 msgid "An entity responsible for making contributions to the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:101
-#: templates/transfer/metadata_edit.html:100
+#: templates/ingest/metadata_edit.html:102
+#: templates/transfer/metadata_edit.html:101
 msgid ""
 "A point or period of time associated with an event in the lifecycle of the "
 "resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:106
-#: templates/transfer/metadata_edit.html:105
+#: templates/ingest/metadata_edit.html:107
+#: templates/transfer/metadata_edit.html:106
 msgid "The nature or genre of the resource."
 msgstr "Nature ou genre de la ressource."
 
-#: templates/ingest/metadata_edit.html:108
-#: templates/transfer/metadata_edit.html:107
+#: templates/ingest/metadata_edit.html:109
+#: templates/transfer/metadata_edit.html:108
 msgid ""
 "\n"
 "        You may wish to use the DCMI type vocabulary provided here: <a href="
@@ -4280,13 +4305,13 @@ msgid ""
 "      "
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:116
-#: templates/transfer/metadata_edit.html:115
+#: templates/ingest/metadata_edit.html:117
+#: templates/transfer/metadata_edit.html:116
 msgid "The file format, physical medium, or dimensions of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:118
-#: templates/transfer/metadata_edit.html:117
+#: templates/ingest/metadata_edit.html:119
+#: templates/transfer/metadata_edit.html:118
 msgid ""
 "\n"
 "        Best practice is to use a controlled vocabulary such as the list of "
@@ -4296,35 +4321,35 @@ msgid ""
 "      "
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:125
-#: templates/transfer/metadata_edit.html:124
+#: templates/ingest/metadata_edit.html:126
+#: templates/transfer/metadata_edit.html:125
 msgid "An unambiguous reference to the resource within a given context."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:129
-#: templates/transfer/metadata_edit.html:128
+#: templates/ingest/metadata_edit.html:130
+#: templates/transfer/metadata_edit.html:129
 msgid "A related resource from which the described resource is derived."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:133
-#: templates/transfer/metadata_edit.html:132
+#: templates/ingest/metadata_edit.html:134
+#: templates/transfer/metadata_edit.html:133
 msgid "A related resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:137
-#: templates/transfer/metadata_edit.html:136
+#: templates/ingest/metadata_edit.html:138
+#: templates/transfer/metadata_edit.html:137
 msgid "A language of the resource."
 msgstr "Langue de la ressource"
 
-#: templates/ingest/metadata_edit.html:141
-#: templates/transfer/metadata_edit.html:140
+#: templates/ingest/metadata_edit.html:142
+#: templates/transfer/metadata_edit.html:141
 msgid ""
 "The spatial or temporal topic of the resource, the spatial applicability of "
 "the resource, or the jurisdiction under which the resource is relevant."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:145
-#: templates/transfer/metadata_edit.html:144
+#: templates/ingest/metadata_edit.html:146
+#: templates/transfer/metadata_edit.html:145
 msgid "Information about rights held in and over the resource."
 msgstr "Informations sur les droits s'appliquant à la ressource."
 
@@ -4385,15 +4410,15 @@ msgstr ""
 "\n"
 "Affiche %(start_index)s-%(end_index)s de %(total_items)s"
 
-#: templates/installer/storagesetup.html:25
+#: templates/installer/storagesetup.html:26
 msgid "Register this pipeline in the Storage Service"
 msgstr "Enregistrer ce pipeline dans le Service de stockage"
 
-#: templates/installer/storagesetup.html:30
+#: templates/installer/storagesetup.html:31
 msgid "Dashboard UUID"
 msgstr "UUID du tableau de bord"
 
-#: templates/installer/storagesetup.html:39
+#: templates/installer/storagesetup.html:40
 msgid "Register"
 msgstr ""
 
@@ -4415,7 +4440,7 @@ msgstr ""
 msgid "Archivematica Dashboard"
 msgstr "Tableau de bord Archivematica"
 
-#: templates/layout.html:55 templates/rights/rights_edit.html:18
+#: templates/layout.html:57 templates/rights/rights_edit.html:18
 #: templates/rights/rights_grants_edit.html:18
 #: templates/rights/rights_list.html:11 templates/transfer/component.html:10
 #: templates/transfer/detail.html:9 templates/transfer/grid.html:5
@@ -4425,19 +4450,19 @@ msgstr "Tableau de bord Archivematica"
 msgid "Transfer"
 msgstr "Transfert"
 
-#: templates/layout.html:57
+#: templates/layout.html:59
 msgid "Backlog"
 msgstr "Backlog"
 
-#: templates/layout.html:64
+#: templates/layout.html:66
 msgid "Preservation planning"
 msgstr "Planification de la préservation"
 
-#: templates/layout.html:74
+#: templates/layout.html:76
 msgid "Your profile"
 msgstr "Votre profil"
 
-#: templates/layout.html:76
+#: templates/layout.html:78
 msgid "Log out"
 msgstr "Fermeture de session"
 
@@ -4550,28 +4575,28 @@ msgstr ""
 "\n"
 "Nouveau contenu ajouté : %(type)s"
 
-#: templates/rights/rights_edit.html:96
+#: templates/rights/rights_edit.html:97
 msgid "Copyright documentation identifier:"
 msgstr "Identifiant de la documentation sur le droit d'auteur :"
 
-#: templates/rights/rights_edit.html:109 templates/rights/rights_edit.html:161
-#: templates/rights/rights_edit.html:211 templates/rights/rights_edit.html:259
+#: templates/rights/rights_edit.html:110 templates/rights/rights_edit.html:162
+#: templates/rights/rights_edit.html:212 templates/rights/rights_edit.html:260
 msgid "Role"
 msgstr "Rôle "
 
-#: templates/rights/rights_edit.html:147
+#: templates/rights/rights_edit.html:148
 msgid "Statute documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:197
+#: templates/rights/rights_edit.html:198
 msgid "License documentation identifier:"
 msgstr "Identifiant de la documentation sur la licence :"
 
-#: templates/rights/rights_edit.html:245
+#: templates/rights/rights_edit.html:246
 msgid "Documentation identifier"
 msgstr "Identifiant de la documentation"
 
-#: templates/rights/rights_edit.html:266
+#: templates/rights/rights_edit.html:267
 msgid "Note"
 msgstr "Note"
 
@@ -4582,23 +4607,23 @@ msgstr ""
 "Vous pouvez maintenant ajouter des informations supplémentaires telles que "
 "des identifiants de document et des notes."
 
-#: templates/rights/rights_grants_edit.html:79
+#: templates/rights/rights_grants_edit.html:80
 msgid "Allow"
 msgstr "Autoriser"
 
-#: templates/rights/rights_grants_edit.html:80
+#: templates/rights/rights_grants_edit.html:81
 msgid "Disallow"
 msgstr "Empêcher"
 
-#: templates/rights/rights_grants_edit.html:81
+#: templates/rights/rights_grants_edit.html:82
 msgid "Conditional"
 msgstr "Conditionnel"
 
-#: templates/rights/rights_grants_edit.html:87
+#: templates/rights/rights_grants_edit.html:88
 msgid "Grant/restriction note"
 msgstr "Note d'autorisation/de restriction"
 
-#: templates/rights/rights_grants_edit.html:108
+#: templates/rights/rights_grants_edit.html:109
 msgid "Done"
 msgstr "Complété"
 
@@ -4631,6 +4656,14 @@ msgstr "Transférer les métadonnées"
 #: templates/transfer/grid.html:86
 msgid "Transfer start time"
 msgstr "Heure de début du transfert"
+
+#~ msgid ""
+#~ "\n"
+#~ "          %(count)s AIP files indexed.\n"
+#~ "        "
+#~ msgstr ""
+#~ "\n"
+#~ " %(count)s Fichiers AIP indexés."
 
 #~ msgid "Send transfer to quarantine"
 #~ msgstr "Placer le transfert en quarantaine"

--- a/src/dashboard/src/locale/fr/LC_MESSAGES/djangojs.po
+++ b/src/dashboard/src/locale/fr/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 12:27-0400\n"
+"POT-Creation-Date: 2020-07-27 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Isabelle Alain <ialain@archivescanada.ca>, 2017\n"
 "Language-Team: French (https://www.transifex.com/artefactual/teams/1506/"
@@ -29,7 +29,7 @@ msgid "Are you sure you want to delete this level of description?"
 msgstr "Êtes-vous certain de vouloir supprimer ce niveau de description ?"
 
 #: media/js/advanced-search-query-creator.js:14 media/js/file_browser.js:59
-#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:209
+#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:211
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -48,7 +48,7 @@ msgid "Any"
 msgstr "N'importe quel"
 
 #: media/js/archival_storage/archival_storage_search.js:61
-#: media/js/archival_storage/archival_storage_search.js:238
+#: media/js/archival_storage/archival_storage_search.js:242
 msgid "File UUID"
 msgstr "Fichier UUID"
 
@@ -107,227 +107,233 @@ msgstr "Phrase"
 msgid "Date range"
 msgstr "Plage de dates"
 
-#: media/js/archival_storage/archival_storage_search.js:148
+#: media/js/archival_storage/archival_storage_search.js:152
 msgid "view raw"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:169
+#: media/js/archival_storage/archival_storage_search.js:173
 #: media/js/backlog/backlog-search.js:6 media/js/backlog/backlog-search.js:12
 msgid "Download"
 msgstr "Télécharger"
 
-#: media/js/archival_storage/archival_storage_search.js:184
+#: media/js/archival_storage/archival_storage_search.js:188
 msgid "AIPs in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:185
+#: media/js/archival_storage/archival_storage_search.js:189
 msgid "AIP in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:188
+#: media/js/archival_storage/archival_storage_search.js:192
 #, fuzzy
 #| msgid "Part of AIC"
 msgid "Part of"
 msgstr "Partie d'une AIC"
 
-#: media/js/archival_storage/archival_storage_search.js:190
+#: media/js/archival_storage/archival_storage_search.js:194
 msgid "None"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:197
+#: media/js/archival_storage/archival_storage_search.js:201
 msgid "View"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "True"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "False"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 msgid "Deletion requested"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 #: media/js/backlog/backlog-search.js:19
 msgid "Stored"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:236
+#: media/js/archival_storage/archival_storage_search.js:240
 msgid "Thumbnail"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:237
+#: media/js/archival_storage/archival_storage_search.js:241
 #, fuzzy
 #| msgid "Filename"
 msgid "File"
 msgstr "Nom du fichier"
 
-#: media/js/archival_storage/archival_storage_search.js:239
+#: media/js/archival_storage/archival_storage_search.js:243
 msgid "AIP"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:240
+#: media/js/archival_storage/archival_storage_search.js:244
 #: media/js/backlog/backlog-search.js:42 media/js/backlog/backlog-search.js:53
 #: media/js/ingest/backlog.js:37
 msgid "Accession number"
 msgstr "Numéro d'acquisition"
 
-#: media/js/archival_storage/archival_storage_search.js:241
-#: media/js/archival_storage/archival_storage_search.js:254
+#: media/js/archival_storage/archival_storage_search.js:245
+#: media/js/archival_storage/archival_storage_search.js:258
 #: media/js/backlog/backlog-search.js:43 media/js/backlog/backlog-search.js:55
 msgid "Status"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:242
-#: media/js/archival_storage/archival_storage_search.js:256
+#: media/js/archival_storage/archival_storage_search.js:246
+#: media/js/archival_storage/archival_storage_search.js:261
 #: media/js/backlog/backlog-search.js:44 media/js/backlog/backlog-search.js:56
-#: media/js/ingest.js:216 media/js/transfer.js:153
+#: media/js/ingest.js:217 media/js/transfer.js:154
 msgid "Actions"
 msgstr "Actions"
 
-#: media/js/archival_storage/archival_storage_search.js:247
+#: media/js/archival_storage/archival_storage_search.js:251
 #: media/js/backlog/backlog-search.js:49
 msgid "Name"
 msgstr "Nom"
 
-#: media/js/archival_storage/archival_storage_search.js:248
+#: media/js/archival_storage/archival_storage_search.js:252
 #, fuzzy
 #| msgid "AIP UUID"
 msgid "UUID"
 msgstr "UUID de l'AIP"
 
-#: media/js/archival_storage/archival_storage_search.js:249
+#: media/js/archival_storage/archival_storage_search.js:253
 msgid "AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:250
+#: media/js/archival_storage/archival_storage_search.js:254
 #: media/js/backlog/backlog-search.js:51
 msgid "Size"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:251
+#: media/js/archival_storage/archival_storage_search.js:255
 #: media/js/backlog/backlog-search.js:52
 msgid "File count"
 msgstr "Nombre de fichiers"
 
-#: media/js/archival_storage/archival_storage_search.js:252
+#: media/js/archival_storage/archival_storage_search.js:256
 #, fuzzy
 #| msgid "Accession number"
 msgid "Accession numbers"
 msgstr "Numéro d'acquisition"
 
-#: media/js/archival_storage/archival_storage_search.js:253
+#: media/js/archival_storage/archival_storage_search.js:257
 #, fuzzy
 #| msgid "Create SIP"
 msgid "Created"
 msgstr "Créer un SIP "
 
-#: media/js/archival_storage/archival_storage_search.js:255
+#: media/js/archival_storage/archival_storage_search.js:259
 msgid "Encrypted"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:309
-#: media/js/backlog/backlog-search.js:109
+#: media/js/archival_storage/archival_storage_search.js:260
+#, fuzzy
+#| msgid "Actions"
+msgid "Location"
+msgstr "Actions"
+
+#: media/js/archival_storage/archival_storage_search.js:315
+#: media/js/backlog/backlog-search.js:110
 #, fuzzy
 #| msgid "Select an action..."
 msgid "Select columns"
 msgstr "Sélectionner une action..."
 
-#: media/js/archival_storage/archival_storage_search.js:313
-#: media/js/backlog/backlog-search.js:113
+#: media/js/archival_storage/archival_storage_search.js:319
+#: media/js/backlog/backlog-search.js:114
 msgctxt "DataTable - sEmptyTable"
 msgid "No data available in table"
 msgstr "Aucune donnée disponible dans le tableau"
 
-#: media/js/archival_storage/archival_storage_search.js:314
-#: media/js/backlog/backlog-search.js:114
+#: media/js/archival_storage/archival_storage_search.js:320
+#: media/js/backlog/backlog-search.js:115
 msgctxt "DataTable - sInfo"
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Afficher _START_ to _END_ of _TOTAL_ entrées"
 
-#: media/js/archival_storage/archival_storage_search.js:315
-#: media/js/backlog/backlog-search.js:115
+#: media/js/archival_storage/archival_storage_search.js:321
+#: media/js/backlog/backlog-search.js:116
 msgctxt "DataTable - sInfoEmpty"
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Afficher 0 à 0 sur 0 entrées"
 
-#: media/js/archival_storage/archival_storage_search.js:316
-#: media/js/backlog/backlog-search.js:116
+#: media/js/archival_storage/archival_storage_search.js:322
+#: media/js/backlog/backlog-search.js:117
 msgctxt "DataTable - sInfoFiltered"
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filtrés à partir d'un total de _MAX_ entrées)"
 
-#: media/js/archival_storage/archival_storage_search.js:318
-#: media/js/backlog/backlog-search.js:118
+#: media/js/archival_storage/archival_storage_search.js:324
+#: media/js/backlog/backlog-search.js:119
 msgctxt "DataTable - sInfoThousands"
 msgid ","
 msgstr ","
 
-#: media/js/archival_storage/archival_storage_search.js:319
-#: media/js/backlog/backlog-search.js:119
+#: media/js/archival_storage/archival_storage_search.js:325
+#: media/js/backlog/backlog-search.js:120
 msgctxt "DataTable - sLengthMenu"
 msgid "Show _MENU_ entries"
 msgstr "Afficher _MENU_ entries"
 
-#: media/js/archival_storage/archival_storage_search.js:320
-#: media/js/backlog/backlog-search.js:120
+#: media/js/archival_storage/archival_storage_search.js:326
+#: media/js/backlog/backlog-search.js:121
 msgctxt "DataTable - sLoadingRecords"
 msgid "Loading..."
 msgstr "Chargement …"
 
-#: media/js/archival_storage/archival_storage_search.js:321
-#: media/js/backlog/backlog-search.js:121
+#: media/js/archival_storage/archival_storage_search.js:327
+#: media/js/backlog/backlog-search.js:122
 msgctxt "DataTable - sProcessing"
 msgid "Processing..."
 msgstr "En traitement..."
 
-#: media/js/archival_storage/archival_storage_search.js:322
-#: media/js/backlog/backlog-search.js:122
+#: media/js/archival_storage/archival_storage_search.js:328
+#: media/js/backlog/backlog-search.js:123
 msgctxt "DataTable - sSearch"
 msgid "Search:"
 msgstr "Rechercher :"
 
-#: media/js/archival_storage/archival_storage_search.js:323
-#: media/js/backlog/backlog-search.js:123
+#: media/js/archival_storage/archival_storage_search.js:329
+#: media/js/backlog/backlog-search.js:124
 msgctxt "DataTable - sZeroRecords"
 msgid "No matching records found"
 msgstr "Aucun enregistrement correspondant trouvé"
 
-#: media/js/archival_storage/archival_storage_search.js:325
-#: media/js/backlog/backlog-search.js:125
+#: media/js/archival_storage/archival_storage_search.js:331
+#: media/js/backlog/backlog-search.js:126
 msgctxt "DataTable - sFirst"
 msgid "First"
 msgstr "Premier"
 
-#: media/js/archival_storage/archival_storage_search.js:326
-#: media/js/backlog/backlog-search.js:126
+#: media/js/archival_storage/archival_storage_search.js:332
+#: media/js/backlog/backlog-search.js:127
 msgctxt "DataTable - sLast"
 msgid "Last"
 msgstr "Dernier"
 
-#: media/js/archival_storage/archival_storage_search.js:327
-#: media/js/backlog/backlog-search.js:127
+#: media/js/archival_storage/archival_storage_search.js:333
+#: media/js/backlog/backlog-search.js:128
 msgctxt "DataTable - sNext"
 msgid "Next"
 msgstr "Suivant"
 
-#: media/js/archival_storage/archival_storage_search.js:328
-#: media/js/backlog/backlog-search.js:128
+#: media/js/archival_storage/archival_storage_search.js:334
+#: media/js/backlog/backlog-search.js:129
 msgctxt "DataTable - sPrevious"
 msgid "Previous"
 msgstr "Précédent"
 
-#: media/js/archival_storage/archival_storage_search.js:331
-#: media/js/backlog/backlog-search.js:131
+#: media/js/archival_storage/archival_storage_search.js:337
+#: media/js/backlog/backlog-search.js:132
 msgctxt "DataTable - sSortAscending"
 msgid ": activate to sort column ascending"
 msgstr ": activer le tri ascendant"
 
-#: media/js/archival_storage/archival_storage_search.js:332
-#: media/js/backlog/backlog-search.js:132
+#: media/js/archival_storage/archival_storage_search.js:338
+#: media/js/backlog/backlog-search.js:133
 msgctxt "DataTable - sSortDescending"
 msgid ": activate to sort column descending"
 msgstr ": activer le tri descendant"
@@ -367,7 +373,7 @@ msgid "Yes"
 msgstr "Oui"
 
 #: media/js/directory_picker.js:90 media/js/file_browser.js:178
-#: media/js/ingest.js:123 media/js/jobs.js:590 media/js/jobs.js:683
+#: media/js/ingest.js:124 media/js/jobs.js:590 media/js/jobs.js:686
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -417,43 +423,43 @@ msgstr "Effacer le SIP"
 msgid "Confirm"
 msgstr "Confirmer"
 
-#: media/js/ingest.js:145
+#: media/js/ingest.js:146
 msgid "Dublin Core metadata editor"
 msgstr "Éditeur de métadonnées Dublin Core"
 
-#: media/js/ingest.js:152 media/js/jobs.js:535
+#: media/js/ingest.js:153 media/js/jobs.js:535
 msgid "Close"
 msgstr "Fermer"
 
-#: media/js/ingest.js:173
+#: media/js/ingest.js:174
 msgid "Error"
 msgstr "Erreur"
 
-#: media/js/ingest.js:240
+#: media/js/ingest.js:241
 msgid "Report"
 msgstr "Rapport"
 
-#: media/js/ingest.js:243
+#: media/js/ingest.js:244
 msgid "Match DIP objects to resources"
 msgstr "Faire correspondre les objets DIP aux ressources"
 
-#: media/js/ingest.js:301
+#: media/js/ingest.js:303
 msgid "Loading..."
 msgstr "Chargement … "
 
-#: media/js/ingest/as_matcher.js:551
+#: media/js/ingest/as_matcher.js:553
 msgid "No resource selected."
 msgstr "Aucune ressource sélectionnée."
 
-#: media/js/ingest/as_matcher.js:558
+#: media/js/ingest/as_matcher.js:560
 msgid "No objects selected."
 msgstr "Aucun objet sélectionné"
 
-#: media/js/ingest/as_matcher.js:670
+#: media/js/ingest/as_matcher.js:673
 msgid "Warning"
 msgstr "Avertissement"
 
-#: media/js/ingest/as_matcher.js:674
+#: media/js/ingest/as_matcher.js:677
 msgid "Dismiss"
 msgstr "Rejeter"
 
@@ -465,15 +471,15 @@ msgstr "Nom du fichier"
 msgid "Ingest date (YYYY-MM-DD)"
 msgstr "Date d'entrée (AAAA-MM-JJ)"
 
-#: media/js/ingest/metadata_form.js:83
+#: media/js/ingest/metadata_form.js:84
 msgid "Browse"
 msgstr "Naviguer"
 
-#: media/js/ingest/metadata_form.js:85
+#: media/js/ingest/metadata_form.js:86
 msgid "Add files"
 msgstr "Ajouter des fichiers"
 
-#: media/js/ingest/metadata_form.js:124
+#: media/js/ingest/metadata_form.js:125
 msgid "Please select at least one metadata file."
 msgstr "Sélectionner au moins un fichier de métadonnées."
 
@@ -503,36 +509,36 @@ msgstr ""
 msgid "Remove All Completed %ss"
 msgstr "Retirer tous les %ss terminés"
 
-#: media/js/jobs.js:661
+#: media/js/jobs.js:664
 #, javascript-format
 msgid "There were no completed %ss to remove"
 msgstr "Il n'y avait aucun %s complété à retirer"
 
-#: media/js/jobs.js:665
+#: media/js/jobs.js:668
 #, javascript-format
 msgid "Successfully removed the following %ss: %s"
 msgstr "Suppression réussie des éléments suivants %ss: %s"
 
-#: media/js/jobs.js:671
+#: media/js/jobs.js:674
 #, javascript-format
 msgid "Failed to remove all completed %ss"
 msgstr "Échec de la suppression de tous les éléments terminés %ss"
 
-#: media/js/jobs.js:797
+#: media/js/jobs.js:800
 msgid "Previous"
 msgstr "Précédent"
 
-#: media/js/jobs.js:812
+#: media/js/jobs.js:815
 msgid "Next"
 msgstr "Suivant"
 
-#: media/js/jobs.js:850
+#: media/js/jobs.js:853
 msgid "Error trying to connect to database. Trying again..."
 msgstr ""
 "Erreur lors de la tentative de connexion à la base de données. Essayer de "
 "nouveau..."
 
-#: media/js/jobs.js:900
+#: media/js/jobs.js:903
 msgid "Error trying to connect to MCP server. Trying again..."
 msgstr ""
 "Erreur lors de la tentative de connexion au serveur MPC. Essayer de "
@@ -550,7 +556,7 @@ msgstr "Chargement"
 msgid "Disconnected"
 msgstr "Déconnecté"
 
-#: media/js/repeating-ajax-data.js:215
+#: media/js/repeating-ajax-data.js:217
 msgid "Are you sure?"
 msgstr "Êtes-vous certain?"
 

--- a/src/dashboard/src/locale/ja/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/ja/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 11:52-0400\n"
+"POT-Creation-Date: 2020-07-27 22:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: artefactual <translate@artefactual.com>, 2018\n"
 "Language-Team: Japanese (https://www.transifex.com/artefactual/teams/1506/"
@@ -19,12 +19,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: components/accounts/views.py:62 components/accounts/views.py:150
-#: components/administration/views.py:459
-#: components/administration/views.py:474
-#: components/administration/views.py:486
-#: components/administration/views.py:513
-#: components/administration/views.py:564
+#: components/accounts/views.py:61 components/accounts/views.py:149
+#: components/administration/views.py:454
+#: components/administration/views.py:469
+#: components/administration/views.py:481
+#: components/administration/views.py:508
+#: components/administration/views.py:555
 #: components/administration/views_dip_upload.py:25
 #: components/administration/views_dip_upload.py:39 fpr/views.py:106
 #: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Saved."
 msgstr "保存しました。"
 
-#: components/accounts/views.py:82
+#: components/accounts/views.py:81
 #, python-format
 msgid "Your profile (%s)"
 msgstr "あなたのプロフィール (%s)"
@@ -366,7 +366,7 @@ msgstr ""
 msgid "New"
 msgstr "New"
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:973
+#: components/administration/forms_dip_upload.py:21 main/models.py:1021
 msgid "Other"
 msgstr "その他"
 
@@ -551,97 +551,97 @@ msgstr ""
 msgid "Used in metadata-only DIP upload."
 msgstr ""
 
-#: components/administration/views.py:92 components/administration/views.py:125
-#: components/ingest/views.py:293 fpr/views.py:261 main/views.py:310
+#: components/administration/views.py:89 components/administration/views.py:122
+#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
 msgid "Deleted."
 msgstr "削除しました。"
 
-#: components/administration/views.py:109
+#: components/administration/views.py:106
 msgid "Promoted."
 msgstr "昇格しました。"
 
-#: components/administration/views.py:112
+#: components/administration/views.py:109
 msgid "Error attempting to promote level of description."
 msgstr ""
 
-#: components/administration/views.py:116
+#: components/administration/views.py:113
 msgid "Demoted."
 msgstr "降格しました。"
 
-#: components/administration/views.py:119
+#: components/administration/views.py:116
 msgid "Error attempting to demote level of description."
 msgstr ""
 
-#: components/administration/views.py:127
+#: components/administration/views.py:124
 msgid "Level of description not found."
 msgstr "記述レベルが見つかりません。"
 
-#: components/administration/views.py:193
+#: components/administration/views.py:190
 msgid ""
 "Error retrieving locations: is the storage server running? Please contact an "
 "administrator."
 msgstr ""
 
-#: components/administration/views.py:202
+#: components/administration/views.py:199
 msgid "AIP Storage"
 msgstr ""
 
-#: components/administration/views.py:203
+#: components/administration/views.py:200
 msgid "DIP Storage"
 msgstr ""
 
-#: components/administration/views.py:204
+#: components/administration/views.py:201
 msgid "FEDORA Deposits"
 msgstr ""
 
-#: components/administration/views.py:205
+#: components/administration/views.py:202
 #, fuzzy
 #| msgid "Search transfer backlog"
 msgid "Transfer Backlog"
 msgstr "転送バックログの検索"
 
-#: components/administration/views.py:206
+#: components/administration/views.py:203
 #, fuzzy
 #| msgid "Transfer"
 msgid "Transfer Source"
 msgstr "転送"
 
-#: components/administration/views.py:207
+#: components/administration/views.py:204
 msgid "Replicator"
 msgstr ""
 
-#: components/administration/views.py:224
+#: components/administration/views.py:221
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:407
+#: components/administration/views.py:404
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:410
+#: components/administration/views.py:406
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr "クリア"
 
-#: components/administration/views.py:436
+#: components/administration/views.py:431
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:439
+#: components/administration/views.py:434
 #, python-format
 msgid "No such file or directory: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:580
+#: components/administration/views.py:571
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
 "Storage Sevice URL below.<hr />%(error)s"
 msgstr ""
 
-#: components/administration/views.py:597
+#: components/administration/views.py:588
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -649,7 +649,7 @@ msgid ""
 "%(error)s"
 msgstr ""
 
-#: components/administration/views.py:609
+#: components/administration/views.py:600
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -718,6 +718,7 @@ msgid "Please type in the UUID to confirm"
 msgstr ""
 
 #: components/archival_storage/forms.py:89
+#: components/archival_storage/views.py:210
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -747,35 +748,98 @@ msgstr ""
 msgid "UUID mismatch"
 msgstr ""
 
-#: components/archival_storage/views.py:49
+#: components/archival_storage/views.py:54
 msgid "Stored"
 msgstr ""
 
-#: components/archival_storage/views.py:50
+#: components/archival_storage/views.py:55
 msgid "Deletion requested"
 msgstr ""
 
-#: components/archival_storage/views.py:464
+#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: templates/accounts/profile.html:31
+#: templates/administration/atom_levels_of_description.html:37
+#: templates/administration/reports/failures.html:26
+msgid "Name"
+msgstr "名称"
+
+#: components/archival_storage/views.py:211
+msgid "AICID"
+msgstr ""
+
+#: components/archival_storage/views.py:212
+msgid "Count AIPs in AIC"
+msgstr ""
+
+#: components/archival_storage/views.py:213
+#: templates/administration/usage.html:90
+#: templates/archival_storage/view.html:67
+msgid "Size"
+msgstr "サイズ"
+
+#: components/archival_storage/views.py:214
+#, fuzzy
+#| msgid "File name"
+msgid "File count"
+msgstr "ファイル名"
+
+#: components/archival_storage/views.py:215
+#, fuzzy
+#| msgid "Access"
+msgid "Accession IDs"
+msgstr "アクセス"
+
+#: components/archival_storage/views.py:216
+#, fuzzy
+#| msgid "Created time"
+msgid "Created date (UTC)"
+msgstr "作成時刻"
+
+#: components/archival_storage/views.py:217
+#: templates/archival_storage/view.html:75
+msgid "Status"
+msgstr "ステータス"
+
+#: components/archival_storage/views.py:218
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: templates/administration/reports/failures.html:25
+#: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
+#: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
+msgid "Type"
+msgstr "種別"
+
+#: components/archival_storage/views.py:219
+#: templates/archival_storage/view.html:79
+msgid "Encrypted"
+msgstr ""
+
+#: components/archival_storage/views.py:220
+#: templates/archival_storage/view.html:83
+#: templates/ingest/normalization_report.html:31
+msgid "Location"
+msgstr "所在"
+
+#: components/archival_storage/views.py:600
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:593
+#: components/archival_storage/views.py:729
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 
-#: components/archival_storage/views.py:605
+#: components/archival_storage/views.py:741
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
 "slug: %(slug)s"
 msgstr ""
 
-#: components/archival_storage/views.py:628
+#: components/archival_storage/views.py:764
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr ""
 
-#: components/backlog/views.py:291
+#: components/backlog/views.py:282
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 
@@ -927,40 +991,40 @@ msgstr ""
 msgid "Unable to fetch levels of description from AtoM!"
 msgstr ""
 
-#: components/ingest/views.py:87
+#: components/ingest/views.py:86
 msgid ""
 "Error retrieving originals/arrange directory locations: is the storage "
 "server running? Please contact an administrator."
 msgstr ""
 
-#: components/ingest/views.py:182
+#: components/ingest/views.py:181
 msgid ""
 "Error retrieving source directories: is the storage server running? Please "
 "contact an administrator."
 msgstr ""
 
-#: components/ingest/views.py:191
+#: components/ingest/views.py:190
 msgid ""
 "No transfer source locations are available. Please contact an administrator."
 msgstr ""
 
-#: components/ingest/views.py:283
+#: components/ingest/views.py:278
 msgid "Are you sure you want to delete this metadata?"
 msgstr ""
 
-#: components/ingest/views.py:418
+#: components/ingest/views.py:412
 msgid "Review normalization"
 msgstr ""
 
-#: components/ingest/views.py:421
+#: components/ingest/views.py:415
 msgid "Review AIP"
 msgstr ""
 
-#: components/ingest/views.py:424
+#: components/ingest/views.py:418
 msgid "Review DIP"
 msgstr ""
 
-#: components/ingest/views_as.py:327
+#: components/ingest/views_as.py:325
 msgid "Operation failed, please try again later or contact your administrator."
 msgstr ""
 
@@ -1073,20 +1137,20 @@ msgid ""
 "content."
 msgstr ""
 
-#: components/rights/views.py:277 components/rights/views.py:311
+#: components/rights/views.py:272 components/rights/views.py:306
 msgid "copyright"
 msgstr ""
 
-#: components/rights/views.py:345 components/rights/views.py:379
+#: components/rights/views.py:340 components/rights/views.py:374
 msgid "license"
 msgstr ""
 
-#: components/rights/views.py:391 components/rights/views.py:426
-#: components/rights/views.py:466 components/rights/views.py:497
+#: components/rights/views.py:386 components/rights/views.py:421
+#: components/rights/views.py:461 components/rights/views.py:492
 msgid "statute"
 msgstr ""
 
-#: components/rights/views.py:483
+#: components/rights/views.py:478
 msgid "statue"
 msgstr ""
 
@@ -1094,11 +1158,11 @@ msgstr ""
 msgid "Error retrieving source directories"
 msgstr ""
 
-#: components/transfer/views.py:210
+#: components/transfer/views.py:208
 msgid "Updated path was not provided."
 msgstr ""
 
-#: components/transfer/views.py:212
+#: components/transfer/views.py:210
 msgid "Unable to update transfer metadata set, contact administrator:"
 msgstr ""
 
@@ -1135,440 +1199,440 @@ msgstr ""
 msgid "the related model"
 msgstr "作成時刻"
 
-#: fpr/models.py:51 fpr/models.py:362 fpr/models.py:560 fpr/models.py:603
-#: fpr/models.py:643 fpr/models.py:659 fpr/models.py:677 fpr/models.py:705
-#: fpr/models.py:730 fpr/models.py:749 fpr/models.py:770
+#: fpr/models.py:52 fpr/models.py:378 fpr/models.py:586 fpr/models.py:629
+#: fpr/models.py:669 fpr/models.py:685 fpr/models.py:703 fpr/models.py:731
+#: fpr/models.py:757 fpr/models.py:776 fpr/models.py:797
 msgid "enabled"
 msgstr ""
 
-#: fpr/models.py:52 fpr/models.py:601 fpr/models.py:640 fpr/models.py:657
-#: fpr/models.py:675 fpr/models.py:703 fpr/models.py:728 fpr/models.py:747
-#: fpr/models.py:768
+#: fpr/models.py:53 fpr/models.py:627 fpr/models.py:666 fpr/models.py:683
+#: fpr/models.py:701 fpr/models.py:729 fpr/models.py:755 fpr/models.py:774
+#: fpr/models.py:795
 msgid "last modified"
 msgstr ""
 
-#: fpr/models.py:141 fpr/models.py:165 fpr/models.py:182 fpr/models.py:251
-#: fpr/models.py:306 fpr/models.py:356 fpr/models.py:388 fpr/models.py:484
-#: fpr/models.py:554
+#: fpr/models.py:142 fpr/models.py:170 fpr/models.py:187 fpr/models.py:257
+#: fpr/models.py:316 fpr/models.py:372 fpr/models.py:404 fpr/models.py:506
+#: fpr/models.py:580
 #, fuzzy
 #| msgid "Identifier"
 msgid "Unique identifier"
 msgstr "識別子"
 
-#: fpr/models.py:144 fpr/models.py:167 fpr/models.py:194 fpr/models.py:254
-#: fpr/models.py:359 fpr/models.py:494 fpr/models.py:557 fpr/models.py:631
-#: fpr/models.py:652 fpr/models.py:671 fpr/models.py:686
+#: fpr/models.py:145 fpr/models.py:172 fpr/models.py:200 fpr/models.py:260
+#: fpr/models.py:375 fpr/models.py:517 fpr/models.py:583 fpr/models.py:657
+#: fpr/models.py:678 fpr/models.py:697 fpr/models.py:712
 #, fuzzy
 #| msgid "Description"
 msgid "description"
 msgstr "記述"
 
-#: fpr/models.py:144
+#: fpr/models.py:145
 msgid "Common name of format"
 msgstr ""
 
-#: fpr/models.py:147
+#: fpr/models.py:151
 #, fuzzy
 #| msgid "A related resource."
 msgid "the related group"
 msgstr "関連リソース。"
 
-#: fpr/models.py:149 fpr/models.py:168 fpr/models.py:364 fpr/models.py:561
+#: fpr/models.py:154 fpr/models.py:173 fpr/models.py:380 fpr/models.py:587
 msgid "slug"
 msgstr ""
 
-#: fpr/models.py:154 fpr/templates/fpr/format/version/detail.html:31
+#: fpr/models.py:159 fpr/templates/fpr/format/version/detail.html:31
 #: fpr/templates/fpr/fprule/detail.html:30
 #: fpr/templates/fpr/fprule/list.html:30 fpr/templates/fpr/idrule/list.html:28
 #: templates/ingest/normalization_report.html:32
 msgid "Format"
 msgstr "フォーマット"
 
-#: fpr/models.py:171
+#: fpr/models.py:176
 #, fuzzy
 #| msgid "Format"
 msgid "Format group"
 msgstr "フォーマット"
 
-#: fpr/models.py:189 fpr/models.py:312 fpr/models.py:444 fpr/models.py:713
+#: fpr/models.py:194 fpr/models.py:327 fpr/models.py:465 fpr/models.py:739
 msgid "the related format"
 msgstr ""
 
-#: fpr/models.py:191 fpr/models.py:361 fpr/models.py:559
+#: fpr/models.py:197 fpr/models.py:377 fpr/models.py:585
 #, fuzzy
 #| msgid "Version"
 msgid "version"
 msgstr "バージョン"
 
-#: fpr/models.py:192
+#: fpr/models.py:198
 msgid "pronom id"
 msgstr ""
 
-#: fpr/models.py:198
+#: fpr/models.py:204
 msgid "Formal name to go in the METS file."
 msgstr ""
 
-#: fpr/models.py:200
+#: fpr/models.py:206
 msgid "access format"
 msgstr ""
 
-#: fpr/models.py:201
+#: fpr/models.py:207
 msgid "preservation format"
 msgstr ""
 
-#: fpr/models.py:208 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
 #, fuzzy
 #| msgid "Format"
 msgid "Format version"
 msgstr "フォーマット"
 
-#: fpr/models.py:227
+#: fpr/models.py:233
 msgid ""
 "Unable to save, an active Format Version  with this pronom id already exists."
 msgstr ""
 
-#: fpr/models.py:234
+#: fpr/models.py:240
 #, python-format
 msgid "%(format)s: %(description)s (%(pronom_id)s)"
 msgstr ""
 
-#: fpr/models.py:254
+#: fpr/models.py:260
 msgid "Name to identify script"
 msgstr ""
 
-#: fpr/models.py:257
+#: fpr/models.py:263
 msgid "PUID"
 msgstr ""
 
-#: fpr/models.py:258
+#: fpr/models.py:264
 msgid "MIME type"
 msgstr ""
 
-#: fpr/models.py:259
+#: fpr/models.py:265
 msgid "File extension"
 msgstr ""
 
-#: fpr/models.py:261
+#: fpr/models.py:267
 #, fuzzy
 #| msgid "Configuration"
 msgid "configuration"
 msgstr "設定"
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 #, fuzzy
 #| msgid "Description"
 msgid "script"
 msgstr "記述"
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 msgid "Script to be executed."
 msgstr ""
 
-#: fpr/models.py:265 fpr/models.py:497
+#: fpr/models.py:271 fpr/models.py:520
 msgid "Bash script"
 msgstr ""
 
-#: fpr/models.py:266 fpr/models.py:498
+#: fpr/models.py:272 fpr/models.py:521
 msgid "Python script"
 msgstr ""
 
-#: fpr/models.py:267 fpr/models.py:499
+#: fpr/models.py:273 fpr/models.py:522
 msgid "Command line"
 msgstr ""
 
-#: fpr/models.py:268 fpr/models.py:500
+#: fpr/models.py:274 fpr/models.py:523
 msgid "No shebang needed"
 msgstr ""
 
-#: fpr/models.py:271 fpr/models.py:503
+#: fpr/models.py:277 fpr/models.py:526
 msgid "script type"
 msgstr ""
 
-#: fpr/models.py:274 fpr/models.py:492
+#: fpr/models.py:283 fpr/models.py:514
 msgid "the related tool"
 msgstr ""
 
-#: fpr/models.py:278
+#: fpr/models.py:288
 msgid "Format identification command"
 msgstr ""
 
-#: fpr/models.py:282
+#: fpr/models.py:292
 #, python-format
 msgid "%(tool)s %(config)s runs %(command)s"
 msgstr ""
 
-#: fpr/models.py:309 fpr/models.py:441
+#: fpr/models.py:321 fpr/models.py:459
 msgid "the related command"
 msgstr ""
 
-#: fpr/models.py:315
+#: fpr/models.py:331
 msgid "command output"
 msgstr ""
 
-#: fpr/models.py:318
+#: fpr/models.py:334
 msgid "Format identification rule"
 msgstr ""
 
-#: fpr/models.py:335
+#: fpr/models.py:351
 msgid ""
 "Unable to save, a rule with this output already exists for this command."
 msgstr ""
 
-#: fpr/models.py:342
+#: fpr/models.py:358
 #, python-format
 msgid "Format identification rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:345
+#: fpr/models.py:361
 #, python-format
 msgid "%(command)s with %(output)s is %(format)s"
 msgstr ""
 
-#: fpr/models.py:359 fpr/models.py:557
+#: fpr/models.py:375 fpr/models.py:583
 msgid "Name of tool"
 msgstr ""
 
-#: fpr/models.py:368
+#: fpr/models.py:384
 msgid "Format identification tool"
 msgstr ""
 
-#: fpr/models.py:374 fpr/models.py:568
+#: fpr/models.py:390 fpr/models.py:594
 #, fuzzy, python-format
 #| msgid "Description"
 msgid "%(description)s"
 msgstr "記述"
 
-#: fpr/models.py:416 templates/layout.html:65 templates/main/access.html:4
+#: fpr/models.py:432 templates/layout.html:67 templates/main/access.html:4
 #: templates/main/access.html:5
 msgid "Access"
 msgstr "アクセス"
 
-#: fpr/models.py:417 fpr/models.py:514
+#: fpr/models.py:433 fpr/models.py:538
 msgid "Characterization"
 msgstr ""
 
-#: fpr/models.py:418
+#: fpr/models.py:434
 #, fuzzy
 #| msgid "Extract packages"
 msgid "Extract"
 msgstr "パッケージの抽出"
 
-#: fpr/models.py:419 fpr/templates/fpr/format/version/detail.html:33
+#: fpr/models.py:435 fpr/templates/fpr/format/version/detail.html:33
 #, fuzzy
 #| msgid "Description"
 msgid "Preservation"
 msgstr "記述"
 
-#: fpr/models.py:420
+#: fpr/models.py:436
 msgid "Thumbnail"
 msgstr ""
 
-#: fpr/models.py:421 fpr/models.py:518
+#: fpr/models.py:437 fpr/models.py:542
 #, fuzzy
 #| msgid "Description"
 msgid "Transcription"
 msgstr "記述"
 
-#: fpr/models.py:422 fpr/models.py:519
+#: fpr/models.py:438 fpr/models.py:543
 msgid "Validation"
 msgstr ""
 
-#: fpr/models.py:423
+#: fpr/models.py:439
 msgid "Validation against a policy"
 msgstr ""
 
-#: fpr/models.py:426
+#: fpr/models.py:442
 #, fuzzy
 #| msgid "Delete successful."
 msgid "Default access"
 msgstr "削除が成功しました。"
 
-#: fpr/models.py:427
+#: fpr/models.py:443
 #, fuzzy
 #| msgid "Default location"
 msgid "Default characterization"
 msgstr "デフォルトの場所"
 
-#: fpr/models.py:428
+#: fpr/models.py:444
 #, fuzzy
 #| msgid "Default location"
 msgid "Default thumbnail"
 msgstr "デフォルトの場所"
 
-#: fpr/models.py:439
+#: fpr/models.py:455
 #, fuzzy
 #| msgid "Purpose"
 msgid "purpose"
 msgstr "目的"
 
-#: fpr/models.py:447
+#: fpr/models.py:469
 msgid "count attempts"
 msgstr ""
 
-#: fpr/models.py:448
+#: fpr/models.py:470
 msgid "count okay"
 msgstr ""
 
-#: fpr/models.py:449
+#: fpr/models.py:471
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:452 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:732
 msgid "Format policy rule"
 msgstr ""
 
-#: fpr/models.py:472
+#: fpr/models.py:494
 #, python-format
 msgid "Format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:475
+#: fpr/models.py:497
 #, python-format
 msgid "Normalize %(format)s for %(purpose)s via %(command)s"
 msgstr ""
 
-#: fpr/models.py:495 fpr/models.py:627 fpr/models.py:744
+#: fpr/models.py:518 fpr/models.py:653 fpr/models.py:771
 msgid "command"
 msgstr ""
 
-#: fpr/models.py:505 fpr/models.py:629
+#: fpr/models.py:528 fpr/models.py:655
 #, fuzzy
 #| msgid "Default location"
 msgid "output location"
 msgstr "デフォルトの場所"
 
-#: fpr/models.py:511
+#: fpr/models.py:534
 msgid "the related output format"
 msgstr ""
 
-#: fpr/models.py:515
+#: fpr/models.py:539
 msgid "Event Detail"
 msgstr ""
 
-#: fpr/models.py:516
+#: fpr/models.py:540
 #, fuzzy
 #| msgid "Duration"
 msgid "Extraction"
 msgstr "期限"
 
-#: fpr/models.py:517
+#: fpr/models.py:541
 #, fuzzy
 #| msgid "Approve normalization"
 msgid "Normalization"
 msgstr "正常化／normalizationを承認"
 
-#: fpr/models.py:520
+#: fpr/models.py:544
 #, fuzzy
 #| msgid "Description"
 msgid "Verification"
 msgstr "記述"
 
-#: fpr/models.py:523 fpr/models.py:613
+#: fpr/models.py:547 fpr/models.py:639
 msgid "command usage"
 msgstr ""
 
-#: fpr/models.py:531
+#: fpr/models.py:555
 msgid "the related verification command"
 msgstr ""
 
-#: fpr/models.py:539
+#: fpr/models.py:564
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:543 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:731
 msgid "Format policy command"
 msgstr ""
 
-#: fpr/models.py:565
+#: fpr/models.py:591
 #, fuzzy
 #| msgid "Approve normalization"
 msgid "Normalization tool"
 msgstr "正常化／normalizationを承認"
 
-#: fpr/models.py:582
+#: fpr/models.py:608
 msgid "agent identifier type"
 msgstr ""
 
-#: fpr/models.py:583
+#: fpr/models.py:609
 msgid "agent identifier value"
 msgstr ""
 
-#: fpr/models.py:584
+#: fpr/models.py:610
 #, fuzzy
 #| msgid "File name"
 msgid "agent name"
 msgstr "ファイル名"
 
-#: fpr/models.py:585
+#: fpr/models.py:611
 msgid "agent type"
 msgstr ""
 
-#: fpr/models.py:586
+#: fpr/models.py:612
 msgid "client IP address"
 msgstr ""
 
-#: fpr/models.py:598 fpr/models.py:637 fpr/models.py:655 fpr/models.py:673
-#: fpr/models.py:701 fpr/models.py:726 fpr/models.py:746 fpr/models.py:766
+#: fpr/models.py:624 fpr/models.py:663 fpr/models.py:681 fpr/models.py:699
+#: fpr/models.py:727 fpr/models.py:753 fpr/models.py:773 fpr/models.py:793
 #, fuzzy
 #| msgid "Replace"
 msgid "replaces"
 msgstr "置換"
 
-#: fpr/models.py:600
+#: fpr/models.py:626
 msgid "type"
 msgstr ""
 
-#: fpr/models.py:614
+#: fpr/models.py:640
 msgid "command type"
 msgstr ""
 
-#: fpr/models.py:617
+#: fpr/models.py:643
 msgid "verification command"
 msgstr ""
 
-#: fpr/models.py:621
+#: fpr/models.py:647
 msgid "event detail command"
 msgstr ""
 
-#: fpr/models.py:625
+#: fpr/models.py:651
 msgid "supported by"
 msgstr ""
 
-#: fpr/models.py:633
+#: fpr/models.py:659
 msgid "output file format"
 msgstr ""
 
-#: fpr/models.py:688
+#: fpr/models.py:714
 msgid "valid preservation format"
 msgstr ""
 
-#: fpr/models.py:694
+#: fpr/models.py:720
 msgid "valid access format"
 msgstr ""
 
-#: fpr/models.py:698
+#: fpr/models.py:724
 msgid "file ID type"
 msgstr ""
 
-#: fpr/models.py:723
+#: fpr/models.py:750
 msgid "classification"
 msgstr ""
 
-#: fpr/models.py:740
+#: fpr/models.py:767
 msgid "command clasification"
 msgstr ""
 
-#: fpr/models.py:745 fpr/models.py:759
+#: fpr/models.py:772 fpr/models.py:786
 #, fuzzy
 #| msgid "File UUID"
 msgid "file ID"
 msgstr "ファイル UUID"
 
-#: fpr/models.py:761
+#: fpr/models.py:788
 msgid "tool"
 msgstr ""
 
-#: fpr/models.py:763
+#: fpr/models.py:790
 #, fuzzy
 #| msgid "Version"
 msgid "tool version"
@@ -1749,12 +1813,12 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:50 templates/accounts/add.html:36
 #: templates/accounts/edit.html:40 templates/accounts/profile.html:49
 #: templates/administration/processing_edit.html:40
-#: templates/delete_request.html:19 templates/ingest/as/match.html:129
-#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:66
-#: templates/rights/rights_edit.html:290 templates/rights/rights_edit.html:292
-#: templates/rights/rights_grants_edit.html:111
-#: templates/rights/rights_grants_edit.html:113
-#: templates/simple_confirm.html:10 templates/transfer/metadata_edit.html:65
+#: templates/delete_request.html:20 templates/ingest/as/match.html:129
+#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:67
+#: templates/rights/rights_edit.html:291 templates/rights/rights_edit.html:293
+#: templates/rights/rights_grants_edit.html:112
+#: templates/rights/rights_grants_edit.html:114
+#: templates/simple_confirm.html:11 templates/transfer/metadata_edit.html:66
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -1934,18 +1998,18 @@ msgstr ""
 #: fpr/templates/fpr/idcommand/form.html:32
 #: fpr/templates/fpr/idrule/form.html:29 fpr/templates/fpr/idtool/form.html:30
 #: templates/accounts/edit.html:39 templates/accounts/profile.html:48
-#: templates/administration/api.html:36
-#: templates/administration/dips_as_edit.html:29
-#: templates/administration/dips_atom_edit.html:44
-#: templates/administration/general.html:67
-#: templates/administration/handle_config.html:24
-#: templates/administration/premis_agent.html:24
+#: templates/administration/api.html:37
+#: templates/administration/dips_as_edit.html:30
+#: templates/administration/dips_atom_edit.html:45
+#: templates/administration/general.html:68
+#: templates/administration/handle_config.html:25
+#: templates/administration/premis_agent.html:25
 #: templates/administration/processing_edit.html:39
-#: templates/administration/term_detail.html:34
-#: templates/ingest/metadata_edit.html:62 templates/rights/rights_edit.html:285
-#: templates/rights/rights_grants_edit.html:106
-#: templates/transfer/component.html:54
-#: templates/transfer/metadata_edit.html:61
+#: templates/administration/term_detail.html:35
+#: templates/ingest/metadata_edit.html:63 templates/rights/rights_edit.html:286
+#: templates/rights/rights_grants_edit.html:107
+#: templates/transfer/component.html:55
+#: templates/transfer/metadata_edit.html:62
 msgid "Save"
 msgstr "保存"
 
@@ -1958,11 +2022,11 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:12
 #: fpr/templates/fpr/format/group/delete.html:49
 #: fpr/templates/fpr/format/group/list.html:51 templates/accounts/list.html:42
-#: templates/administration/atom_levels_of_description.html:44
+#: templates/administration/atom_levels_of_description.html:45
 #: templates/administration/processing.html:33
-#: templates/administration/reports/failure_detail.html:31
+#: templates/administration/reports/failure_detail.html:32
 #: templates/administration/reports/failures.html:39
-#: templates/administration/term_detail.html:35
+#: templates/administration/term_detail.html:36
 #: templates/archival_storage/view.html:111
 #: templates/archival_storage/view.html:154 templates/main/access.html:25
 #: templates/rights/rights_list.html:55 templates/rights/rights_list.html:58
@@ -2245,13 +2309,6 @@ msgstr ""
 msgid "Script"
 msgstr ""
 
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:959
-#: templates/administration/reports/failures.html:25
-#: templates/rights/rights_edit.html:101 templates/rights/rights_edit.html:153
-#: templates/rights/rights_edit.html:203 templates/rights/rights_edit.html:251
-msgid "Type"
-msgstr "種別"
-
 #: fpr/templates/fpr/idcommand/list.html:56
 msgid "No identification commands exist."
 msgstr ""
@@ -2303,7 +2360,7 @@ msgstr "設定"
 #: fpr/templates/fpr/idtool/detail.html:49
 #: templates/ingest/as/_search_form.html:5 templates/ingest/as/match.html:102
 #: templates/ingest/as/match.html:120
-#: templates/ingest/as/review_matches.html:30 templates/ingest/grid.html:165
+#: templates/ingest/as/review_matches.html:31 templates/ingest/grid.html:165
 msgid "Identifier"
 msgstr "識別子"
 
@@ -2514,462 +2571,462 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: main/models.py:243
+#: main/models.py:245
 msgid "Part of AIC"
 msgstr "AIC部"
 
-#: main/models.py:244
+#: main/models.py:246
 msgid "Optional: leave blank if unsure"
 msgstr ""
 
-#: main/models.py:253
+#: main/models.py:255
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:263
+#: main/models.py:265
 msgid "Use ISO 639"
 msgstr ""
 
-#: main/models.py:281
+#: main/models.py:283
 msgid "Untitled"
 msgstr ""
 
-#: main/models.py:329
+#: main/models.py:336
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr ""
 
-#: main/models.py:371
+#: main/models.py:381
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr ""
 
-#: main/models.py:399
+#: main/models.py:409
 msgid "SIP"
 msgstr ""
 
-#: main/models.py:400
+#: main/models.py:410
 msgid "AIC"
 msgstr "AIC"
 
-#: main/models.py:401
+#: main/models.py:411
 msgid "Reingested AIP"
 msgstr ""
 
-#: main/models.py:402
+#: main/models.py:412
 msgid "Reingested AIC"
 msgstr ""
 
-#: main/models.py:416
+#: main/models.py:426
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr ""
 
-#: main/models.py:529
+#: main/models.py:547
 msgid "Arranged SIPs"
 msgstr ""
 
-#: main/models.py:533
+#: main/models.py:551
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr ""
 
-#: main/models.py:578
+#: main/models.py:596
 msgid "Identifier Type"
 msgstr ""
 
-#: main/models.py:580
+#: main/models.py:598
 msgid "Identifier Value"
 msgstr ""
 
-#: main/models.py:582
+#: main/models.py:600
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
 msgstr ""
 
-#: main/models.py:645
+#: main/models.py:673
 #, python-format
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:681
+#: main/models.py:719
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:740
+#: main/models.py:783
 #, python-format
 msgid "%(file)s is %(format)s"
 msgstr ""
 
-#: main/models.py:758
+#: main/models.py:801
 msgid "(Unnamed)"
 msgstr ""
 
-#: main/models.py:780
+#: main/models.py:823
 msgid "Unknown"
 msgstr "不明"
 
-#: main/models.py:781
+#: main/models.py:824
 msgid "Awaiting decision"
 msgstr ""
 
-#: main/models.py:782
+#: main/models.py:825
 msgid "Completed successfully"
 msgstr ""
 
-#: main/models.py:783
+#: main/models.py:826
 msgid "Executing command(s)"
 msgstr ""
 
-#: main/models.py:784
+#: main/models.py:827
 msgid "Failed"
 msgstr ""
 
-#: main/models.py:879
+#: main/models.py:924
 msgid "Agent Identifier Type"
 msgstr ""
 
-#: main/models.py:884
+#: main/models.py:929
 msgid "Agent Identifier Value"
 msgstr ""
 
-#: main/models.py:886
+#: main/models.py:931
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
 msgstr ""
 
-#: main/models.py:893
+#: main/models.py:938
 msgid "Agent Name"
 msgstr ""
 
-#: main/models.py:894
+#: main/models.py:939
 msgid "Used for premis:agentName in the METS file."
 msgstr ""
 
-#: main/models.py:900
+#: main/models.py:945
 msgid "Agent Type"
 msgstr ""
 
-#: main/models.py:901
+#: main/models.py:946
 msgid "Used for premis:agentType in the METS file."
 msgstr ""
 
-#: main/models.py:925
+#: main/models.py:970
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:927
+#: main/models.py:972
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:962 templates/rights/rights_edit.html:105
-#: templates/rights/rights_edit.html:157 templates/rights/rights_edit.html:207
-#: templates/rights/rights_edit.html:255
+#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
+#: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr ""
 
-#: main/models.py:965
+#: main/models.py:1013
 msgid "Rights holder"
 msgstr "権利保持者"
 
-#: main/models.py:968
+#: main/models.py:1016
 msgid "Copyright"
 msgstr "著作権"
 
-#: main/models.py:969
+#: main/models.py:1017
 msgid "Statute"
 msgstr "法令"
 
-#: main/models.py:970
+#: main/models.py:1018
 msgid "License"
 msgstr "ライセンス"
 
-#: main/models.py:971
+#: main/models.py:1019
 msgid "Donor"
 msgstr "寄贈者"
 
-#: main/models.py:972
+#: main/models.py:1020
 msgid "Policy"
 msgstr "ポリシー"
 
-#: main/models.py:979 templates/rights/rights_list.html:34
+#: main/models.py:1027 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr ""
 
-#: main/models.py:991
+#: main/models.py:1039
 msgid "Rights Statement"
 msgstr ""
 
-#: main/models.py:995
+#: main/models.py:1043
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr ""
 
-#: main/models.py:1008
+#: main/models.py:1058
 msgid "copyrighted"
 msgstr ""
 
-#: main/models.py:1009
+#: main/models.py:1059
 msgid "public domain"
 msgstr ""
 
-#: main/models.py:1010
+#: main/models.py:1060
 msgid "unknown"
 msgstr ""
 
-#: main/models.py:1015
+#: main/models.py:1065
 msgid "Copyright status"
 msgstr "著作権のステータス"
 
-#: main/models.py:1020
+#: main/models.py:1070
 msgid "Copyright jurisdiction"
 msgstr "著作権法制"
 
-#: main/models.py:1026
+#: main/models.py:1076
 msgid "Copyright determination date"
 msgstr ""
 
-#: main/models.py:1027 main/models.py:1034 main/models.py:1041
-#: main/models.py:1105 main/models.py:1112 main/models.py:1172
-#: main/models.py:1179 main/models.py:1237 main/models.py:1246
-#: main/models.py:1253 main/models.py:1321 main/models.py:1328
+#: main/models.py:1077 main/models.py:1084 main/models.py:1091
+#: main/models.py:1161 main/models.py:1168 main/models.py:1234
+#: main/models.py:1241 main/models.py:1303 main/models.py:1312
+#: main/models.py:1319 main/models.py:1391 main/models.py:1398
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:1033
+#: main/models.py:1083
 msgid "Copyright start date"
 msgstr ""
 
-#: main/models.py:1040
+#: main/models.py:1090
 msgid "Copyright end date"
 msgstr ""
 
-#: main/models.py:1046 main/models.py:1117 main/models.py:1186
-#: main/models.py:1258 main/models.py:1333
+#: main/models.py:1096 main/models.py:1173 main/models.py:1248
+#: main/models.py:1324 main/models.py:1403
 msgid "Open End Date"
 msgstr ""
 
-#: main/models.py:1047 main/models.py:1118 main/models.py:1187
-#: main/models.py:1259 main/models.py:1334
+#: main/models.py:1097 main/models.py:1174 main/models.py:1249
+#: main/models.py:1325 main/models.py:1404
 msgid "Indicate end date is open"
 msgstr ""
 
-#: main/models.py:1052
+#: main/models.py:1102
 msgid "Rights: Copyright"
 msgstr ""
 
-#: main/models.py:1062
+#: main/models.py:1114
 msgid "Copyright document identification type"
 msgstr ""
 
-#: main/models.py:1066
+#: main/models.py:1118
 msgid "Copyright document identification value"
 msgstr ""
 
-#: main/models.py:1072
+#: main/models.py:1124
 msgid "Copyright document identification role"
 msgstr ""
 
-#: main/models.py:1077
+#: main/models.py:1129
 msgid "Rights: Copyright: Docs ID"
 msgstr ""
 
-#: main/models.py:1086 templates/rights/rights_edit.html:116
+#: main/models.py:1140 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr ""
 
-#: main/models.py:1091
+#: main/models.py:1145
 msgid "Rights: Copyright: Note"
 msgstr ""
 
-#: main/models.py:1098
+#: main/models.py:1154
 msgid "License terms"
 msgstr "ライセンス条件"
 
-#: main/models.py:1104
+#: main/models.py:1160
 msgid "License start date"
 msgstr ""
 
-#: main/models.py:1111
+#: main/models.py:1167
 msgid "License end date"
 msgstr ""
 
-#: main/models.py:1123
+#: main/models.py:1179
 msgid "Rights: License"
 msgstr ""
 
-#: main/models.py:1133
+#: main/models.py:1191
 msgid "License documentation identification type"
 msgstr ""
 
-#: main/models.py:1137
+#: main/models.py:1195
 msgid "License documentation identification value"
 msgstr ""
 
-#: main/models.py:1143
+#: main/models.py:1201
 msgid "License document identification role"
 msgstr ""
 
-#: main/models.py:1148
+#: main/models.py:1206
 msgid "Rights: License: Docs ID"
 msgstr ""
 
-#: main/models.py:1157 templates/rights/rights_edit.html:218
+#: main/models.py:1217 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr "ライセンス注記"
 
-#: main/models.py:1162
+#: main/models.py:1222
 msgid "Rights: License: Note"
 msgstr ""
 
-#: main/models.py:1171 templates/rights/rights_list.html:36
+#: main/models.py:1233 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr "開始"
 
-#: main/models.py:1178 templates/rights/rights_list.html:37
+#: main/models.py:1240 templates/rights/rights_list.html:37
 msgid "End"
 msgstr "終了"
 
-#: main/models.py:1192
+#: main/models.py:1254
 msgid "Rights: Granted"
 msgstr ""
 
-#: main/models.py:1203
+#: main/models.py:1266
 msgid "Rights note"
 msgstr ""
 
-#: main/models.py:1208
+#: main/models.py:1271
 msgid "Rights: Granted: Note"
 msgstr ""
 
-#: main/models.py:1222
+#: main/models.py:1286
 msgid "Rights: Granted: Restriction"
 msgstr ""
 
-#: main/models.py:1229
+#: main/models.py:1295
 msgid "Statute jurisdiction"
 msgstr "法令の管轄"
 
-#: main/models.py:1232
+#: main/models.py:1298
 msgid "Statute citation"
 msgstr "法令の引用"
 
-#: main/models.py:1236
+#: main/models.py:1302
 msgid "Statute determination date"
 msgstr "法令の制定日"
 
-#: main/models.py:1245
+#: main/models.py:1311
 msgid "Statute start date"
 msgstr ""
 
-#: main/models.py:1252
+#: main/models.py:1318
 msgid "Statute end date"
 msgstr ""
 
-#: main/models.py:1264
+#: main/models.py:1330
 msgid "Rights: Statute"
 msgstr ""
 
-#: main/models.py:1274 templates/rights/rights_edit.html:168
+#: main/models.py:1341 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr "状態注記"
 
-#: main/models.py:1279
+#: main/models.py:1346
 msgid "Rights: Statute: Note"
 msgstr ""
 
-#: main/models.py:1290
+#: main/models.py:1358
 msgid "Statute document identification type"
 msgstr ""
 
-#: main/models.py:1294
+#: main/models.py:1362
 msgid "Statute document identification value"
 msgstr ""
 
-#: main/models.py:1300
+#: main/models.py:1368
 msgid "Statute document identification role"
 msgstr ""
 
-#: main/models.py:1305
+#: main/models.py:1373
 msgid "Rights: Statute: Docs ID"
 msgstr ""
 
-#: main/models.py:1313
+#: main/models.py:1383
 msgid "Other rights basis"
 msgstr ""
 
-#: main/models.py:1320
+#: main/models.py:1390
 msgid "Other rights start date"
 msgstr ""
 
-#: main/models.py:1327
+#: main/models.py:1397
 msgid "Other rights end date"
 msgstr ""
 
-#: main/models.py:1339
+#: main/models.py:1409
 msgid "Rights: Other"
 msgstr ""
 
-#: main/models.py:1350
+#: main/models.py:1421
 msgid "Other rights document identification type"
 msgstr ""
 
-#: main/models.py:1354
+#: main/models.py:1425
 msgid "Other right document identification value"
 msgstr ""
 
-#: main/models.py:1360
+#: main/models.py:1431
 msgid "Other rights document identification role"
 msgstr ""
 
-#: main/models.py:1365
+#: main/models.py:1436
 msgid "Rights: Other: Docs ID"
 msgstr ""
 
-#: main/models.py:1375
+#: main/models.py:1447
 msgid "Other rights note"
 msgstr ""
 
-#: main/models.py:1380
+#: main/models.py:1452
 msgid "Rights: Other: Note"
 msgstr ""
 
-#: main/models.py:1388
+#: main/models.py:1462
 msgid "Linking Agent"
 msgstr ""
 
-#: main/models.py:1393
+#: main/models.py:1467
 msgid "Linking Agent Value"
 msgstr ""
 
-#: main/models.py:1399
+#: main/models.py:1473
 msgid "Rights: Agent"
 msgstr ""
 
-#: main/models.py:1435
+#: main/models.py:1509
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr ""
 
-#: main/models.py:1473
+#: main/models.py:1547
 msgid "ASDIPObjectResourcePairing"
 msgstr ""
 
-#: main/models.py:1488
+#: main/models.py:1562
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr ""
 
-#: main/models.py:1495
+#: main/models.py:1569
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 
-#: main/models.py:1615
+#: main/models.py:1709
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr "%(sortorder)s: %(name)s"
@@ -2978,15 +3035,15 @@ msgstr "%(sortorder)s: %(name)s"
 msgid "<no API key generated>"
 msgstr "<no API key generated>"
 
-#: main/views.py:302
+#: main/views.py:299
 msgid "Added."
 msgstr "追加しました。"
 
-#: main/views.py:307
+#: main/views.py:304
 msgid "Error: no delete ID supplied."
 msgstr ""
 
-#: main/views.py:322
+#: main/views.py:319
 msgid "Incorrect type."
 msgstr ""
 
@@ -3018,38 +3075,38 @@ msgstr ""
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:436
+#: settings/base.py:435
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
 msgstr ""
 
-#: settings/base.py:439
+#: settings/base.py:438
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
 "has been moved into storage."
 msgstr ""
 
-#: settings/base.py:441
+#: settings/base.py:440
 msgid "Create a SIP from the transfer."
 msgstr ""
 
-#: settings/base.py:443
+#: settings/base.py:442
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
 "start ingest micro-services."
 msgstr ""
 
-#: settings/base.py:446
+#: settings/base.py:445
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
 "system."
 msgstr ""
 
-#: settings/base.py:449
+#: settings/base.py:448
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -3058,13 +3115,13 @@ msgid ""
 "view the tool output and error message."
 msgstr ""
 
-#: settings/base.py:452
+#: settings/base.py:451
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
 msgstr ""
 
-#: settings/base.py:455
+#: settings/base.py:454
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3099,7 +3156,7 @@ msgid "Previous"
 msgstr "前"
 
 #: templates/_pager.html:35 templates/ingest/normalization_report.html:121
-#: templates/rights/rights_edit.html:287
+#: templates/rights/rights_edit.html:288
 msgid "Next"
 msgstr "次"
 
@@ -3133,8 +3190,8 @@ msgstr "ユーザー"
 msgid "Add new user"
 msgstr "新規のユーザーを追加"
 
-#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:64
-#: templates/installer/welcome.html:49 templates/transfer/metadata_edit.html:63
+#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:65
+#: templates/installer/welcome.html:50 templates/transfer/metadata_edit.html:64
 msgid "Create"
 msgstr "作成する"
 
@@ -3146,12 +3203,6 @@ msgstr ""
 #: templates/accounts/list.html:23 templates/accounts/profile.html:29
 msgid "Username"
 msgstr ""
-
-#: templates/accounts/list.html:24 templates/accounts/profile.html:31
-#: templates/administration/atom_levels_of_description.html:36
-#: templates/administration/reports/failures.html:26
-msgid "Name"
-msgstr "名称"
 
 #: templates/accounts/list.html:25 templates/accounts/profile.html:33
 msgid "E-mail"
@@ -3214,14 +3265,12 @@ msgstr "管理者"
 #: templates/administration/reports/failure_detail.html:6
 #: templates/administration/reports/failures.html:5
 #: templates/administration/reports/failures.html:6
-#: templates/administration/search.html:5
-#: templates/administration/search.html:6
 #: templates/administration/taxonomy.html:5
 #: templates/administration/taxonomy.html:6
 #: templates/administration/term_detail.html:5
 #: templates/administration/term_detail.html:6
 #: templates/administration/terms.html:5 templates/administration/terms.html:6
-#: templates/layout.html:66
+#: templates/layout.html:68
 msgid "Administration"
 msgstr ""
 
@@ -3251,15 +3300,15 @@ msgstr ""
 msgid "AtoM Levels of Description"
 msgstr ""
 
-#: templates/administration/atom_levels_of_description.html:45
+#: templates/administration/atom_levels_of_description.html:46
 msgid "Promote"
 msgstr "昇格"
 
-#: templates/administration/atom_levels_of_description.html:46
+#: templates/administration/atom_levels_of_description.html:47
 msgid "Demote"
 msgstr "降格"
 
-#: templates/administration/atom_levels_of_description.html:54
+#: templates/administration/atom_levels_of_description.html:55
 msgid "No levels found."
 msgstr "レベルが見つからない。"
 
@@ -3271,11 +3320,11 @@ msgstr ""
 msgid "Levels of Description"
 msgstr "記述レベル"
 
-#: templates/administration/dips_atom_edit.html:37
+#: templates/administration/dips_atom_edit.html:38
 msgid "AtoM/Binder DIP upload"
 msgstr ""
 
-#: templates/administration/dips_atom_edit.html:39
+#: templates/administration/dips_atom_edit.html:40
 msgid "The settings below configure DIP uploading to AtoM/Binder."
 msgstr ""
 
@@ -3291,31 +3340,31 @@ msgstr ""
 msgid "General configuration"
 msgstr "一般的な設定"
 
-#: templates/administration/general.html:39
+#: templates/administration/general.html:40
 msgid "Storage Service options"
 msgstr ""
 
-#: templates/administration/general.html:43
+#: templates/administration/general.html:44
 msgid "Checksum algorithm"
 msgstr "チェックサム・アルゴリズム"
 
-#: templates/administration/general.html:47
+#: templates/administration/general.html:48
 msgid "Elasticsearch Indexing"
 msgstr ""
 
-#: templates/administration/general.html:52
+#: templates/administration/general.html:53
 msgid "Transfers related indexes enabled."
 msgstr ""
 
-#: templates/administration/general.html:54
+#: templates/administration/general.html:55
 msgid "Transfers related indexes disabled."
 msgstr ""
 
-#: templates/administration/general.html:59
+#: templates/administration/general.html:60
 msgid "AIPs related indexes enabled."
 msgstr ""
 
-#: templates/administration/general.html:61
+#: templates/administration/general.html:62
 msgid "AIPs related indexes disabled."
 msgstr ""
 
@@ -3429,22 +3478,6 @@ msgstr "日付"
 
 #: templates/administration/reports/failures.html:56
 msgid "No reports found."
-msgstr ""
-
-#: templates/administration/search.html:23
-msgid "Search administration"
-msgstr ""
-
-#: templates/administration/search.html:26
-#, python-format
-msgid ""
-"\n"
-"          %(count)s AIP files indexed.\n"
-"        "
-msgstr ""
-
-#: templates/administration/search.html:33
-msgid "Flush AIP Index"
 msgstr ""
 
 #: templates/administration/sidebar.html:23
@@ -3573,11 +3606,6 @@ msgid ""
 "cleared manually."
 msgstr ""
 
-#: templates/administration/usage.html:90
-#: templates/archival_storage/view.html:67
-msgid "Size"
-msgstr "サイズ"
-
 #: templates/administration/version.html:19
 msgid "About Archivematica"
 msgstr ""
@@ -3587,12 +3615,12 @@ msgid "Agent code"
 msgstr ""
 
 #: templates/appraisal/appraisal.html:4 templates/appraisal/appraisal.html:5
-#: templates/layout.html:58
+#: templates/layout.html:60
 msgid "Appraisal"
 msgstr ""
 
 #: templates/appraisal/appraisal.html:30
-#: templates/archival_storage/archival_storage.html:70
+#: templates/archival_storage/archival_storage.html:74
 #: templates/backlog/backlog.html:34
 msgid "Elasticsearch Indexing Disabled"
 msgstr ""
@@ -3615,23 +3643,23 @@ msgstr ""
 
 #: templates/archival_storage/archival_storage.html:6
 #: templates/archival_storage/archival_storage.html:7
-#: templates/archival_storage/archival_storage.html:32
+#: templates/archival_storage/archival_storage.html:31
 #: templates/archival_storage/view.html:6
 #: templates/archival_storage/view.html:7
-#: templates/archival_storage/view.html:50 templates/layout.html:62
+#: templates/archival_storage/view.html:50 templates/layout.html:64
 msgid "Archival storage"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:33
+#: templates/archival_storage/archival_storage.html:32
 #: templates/ingest/as/_search_form.html:6
 msgid "Search"
 msgstr "検索"
 
-#: templates/archival_storage/archival_storage.html:41
+#: templates/archival_storage/archival_storage.html:40
 msgid "Browse archival storage"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:44
+#: templates/archival_storage/archival_storage.html:43
 #, python-format
 msgid ""
 "\n"
@@ -3639,7 +3667,7 @@ msgid ""
 "          "
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:50
+#: templates/archival_storage/archival_storage.html:49
 #, python-format
 msgid ""
 "\n"
@@ -3647,17 +3675,29 @@ msgid ""
 "            "
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:61
+#: templates/archival_storage/archival_storage.html:60
 msgid "Create an AIC from current search results"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:62
+#: templates/archival_storage/archival_storage.html:61
 #, fuzzy
 #| msgid "Create SIP"
 msgid "Create an AIC"
 msgstr "SIPの作成"
 
-#: templates/archival_storage/archival_storage.html:71
+#: templates/archival_storage/archival_storage.html:65
+msgid ""
+"Download all results from archival storage as a CSV (Comma-separated-values) "
+"table"
+msgstr ""
+
+#: templates/archival_storage/archival_storage.html:66
+#, fuzzy
+#| msgid "Download"
+msgid "Download CSV"
+msgstr "ダウンロード"
+
+#: templates/archival_storage/archival_storage.html:75
 msgid ""
 "Sorry, Elasticsearch indexing has been disabled for the AIPs related indexes "
 "in this Archivematica installation. The archival storage tab is non-"
@@ -3671,19 +3711,6 @@ msgstr ""
 #: templates/archival_storage/view.html:71
 msgid "Date stored"
 msgstr ""
-
-#: templates/archival_storage/view.html:75
-msgid "Status"
-msgstr "ステータス"
-
-#: templates/archival_storage/view.html:79
-msgid "Encrypted"
-msgstr ""
-
-#: templates/archival_storage/view.html:83
-#: templates/ingest/normalization_report.html:31
-msgid "Location"
-msgstr "所在"
 
 #: templates/archival_storage/view.html:90
 msgid "METS file"
@@ -3734,7 +3761,7 @@ msgid ""
 "functional when indexing is turned off."
 msgstr ""
 
-#: templates/delete_request.html:14
+#: templates/delete_request.html:15
 msgid "Reason for deletion:"
 msgstr ""
 
@@ -3781,7 +3808,7 @@ msgstr "AIP"
 #: templates/ingest/grid.html:5 templates/ingest/grid.html:6
 #: templates/ingest/metadata_add_files.html:31
 #: templates/ingest/metadata_edit.html:31
-#: templates/ingest/microservices.html:11 templates/layout.html:60
+#: templates/ingest/microservices.html:11 templates/layout.html:62
 #: templates/rights/rights_edit.html:16
 #: templates/rights/rights_grants_edit.html:16
 #: templates/rights/rights_list.html:9
@@ -3798,7 +3825,7 @@ msgstr "初期化中..."
 #: templates/ingest/as/resource_component.html:52
 #: templates/ingest/as/resource_detail.html:42
 #: templates/ingest/as/resource_list.html:34
-#: templates/ingest/as/review_matches.html:29
+#: templates/ingest/as/review_matches.html:30
 msgid "Title"
 msgstr "タイトル"
 
@@ -3842,7 +3869,7 @@ msgstr ""
 #: templates/ingest/as/resource_detail.html:30
 #: templates/ingest/as/resource_list.html:25
 #: templates/ingest/as/resource_list.html:27
-#: templates/ingest/as/review_matches.html:20
+#: templates/ingest/as/review_matches.html:21
 msgid "Restart matching"
 msgstr ""
 
@@ -3868,7 +3895,7 @@ msgid "Resources"
 msgstr ""
 
 #: templates/ingest/as/match.html:100 templates/ingest/as/match.html:118
-#: templates/ingest/as/review_matches.html:28
+#: templates/ingest/as/review_matches.html:29
 msgid "Level"
 msgstr "レベル"
 
@@ -3876,7 +3903,7 @@ msgstr "レベル"
 #: templates/ingest/as/resource_component.html:53
 #: templates/ingest/as/resource_detail.html:43
 #: templates/ingest/as/resource_list.html:35
-#: templates/ingest/as/review_matches.html:31
+#: templates/ingest/as/review_matches.html:32
 msgid "Dates"
 msgstr "日付"
 
@@ -3885,7 +3912,7 @@ msgid "Pairs"
 msgstr ""
 
 #: templates/ingest/as/match.html:117
-#: templates/ingest/as/review_matches.html:27
+#: templates/ingest/as/review_matches.html:28
 msgid "File"
 msgstr "ファイル"
 
@@ -3924,7 +3951,7 @@ msgstr ""
 msgid "Collections"
 msgstr "コレクション"
 
-#: templates/ingest/as/review_matches.html:21
+#: templates/ingest/as/review_matches.html:22
 msgid "Finish matching"
 msgstr ""
 
@@ -4028,50 +4055,50 @@ msgstr ""
 msgid "Select a directory"
 msgstr "ディレクトリを選択"
 
-#: templates/ingest/metadata_edit.html:77
-#: templates/transfer/metadata_edit.html:76
+#: templates/ingest/metadata_edit.html:78
+#: templates/transfer/metadata_edit.html:77
 msgid "A name given to the resource."
 msgstr "リソースに与えられた名前。"
 
-#: templates/ingest/metadata_edit.html:81
-#: templates/transfer/metadata_edit.html:80
+#: templates/ingest/metadata_edit.html:82
+#: templates/transfer/metadata_edit.html:81
 msgid "An entity primarily responsible for making the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:85
-#: templates/transfer/metadata_edit.html:84
+#: templates/ingest/metadata_edit.html:86
+#: templates/transfer/metadata_edit.html:85
 msgid "The topic of the resource."
 msgstr "リソースのトピック。"
 
-#: templates/ingest/metadata_edit.html:89
-#: templates/transfer/metadata_edit.html:88
+#: templates/ingest/metadata_edit.html:90
+#: templates/transfer/metadata_edit.html:89
 msgid "An account of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:93
-#: templates/transfer/metadata_edit.html:92
+#: templates/ingest/metadata_edit.html:94
+#: templates/transfer/metadata_edit.html:93
 msgid "An entity responsible for making the resource available."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:97
-#: templates/transfer/metadata_edit.html:96
+#: templates/ingest/metadata_edit.html:98
+#: templates/transfer/metadata_edit.html:97
 msgid "An entity responsible for making contributions to the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:101
-#: templates/transfer/metadata_edit.html:100
+#: templates/ingest/metadata_edit.html:102
+#: templates/transfer/metadata_edit.html:101
 msgid ""
 "A point or period of time associated with an event in the lifecycle of the "
 "resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:106
-#: templates/transfer/metadata_edit.html:105
+#: templates/ingest/metadata_edit.html:107
+#: templates/transfer/metadata_edit.html:106
 msgid "The nature or genre of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:108
-#: templates/transfer/metadata_edit.html:107
+#: templates/ingest/metadata_edit.html:109
+#: templates/transfer/metadata_edit.html:108
 msgid ""
 "\n"
 "        You may wish to use the DCMI type vocabulary provided here: <a href="
@@ -4080,13 +4107,13 @@ msgid ""
 "      "
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:116
-#: templates/transfer/metadata_edit.html:115
+#: templates/ingest/metadata_edit.html:117
+#: templates/transfer/metadata_edit.html:116
 msgid "The file format, physical medium, or dimensions of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:118
-#: templates/transfer/metadata_edit.html:117
+#: templates/ingest/metadata_edit.html:119
+#: templates/transfer/metadata_edit.html:118
 msgid ""
 "\n"
 "        Best practice is to use a controlled vocabulary such as the list of "
@@ -4096,35 +4123,35 @@ msgid ""
 "      "
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:125
-#: templates/transfer/metadata_edit.html:124
+#: templates/ingest/metadata_edit.html:126
+#: templates/transfer/metadata_edit.html:125
 msgid "An unambiguous reference to the resource within a given context."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:129
-#: templates/transfer/metadata_edit.html:128
+#: templates/ingest/metadata_edit.html:130
+#: templates/transfer/metadata_edit.html:129
 msgid "A related resource from which the described resource is derived."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:133
-#: templates/transfer/metadata_edit.html:132
+#: templates/ingest/metadata_edit.html:134
+#: templates/transfer/metadata_edit.html:133
 msgid "A related resource."
 msgstr "関連リソース。"
 
-#: templates/ingest/metadata_edit.html:137
-#: templates/transfer/metadata_edit.html:136
+#: templates/ingest/metadata_edit.html:138
+#: templates/transfer/metadata_edit.html:137
 msgid "A language of the resource."
 msgstr "リソースの言語。"
 
-#: templates/ingest/metadata_edit.html:141
-#: templates/transfer/metadata_edit.html:140
+#: templates/ingest/metadata_edit.html:142
+#: templates/transfer/metadata_edit.html:141
 msgid ""
 "The spatial or temporal topic of the resource, the spatial applicability of "
 "the resource, or the jurisdiction under which the resource is relevant."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:145
-#: templates/transfer/metadata_edit.html:144
+#: templates/ingest/metadata_edit.html:146
+#: templates/transfer/metadata_edit.html:145
 msgid "Information about rights held in and over the resource."
 msgstr ""
 
@@ -4183,15 +4210,15 @@ msgid ""
 "    "
 msgstr ""
 
-#: templates/installer/storagesetup.html:25
+#: templates/installer/storagesetup.html:26
 msgid "Register this pipeline in the Storage Service"
 msgstr ""
 
-#: templates/installer/storagesetup.html:30
+#: templates/installer/storagesetup.html:31
 msgid "Dashboard UUID"
 msgstr "ダッシュボードUUID"
 
-#: templates/installer/storagesetup.html:39
+#: templates/installer/storagesetup.html:40
 msgid "Register"
 msgstr "登録"
 
@@ -4213,7 +4240,7 @@ msgstr ""
 msgid "Archivematica Dashboard"
 msgstr "Archivematica ダッシュボード"
 
-#: templates/layout.html:55 templates/rights/rights_edit.html:18
+#: templates/layout.html:57 templates/rights/rights_edit.html:18
 #: templates/rights/rights_grants_edit.html:18
 #: templates/rights/rights_list.html:11 templates/transfer/component.html:10
 #: templates/transfer/detail.html:9 templates/transfer/grid.html:5
@@ -4223,19 +4250,19 @@ msgstr "Archivematica ダッシュボード"
 msgid "Transfer"
 msgstr "転送"
 
-#: templates/layout.html:57
+#: templates/layout.html:59
 msgid "Backlog"
 msgstr "バックログ"
 
-#: templates/layout.html:64
+#: templates/layout.html:66
 msgid "Preservation planning"
 msgstr ""
 
-#: templates/layout.html:74
+#: templates/layout.html:76
 msgid "Your profile"
 msgstr "あなたのプロフィール"
 
-#: templates/layout.html:76
+#: templates/layout.html:78
 msgid "Log out"
 msgstr "ログアウト"
 
@@ -4344,28 +4371,28 @@ msgid ""
 "                "
 msgstr ""
 
-#: templates/rights/rights_edit.html:96
+#: templates/rights/rights_edit.html:97
 msgid "Copyright documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:109 templates/rights/rights_edit.html:161
-#: templates/rights/rights_edit.html:211 templates/rights/rights_edit.html:259
+#: templates/rights/rights_edit.html:110 templates/rights/rights_edit.html:162
+#: templates/rights/rights_edit.html:212 templates/rights/rights_edit.html:260
 msgid "Role"
 msgstr "役割"
 
-#: templates/rights/rights_edit.html:147
+#: templates/rights/rights_edit.html:148
 msgid "Statute documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:197
+#: templates/rights/rights_edit.html:198
 msgid "License documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:245
+#: templates/rights/rights_edit.html:246
 msgid "Documentation identifier"
 msgstr ""
 
-#: templates/rights/rights_edit.html:266
+#: templates/rights/rights_edit.html:267
 msgid "Note"
 msgstr "注記"
 
@@ -4374,23 +4401,23 @@ msgid ""
 "You may now add additional information such as document identifers and notes."
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:79
+#: templates/rights/rights_grants_edit.html:80
 msgid "Allow"
 msgstr "許可する"
 
-#: templates/rights/rights_grants_edit.html:80
+#: templates/rights/rights_grants_edit.html:81
 msgid "Disallow"
 msgstr "禁止する"
 
-#: templates/rights/rights_grants_edit.html:81
+#: templates/rights/rights_grants_edit.html:82
 msgid "Conditional"
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:87
+#: templates/rights/rights_grants_edit.html:88
 msgid "Grant/restriction note"
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:108
+#: templates/rights/rights_grants_edit.html:109
 msgid "Done"
 msgstr "完了"
 

--- a/src/dashboard/src/locale/ja/LC_MESSAGES/djangojs.po
+++ b/src/dashboard/src/locale/ja/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 12:27-0400\n"
+"POT-Creation-Date: 2020-07-27 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Naosuke Okamoto, 2018\n"
 "Language-Team: Japanese (https://www.transifex.com/artefactual/teams/1506/"
@@ -28,7 +28,7 @@ msgid "Are you sure you want to delete this level of description?"
 msgstr "この記述レベルを削除しますか？"
 
 #: media/js/advanced-search-query-creator.js:14 media/js/file_browser.js:59
-#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:209
+#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:211
 msgid "Delete"
 msgstr "削除"
 
@@ -47,7 +47,7 @@ msgid "Any"
 msgstr "任意"
 
 #: media/js/archival_storage/archival_storage_search.js:61
-#: media/js/archival_storage/archival_storage_search.js:238
+#: media/js/archival_storage/archival_storage_search.js:242
 msgid "File UUID"
 msgstr "ファイル UUID"
 
@@ -106,227 +106,233 @@ msgstr "語句"
 msgid "Date range"
 msgstr "日付の範囲"
 
-#: media/js/archival_storage/archival_storage_search.js:148
+#: media/js/archival_storage/archival_storage_search.js:152
 msgid "view raw"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:169
+#: media/js/archival_storage/archival_storage_search.js:173
 #: media/js/backlog/backlog-search.js:6 media/js/backlog/backlog-search.js:12
 msgid "Download"
 msgstr "ダウンロード"
 
-#: media/js/archival_storage/archival_storage_search.js:184
+#: media/js/archival_storage/archival_storage_search.js:188
 msgid "AIPs in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:185
+#: media/js/archival_storage/archival_storage_search.js:189
 msgid "AIP in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:188
+#: media/js/archival_storage/archival_storage_search.js:192
 #, fuzzy
 #| msgid "Part of AIC"
 msgid "Part of"
 msgstr "AIC部"
 
-#: media/js/archival_storage/archival_storage_search.js:190
+#: media/js/archival_storage/archival_storage_search.js:194
 msgid "None"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:197
+#: media/js/archival_storage/archival_storage_search.js:201
 msgid "View"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "True"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "False"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 msgid "Deletion requested"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 #: media/js/backlog/backlog-search.js:19
 msgid "Stored"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:236
+#: media/js/archival_storage/archival_storage_search.js:240
 msgid "Thumbnail"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:237
+#: media/js/archival_storage/archival_storage_search.js:241
 #, fuzzy
 #| msgid "Filename"
 msgid "File"
 msgstr "ファイル名"
 
-#: media/js/archival_storage/archival_storage_search.js:239
+#: media/js/archival_storage/archival_storage_search.js:243
 msgid "AIP"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:240
+#: media/js/archival_storage/archival_storage_search.js:244
 #: media/js/backlog/backlog-search.js:42 media/js/backlog/backlog-search.js:53
 #: media/js/ingest/backlog.js:37
 msgid "Accession number"
 msgstr "受入番号"
 
-#: media/js/archival_storage/archival_storage_search.js:241
-#: media/js/archival_storage/archival_storage_search.js:254
+#: media/js/archival_storage/archival_storage_search.js:245
+#: media/js/archival_storage/archival_storage_search.js:258
 #: media/js/backlog/backlog-search.js:43 media/js/backlog/backlog-search.js:55
 msgid "Status"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:242
-#: media/js/archival_storage/archival_storage_search.js:256
+#: media/js/archival_storage/archival_storage_search.js:246
+#: media/js/archival_storage/archival_storage_search.js:261
 #: media/js/backlog/backlog-search.js:44 media/js/backlog/backlog-search.js:56
-#: media/js/ingest.js:216 media/js/transfer.js:153
+#: media/js/ingest.js:217 media/js/transfer.js:154
 msgid "Actions"
 msgstr "行動"
 
-#: media/js/archival_storage/archival_storage_search.js:247
+#: media/js/archival_storage/archival_storage_search.js:251
 #: media/js/backlog/backlog-search.js:49
 msgid "Name"
 msgstr "名称"
 
-#: media/js/archival_storage/archival_storage_search.js:248
+#: media/js/archival_storage/archival_storage_search.js:252
 #, fuzzy
 #| msgid "AIP UUID"
 msgid "UUID"
 msgstr "AIP UUID"
 
-#: media/js/archival_storage/archival_storage_search.js:249
+#: media/js/archival_storage/archival_storage_search.js:253
 msgid "AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:250
+#: media/js/archival_storage/archival_storage_search.js:254
 #: media/js/backlog/backlog-search.js:51
 msgid "Size"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:251
+#: media/js/archival_storage/archival_storage_search.js:255
 #: media/js/backlog/backlog-search.js:52
 msgid "File count"
 msgstr "ファイル数"
 
-#: media/js/archival_storage/archival_storage_search.js:252
+#: media/js/archival_storage/archival_storage_search.js:256
 #, fuzzy
 #| msgid "Accession number"
 msgid "Accession numbers"
 msgstr "受入番号"
 
-#: media/js/archival_storage/archival_storage_search.js:253
+#: media/js/archival_storage/archival_storage_search.js:257
 #, fuzzy
 #| msgid "Create SIP"
 msgid "Created"
 msgstr "SIPの作成"
 
-#: media/js/archival_storage/archival_storage_search.js:255
+#: media/js/archival_storage/archival_storage_search.js:259
 msgid "Encrypted"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:309
-#: media/js/backlog/backlog-search.js:109
+#: media/js/archival_storage/archival_storage_search.js:260
+#, fuzzy
+#| msgid "Actions"
+msgid "Location"
+msgstr "行動"
+
+#: media/js/archival_storage/archival_storage_search.js:315
+#: media/js/backlog/backlog-search.js:110
 #, fuzzy
 #| msgid "Select an action..."
 msgid "Select columns"
 msgstr "アクションを選択..."
 
-#: media/js/archival_storage/archival_storage_search.js:313
-#: media/js/backlog/backlog-search.js:113
+#: media/js/archival_storage/archival_storage_search.js:319
+#: media/js/backlog/backlog-search.js:114
 msgctxt "DataTable - sEmptyTable"
 msgid "No data available in table"
 msgstr "テーブルにデータがありません"
 
-#: media/js/archival_storage/archival_storage_search.js:314
-#: media/js/backlog/backlog-search.js:114
+#: media/js/archival_storage/archival_storage_search.js:320
+#: media/js/backlog/backlog-search.js:115
 msgctxt "DataTable - sInfo"
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "総数 _TOTAL_ の _START_ から _END_ を表示"
 
-#: media/js/archival_storage/archival_storage_search.js:315
-#: media/js/backlog/backlog-search.js:115
+#: media/js/archival_storage/archival_storage_search.js:321
+#: media/js/backlog/backlog-search.js:116
 msgctxt "DataTable - sInfoEmpty"
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "総数 0 の 0 から 0 を表示"
 
-#: media/js/archival_storage/archival_storage_search.js:316
-#: media/js/backlog/backlog-search.js:116
+#: media/js/archival_storage/archival_storage_search.js:322
+#: media/js/backlog/backlog-search.js:117
 msgctxt "DataTable - sInfoFiltered"
 msgid "(filtered from _MAX_ total entries)"
 msgstr "( _MAX_ の総エントリからフィルタしました)"
 
-#: media/js/archival_storage/archival_storage_search.js:318
-#: media/js/backlog/backlog-search.js:118
+#: media/js/archival_storage/archival_storage_search.js:324
+#: media/js/backlog/backlog-search.js:119
 msgctxt "DataTable - sInfoThousands"
 msgid ","
 msgstr ","
 
-#: media/js/archival_storage/archival_storage_search.js:319
-#: media/js/backlog/backlog-search.js:119
+#: media/js/archival_storage/archival_storage_search.js:325
+#: media/js/backlog/backlog-search.js:120
 msgctxt "DataTable - sLengthMenu"
 msgid "Show _MENU_ entries"
 msgstr "_MENU_ エントリを表示"
 
-#: media/js/archival_storage/archival_storage_search.js:320
-#: media/js/backlog/backlog-search.js:120
+#: media/js/archival_storage/archival_storage_search.js:326
+#: media/js/backlog/backlog-search.js:121
 msgctxt "DataTable - sLoadingRecords"
 msgid "Loading..."
 msgstr "ロード中..."
 
-#: media/js/archival_storage/archival_storage_search.js:321
-#: media/js/backlog/backlog-search.js:121
+#: media/js/archival_storage/archival_storage_search.js:327
+#: media/js/backlog/backlog-search.js:122
 msgctxt "DataTable - sProcessing"
 msgid "Processing..."
 msgstr "処理中..."
 
-#: media/js/archival_storage/archival_storage_search.js:322
-#: media/js/backlog/backlog-search.js:122
+#: media/js/archival_storage/archival_storage_search.js:328
+#: media/js/backlog/backlog-search.js:123
 msgctxt "DataTable - sSearch"
 msgid "Search:"
 msgstr "検索："
 
-#: media/js/archival_storage/archival_storage_search.js:323
-#: media/js/backlog/backlog-search.js:123
+#: media/js/archival_storage/archival_storage_search.js:329
+#: media/js/backlog/backlog-search.js:124
 msgctxt "DataTable - sZeroRecords"
 msgid "No matching records found"
 msgstr "該当するレコードが見つかりません"
 
-#: media/js/archival_storage/archival_storage_search.js:325
-#: media/js/backlog/backlog-search.js:125
+#: media/js/archival_storage/archival_storage_search.js:331
+#: media/js/backlog/backlog-search.js:126
 msgctxt "DataTable - sFirst"
 msgid "First"
 msgstr "先頭"
 
-#: media/js/archival_storage/archival_storage_search.js:326
-#: media/js/backlog/backlog-search.js:126
+#: media/js/archival_storage/archival_storage_search.js:332
+#: media/js/backlog/backlog-search.js:127
 msgctxt "DataTable - sLast"
 msgid "Last"
 msgstr "最後"
 
-#: media/js/archival_storage/archival_storage_search.js:327
-#: media/js/backlog/backlog-search.js:127
+#: media/js/archival_storage/archival_storage_search.js:333
+#: media/js/backlog/backlog-search.js:128
 msgctxt "DataTable - sNext"
 msgid "Next"
 msgstr "次"
 
-#: media/js/archival_storage/archival_storage_search.js:328
-#: media/js/backlog/backlog-search.js:128
+#: media/js/archival_storage/archival_storage_search.js:334
+#: media/js/backlog/backlog-search.js:129
 msgctxt "DataTable - sPrevious"
 msgid "Previous"
 msgstr "前"
 
-#: media/js/archival_storage/archival_storage_search.js:331
-#: media/js/backlog/backlog-search.js:131
+#: media/js/archival_storage/archival_storage_search.js:337
+#: media/js/backlog/backlog-search.js:132
 msgctxt "DataTable - sSortAscending"
 msgid ": activate to sort column ascending"
 msgstr "：昇順に並べ替えるためアクティブにする"
 
-#: media/js/archival_storage/archival_storage_search.js:332
-#: media/js/backlog/backlog-search.js:132
+#: media/js/archival_storage/archival_storage_search.js:338
+#: media/js/backlog/backlog-search.js:133
 msgctxt "DataTable - sSortDescending"
 msgid ": activate to sort column descending"
 msgstr "：降順に並べ替えるためアクティブにする"
@@ -366,7 +372,7 @@ msgid "Yes"
 msgstr "はい"
 
 #: media/js/directory_picker.js:90 media/js/file_browser.js:178
-#: media/js/ingest.js:123 media/js/jobs.js:590 media/js/jobs.js:683
+#: media/js/ingest.js:124 media/js/jobs.js:590 media/js/jobs.js:686
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -416,43 +422,43 @@ msgstr "SIPを取り除く"
 msgid "Confirm"
 msgstr "確認する"
 
-#: media/js/ingest.js:145
+#: media/js/ingest.js:146
 msgid "Dublin Core metadata editor"
 msgstr "ダブリンコア　メタデータエディタ"
 
-#: media/js/ingest.js:152 media/js/jobs.js:535
+#: media/js/ingest.js:153 media/js/jobs.js:535
 msgid "Close"
 msgstr "閉じる"
 
-#: media/js/ingest.js:173
+#: media/js/ingest.js:174
 msgid "Error"
 msgstr "エラー"
 
-#: media/js/ingest.js:240
+#: media/js/ingest.js:241
 msgid "Report"
 msgstr "レポート"
 
-#: media/js/ingest.js:243
+#: media/js/ingest.js:244
 msgid "Match DIP objects to resources"
 msgstr "DIPオブジェクトとリソースを照合する"
 
-#: media/js/ingest.js:301
+#: media/js/ingest.js:303
 msgid "Loading..."
 msgstr "ロード中..."
 
-#: media/js/ingest/as_matcher.js:551
+#: media/js/ingest/as_matcher.js:553
 msgid "No resource selected."
 msgstr "リソースが選択されていません。"
 
-#: media/js/ingest/as_matcher.js:558
+#: media/js/ingest/as_matcher.js:560
 msgid "No objects selected."
 msgstr "オブジェクトが選択されていません。"
 
-#: media/js/ingest/as_matcher.js:670
+#: media/js/ingest/as_matcher.js:673
 msgid "Warning"
 msgstr "警告"
 
-#: media/js/ingest/as_matcher.js:674
+#: media/js/ingest/as_matcher.js:677
 msgid "Dismiss"
 msgstr "却下"
 
@@ -464,15 +470,15 @@ msgstr "ファイル名"
 msgid "Ingest date (YYYY-MM-DD)"
 msgstr "取込日（Ingest date） (YYYY-MM-DD)"
 
-#: media/js/ingest/metadata_form.js:83
+#: media/js/ingest/metadata_form.js:84
 msgid "Browse"
 msgstr "ブラウズ"
 
-#: media/js/ingest/metadata_form.js:85
+#: media/js/ingest/metadata_form.js:86
 msgid "Add files"
 msgstr "ファイル追加"
 
-#: media/js/ingest/metadata_form.js:124
+#: media/js/ingest/metadata_form.js:125
 msgid "Please select at least one metadata file."
 msgstr "少なくとも1つのメタデータファイルを選択してください。"
 
@@ -499,35 +505,35 @@ msgstr ""
 msgid "Remove All Completed %ss"
 msgstr "完了した %s 全てを削除"
 
-#: media/js/jobs.js:661
+#: media/js/jobs.js:664
 #, javascript-format
 msgid "There were no completed %ss to remove"
 msgstr "削除する %s は完了しませんでした"
 
-#: media/js/jobs.js:665
+#: media/js/jobs.js:668
 #, javascript-format
 msgid "Successfully removed the following %ss: %s"
 msgstr "次の %sを正常に削除しました： %s"
 
-#: media/js/jobs.js:671
+#: media/js/jobs.js:674
 #, javascript-format
 msgid "Failed to remove all completed %ss"
 msgstr ""
 
-#: media/js/jobs.js:797
+#: media/js/jobs.js:800
 msgid "Previous"
 msgstr "前"
 
-#: media/js/jobs.js:812
+#: media/js/jobs.js:815
 msgid "Next"
 msgstr "次"
 
-#: media/js/jobs.js:850
+#: media/js/jobs.js:853
 msgid "Error trying to connect to database. Trying again..."
 msgstr ""
 "データベースへの接続中にエラーが発生しました。 もう一度やり直してください..."
 
-#: media/js/jobs.js:900
+#: media/js/jobs.js:903
 msgid "Error trying to connect to MCP server. Trying again..."
 msgstr ""
 "MCPサーバーへの接続中にエラーが発生しました。 もう一度やり直してください..."
@@ -544,7 +550,7 @@ msgstr "ロード中"
 msgid "Disconnected"
 msgstr "切断済"
 
-#: media/js/repeating-ajax-data.js:215
+#: media/js/repeating-ajax-data.js:217
 msgid "Are you sure?"
 msgstr "本当によろしいですか？"
 

--- a/src/dashboard/src/locale/pt/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/pt/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 11:52-0400\n"
+"POT-Creation-Date: 2020-07-27 22:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: artefactual <translate@artefactual.com>, 2018\n"
 "Language-Team: Portuguese (https://www.transifex.com/artefactual/teams/1506/"
@@ -19,12 +19,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: components/accounts/views.py:62 components/accounts/views.py:150
-#: components/administration/views.py:459
-#: components/administration/views.py:474
-#: components/administration/views.py:486
-#: components/administration/views.py:513
-#: components/administration/views.py:564
+#: components/accounts/views.py:61 components/accounts/views.py:149
+#: components/administration/views.py:454
+#: components/administration/views.py:469
+#: components/administration/views.py:481
+#: components/administration/views.py:508
+#: components/administration/views.py:555
 #: components/administration/views_dip_upload.py:25
 #: components/administration/views_dip_upload.py:39 fpr/views.py:106
 #: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: components/accounts/views.py:82
+#: components/accounts/views.py:81
 #, python-format
 msgid "Your profile (%s)"
 msgstr ""
@@ -366,7 +366,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:973
+#: components/administration/forms_dip_upload.py:21 main/models.py:1021
 msgid "Other"
 msgstr ""
 
@@ -549,93 +549,93 @@ msgstr ""
 msgid "Used in metadata-only DIP upload."
 msgstr ""
 
-#: components/administration/views.py:92 components/administration/views.py:125
-#: components/ingest/views.py:293 fpr/views.py:261 main/views.py:310
+#: components/administration/views.py:89 components/administration/views.py:122
+#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
 msgid "Deleted."
 msgstr ""
 
-#: components/administration/views.py:109
+#: components/administration/views.py:106
 msgid "Promoted."
 msgstr ""
 
-#: components/administration/views.py:112
+#: components/administration/views.py:109
 msgid "Error attempting to promote level of description."
 msgstr ""
 
-#: components/administration/views.py:116
+#: components/administration/views.py:113
 msgid "Demoted."
 msgstr ""
 
-#: components/administration/views.py:119
+#: components/administration/views.py:116
 msgid "Error attempting to demote level of description."
 msgstr ""
 
-#: components/administration/views.py:127
+#: components/administration/views.py:124
 msgid "Level of description not found."
 msgstr ""
 
-#: components/administration/views.py:193
+#: components/administration/views.py:190
 msgid ""
 "Error retrieving locations: is the storage server running? Please contact an "
 "administrator."
 msgstr ""
 
-#: components/administration/views.py:202
+#: components/administration/views.py:199
 msgid "AIP Storage"
 msgstr ""
 
-#: components/administration/views.py:203
+#: components/administration/views.py:200
 msgid "DIP Storage"
 msgstr ""
 
-#: components/administration/views.py:204
+#: components/administration/views.py:201
 msgid "FEDORA Deposits"
 msgstr ""
 
-#: components/administration/views.py:205
+#: components/administration/views.py:202
 msgid "Transfer Backlog"
 msgstr ""
 
-#: components/administration/views.py:206
+#: components/administration/views.py:203
 msgid "Transfer Source"
 msgstr ""
 
-#: components/administration/views.py:207
+#: components/administration/views.py:204
 msgid "Replicator"
 msgstr ""
 
-#: components/administration/views.py:224
+#: components/administration/views.py:221
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:407
+#: components/administration/views.py:404
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:410
+#: components/administration/views.py:406
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr ""
 
-#: components/administration/views.py:436
+#: components/administration/views.py:431
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:439
+#: components/administration/views.py:434
 #, python-format
 msgid "No such file or directory: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:580
+#: components/administration/views.py:571
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
 "Storage Sevice URL below.<hr />%(error)s"
 msgstr ""
 
-#: components/administration/views.py:597
+#: components/administration/views.py:588
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -643,7 +643,7 @@ msgid ""
 "%(error)s"
 msgstr ""
 
-#: components/administration/views.py:609
+#: components/administration/views.py:600
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -712,6 +712,7 @@ msgid "Please type in the UUID to confirm"
 msgstr ""
 
 #: components/archival_storage/forms.py:89
+#: components/archival_storage/views.py:210
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -741,35 +742,92 @@ msgstr ""
 msgid "UUID mismatch"
 msgstr ""
 
-#: components/archival_storage/views.py:49
+#: components/archival_storage/views.py:54
 msgid "Stored"
 msgstr ""
 
-#: components/archival_storage/views.py:50
+#: components/archival_storage/views.py:55
 msgid "Deletion requested"
 msgstr ""
 
-#: components/archival_storage/views.py:464
+#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: templates/accounts/profile.html:31
+#: templates/administration/atom_levels_of_description.html:37
+#: templates/administration/reports/failures.html:26
+msgid "Name"
+msgstr ""
+
+#: components/archival_storage/views.py:211
+msgid "AICID"
+msgstr ""
+
+#: components/archival_storage/views.py:212
+msgid "Count AIPs in AIC"
+msgstr ""
+
+#: components/archival_storage/views.py:213
+#: templates/administration/usage.html:90
+#: templates/archival_storage/view.html:67
+msgid "Size"
+msgstr ""
+
+#: components/archival_storage/views.py:214
+msgid "File count"
+msgstr ""
+
+#: components/archival_storage/views.py:215
+msgid "Accession IDs"
+msgstr ""
+
+#: components/archival_storage/views.py:216
+msgid "Created date (UTC)"
+msgstr ""
+
+#: components/archival_storage/views.py:217
+#: templates/archival_storage/view.html:75
+msgid "Status"
+msgstr ""
+
+#: components/archival_storage/views.py:218
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: templates/administration/reports/failures.html:25
+#: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
+#: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
+msgid "Type"
+msgstr ""
+
+#: components/archival_storage/views.py:219
+#: templates/archival_storage/view.html:79
+msgid "Encrypted"
+msgstr ""
+
+#: components/archival_storage/views.py:220
+#: templates/archival_storage/view.html:83
+#: templates/ingest/normalization_report.html:31
+msgid "Location"
+msgstr ""
+
+#: components/archival_storage/views.py:600
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:593
+#: components/archival_storage/views.py:729
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 
-#: components/archival_storage/views.py:605
+#: components/archival_storage/views.py:741
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
 "slug: %(slug)s"
 msgstr ""
 
-#: components/archival_storage/views.py:628
+#: components/archival_storage/views.py:764
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr ""
 
-#: components/backlog/views.py:291
+#: components/backlog/views.py:282
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 
@@ -922,40 +980,40 @@ msgstr ""
 msgid "Unable to fetch levels of description from AtoM!"
 msgstr ""
 
-#: components/ingest/views.py:87
+#: components/ingest/views.py:86
 msgid ""
 "Error retrieving originals/arrange directory locations: is the storage "
 "server running? Please contact an administrator."
 msgstr ""
 
-#: components/ingest/views.py:182
+#: components/ingest/views.py:181
 msgid ""
 "Error retrieving source directories: is the storage server running? Please "
 "contact an administrator."
 msgstr ""
 
-#: components/ingest/views.py:191
+#: components/ingest/views.py:190
 msgid ""
 "No transfer source locations are available. Please contact an administrator."
 msgstr ""
 
-#: components/ingest/views.py:283
+#: components/ingest/views.py:278
 msgid "Are you sure you want to delete this metadata?"
 msgstr ""
 
-#: components/ingest/views.py:418
+#: components/ingest/views.py:412
 msgid "Review normalization"
 msgstr ""
 
-#: components/ingest/views.py:421
+#: components/ingest/views.py:415
 msgid "Review AIP"
 msgstr ""
 
-#: components/ingest/views.py:424
+#: components/ingest/views.py:418
 msgid "Review DIP"
 msgstr ""
 
-#: components/ingest/views_as.py:327
+#: components/ingest/views_as.py:325
 msgid "Operation failed, please try again later or contact your administrator."
 msgstr ""
 
@@ -1068,20 +1126,20 @@ msgid ""
 "content."
 msgstr ""
 
-#: components/rights/views.py:277 components/rights/views.py:311
+#: components/rights/views.py:272 components/rights/views.py:306
 msgid "copyright"
 msgstr ""
 
-#: components/rights/views.py:345 components/rights/views.py:379
+#: components/rights/views.py:340 components/rights/views.py:374
 msgid "license"
 msgstr ""
 
-#: components/rights/views.py:391 components/rights/views.py:426
-#: components/rights/views.py:466 components/rights/views.py:497
+#: components/rights/views.py:386 components/rights/views.py:421
+#: components/rights/views.py:461 components/rights/views.py:492
 msgid "statute"
 msgstr ""
 
-#: components/rights/views.py:483
+#: components/rights/views.py:478
 msgid "statue"
 msgstr ""
 
@@ -1089,11 +1147,11 @@ msgstr ""
 msgid "Error retrieving source directories"
 msgstr ""
 
-#: components/transfer/views.py:210
+#: components/transfer/views.py:208
 msgid "Updated path was not provided."
 msgstr ""
 
-#: components/transfer/views.py:212
+#: components/transfer/views.py:210
 msgid "Unable to update transfer metadata set, contact administrator:"
 msgstr ""
 
@@ -1126,395 +1184,395 @@ msgstr ""
 msgid "the related model"
 msgstr ""
 
-#: fpr/models.py:51 fpr/models.py:362 fpr/models.py:560 fpr/models.py:603
-#: fpr/models.py:643 fpr/models.py:659 fpr/models.py:677 fpr/models.py:705
-#: fpr/models.py:730 fpr/models.py:749 fpr/models.py:770
+#: fpr/models.py:52 fpr/models.py:378 fpr/models.py:586 fpr/models.py:629
+#: fpr/models.py:669 fpr/models.py:685 fpr/models.py:703 fpr/models.py:731
+#: fpr/models.py:757 fpr/models.py:776 fpr/models.py:797
 msgid "enabled"
 msgstr ""
 
-#: fpr/models.py:52 fpr/models.py:601 fpr/models.py:640 fpr/models.py:657
-#: fpr/models.py:675 fpr/models.py:703 fpr/models.py:728 fpr/models.py:747
-#: fpr/models.py:768
+#: fpr/models.py:53 fpr/models.py:627 fpr/models.py:666 fpr/models.py:683
+#: fpr/models.py:701 fpr/models.py:729 fpr/models.py:755 fpr/models.py:774
+#: fpr/models.py:795
 msgid "last modified"
 msgstr ""
 
-#: fpr/models.py:141 fpr/models.py:165 fpr/models.py:182 fpr/models.py:251
-#: fpr/models.py:306 fpr/models.py:356 fpr/models.py:388 fpr/models.py:484
-#: fpr/models.py:554
+#: fpr/models.py:142 fpr/models.py:170 fpr/models.py:187 fpr/models.py:257
+#: fpr/models.py:316 fpr/models.py:372 fpr/models.py:404 fpr/models.py:506
+#: fpr/models.py:580
 msgid "Unique identifier"
 msgstr ""
 
-#: fpr/models.py:144 fpr/models.py:167 fpr/models.py:194 fpr/models.py:254
-#: fpr/models.py:359 fpr/models.py:494 fpr/models.py:557 fpr/models.py:631
-#: fpr/models.py:652 fpr/models.py:671 fpr/models.py:686
+#: fpr/models.py:145 fpr/models.py:172 fpr/models.py:200 fpr/models.py:260
+#: fpr/models.py:375 fpr/models.py:517 fpr/models.py:583 fpr/models.py:657
+#: fpr/models.py:678 fpr/models.py:697 fpr/models.py:712
 msgid "description"
 msgstr ""
 
-#: fpr/models.py:144
+#: fpr/models.py:145
 msgid "Common name of format"
 msgstr ""
 
-#: fpr/models.py:147
+#: fpr/models.py:151
 msgid "the related group"
 msgstr ""
 
-#: fpr/models.py:149 fpr/models.py:168 fpr/models.py:364 fpr/models.py:561
+#: fpr/models.py:154 fpr/models.py:173 fpr/models.py:380 fpr/models.py:587
 msgid "slug"
 msgstr ""
 
-#: fpr/models.py:154 fpr/templates/fpr/format/version/detail.html:31
+#: fpr/models.py:159 fpr/templates/fpr/format/version/detail.html:31
 #: fpr/templates/fpr/fprule/detail.html:30
 #: fpr/templates/fpr/fprule/list.html:30 fpr/templates/fpr/idrule/list.html:28
 #: templates/ingest/normalization_report.html:32
 msgid "Format"
 msgstr ""
 
-#: fpr/models.py:171
+#: fpr/models.py:176
 msgid "Format group"
 msgstr ""
 
-#: fpr/models.py:189 fpr/models.py:312 fpr/models.py:444 fpr/models.py:713
+#: fpr/models.py:194 fpr/models.py:327 fpr/models.py:465 fpr/models.py:739
 msgid "the related format"
 msgstr ""
 
-#: fpr/models.py:191 fpr/models.py:361 fpr/models.py:559
+#: fpr/models.py:197 fpr/models.py:377 fpr/models.py:585
 msgid "version"
 msgstr ""
 
-#: fpr/models.py:192
+#: fpr/models.py:198
 msgid "pronom id"
 msgstr ""
 
-#: fpr/models.py:198
+#: fpr/models.py:204
 msgid "Formal name to go in the METS file."
 msgstr ""
 
-#: fpr/models.py:200
+#: fpr/models.py:206
 msgid "access format"
 msgstr ""
 
-#: fpr/models.py:201
+#: fpr/models.py:207
 msgid "preservation format"
 msgstr ""
 
-#: fpr/models.py:208 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
 msgid "Format version"
 msgstr ""
 
-#: fpr/models.py:227
+#: fpr/models.py:233
 msgid ""
 "Unable to save, an active Format Version  with this pronom id already exists."
 msgstr ""
 
-#: fpr/models.py:234
+#: fpr/models.py:240
 #, python-format
 msgid "%(format)s: %(description)s (%(pronom_id)s)"
 msgstr ""
 
-#: fpr/models.py:254
+#: fpr/models.py:260
 msgid "Name to identify script"
 msgstr ""
 
-#: fpr/models.py:257
+#: fpr/models.py:263
 msgid "PUID"
 msgstr ""
 
-#: fpr/models.py:258
+#: fpr/models.py:264
 msgid "MIME type"
 msgstr ""
 
-#: fpr/models.py:259
+#: fpr/models.py:265
 msgid "File extension"
 msgstr ""
 
-#: fpr/models.py:261
+#: fpr/models.py:267
 msgid "configuration"
 msgstr ""
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 msgid "script"
 msgstr ""
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 msgid "Script to be executed."
 msgstr ""
 
-#: fpr/models.py:265 fpr/models.py:497
+#: fpr/models.py:271 fpr/models.py:520
 msgid "Bash script"
 msgstr ""
 
-#: fpr/models.py:266 fpr/models.py:498
+#: fpr/models.py:272 fpr/models.py:521
 msgid "Python script"
 msgstr ""
 
-#: fpr/models.py:267 fpr/models.py:499
+#: fpr/models.py:273 fpr/models.py:522
 msgid "Command line"
 msgstr ""
 
-#: fpr/models.py:268 fpr/models.py:500
+#: fpr/models.py:274 fpr/models.py:523
 msgid "No shebang needed"
 msgstr ""
 
-#: fpr/models.py:271 fpr/models.py:503
+#: fpr/models.py:277 fpr/models.py:526
 msgid "script type"
 msgstr ""
 
-#: fpr/models.py:274 fpr/models.py:492
+#: fpr/models.py:283 fpr/models.py:514
 msgid "the related tool"
 msgstr ""
 
-#: fpr/models.py:278
+#: fpr/models.py:288
 msgid "Format identification command"
 msgstr ""
 
-#: fpr/models.py:282
+#: fpr/models.py:292
 #, python-format
 msgid "%(tool)s %(config)s runs %(command)s"
 msgstr ""
 
-#: fpr/models.py:309 fpr/models.py:441
+#: fpr/models.py:321 fpr/models.py:459
 msgid "the related command"
 msgstr ""
 
-#: fpr/models.py:315
+#: fpr/models.py:331
 msgid "command output"
 msgstr ""
 
-#: fpr/models.py:318
+#: fpr/models.py:334
 msgid "Format identification rule"
 msgstr ""
 
-#: fpr/models.py:335
+#: fpr/models.py:351
 msgid ""
 "Unable to save, a rule with this output already exists for this command."
 msgstr ""
 
-#: fpr/models.py:342
+#: fpr/models.py:358
 #, python-format
 msgid "Format identification rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:345
+#: fpr/models.py:361
 #, python-format
 msgid "%(command)s with %(output)s is %(format)s"
 msgstr ""
 
-#: fpr/models.py:359 fpr/models.py:557
+#: fpr/models.py:375 fpr/models.py:583
 msgid "Name of tool"
 msgstr ""
 
-#: fpr/models.py:368
+#: fpr/models.py:384
 msgid "Format identification tool"
 msgstr ""
 
-#: fpr/models.py:374 fpr/models.py:568
+#: fpr/models.py:390 fpr/models.py:594
 #, python-format
 msgid "%(description)s"
 msgstr ""
 
-#: fpr/models.py:416 templates/layout.html:65 templates/main/access.html:4
+#: fpr/models.py:432 templates/layout.html:67 templates/main/access.html:4
 #: templates/main/access.html:5
 msgid "Access"
 msgstr ""
 
-#: fpr/models.py:417 fpr/models.py:514
+#: fpr/models.py:433 fpr/models.py:538
 msgid "Characterization"
 msgstr ""
 
-#: fpr/models.py:418
+#: fpr/models.py:434
 msgid "Extract"
 msgstr ""
 
-#: fpr/models.py:419 fpr/templates/fpr/format/version/detail.html:33
+#: fpr/models.py:435 fpr/templates/fpr/format/version/detail.html:33
 msgid "Preservation"
 msgstr ""
 
-#: fpr/models.py:420
+#: fpr/models.py:436
 msgid "Thumbnail"
 msgstr ""
 
-#: fpr/models.py:421 fpr/models.py:518
+#: fpr/models.py:437 fpr/models.py:542
 msgid "Transcription"
 msgstr ""
 
-#: fpr/models.py:422 fpr/models.py:519
+#: fpr/models.py:438 fpr/models.py:543
 msgid "Validation"
 msgstr ""
 
-#: fpr/models.py:423
+#: fpr/models.py:439
 msgid "Validation against a policy"
 msgstr ""
 
-#: fpr/models.py:426
+#: fpr/models.py:442
 msgid "Default access"
 msgstr ""
 
-#: fpr/models.py:427
+#: fpr/models.py:443
 msgid "Default characterization"
 msgstr ""
 
-#: fpr/models.py:428
+#: fpr/models.py:444
 msgid "Default thumbnail"
 msgstr ""
 
-#: fpr/models.py:439
+#: fpr/models.py:455
 msgid "purpose"
 msgstr ""
 
-#: fpr/models.py:447
+#: fpr/models.py:469
 msgid "count attempts"
 msgstr ""
 
-#: fpr/models.py:448
+#: fpr/models.py:470
 msgid "count okay"
 msgstr ""
 
-#: fpr/models.py:449
+#: fpr/models.py:471
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:452 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:732
 msgid "Format policy rule"
 msgstr ""
 
-#: fpr/models.py:472
+#: fpr/models.py:494
 #, python-format
 msgid "Format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:475
+#: fpr/models.py:497
 #, python-format
 msgid "Normalize %(format)s for %(purpose)s via %(command)s"
 msgstr ""
 
-#: fpr/models.py:495 fpr/models.py:627 fpr/models.py:744
+#: fpr/models.py:518 fpr/models.py:653 fpr/models.py:771
 msgid "command"
 msgstr ""
 
-#: fpr/models.py:505 fpr/models.py:629
+#: fpr/models.py:528 fpr/models.py:655
 #, fuzzy
 #| msgid "Statute citation"
 msgid "output location"
 msgstr "Citação do estatuto"
 
-#: fpr/models.py:511
+#: fpr/models.py:534
 msgid "the related output format"
 msgstr ""
 
-#: fpr/models.py:515
+#: fpr/models.py:539
 msgid "Event Detail"
 msgstr ""
 
-#: fpr/models.py:516
+#: fpr/models.py:540
 msgid "Extraction"
 msgstr ""
 
-#: fpr/models.py:517
+#: fpr/models.py:541
 msgid "Normalization"
 msgstr ""
 
-#: fpr/models.py:520
+#: fpr/models.py:544
 msgid "Verification"
 msgstr ""
 
-#: fpr/models.py:523 fpr/models.py:613
+#: fpr/models.py:547 fpr/models.py:639
 msgid "command usage"
 msgstr ""
 
-#: fpr/models.py:531
+#: fpr/models.py:555
 msgid "the related verification command"
 msgstr ""
 
-#: fpr/models.py:539
+#: fpr/models.py:564
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:543 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:731
 msgid "Format policy command"
 msgstr ""
 
-#: fpr/models.py:565
+#: fpr/models.py:591
 msgid "Normalization tool"
 msgstr ""
 
-#: fpr/models.py:582
+#: fpr/models.py:608
 msgid "agent identifier type"
 msgstr ""
 
-#: fpr/models.py:583
+#: fpr/models.py:609
 msgid "agent identifier value"
 msgstr ""
 
-#: fpr/models.py:584
+#: fpr/models.py:610
 msgid "agent name"
 msgstr ""
 
-#: fpr/models.py:585
+#: fpr/models.py:611
 msgid "agent type"
 msgstr ""
 
-#: fpr/models.py:586
+#: fpr/models.py:612
 msgid "client IP address"
 msgstr ""
 
-#: fpr/models.py:598 fpr/models.py:637 fpr/models.py:655 fpr/models.py:673
-#: fpr/models.py:701 fpr/models.py:726 fpr/models.py:746 fpr/models.py:766
+#: fpr/models.py:624 fpr/models.py:663 fpr/models.py:681 fpr/models.py:699
+#: fpr/models.py:727 fpr/models.py:753 fpr/models.py:773 fpr/models.py:793
 msgid "replaces"
 msgstr ""
 
-#: fpr/models.py:600
+#: fpr/models.py:626
 msgid "type"
 msgstr ""
 
-#: fpr/models.py:614
+#: fpr/models.py:640
 msgid "command type"
 msgstr ""
 
-#: fpr/models.py:617
+#: fpr/models.py:643
 msgid "verification command"
 msgstr ""
 
-#: fpr/models.py:621
+#: fpr/models.py:647
 msgid "event detail command"
 msgstr ""
 
-#: fpr/models.py:625
+#: fpr/models.py:651
 msgid "supported by"
 msgstr ""
 
-#: fpr/models.py:633
+#: fpr/models.py:659
 msgid "output file format"
 msgstr ""
 
-#: fpr/models.py:688
+#: fpr/models.py:714
 msgid "valid preservation format"
 msgstr ""
 
-#: fpr/models.py:694
+#: fpr/models.py:720
 msgid "valid access format"
 msgstr ""
 
-#: fpr/models.py:698
+#: fpr/models.py:724
 msgid "file ID type"
 msgstr ""
 
-#: fpr/models.py:723
+#: fpr/models.py:750
 msgid "classification"
 msgstr ""
 
-#: fpr/models.py:740
+#: fpr/models.py:767
 msgid "command clasification"
 msgstr ""
 
-#: fpr/models.py:745 fpr/models.py:759
+#: fpr/models.py:772 fpr/models.py:786
 msgid "file ID"
 msgstr ""
 
-#: fpr/models.py:761
+#: fpr/models.py:788
 msgid "tool"
 msgstr ""
 
-#: fpr/models.py:763
+#: fpr/models.py:790
 msgid "tool version"
 msgstr ""
 
@@ -1679,12 +1737,12 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:50 templates/accounts/add.html:36
 #: templates/accounts/edit.html:40 templates/accounts/profile.html:49
 #: templates/administration/processing_edit.html:40
-#: templates/delete_request.html:19 templates/ingest/as/match.html:129
-#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:66
-#: templates/rights/rights_edit.html:290 templates/rights/rights_edit.html:292
-#: templates/rights/rights_grants_edit.html:111
-#: templates/rights/rights_grants_edit.html:113
-#: templates/simple_confirm.html:10 templates/transfer/metadata_edit.html:65
+#: templates/delete_request.html:20 templates/ingest/as/match.html:129
+#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:67
+#: templates/rights/rights_edit.html:291 templates/rights/rights_edit.html:293
+#: templates/rights/rights_grants_edit.html:112
+#: templates/rights/rights_grants_edit.html:114
+#: templates/simple_confirm.html:11 templates/transfer/metadata_edit.html:66
 msgid "Cancel"
 msgstr ""
 
@@ -1861,18 +1919,18 @@ msgstr ""
 #: fpr/templates/fpr/idcommand/form.html:32
 #: fpr/templates/fpr/idrule/form.html:29 fpr/templates/fpr/idtool/form.html:30
 #: templates/accounts/edit.html:39 templates/accounts/profile.html:48
-#: templates/administration/api.html:36
-#: templates/administration/dips_as_edit.html:29
-#: templates/administration/dips_atom_edit.html:44
-#: templates/administration/general.html:67
-#: templates/administration/handle_config.html:24
-#: templates/administration/premis_agent.html:24
+#: templates/administration/api.html:37
+#: templates/administration/dips_as_edit.html:30
+#: templates/administration/dips_atom_edit.html:45
+#: templates/administration/general.html:68
+#: templates/administration/handle_config.html:25
+#: templates/administration/premis_agent.html:25
 #: templates/administration/processing_edit.html:39
-#: templates/administration/term_detail.html:34
-#: templates/ingest/metadata_edit.html:62 templates/rights/rights_edit.html:285
-#: templates/rights/rights_grants_edit.html:106
-#: templates/transfer/component.html:54
-#: templates/transfer/metadata_edit.html:61
+#: templates/administration/term_detail.html:35
+#: templates/ingest/metadata_edit.html:63 templates/rights/rights_edit.html:286
+#: templates/rights/rights_grants_edit.html:107
+#: templates/transfer/component.html:55
+#: templates/transfer/metadata_edit.html:62
 msgid "Save"
 msgstr ""
 
@@ -1885,11 +1943,11 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:12
 #: fpr/templates/fpr/format/group/delete.html:49
 #: fpr/templates/fpr/format/group/list.html:51 templates/accounts/list.html:42
-#: templates/administration/atom_levels_of_description.html:44
+#: templates/administration/atom_levels_of_description.html:45
 #: templates/administration/processing.html:33
-#: templates/administration/reports/failure_detail.html:31
+#: templates/administration/reports/failure_detail.html:32
 #: templates/administration/reports/failures.html:39
-#: templates/administration/term_detail.html:35
+#: templates/administration/term_detail.html:36
 #: templates/archival_storage/view.html:111
 #: templates/archival_storage/view.html:154 templates/main/access.html:25
 #: templates/rights/rights_list.html:55 templates/rights/rights_list.html:58
@@ -2163,13 +2221,6 @@ msgstr ""
 msgid "Script"
 msgstr ""
 
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:959
-#: templates/administration/reports/failures.html:25
-#: templates/rights/rights_edit.html:101 templates/rights/rights_edit.html:153
-#: templates/rights/rights_edit.html:203 templates/rights/rights_edit.html:251
-msgid "Type"
-msgstr ""
-
 #: fpr/templates/fpr/idcommand/list.html:56
 msgid "No identification commands exist."
 msgstr ""
@@ -2219,7 +2270,7 @@ msgstr ""
 #: fpr/templates/fpr/idtool/detail.html:49
 #: templates/ingest/as/_search_form.html:5 templates/ingest/as/match.html:102
 #: templates/ingest/as/match.html:120
-#: templates/ingest/as/review_matches.html:30 templates/ingest/grid.html:165
+#: templates/ingest/as/review_matches.html:31 templates/ingest/grid.html:165
 msgid "Identifier"
 msgstr ""
 
@@ -2420,462 +2471,462 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: main/models.py:243
+#: main/models.py:245
 msgid "Part of AIC"
 msgstr ""
 
-#: main/models.py:244
+#: main/models.py:246
 msgid "Optional: leave blank if unsure"
 msgstr ""
 
-#: main/models.py:253
+#: main/models.py:255
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:263
+#: main/models.py:265
 msgid "Use ISO 639"
 msgstr ""
 
-#: main/models.py:281
+#: main/models.py:283
 msgid "Untitled"
 msgstr ""
 
-#: main/models.py:329
+#: main/models.py:336
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr ""
 
-#: main/models.py:371
+#: main/models.py:381
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr ""
 
-#: main/models.py:399
+#: main/models.py:409
 msgid "SIP"
 msgstr ""
 
-#: main/models.py:400
+#: main/models.py:410
 msgid "AIC"
 msgstr ""
 
-#: main/models.py:401
+#: main/models.py:411
 msgid "Reingested AIP"
 msgstr ""
 
-#: main/models.py:402
+#: main/models.py:412
 msgid "Reingested AIC"
 msgstr ""
 
-#: main/models.py:416
+#: main/models.py:426
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr ""
 
-#: main/models.py:529
+#: main/models.py:547
 msgid "Arranged SIPs"
 msgstr ""
 
-#: main/models.py:533
+#: main/models.py:551
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr ""
 
-#: main/models.py:578
+#: main/models.py:596
 msgid "Identifier Type"
 msgstr ""
 
-#: main/models.py:580
+#: main/models.py:598
 msgid "Identifier Value"
 msgstr ""
 
-#: main/models.py:582
+#: main/models.py:600
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
 msgstr ""
 
-#: main/models.py:645
+#: main/models.py:673
 #, python-format
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:681
+#: main/models.py:719
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:740
+#: main/models.py:783
 #, python-format
 msgid "%(file)s is %(format)s"
 msgstr ""
 
-#: main/models.py:758
+#: main/models.py:801
 msgid "(Unnamed)"
 msgstr ""
 
-#: main/models.py:780
+#: main/models.py:823
 msgid "Unknown"
 msgstr ""
 
-#: main/models.py:781
+#: main/models.py:824
 msgid "Awaiting decision"
 msgstr ""
 
-#: main/models.py:782
+#: main/models.py:825
 msgid "Completed successfully"
 msgstr ""
 
-#: main/models.py:783
+#: main/models.py:826
 msgid "Executing command(s)"
 msgstr ""
 
-#: main/models.py:784
+#: main/models.py:827
 msgid "Failed"
 msgstr ""
 
-#: main/models.py:879
+#: main/models.py:924
 msgid "Agent Identifier Type"
 msgstr ""
 
-#: main/models.py:884
+#: main/models.py:929
 msgid "Agent Identifier Value"
 msgstr ""
 
-#: main/models.py:886
+#: main/models.py:931
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
 msgstr ""
 
-#: main/models.py:893
+#: main/models.py:938
 msgid "Agent Name"
 msgstr ""
 
-#: main/models.py:894
+#: main/models.py:939
 msgid "Used for premis:agentName in the METS file."
 msgstr ""
 
-#: main/models.py:900
+#: main/models.py:945
 msgid "Agent Type"
 msgstr ""
 
-#: main/models.py:901
+#: main/models.py:946
 msgid "Used for premis:agentType in the METS file."
 msgstr ""
 
-#: main/models.py:925
+#: main/models.py:970
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:927
+#: main/models.py:972
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:962 templates/rights/rights_edit.html:105
-#: templates/rights/rights_edit.html:157 templates/rights/rights_edit.html:207
-#: templates/rights/rights_edit.html:255
+#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
+#: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr ""
 
-#: main/models.py:965
+#: main/models.py:1013
 msgid "Rights holder"
 msgstr "Proprietário dos direitos"
 
-#: main/models.py:968
+#: main/models.py:1016
 msgid "Copyright"
 msgstr "Direitos de autor"
 
-#: main/models.py:969
+#: main/models.py:1017
 msgid "Statute"
 msgstr "Estatuto"
 
-#: main/models.py:970
+#: main/models.py:1018
 msgid "License"
 msgstr "Licença"
 
-#: main/models.py:971
+#: main/models.py:1019
 msgid "Donor"
 msgstr "Doador"
 
-#: main/models.py:972
+#: main/models.py:1020
 msgid "Policy"
 msgstr "Política"
 
-#: main/models.py:979 templates/rights/rights_list.html:34
+#: main/models.py:1027 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr ""
 
-#: main/models.py:991
+#: main/models.py:1039
 msgid "Rights Statement"
 msgstr ""
 
-#: main/models.py:995
+#: main/models.py:1043
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr ""
 
-#: main/models.py:1008
+#: main/models.py:1058
 msgid "copyrighted"
 msgstr ""
 
-#: main/models.py:1009
+#: main/models.py:1059
 msgid "public domain"
 msgstr ""
 
-#: main/models.py:1010
+#: main/models.py:1060
 msgid "unknown"
 msgstr ""
 
-#: main/models.py:1015
+#: main/models.py:1065
 msgid "Copyright status"
 msgstr "Estado dos direitos de autor"
 
-#: main/models.py:1020
+#: main/models.py:1070
 msgid "Copyright jurisdiction"
 msgstr "Jurisdição dos direitos de autor"
 
-#: main/models.py:1026
+#: main/models.py:1076
 msgid "Copyright determination date"
 msgstr ""
 
-#: main/models.py:1027 main/models.py:1034 main/models.py:1041
-#: main/models.py:1105 main/models.py:1112 main/models.py:1172
-#: main/models.py:1179 main/models.py:1237 main/models.py:1246
-#: main/models.py:1253 main/models.py:1321 main/models.py:1328
+#: main/models.py:1077 main/models.py:1084 main/models.py:1091
+#: main/models.py:1161 main/models.py:1168 main/models.py:1234
+#: main/models.py:1241 main/models.py:1303 main/models.py:1312
+#: main/models.py:1319 main/models.py:1391 main/models.py:1398
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:1033
+#: main/models.py:1083
 msgid "Copyright start date"
 msgstr ""
 
-#: main/models.py:1040
+#: main/models.py:1090
 msgid "Copyright end date"
 msgstr ""
 
-#: main/models.py:1046 main/models.py:1117 main/models.py:1186
-#: main/models.py:1258 main/models.py:1333
+#: main/models.py:1096 main/models.py:1173 main/models.py:1248
+#: main/models.py:1324 main/models.py:1403
 msgid "Open End Date"
 msgstr ""
 
-#: main/models.py:1047 main/models.py:1118 main/models.py:1187
-#: main/models.py:1259 main/models.py:1334
+#: main/models.py:1097 main/models.py:1174 main/models.py:1249
+#: main/models.py:1325 main/models.py:1404
 msgid "Indicate end date is open"
 msgstr ""
 
-#: main/models.py:1052
+#: main/models.py:1102
 msgid "Rights: Copyright"
 msgstr ""
 
-#: main/models.py:1062
+#: main/models.py:1114
 msgid "Copyright document identification type"
 msgstr ""
 
-#: main/models.py:1066
+#: main/models.py:1118
 msgid "Copyright document identification value"
 msgstr ""
 
-#: main/models.py:1072
+#: main/models.py:1124
 msgid "Copyright document identification role"
 msgstr ""
 
-#: main/models.py:1077
+#: main/models.py:1129
 msgid "Rights: Copyright: Docs ID"
 msgstr ""
 
-#: main/models.py:1086 templates/rights/rights_edit.html:116
+#: main/models.py:1140 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr ""
 
-#: main/models.py:1091
+#: main/models.py:1145
 msgid "Rights: Copyright: Note"
 msgstr ""
 
-#: main/models.py:1098
+#: main/models.py:1154
 msgid "License terms"
 msgstr "Termos da licença"
 
-#: main/models.py:1104
+#: main/models.py:1160
 msgid "License start date"
 msgstr ""
 
-#: main/models.py:1111
+#: main/models.py:1167
 msgid "License end date"
 msgstr ""
 
-#: main/models.py:1123
+#: main/models.py:1179
 msgid "Rights: License"
 msgstr ""
 
-#: main/models.py:1133
+#: main/models.py:1191
 msgid "License documentation identification type"
 msgstr ""
 
-#: main/models.py:1137
+#: main/models.py:1195
 msgid "License documentation identification value"
 msgstr ""
 
-#: main/models.py:1143
+#: main/models.py:1201
 msgid "License document identification role"
 msgstr ""
 
-#: main/models.py:1148
+#: main/models.py:1206
 msgid "Rights: License: Docs ID"
 msgstr ""
 
-#: main/models.py:1157 templates/rights/rights_edit.html:218
+#: main/models.py:1217 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr ""
 
-#: main/models.py:1162
+#: main/models.py:1222
 msgid "Rights: License: Note"
 msgstr ""
 
-#: main/models.py:1171 templates/rights/rights_list.html:36
+#: main/models.py:1233 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr ""
 
-#: main/models.py:1178 templates/rights/rights_list.html:37
+#: main/models.py:1240 templates/rights/rights_list.html:37
 msgid "End"
 msgstr ""
 
-#: main/models.py:1192
+#: main/models.py:1254
 msgid "Rights: Granted"
 msgstr ""
 
-#: main/models.py:1203
+#: main/models.py:1266
 msgid "Rights note"
 msgstr ""
 
-#: main/models.py:1208
+#: main/models.py:1271
 msgid "Rights: Granted: Note"
 msgstr ""
 
-#: main/models.py:1222
+#: main/models.py:1286
 msgid "Rights: Granted: Restriction"
 msgstr ""
 
-#: main/models.py:1229
+#: main/models.py:1295
 msgid "Statute jurisdiction"
 msgstr "Jurisdição do estatuto"
 
-#: main/models.py:1232
+#: main/models.py:1298
 msgid "Statute citation"
 msgstr "Citação do estatuto"
 
-#: main/models.py:1236
+#: main/models.py:1302
 msgid "Statute determination date"
 msgstr "Data de atribuição do estatuto"
 
-#: main/models.py:1245
+#: main/models.py:1311
 msgid "Statute start date"
 msgstr ""
 
-#: main/models.py:1252
+#: main/models.py:1318
 msgid "Statute end date"
 msgstr ""
 
-#: main/models.py:1264
+#: main/models.py:1330
 msgid "Rights: Statute"
 msgstr ""
 
-#: main/models.py:1274 templates/rights/rights_edit.html:168
+#: main/models.py:1341 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr ""
 
-#: main/models.py:1279
+#: main/models.py:1346
 msgid "Rights: Statute: Note"
 msgstr ""
 
-#: main/models.py:1290
+#: main/models.py:1358
 msgid "Statute document identification type"
 msgstr ""
 
-#: main/models.py:1294
+#: main/models.py:1362
 msgid "Statute document identification value"
 msgstr ""
 
-#: main/models.py:1300
+#: main/models.py:1368
 msgid "Statute document identification role"
 msgstr ""
 
-#: main/models.py:1305
+#: main/models.py:1373
 msgid "Rights: Statute: Docs ID"
 msgstr ""
 
-#: main/models.py:1313
+#: main/models.py:1383
 msgid "Other rights basis"
 msgstr ""
 
-#: main/models.py:1320
+#: main/models.py:1390
 msgid "Other rights start date"
 msgstr ""
 
-#: main/models.py:1327
+#: main/models.py:1397
 msgid "Other rights end date"
 msgstr ""
 
-#: main/models.py:1339
+#: main/models.py:1409
 msgid "Rights: Other"
 msgstr ""
 
-#: main/models.py:1350
+#: main/models.py:1421
 msgid "Other rights document identification type"
 msgstr ""
 
-#: main/models.py:1354
+#: main/models.py:1425
 msgid "Other right document identification value"
 msgstr ""
 
-#: main/models.py:1360
+#: main/models.py:1431
 msgid "Other rights document identification role"
 msgstr ""
 
-#: main/models.py:1365
+#: main/models.py:1436
 msgid "Rights: Other: Docs ID"
 msgstr ""
 
-#: main/models.py:1375
+#: main/models.py:1447
 msgid "Other rights note"
 msgstr ""
 
-#: main/models.py:1380
+#: main/models.py:1452
 msgid "Rights: Other: Note"
 msgstr ""
 
-#: main/models.py:1388
+#: main/models.py:1462
 msgid "Linking Agent"
 msgstr ""
 
-#: main/models.py:1393
+#: main/models.py:1467
 msgid "Linking Agent Value"
 msgstr ""
 
-#: main/models.py:1399
+#: main/models.py:1473
 msgid "Rights: Agent"
 msgstr ""
 
-#: main/models.py:1435
+#: main/models.py:1509
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr ""
 
-#: main/models.py:1473
+#: main/models.py:1547
 msgid "ASDIPObjectResourcePairing"
 msgstr ""
 
-#: main/models.py:1488
+#: main/models.py:1562
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr ""
 
-#: main/models.py:1495
+#: main/models.py:1569
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 
-#: main/models.py:1615
+#: main/models.py:1709
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr ""
@@ -2884,15 +2935,15 @@ msgstr ""
 msgid "<no API key generated>"
 msgstr ""
 
-#: main/views.py:302
+#: main/views.py:299
 msgid "Added."
 msgstr ""
 
-#: main/views.py:307
+#: main/views.py:304
 msgid "Error: no delete ID supplied."
 msgstr ""
 
-#: main/views.py:322
+#: main/views.py:319
 msgid "Incorrect type."
 msgstr ""
 
@@ -2924,38 +2975,38 @@ msgstr ""
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:436
+#: settings/base.py:435
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
 msgstr ""
 
-#: settings/base.py:439
+#: settings/base.py:438
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
 "has been moved into storage."
 msgstr ""
 
-#: settings/base.py:441
+#: settings/base.py:440
 msgid "Create a SIP from the transfer."
 msgstr ""
 
-#: settings/base.py:443
+#: settings/base.py:442
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
 "start ingest micro-services."
 msgstr ""
 
-#: settings/base.py:446
+#: settings/base.py:445
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
 "system."
 msgstr ""
 
-#: settings/base.py:449
+#: settings/base.py:448
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -2964,13 +3015,13 @@ msgid ""
 "view the tool output and error message."
 msgstr ""
 
-#: settings/base.py:452
+#: settings/base.py:451
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
 msgstr ""
 
-#: settings/base.py:455
+#: settings/base.py:454
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3005,7 +3056,7 @@ msgid "Previous"
 msgstr ""
 
 #: templates/_pager.html:35 templates/ingest/normalization_report.html:121
-#: templates/rights/rights_edit.html:287
+#: templates/rights/rights_edit.html:288
 msgid "Next"
 msgstr ""
 
@@ -3039,8 +3090,8 @@ msgstr ""
 msgid "Add new user"
 msgstr ""
 
-#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:64
-#: templates/installer/welcome.html:49 templates/transfer/metadata_edit.html:63
+#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:65
+#: templates/installer/welcome.html:50 templates/transfer/metadata_edit.html:64
 msgid "Create"
 msgstr ""
 
@@ -3051,12 +3102,6 @@ msgstr ""
 
 #: templates/accounts/list.html:23 templates/accounts/profile.html:29
 msgid "Username"
-msgstr ""
-
-#: templates/accounts/list.html:24 templates/accounts/profile.html:31
-#: templates/administration/atom_levels_of_description.html:36
-#: templates/administration/reports/failures.html:26
-msgid "Name"
 msgstr ""
 
 #: templates/accounts/list.html:25 templates/accounts/profile.html:33
@@ -3120,14 +3165,12 @@ msgstr ""
 #: templates/administration/reports/failure_detail.html:6
 #: templates/administration/reports/failures.html:5
 #: templates/administration/reports/failures.html:6
-#: templates/administration/search.html:5
-#: templates/administration/search.html:6
 #: templates/administration/taxonomy.html:5
 #: templates/administration/taxonomy.html:6
 #: templates/administration/term_detail.html:5
 #: templates/administration/term_detail.html:6
 #: templates/administration/terms.html:5 templates/administration/terms.html:6
-#: templates/layout.html:66
+#: templates/layout.html:68
 msgid "Administration"
 msgstr ""
 
@@ -3157,15 +3200,15 @@ msgstr ""
 msgid "AtoM Levels of Description"
 msgstr ""
 
-#: templates/administration/atom_levels_of_description.html:45
+#: templates/administration/atom_levels_of_description.html:46
 msgid "Promote"
 msgstr ""
 
-#: templates/administration/atom_levels_of_description.html:46
+#: templates/administration/atom_levels_of_description.html:47
 msgid "Demote"
 msgstr ""
 
-#: templates/administration/atom_levels_of_description.html:54
+#: templates/administration/atom_levels_of_description.html:55
 msgid "No levels found."
 msgstr ""
 
@@ -3177,11 +3220,11 @@ msgstr ""
 msgid "Levels of Description"
 msgstr ""
 
-#: templates/administration/dips_atom_edit.html:37
+#: templates/administration/dips_atom_edit.html:38
 msgid "AtoM/Binder DIP upload"
 msgstr ""
 
-#: templates/administration/dips_atom_edit.html:39
+#: templates/administration/dips_atom_edit.html:40
 msgid "The settings below configure DIP uploading to AtoM/Binder."
 msgstr ""
 
@@ -3197,31 +3240,31 @@ msgstr ""
 msgid "General configuration"
 msgstr ""
 
-#: templates/administration/general.html:39
+#: templates/administration/general.html:40
 msgid "Storage Service options"
 msgstr ""
 
-#: templates/administration/general.html:43
+#: templates/administration/general.html:44
 msgid "Checksum algorithm"
 msgstr ""
 
-#: templates/administration/general.html:47
+#: templates/administration/general.html:48
 msgid "Elasticsearch Indexing"
 msgstr ""
 
-#: templates/administration/general.html:52
+#: templates/administration/general.html:53
 msgid "Transfers related indexes enabled."
 msgstr ""
 
-#: templates/administration/general.html:54
+#: templates/administration/general.html:55
 msgid "Transfers related indexes disabled."
 msgstr ""
 
-#: templates/administration/general.html:59
+#: templates/administration/general.html:60
 msgid "AIPs related indexes enabled."
 msgstr ""
 
-#: templates/administration/general.html:61
+#: templates/administration/general.html:62
 msgid "AIPs related indexes disabled."
 msgstr ""
 
@@ -3335,22 +3378,6 @@ msgstr ""
 
 #: templates/administration/reports/failures.html:56
 msgid "No reports found."
-msgstr ""
-
-#: templates/administration/search.html:23
-msgid "Search administration"
-msgstr ""
-
-#: templates/administration/search.html:26
-#, python-format
-msgid ""
-"\n"
-"          %(count)s AIP files indexed.\n"
-"        "
-msgstr ""
-
-#: templates/administration/search.html:33
-msgid "Flush AIP Index"
 msgstr ""
 
 #: templates/administration/sidebar.html:23
@@ -3469,11 +3496,6 @@ msgid ""
 "cleared manually."
 msgstr ""
 
-#: templates/administration/usage.html:90
-#: templates/archival_storage/view.html:67
-msgid "Size"
-msgstr ""
-
 #: templates/administration/version.html:19
 msgid "About Archivematica"
 msgstr ""
@@ -3483,12 +3505,12 @@ msgid "Agent code"
 msgstr ""
 
 #: templates/appraisal/appraisal.html:4 templates/appraisal/appraisal.html:5
-#: templates/layout.html:58
+#: templates/layout.html:60
 msgid "Appraisal"
 msgstr ""
 
 #: templates/appraisal/appraisal.html:30
-#: templates/archival_storage/archival_storage.html:70
+#: templates/archival_storage/archival_storage.html:74
 #: templates/backlog/backlog.html:34
 msgid "Elasticsearch Indexing Disabled"
 msgstr ""
@@ -3511,23 +3533,23 @@ msgstr ""
 
 #: templates/archival_storage/archival_storage.html:6
 #: templates/archival_storage/archival_storage.html:7
-#: templates/archival_storage/archival_storage.html:32
+#: templates/archival_storage/archival_storage.html:31
 #: templates/archival_storage/view.html:6
 #: templates/archival_storage/view.html:7
-#: templates/archival_storage/view.html:50 templates/layout.html:62
+#: templates/archival_storage/view.html:50 templates/layout.html:64
 msgid "Archival storage"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:33
+#: templates/archival_storage/archival_storage.html:32
 #: templates/ingest/as/_search_form.html:6
 msgid "Search"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:41
+#: templates/archival_storage/archival_storage.html:40
 msgid "Browse archival storage"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:44
+#: templates/archival_storage/archival_storage.html:43
 #, python-format
 msgid ""
 "\n"
@@ -3535,7 +3557,7 @@ msgid ""
 "          "
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:50
+#: templates/archival_storage/archival_storage.html:49
 #, python-format
 msgid ""
 "\n"
@@ -3543,15 +3565,25 @@ msgid ""
 "            "
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:61
+#: templates/archival_storage/archival_storage.html:60
 msgid "Create an AIC from current search results"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:62
+#: templates/archival_storage/archival_storage.html:61
 msgid "Create an AIC"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:71
+#: templates/archival_storage/archival_storage.html:65
+msgid ""
+"Download all results from archival storage as a CSV (Comma-separated-values) "
+"table"
+msgstr ""
+
+#: templates/archival_storage/archival_storage.html:66
+msgid "Download CSV"
+msgstr ""
+
+#: templates/archival_storage/archival_storage.html:75
 msgid ""
 "Sorry, Elasticsearch indexing has been disabled for the AIPs related indexes "
 "in this Archivematica installation. The archival storage tab is non-"
@@ -3564,19 +3596,6 @@ msgstr ""
 
 #: templates/archival_storage/view.html:71
 msgid "Date stored"
-msgstr ""
-
-#: templates/archival_storage/view.html:75
-msgid "Status"
-msgstr ""
-
-#: templates/archival_storage/view.html:79
-msgid "Encrypted"
-msgstr ""
-
-#: templates/archival_storage/view.html:83
-#: templates/ingest/normalization_report.html:31
-msgid "Location"
 msgstr ""
 
 #: templates/archival_storage/view.html:90
@@ -3628,7 +3647,7 @@ msgid ""
 "functional when indexing is turned off."
 msgstr ""
 
-#: templates/delete_request.html:14
+#: templates/delete_request.html:15
 msgid "Reason for deletion:"
 msgstr ""
 
@@ -3675,7 +3694,7 @@ msgstr ""
 #: templates/ingest/grid.html:5 templates/ingest/grid.html:6
 #: templates/ingest/metadata_add_files.html:31
 #: templates/ingest/metadata_edit.html:31
-#: templates/ingest/microservices.html:11 templates/layout.html:60
+#: templates/ingest/microservices.html:11 templates/layout.html:62
 #: templates/rights/rights_edit.html:16
 #: templates/rights/rights_grants_edit.html:16
 #: templates/rights/rights_list.html:9
@@ -3692,7 +3711,7 @@ msgstr ""
 #: templates/ingest/as/resource_component.html:52
 #: templates/ingest/as/resource_detail.html:42
 #: templates/ingest/as/resource_list.html:34
-#: templates/ingest/as/review_matches.html:29
+#: templates/ingest/as/review_matches.html:30
 msgid "Title"
 msgstr ""
 
@@ -3736,7 +3755,7 @@ msgstr ""
 #: templates/ingest/as/resource_detail.html:30
 #: templates/ingest/as/resource_list.html:25
 #: templates/ingest/as/resource_list.html:27
-#: templates/ingest/as/review_matches.html:20
+#: templates/ingest/as/review_matches.html:21
 msgid "Restart matching"
 msgstr ""
 
@@ -3762,7 +3781,7 @@ msgid "Resources"
 msgstr ""
 
 #: templates/ingest/as/match.html:100 templates/ingest/as/match.html:118
-#: templates/ingest/as/review_matches.html:28
+#: templates/ingest/as/review_matches.html:29
 msgid "Level"
 msgstr ""
 
@@ -3770,7 +3789,7 @@ msgstr ""
 #: templates/ingest/as/resource_component.html:53
 #: templates/ingest/as/resource_detail.html:43
 #: templates/ingest/as/resource_list.html:35
-#: templates/ingest/as/review_matches.html:31
+#: templates/ingest/as/review_matches.html:32
 msgid "Dates"
 msgstr ""
 
@@ -3779,7 +3798,7 @@ msgid "Pairs"
 msgstr ""
 
 #: templates/ingest/as/match.html:117
-#: templates/ingest/as/review_matches.html:27
+#: templates/ingest/as/review_matches.html:28
 msgid "File"
 msgstr ""
 
@@ -3818,7 +3837,7 @@ msgstr ""
 msgid "Collections"
 msgstr ""
 
-#: templates/ingest/as/review_matches.html:21
+#: templates/ingest/as/review_matches.html:22
 msgid "Finish matching"
 msgstr ""
 
@@ -3922,50 +3941,50 @@ msgstr ""
 msgid "Select a directory"
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:77
-#: templates/transfer/metadata_edit.html:76
+#: templates/ingest/metadata_edit.html:78
+#: templates/transfer/metadata_edit.html:77
 msgid "A name given to the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:81
-#: templates/transfer/metadata_edit.html:80
+#: templates/ingest/metadata_edit.html:82
+#: templates/transfer/metadata_edit.html:81
 msgid "An entity primarily responsible for making the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:85
-#: templates/transfer/metadata_edit.html:84
+#: templates/ingest/metadata_edit.html:86
+#: templates/transfer/metadata_edit.html:85
 msgid "The topic of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:89
-#: templates/transfer/metadata_edit.html:88
+#: templates/ingest/metadata_edit.html:90
+#: templates/transfer/metadata_edit.html:89
 msgid "An account of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:93
-#: templates/transfer/metadata_edit.html:92
+#: templates/ingest/metadata_edit.html:94
+#: templates/transfer/metadata_edit.html:93
 msgid "An entity responsible for making the resource available."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:97
-#: templates/transfer/metadata_edit.html:96
+#: templates/ingest/metadata_edit.html:98
+#: templates/transfer/metadata_edit.html:97
 msgid "An entity responsible for making contributions to the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:101
-#: templates/transfer/metadata_edit.html:100
+#: templates/ingest/metadata_edit.html:102
+#: templates/transfer/metadata_edit.html:101
 msgid ""
 "A point or period of time associated with an event in the lifecycle of the "
 "resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:106
-#: templates/transfer/metadata_edit.html:105
+#: templates/ingest/metadata_edit.html:107
+#: templates/transfer/metadata_edit.html:106
 msgid "The nature or genre of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:108
-#: templates/transfer/metadata_edit.html:107
+#: templates/ingest/metadata_edit.html:109
+#: templates/transfer/metadata_edit.html:108
 msgid ""
 "\n"
 "        You may wish to use the DCMI type vocabulary provided here: <a href="
@@ -3974,13 +3993,13 @@ msgid ""
 "      "
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:116
-#: templates/transfer/metadata_edit.html:115
+#: templates/ingest/metadata_edit.html:117
+#: templates/transfer/metadata_edit.html:116
 msgid "The file format, physical medium, or dimensions of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:118
-#: templates/transfer/metadata_edit.html:117
+#: templates/ingest/metadata_edit.html:119
+#: templates/transfer/metadata_edit.html:118
 msgid ""
 "\n"
 "        Best practice is to use a controlled vocabulary such as the list of "
@@ -3990,35 +4009,35 @@ msgid ""
 "      "
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:125
-#: templates/transfer/metadata_edit.html:124
+#: templates/ingest/metadata_edit.html:126
+#: templates/transfer/metadata_edit.html:125
 msgid "An unambiguous reference to the resource within a given context."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:129
-#: templates/transfer/metadata_edit.html:128
+#: templates/ingest/metadata_edit.html:130
+#: templates/transfer/metadata_edit.html:129
 msgid "A related resource from which the described resource is derived."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:133
-#: templates/transfer/metadata_edit.html:132
+#: templates/ingest/metadata_edit.html:134
+#: templates/transfer/metadata_edit.html:133
 msgid "A related resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:137
-#: templates/transfer/metadata_edit.html:136
+#: templates/ingest/metadata_edit.html:138
+#: templates/transfer/metadata_edit.html:137
 msgid "A language of the resource."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:141
-#: templates/transfer/metadata_edit.html:140
+#: templates/ingest/metadata_edit.html:142
+#: templates/transfer/metadata_edit.html:141
 msgid ""
 "The spatial or temporal topic of the resource, the spatial applicability of "
 "the resource, or the jurisdiction under which the resource is relevant."
 msgstr ""
 
-#: templates/ingest/metadata_edit.html:145
-#: templates/transfer/metadata_edit.html:144
+#: templates/ingest/metadata_edit.html:146
+#: templates/transfer/metadata_edit.html:145
 msgid "Information about rights held in and over the resource."
 msgstr ""
 
@@ -4077,15 +4096,15 @@ msgid ""
 "    "
 msgstr ""
 
-#: templates/installer/storagesetup.html:25
+#: templates/installer/storagesetup.html:26
 msgid "Register this pipeline in the Storage Service"
 msgstr ""
 
-#: templates/installer/storagesetup.html:30
+#: templates/installer/storagesetup.html:31
 msgid "Dashboard UUID"
 msgstr ""
 
-#: templates/installer/storagesetup.html:39
+#: templates/installer/storagesetup.html:40
 msgid "Register"
 msgstr ""
 
@@ -4107,7 +4126,7 @@ msgstr ""
 msgid "Archivematica Dashboard"
 msgstr ""
 
-#: templates/layout.html:55 templates/rights/rights_edit.html:18
+#: templates/layout.html:57 templates/rights/rights_edit.html:18
 #: templates/rights/rights_grants_edit.html:18
 #: templates/rights/rights_list.html:11 templates/transfer/component.html:10
 #: templates/transfer/detail.html:9 templates/transfer/grid.html:5
@@ -4117,19 +4136,19 @@ msgstr ""
 msgid "Transfer"
 msgstr ""
 
-#: templates/layout.html:57
+#: templates/layout.html:59
 msgid "Backlog"
 msgstr ""
 
-#: templates/layout.html:64
+#: templates/layout.html:66
 msgid "Preservation planning"
 msgstr ""
 
-#: templates/layout.html:74
+#: templates/layout.html:76
 msgid "Your profile"
 msgstr ""
 
-#: templates/layout.html:76
+#: templates/layout.html:78
 msgid "Log out"
 msgstr ""
 
@@ -4238,28 +4257,28 @@ msgid ""
 "                "
 msgstr ""
 
-#: templates/rights/rights_edit.html:96
+#: templates/rights/rights_edit.html:97
 msgid "Copyright documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:109 templates/rights/rights_edit.html:161
-#: templates/rights/rights_edit.html:211 templates/rights/rights_edit.html:259
+#: templates/rights/rights_edit.html:110 templates/rights/rights_edit.html:162
+#: templates/rights/rights_edit.html:212 templates/rights/rights_edit.html:260
 msgid "Role"
 msgstr ""
 
-#: templates/rights/rights_edit.html:147
+#: templates/rights/rights_edit.html:148
 msgid "Statute documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:197
+#: templates/rights/rights_edit.html:198
 msgid "License documentation identifier:"
 msgstr ""
 
-#: templates/rights/rights_edit.html:245
+#: templates/rights/rights_edit.html:246
 msgid "Documentation identifier"
 msgstr ""
 
-#: templates/rights/rights_edit.html:266
+#: templates/rights/rights_edit.html:267
 msgid "Note"
 msgstr ""
 
@@ -4268,23 +4287,23 @@ msgid ""
 "You may now add additional information such as document identifers and notes."
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:79
+#: templates/rights/rights_grants_edit.html:80
 msgid "Allow"
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:80
+#: templates/rights/rights_grants_edit.html:81
 msgid "Disallow"
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:81
+#: templates/rights/rights_grants_edit.html:82
 msgid "Conditional"
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:87
+#: templates/rights/rights_grants_edit.html:88
 msgid "Grant/restriction note"
 msgstr ""
 
-#: templates/rights/rights_grants_edit.html:108
+#: templates/rights/rights_grants_edit.html:109
 msgid "Done"
 msgstr ""
 

--- a/src/dashboard/src/locale/pt/LC_MESSAGES/djangojs.po
+++ b/src/dashboard/src/locale/pt/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 12:27-0400\n"
+"POT-Creation-Date: 2020-07-27 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: Portuguese (https://www.transifex.com/artefactual/teams/1506/"
 "pt/)\n"
@@ -27,7 +27,7 @@ msgid "Are you sure you want to delete this level of description?"
 msgstr ""
 
 #: media/js/advanced-search-query-creator.js:14 media/js/file_browser.js:59
-#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:209
+#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:211
 msgid "Delete"
 msgstr ""
 
@@ -46,7 +46,7 @@ msgid "Any"
 msgstr ""
 
 #: media/js/archival_storage/archival_storage_search.js:61
-#: media/js/archival_storage/archival_storage_search.js:238
+#: media/js/archival_storage/archival_storage_search.js:242
 msgid "File UUID"
 msgstr ""
 
@@ -105,215 +105,219 @@ msgstr ""
 msgid "Date range"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:148
+#: media/js/archival_storage/archival_storage_search.js:152
 msgid "view raw"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:169
+#: media/js/archival_storage/archival_storage_search.js:173
 #: media/js/backlog/backlog-search.js:6 media/js/backlog/backlog-search.js:12
 msgid "Download"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:184
+#: media/js/archival_storage/archival_storage_search.js:188
 msgid "AIPs in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:185
+#: media/js/archival_storage/archival_storage_search.js:189
 msgid "AIP in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:188
+#: media/js/archival_storage/archival_storage_search.js:192
 msgid "Part of"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:190
+#: media/js/archival_storage/archival_storage_search.js:194
 msgid "None"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:197
+#: media/js/archival_storage/archival_storage_search.js:201
 msgid "View"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "True"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "False"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 msgid "Deletion requested"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 #: media/js/backlog/backlog-search.js:19
 msgid "Stored"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:236
+#: media/js/archival_storage/archival_storage_search.js:240
 msgid "Thumbnail"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:237
+#: media/js/archival_storage/archival_storage_search.js:241
 msgid "File"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:239
+#: media/js/archival_storage/archival_storage_search.js:243
 msgid "AIP"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:240
+#: media/js/archival_storage/archival_storage_search.js:244
 #: media/js/backlog/backlog-search.js:42 media/js/backlog/backlog-search.js:53
 #: media/js/ingest/backlog.js:37
 msgid "Accession number"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:241
-#: media/js/archival_storage/archival_storage_search.js:254
+#: media/js/archival_storage/archival_storage_search.js:245
+#: media/js/archival_storage/archival_storage_search.js:258
 #: media/js/backlog/backlog-search.js:43 media/js/backlog/backlog-search.js:55
 msgid "Status"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:242
-#: media/js/archival_storage/archival_storage_search.js:256
+#: media/js/archival_storage/archival_storage_search.js:246
+#: media/js/archival_storage/archival_storage_search.js:261
 #: media/js/backlog/backlog-search.js:44 media/js/backlog/backlog-search.js:56
-#: media/js/ingest.js:216 media/js/transfer.js:153
+#: media/js/ingest.js:217 media/js/transfer.js:154
 msgid "Actions"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:247
+#: media/js/archival_storage/archival_storage_search.js:251
 #: media/js/backlog/backlog-search.js:49
 msgid "Name"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:248
+#: media/js/archival_storage/archival_storage_search.js:252
 msgid "UUID"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:249
+#: media/js/archival_storage/archival_storage_search.js:253
 msgid "AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:250
+#: media/js/archival_storage/archival_storage_search.js:254
 #: media/js/backlog/backlog-search.js:51
 msgid "Size"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:251
+#: media/js/archival_storage/archival_storage_search.js:255
 #: media/js/backlog/backlog-search.js:52
 msgid "File count"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:252
+#: media/js/archival_storage/archival_storage_search.js:256
 msgid "Accession numbers"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:253
+#: media/js/archival_storage/archival_storage_search.js:257
 msgid "Created"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:255
+#: media/js/archival_storage/archival_storage_search.js:259
 msgid "Encrypted"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:309
-#: media/js/backlog/backlog-search.js:109
+#: media/js/archival_storage/archival_storage_search.js:260
+msgid "Location"
+msgstr ""
+
+#: media/js/archival_storage/archival_storage_search.js:315
+#: media/js/backlog/backlog-search.js:110
 msgid "Select columns"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:313
-#: media/js/backlog/backlog-search.js:113
+#: media/js/archival_storage/archival_storage_search.js:319
+#: media/js/backlog/backlog-search.js:114
 msgctxt "DataTable - sEmptyTable"
 msgid "No data available in table"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:314
-#: media/js/backlog/backlog-search.js:114
+#: media/js/archival_storage/archival_storage_search.js:320
+#: media/js/backlog/backlog-search.js:115
 msgctxt "DataTable - sInfo"
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:315
-#: media/js/backlog/backlog-search.js:115
+#: media/js/archival_storage/archival_storage_search.js:321
+#: media/js/backlog/backlog-search.js:116
 msgctxt "DataTable - sInfoEmpty"
 msgid "Showing 0 to 0 of 0 entries"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:316
-#: media/js/backlog/backlog-search.js:116
+#: media/js/archival_storage/archival_storage_search.js:322
+#: media/js/backlog/backlog-search.js:117
 msgctxt "DataTable - sInfoFiltered"
 msgid "(filtered from _MAX_ total entries)"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:318
-#: media/js/backlog/backlog-search.js:118
+#: media/js/archival_storage/archival_storage_search.js:324
+#: media/js/backlog/backlog-search.js:119
 msgctxt "DataTable - sInfoThousands"
 msgid ","
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:319
-#: media/js/backlog/backlog-search.js:119
+#: media/js/archival_storage/archival_storage_search.js:325
+#: media/js/backlog/backlog-search.js:120
 msgctxt "DataTable - sLengthMenu"
 msgid "Show _MENU_ entries"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:320
-#: media/js/backlog/backlog-search.js:120
+#: media/js/archival_storage/archival_storage_search.js:326
+#: media/js/backlog/backlog-search.js:121
 msgctxt "DataTable - sLoadingRecords"
 msgid "Loading..."
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:321
-#: media/js/backlog/backlog-search.js:121
+#: media/js/archival_storage/archival_storage_search.js:327
+#: media/js/backlog/backlog-search.js:122
 msgctxt "DataTable - sProcessing"
 msgid "Processing..."
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:322
-#: media/js/backlog/backlog-search.js:122
+#: media/js/archival_storage/archival_storage_search.js:328
+#: media/js/backlog/backlog-search.js:123
 msgctxt "DataTable - sSearch"
 msgid "Search:"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:323
-#: media/js/backlog/backlog-search.js:123
+#: media/js/archival_storage/archival_storage_search.js:329
+#: media/js/backlog/backlog-search.js:124
 msgctxt "DataTable - sZeroRecords"
 msgid "No matching records found"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:325
-#: media/js/backlog/backlog-search.js:125
+#: media/js/archival_storage/archival_storage_search.js:331
+#: media/js/backlog/backlog-search.js:126
 msgctxt "DataTable - sFirst"
 msgid "First"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:326
-#: media/js/backlog/backlog-search.js:126
+#: media/js/archival_storage/archival_storage_search.js:332
+#: media/js/backlog/backlog-search.js:127
 msgctxt "DataTable - sLast"
 msgid "Last"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:327
-#: media/js/backlog/backlog-search.js:127
+#: media/js/archival_storage/archival_storage_search.js:333
+#: media/js/backlog/backlog-search.js:128
 msgctxt "DataTable - sNext"
 msgid "Next"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:328
-#: media/js/backlog/backlog-search.js:128
+#: media/js/archival_storage/archival_storage_search.js:334
+#: media/js/backlog/backlog-search.js:129
 msgctxt "DataTable - sPrevious"
 msgid "Previous"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:331
-#: media/js/backlog/backlog-search.js:131
+#: media/js/archival_storage/archival_storage_search.js:337
+#: media/js/backlog/backlog-search.js:132
 msgctxt "DataTable - sSortAscending"
 msgid ": activate to sort column ascending"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:332
-#: media/js/backlog/backlog-search.js:132
+#: media/js/archival_storage/archival_storage_search.js:338
+#: media/js/backlog/backlog-search.js:133
 msgctxt "DataTable - sSortDescending"
 msgid ": activate to sort column descending"
 msgstr ""
@@ -353,7 +357,7 @@ msgid "Yes"
 msgstr ""
 
 #: media/js/directory_picker.js:90 media/js/file_browser.js:178
-#: media/js/ingest.js:123 media/js/jobs.js:590 media/js/jobs.js:683
+#: media/js/ingest.js:124 media/js/jobs.js:590 media/js/jobs.js:686
 msgid "Cancel"
 msgstr ""
 
@@ -401,43 +405,43 @@ msgstr ""
 msgid "Confirm"
 msgstr ""
 
-#: media/js/ingest.js:145
+#: media/js/ingest.js:146
 msgid "Dublin Core metadata editor"
 msgstr ""
 
-#: media/js/ingest.js:152 media/js/jobs.js:535
+#: media/js/ingest.js:153 media/js/jobs.js:535
 msgid "Close"
 msgstr ""
 
-#: media/js/ingest.js:173
+#: media/js/ingest.js:174
 msgid "Error"
 msgstr ""
 
-#: media/js/ingest.js:240
+#: media/js/ingest.js:241
 msgid "Report"
 msgstr ""
 
-#: media/js/ingest.js:243
+#: media/js/ingest.js:244
 msgid "Match DIP objects to resources"
 msgstr ""
 
-#: media/js/ingest.js:301
+#: media/js/ingest.js:303
 msgid "Loading..."
 msgstr ""
 
-#: media/js/ingest/as_matcher.js:551
+#: media/js/ingest/as_matcher.js:553
 msgid "No resource selected."
 msgstr ""
 
-#: media/js/ingest/as_matcher.js:558
+#: media/js/ingest/as_matcher.js:560
 msgid "No objects selected."
 msgstr ""
 
-#: media/js/ingest/as_matcher.js:670
+#: media/js/ingest/as_matcher.js:673
 msgid "Warning"
 msgstr ""
 
-#: media/js/ingest/as_matcher.js:674
+#: media/js/ingest/as_matcher.js:677
 msgid "Dismiss"
 msgstr ""
 
@@ -449,15 +453,15 @@ msgstr ""
 msgid "Ingest date (YYYY-MM-DD)"
 msgstr ""
 
-#: media/js/ingest/metadata_form.js:83
+#: media/js/ingest/metadata_form.js:84
 msgid "Browse"
 msgstr ""
 
-#: media/js/ingest/metadata_form.js:85
+#: media/js/ingest/metadata_form.js:86
 msgid "Add files"
 msgstr ""
 
-#: media/js/ingest/metadata_form.js:124
+#: media/js/ingest/metadata_form.js:125
 msgid "Please select at least one metadata file."
 msgstr ""
 
@@ -484,34 +488,34 @@ msgstr ""
 msgid "Remove All Completed %ss"
 msgstr ""
 
-#: media/js/jobs.js:661
+#: media/js/jobs.js:664
 #, javascript-format
 msgid "There were no completed %ss to remove"
 msgstr ""
 
-#: media/js/jobs.js:665
+#: media/js/jobs.js:668
 #, javascript-format
 msgid "Successfully removed the following %ss: %s"
 msgstr ""
 
-#: media/js/jobs.js:671
+#: media/js/jobs.js:674
 #, javascript-format
 msgid "Failed to remove all completed %ss"
 msgstr ""
 
-#: media/js/jobs.js:797
+#: media/js/jobs.js:800
 msgid "Previous"
 msgstr ""
 
-#: media/js/jobs.js:812
+#: media/js/jobs.js:815
 msgid "Next"
 msgstr ""
 
-#: media/js/jobs.js:850
+#: media/js/jobs.js:853
 msgid "Error trying to connect to database. Trying again..."
 msgstr ""
 
-#: media/js/jobs.js:900
+#: media/js/jobs.js:903
 msgid "Error trying to connect to MCP server. Trying again..."
 msgstr ""
 
@@ -527,7 +531,7 @@ msgstr ""
 msgid "Disconnected"
 msgstr ""
 
-#: media/js/repeating-ajax-data.js:215
+#: media/js/repeating-ajax-data.js:217
 msgid "Are you sure?"
 msgstr ""
 

--- a/src/dashboard/src/locale/pt_BR/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/pt_BR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 11:52-0400\n"
+"POT-Creation-Date: 2020-07-27 22:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: artefactual <translate@artefactual.com>, 2018\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/artefactual/"
@@ -19,12 +19,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: components/accounts/views.py:62 components/accounts/views.py:150
-#: components/administration/views.py:459
-#: components/administration/views.py:474
-#: components/administration/views.py:486
-#: components/administration/views.py:513
-#: components/administration/views.py:564
+#: components/accounts/views.py:61 components/accounts/views.py:149
+#: components/administration/views.py:454
+#: components/administration/views.py:469
+#: components/administration/views.py:481
+#: components/administration/views.py:508
+#: components/administration/views.py:555
 #: components/administration/views_dip_upload.py:25
 #: components/administration/views_dip_upload.py:39 fpr/views.py:106
 #: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Saved."
 msgstr "Salvo."
 
-#: components/accounts/views.py:82
+#: components/accounts/views.py:81
 #, python-format
 msgid "Your profile (%s)"
 msgstr "Seu perfil (%s)"
@@ -416,7 +416,7 @@ msgstr "Embutir"
 msgid "New"
 msgstr "Novo"
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:973
+#: components/administration/forms_dip_upload.py:21 main/models.py:1021
 msgid "Other"
 msgstr "Outro"
 
@@ -616,32 +616,32 @@ msgstr "API REST chave"
 msgid "Used in metadata-only DIP upload."
 msgstr "Usado no upload de DIP somente para metadata."
 
-#: components/administration/views.py:92 components/administration/views.py:125
-#: components/ingest/views.py:293 fpr/views.py:261 main/views.py:310
+#: components/administration/views.py:89 components/administration/views.py:122
+#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
 msgid "Deleted."
 msgstr "Apagado."
 
-#: components/administration/views.py:109
+#: components/administration/views.py:106
 msgid "Promoted."
 msgstr "Promovido."
 
-#: components/administration/views.py:112
+#: components/administration/views.py:109
 msgid "Error attempting to promote level of description."
 msgstr "Erro ao tentar promover o nível de descrição."
 
-#: components/administration/views.py:116
+#: components/administration/views.py:113
 msgid "Demoted."
 msgstr "Rebaixar"
 
-#: components/administration/views.py:119
+#: components/administration/views.py:116
 msgid "Error attempting to demote level of description."
 msgstr "Erro ao tentar diminuir o nível de descrição."
 
-#: components/administration/views.py:127
+#: components/administration/views.py:124
 msgid "Level of description not found."
 msgstr "Nível de descrição não encontrado."
 
-#: components/administration/views.py:193
+#: components/administration/views.py:190
 msgid ""
 "Error retrieving locations: is the storage server running? Please contact an "
 "administrator."
@@ -649,62 +649,62 @@ msgstr ""
 "Erro ao recuperar locais: o servidor de armazenamento está sendo executado? "
 "Entre em contato com um administrador."
 
-#: components/administration/views.py:202
+#: components/administration/views.py:199
 #, fuzzy
 #| msgid "AIP storage locations"
 msgid "AIP Storage"
 msgstr "Locais de armazenamento AIP"
 
-#: components/administration/views.py:203
+#: components/administration/views.py:200
 msgid "DIP Storage"
 msgstr ""
 
-#: components/administration/views.py:204
+#: components/administration/views.py:201
 msgid "FEDORA Deposits"
 msgstr ""
 
-#: components/administration/views.py:205
+#: components/administration/views.py:202
 #, fuzzy
 #| msgid "Search transfer backlog"
 msgid "Transfer Backlog"
 msgstr "Pesquisar transferência do backlog"
 
-#: components/administration/views.py:206
+#: components/administration/views.py:203
 #, fuzzy
 #| msgid "Transfer source locations"
 msgid "Transfer Source"
 msgstr "Transferir locais de origem"
 
-#: components/administration/views.py:207
+#: components/administration/views.py:204
 msgid "Replicator"
 msgstr ""
 
-#: components/administration/views.py:224
+#: components/administration/views.py:221
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:407
+#: components/administration/views.py:404
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:410
+#: components/administration/views.py:406
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr "Esvaziar"
 
-#: components/administration/views.py:436
+#: components/administration/views.py:431
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:439
+#: components/administration/views.py:434
 #, fuzzy, python-format
 #| msgid "No files or directories found under path: %(path)s"
 msgid "No such file or directory: %(path)s"
 msgstr "Nenhum arquivo ou diretório encontrado no caminho: %(path)s"
 
-#: components/administration/views.py:580
+#: components/administration/views.py:571
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
@@ -714,7 +714,7 @@ msgstr ""
 "com um administrador ou atualize a URL no Serviço de Armazenamento abaixo."
 "<hr />%(error)s"
 
-#: components/administration/views.py:597
+#: components/administration/views.py:588
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -725,7 +725,7 @@ msgstr ""
 "se a pipeline existir mas estiver desabilitada. Por favor, entre em contato "
 "com um administrador.<hr />%(error)s"
 
-#: components/administration/views.py:609
+#: components/administration/views.py:600
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -798,6 +798,7 @@ msgid "Please type in the UUID to confirm"
 msgstr "Digite o UUID para confirmar"
 
 #: components/archival_storage/forms.py:89
+#: components/archival_storage/views.py:210
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -827,25 +828,88 @@ msgstr "uuid deve ser definido"
 msgid "UUID mismatch"
 msgstr "incompatibilidade de UUID "
 
-#: components/archival_storage/views.py:49
+#: components/archival_storage/views.py:54
 msgid "Stored"
 msgstr "Armazenado"
 
-#: components/archival_storage/views.py:50
+#: components/archival_storage/views.py:55
 msgid "Deletion requested"
 msgstr "Eliminação solicitada"
 
-#: components/archival_storage/views.py:464
+#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: templates/accounts/profile.html:31
+#: templates/administration/atom_levels_of_description.html:37
+#: templates/administration/reports/failures.html:26
+msgid "Name"
+msgstr "Nome"
+
+#: components/archival_storage/views.py:211
+msgid "AICID"
+msgstr ""
+
+#: components/archival_storage/views.py:212
+msgid "Count AIPs in AIC"
+msgstr ""
+
+#: components/archival_storage/views.py:213
+#: templates/administration/usage.html:90
+#: templates/archival_storage/view.html:67
+msgid "Size"
+msgstr "Tamanho"
+
+#: components/archival_storage/views.py:214
+#, fuzzy
+#| msgid "Failure report"
+msgid "File count"
+msgstr "Relatório de falha:"
+
+#: components/archival_storage/views.py:215
+#, fuzzy
+#| msgid "Access"
+msgid "Accession IDs"
+msgstr "Acesso"
+
+#: components/archival_storage/views.py:216
+#, fuzzy
+#| msgid "Created time"
+msgid "Created date (UTC)"
+msgstr "Tempo criado"
+
+#: components/archival_storage/views.py:217
+#: templates/archival_storage/view.html:75
+msgid "Status"
+msgstr "Status"
+
+#: components/archival_storage/views.py:218
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: templates/administration/reports/failures.html:25
+#: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
+#: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
+msgid "Type"
+msgstr "Tipo"
+
+#: components/archival_storage/views.py:219
+#: templates/archival_storage/view.html:79
+msgid "Encrypted"
+msgstr "Criptografado"
+
+#: components/archival_storage/views.py:220
+#: templates/archival_storage/view.html:83
+#: templates/ingest/normalization_report.html:31
+msgid "Location"
+msgstr "Localização"
+
+#: components/archival_storage/views.py:600
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:593
+#: components/archival_storage/views.py:729
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 "O upload DIP somente de metadados falhou, verifique os logs para obter mais "
 "detalhes"
 
-#: components/archival_storage/views.py:605
+#: components/archival_storage/views.py:741
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
@@ -854,12 +918,12 @@ msgstr ""
 "O upload DIP somente de metadados foi concluído com sucesso. Novo recurso "
 "tem slug: %(slug)s"
 
-#: components/archival_storage/views.py:628
+#: components/archival_storage/views.py:764
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr "Erro ao readmitir o pacote: %(message)s"
 
-#: components/backlog/views.py:291
+#: components/backlog/views.py:282
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 "Não é possível conectar ao servidor de armazenamento. Entre em contato com o "
@@ -1018,7 +1082,7 @@ msgstr "Configurações de autenticação AtoM não definidas!"
 msgid "Unable to fetch levels of description from AtoM!"
 msgstr "Não é possível buscar níveis de descrição do AtoM!"
 
-#: components/ingest/views.py:87
+#: components/ingest/views.py:86
 msgid ""
 "Error retrieving originals/arrange directory locations: is the storage "
 "server running? Please contact an administrator."
@@ -1027,7 +1091,7 @@ msgstr ""
 "servidor de armazenamento está sendo executado? Entre em contato com um "
 "administrador. "
 
-#: components/ingest/views.py:182
+#: components/ingest/views.py:181
 msgid ""
 "Error retrieving source directories: is the storage server running? Please "
 "contact an administrator."
@@ -1035,30 +1099,30 @@ msgstr ""
 "Erro ao recuperar diretórios de origem: o servidor de armazenamento está "
 "sendo executado? Entre em contato com um administrador."
 
-#: components/ingest/views.py:191
+#: components/ingest/views.py:190
 msgid ""
 "No transfer source locations are available. Please contact an administrator."
 msgstr ""
 "Não há locais de origem de transferência disponíveis. Entre em contato com "
 "um administrador."
 
-#: components/ingest/views.py:283
+#: components/ingest/views.py:278
 msgid "Are you sure you want to delete this metadata?"
 msgstr "Tem certeza de que deseja excluir esses metadados?"
 
-#: components/ingest/views.py:418
+#: components/ingest/views.py:412
 msgid "Review normalization"
 msgstr "Revisar a normalização"
 
-#: components/ingest/views.py:421
+#: components/ingest/views.py:415
 msgid "Review AIP"
 msgstr "Revisar AIP"
 
-#: components/ingest/views.py:424
+#: components/ingest/views.py:418
 msgid "Review DIP"
 msgstr "Revisar DIP"
 
-#: components/ingest/views_as.py:327
+#: components/ingest/views_as.py:325
 msgid "Operation failed, please try again later or contact your administrator."
 msgstr ""
 "A operação falhou, por favor, tente novamente mais tarde, ou entre em "
@@ -1201,20 +1265,20 @@ msgstr ""
 "A data final em que a autorização não se aplica mais ou é aplicada ao "
 "conteúdo."
 
-#: components/rights/views.py:277 components/rights/views.py:311
+#: components/rights/views.py:272 components/rights/views.py:306
 msgid "copyright"
 msgstr "direito autoral"
 
-#: components/rights/views.py:345 components/rights/views.py:379
+#: components/rights/views.py:340 components/rights/views.py:374
 msgid "license"
 msgstr "autorização"
 
-#: components/rights/views.py:391 components/rights/views.py:426
-#: components/rights/views.py:466 components/rights/views.py:497
+#: components/rights/views.py:386 components/rights/views.py:421
+#: components/rights/views.py:461 components/rights/views.py:492
 msgid "statute"
 msgstr "estatuto"
 
-#: components/rights/views.py:483
+#: components/rights/views.py:478
 msgid "statue"
 msgstr "estátua"
 
@@ -1222,11 +1286,11 @@ msgstr "estátua"
 msgid "Error retrieving source directories"
 msgstr "Erro ao recuperar diretórios de origem"
 
-#: components/transfer/views.py:210
+#: components/transfer/views.py:208
 msgid "Updated path was not provided."
 msgstr "O caminho atualizado não foi fornecido."
 
-#: components/transfer/views.py:212
+#: components/transfer/views.py:210
 #, fuzzy
 #| msgid "Unable to update transfer metadata set: contact administrator."
 msgid "Unable to update transfer metadata set, contact administrator:"
@@ -1267,475 +1331,475 @@ msgstr ""
 msgid "the related model"
 msgstr "Tempo criado"
 
-#: fpr/models.py:51 fpr/models.py:362 fpr/models.py:560 fpr/models.py:603
-#: fpr/models.py:643 fpr/models.py:659 fpr/models.py:677 fpr/models.py:705
-#: fpr/models.py:730 fpr/models.py:749 fpr/models.py:770
+#: fpr/models.py:52 fpr/models.py:378 fpr/models.py:586 fpr/models.py:629
+#: fpr/models.py:669 fpr/models.py:685 fpr/models.py:703 fpr/models.py:731
+#: fpr/models.py:757 fpr/models.py:776 fpr/models.py:797
 msgid "enabled"
 msgstr ""
 
-#: fpr/models.py:52 fpr/models.py:601 fpr/models.py:640 fpr/models.py:657
-#: fpr/models.py:675 fpr/models.py:703 fpr/models.py:728 fpr/models.py:747
-#: fpr/models.py:768
+#: fpr/models.py:53 fpr/models.py:627 fpr/models.py:666 fpr/models.py:683
+#: fpr/models.py:701 fpr/models.py:729 fpr/models.py:755 fpr/models.py:774
+#: fpr/models.py:795
 msgid "last modified"
 msgstr ""
 
-#: fpr/models.py:141 fpr/models.py:165 fpr/models.py:182 fpr/models.py:251
-#: fpr/models.py:306 fpr/models.py:356 fpr/models.py:388 fpr/models.py:484
-#: fpr/models.py:554
+#: fpr/models.py:142 fpr/models.py:170 fpr/models.py:187 fpr/models.py:257
+#: fpr/models.py:316 fpr/models.py:372 fpr/models.py:404 fpr/models.py:506
+#: fpr/models.py:580
 #, fuzzy
 #| msgid "Identifier"
 msgid "Unique identifier"
 msgstr "Código de referência"
 
-#: fpr/models.py:144 fpr/models.py:167 fpr/models.py:194 fpr/models.py:254
-#: fpr/models.py:359 fpr/models.py:494 fpr/models.py:557 fpr/models.py:631
-#: fpr/models.py:652 fpr/models.py:671 fpr/models.py:686
+#: fpr/models.py:145 fpr/models.py:172 fpr/models.py:200 fpr/models.py:260
+#: fpr/models.py:375 fpr/models.py:517 fpr/models.py:583 fpr/models.py:657
+#: fpr/models.py:678 fpr/models.py:697 fpr/models.py:712
 #, fuzzy
 #| msgid "Description"
 msgid "description"
 msgstr "Descrição"
 
-#: fpr/models.py:144
+#: fpr/models.py:145
 msgid "Common name of format"
 msgstr ""
 
-#: fpr/models.py:147
+#: fpr/models.py:151
 #, fuzzy
 #| msgid "A related resource."
 msgid "the related group"
 msgstr "Um recurso relacionado."
 
-#: fpr/models.py:149 fpr/models.py:168 fpr/models.py:364 fpr/models.py:561
+#: fpr/models.py:154 fpr/models.py:173 fpr/models.py:380 fpr/models.py:587
 msgid "slug"
 msgstr ""
 
-#: fpr/models.py:154 fpr/templates/fpr/format/version/detail.html:31
+#: fpr/models.py:159 fpr/templates/fpr/format/version/detail.html:31
 #: fpr/templates/fpr/fprule/detail.html:30
 #: fpr/templates/fpr/fprule/list.html:30 fpr/templates/fpr/idrule/list.html:28
 #: templates/ingest/normalization_report.html:32
 msgid "Format"
 msgstr "Formato:"
 
-#: fpr/models.py:171
+#: fpr/models.py:176
 #, fuzzy
 #| msgid "Format"
 msgid "Format group"
 msgstr "Formato:"
 
-#: fpr/models.py:189 fpr/models.py:312 fpr/models.py:444 fpr/models.py:713
+#: fpr/models.py:194 fpr/models.py:327 fpr/models.py:465 fpr/models.py:739
 #, fuzzy
 #| msgid "File format"
 msgid "the related format"
 msgstr "Formato de arquivo"
 
-#: fpr/models.py:191 fpr/models.py:361 fpr/models.py:559
+#: fpr/models.py:197 fpr/models.py:377 fpr/models.py:585
 #, fuzzy
 #| msgid "Version"
 msgid "version"
 msgstr "Versão"
 
-#: fpr/models.py:192
+#: fpr/models.py:198
 msgid "pronom id"
 msgstr ""
 
-#: fpr/models.py:198
+#: fpr/models.py:204
 #, fuzzy
 #| msgid "Used for premis:agentName in the METS file."
 msgid "Formal name to go in the METS file."
 msgstr "Usado como premis:agentName no arquivo METS."
 
-#: fpr/models.py:200
+#: fpr/models.py:206
 #, fuzzy
 #| msgid "Already in access format"
 msgid "access format"
 msgstr "Já está no formato de acesso"
 
-#: fpr/models.py:201
+#: fpr/models.py:207
 #, fuzzy
 #| msgid "Already in preservation format"
 msgid "preservation format"
 msgstr "Já está em formato de preservação"
 
-#: fpr/models.py:208 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
 #, fuzzy
 #| msgid "AtoM/Binder version"
 msgid "Format version"
 msgstr "Versão do AtoM/Binder"
 
-#: fpr/models.py:227
+#: fpr/models.py:233
 msgid ""
 "Unable to save, an active Format Version  with this pronom id already exists."
 msgstr ""
 
-#: fpr/models.py:234
+#: fpr/models.py:240
 #, python-format
 msgid "%(format)s: %(description)s (%(pronom_id)s)"
 msgstr ""
 
-#: fpr/models.py:254
+#: fpr/models.py:260
 msgid "Name to identify script"
 msgstr ""
 
-#: fpr/models.py:257
+#: fpr/models.py:263
 msgid "PUID"
 msgstr ""
 
-#: fpr/models.py:258
+#: fpr/models.py:264
 msgid "MIME type"
 msgstr ""
 
-#: fpr/models.py:259
+#: fpr/models.py:265
 msgid "File extension"
 msgstr ""
 
-#: fpr/models.py:261
+#: fpr/models.py:267
 #, fuzzy
 #| msgid "Configuration"
 msgid "configuration"
 msgstr "Configuração"
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 #, fuzzy
 #| msgid "Description"
 msgid "script"
 msgstr "Descrição"
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 msgid "Script to be executed."
 msgstr ""
 
-#: fpr/models.py:265 fpr/models.py:497
+#: fpr/models.py:271 fpr/models.py:520
 msgid "Bash script"
 msgstr ""
 
-#: fpr/models.py:266 fpr/models.py:498
+#: fpr/models.py:272 fpr/models.py:521
 msgid "Python script"
 msgstr ""
 
-#: fpr/models.py:267 fpr/models.py:499
+#: fpr/models.py:273 fpr/models.py:522
 msgid "Command line"
 msgstr ""
 
-#: fpr/models.py:268 fpr/models.py:500
+#: fpr/models.py:274 fpr/models.py:523
 msgid "No shebang needed"
 msgstr ""
 
-#: fpr/models.py:271 fpr/models.py:503
+#: fpr/models.py:277 fpr/models.py:526
 #, fuzzy
 #| msgid "Object type"
 msgid "script type"
 msgstr "Tipo de objeto"
 
-#: fpr/models.py:274 fpr/models.py:492
+#: fpr/models.py:283 fpr/models.py:514
 msgid "the related tool"
 msgstr ""
 
-#: fpr/models.py:278
+#: fpr/models.py:288
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "Format identification command"
 msgstr "Selecione o comando de identificação do formato de arquivo (Admissão)"
 
-#: fpr/models.py:282
+#: fpr/models.py:292
 #, python-format
 msgid "%(tool)s %(config)s runs %(command)s"
 msgstr ""
 
-#: fpr/models.py:309 fpr/models.py:441
+#: fpr/models.py:321 fpr/models.py:459
 msgid "the related command"
 msgstr ""
 
-#: fpr/models.py:315
+#: fpr/models.py:331
 msgid "command output"
 msgstr ""
 
-#: fpr/models.py:318
+#: fpr/models.py:334
 #, fuzzy
 #| msgid "Copyright document identification role"
 msgid "Format identification rule"
 msgstr "Função do documento de identificação de direitos autorais"
 
-#: fpr/models.py:335
+#: fpr/models.py:351
 msgid ""
 "Unable to save, a rule with this output already exists for this command."
 msgstr ""
 
-#: fpr/models.py:342
+#: fpr/models.py:358
 #, fuzzy, python-format
 #| msgid "Copyright document identification role"
 msgid "Format identification rule %(uuid)s"
 msgstr "Função do documento de identificação de direitos autorais"
 
-#: fpr/models.py:345
+#: fpr/models.py:361
 #, python-format
 msgid "%(command)s with %(output)s is %(format)s"
 msgstr ""
 
-#: fpr/models.py:359 fpr/models.py:557
+#: fpr/models.py:375 fpr/models.py:583
 msgid "Name of tool"
 msgstr ""
 
-#: fpr/models.py:368
+#: fpr/models.py:384
 #, fuzzy
 #| msgid "Copyright document identification role"
 msgid "Format identification tool"
 msgstr "Função do documento de identificação de direitos autorais"
 
-#: fpr/models.py:374 fpr/models.py:568
+#: fpr/models.py:390 fpr/models.py:594
 #, fuzzy, python-format
 #| msgid "Description"
 msgid "%(description)s"
 msgstr "Descrição"
 
-#: fpr/models.py:416 templates/layout.html:65 templates/main/access.html:4
+#: fpr/models.py:432 templates/layout.html:67 templates/main/access.html:4
 #: templates/main/access.html:5
 msgid "Access"
 msgstr "Acesso"
 
-#: fpr/models.py:417 fpr/models.py:514
+#: fpr/models.py:433 fpr/models.py:538
 msgid "Characterization"
 msgstr ""
 
-#: fpr/models.py:418
+#: fpr/models.py:434
 #, fuzzy
 #| msgid "Extract packages"
 msgid "Extract"
 msgstr "Extrair pacotes"
 
-#: fpr/models.py:419 fpr/templates/fpr/format/version/detail.html:33
+#: fpr/models.py:435 fpr/templates/fpr/format/version/detail.html:33
 #, fuzzy
 #| msgid "Preservation planning"
 msgid "Preservation"
 msgstr "Plano de preservação"
 
-#: fpr/models.py:420
+#: fpr/models.py:436
 msgid "Thumbnail"
 msgstr ""
 
-#: fpr/models.py:421 fpr/models.py:518
+#: fpr/models.py:437 fpr/models.py:542
 #, fuzzy
 #| msgid "Description"
 msgid "Transcription"
 msgstr "Descrição"
 
-#: fpr/models.py:422 fpr/models.py:519
+#: fpr/models.py:438 fpr/models.py:543
 msgid "Validation"
 msgstr ""
 
-#: fpr/models.py:423
+#: fpr/models.py:439
 msgid "Validation against a policy"
 msgstr ""
 
-#: fpr/models.py:426
+#: fpr/models.py:442
 #, fuzzy
 #| msgid "Delete successful."
 msgid "Default access"
 msgstr "Exclusão bem sucedida."
 
-#: fpr/models.py:427
+#: fpr/models.py:443
 #, fuzzy
 #| msgid "Default location"
 msgid "Default characterization"
 msgstr "Localização padrão"
 
-#: fpr/models.py:428
+#: fpr/models.py:444
 #, fuzzy
 #| msgid "Generate thumbnails"
 msgid "Default thumbnail"
 msgstr "Gerar miniaturas"
 
-#: fpr/models.py:439
+#: fpr/models.py:455
 #, fuzzy
 #| msgid "Purpose"
 msgid "purpose"
 msgstr "Objetivo"
 
-#: fpr/models.py:447
+#: fpr/models.py:469
 msgid "count attempts"
 msgstr ""
 
-#: fpr/models.py:448
+#: fpr/models.py:470
 msgid "count okay"
 msgstr ""
 
-#: fpr/models.py:449
+#: fpr/models.py:471
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:452 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:732
 msgid "Format policy rule"
 msgstr ""
 
-#: fpr/models.py:472
+#: fpr/models.py:494
 #, python-format
 msgid "Format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:475
+#: fpr/models.py:497
 #, python-format
 msgid "Normalize %(format)s for %(purpose)s via %(command)s"
 msgstr ""
 
-#: fpr/models.py:495 fpr/models.py:627 fpr/models.py:744
+#: fpr/models.py:518 fpr/models.py:653 fpr/models.py:771
 #, fuzzy
 #| msgid "Rsync command"
 msgid "command"
 msgstr "Comando Rsync"
 
-#: fpr/models.py:505 fpr/models.py:629
+#: fpr/models.py:528 fpr/models.py:655
 #, fuzzy
 #| msgid "Default location"
 msgid "output location"
 msgstr "Localização padrão"
 
-#: fpr/models.py:511
+#: fpr/models.py:534
 msgid "the related output format"
 msgstr ""
 
-#: fpr/models.py:515
+#: fpr/models.py:539
 msgid "Event Detail"
 msgstr ""
 
-#: fpr/models.py:516
+#: fpr/models.py:540
 #, fuzzy
 #| msgid "Duration"
 msgid "Extraction"
 msgstr "Duração"
 
-#: fpr/models.py:517
+#: fpr/models.py:541
 #, fuzzy
 #| msgid "Review normalization"
 msgid "Normalization"
 msgstr "Revisar a normalização"
 
-#: fpr/models.py:520
+#: fpr/models.py:544
 #, fuzzy
 #| msgid "Restriction(s)"
 msgid "Verification"
 msgstr "Restrição(ões)"
 
-#: fpr/models.py:523 fpr/models.py:613
+#: fpr/models.py:547 fpr/models.py:639
 msgid "command usage"
 msgstr ""
 
-#: fpr/models.py:531
+#: fpr/models.py:555
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "the related verification command"
 msgstr "Selecione o comando de identificação do formato de arquivo (Admissão)"
 
-#: fpr/models.py:539
+#: fpr/models.py:564
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:543 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:731
 msgid "Format policy command"
 msgstr ""
 
-#: fpr/models.py:565
+#: fpr/models.py:591
 #, fuzzy
 #| msgid "Review normalization"
 msgid "Normalization tool"
 msgstr "Revisar a normalização"
 
-#: fpr/models.py:582
+#: fpr/models.py:608
 #, fuzzy
 #| msgid "Agent Identifier Type"
 msgid "agent identifier type"
 msgstr "Tipo de Identificador de Agente"
 
-#: fpr/models.py:583
+#: fpr/models.py:609
 #, fuzzy
 #| msgid "Agent Identifier Value"
 msgid "agent identifier value"
 msgstr "Valor de Identificador de Agente"
 
-#: fpr/models.py:584
+#: fpr/models.py:610
 #, fuzzy
 #| msgid "Agent Name"
 msgid "agent name"
 msgstr "Nome do Agente"
 
-#: fpr/models.py:585
+#: fpr/models.py:611
 #, fuzzy
 #| msgid "Agent Type"
 msgid "agent type"
 msgstr "Tipo de Agente"
 
-#: fpr/models.py:586
+#: fpr/models.py:612
 msgid "client IP address"
 msgstr ""
 
-#: fpr/models.py:598 fpr/models.py:637 fpr/models.py:655 fpr/models.py:673
-#: fpr/models.py:701 fpr/models.py:726 fpr/models.py:746 fpr/models.py:766
+#: fpr/models.py:624 fpr/models.py:663 fpr/models.py:681 fpr/models.py:699
+#: fpr/models.py:727 fpr/models.py:753 fpr/models.py:773 fpr/models.py:793
 #, fuzzy
 #| msgid "Replace"
 msgid "replaces"
 msgstr "Substituir"
 
-#: fpr/models.py:600
+#: fpr/models.py:626
 msgid "type"
 msgstr ""
 
-#: fpr/models.py:614
+#: fpr/models.py:640
 msgid "command type"
 msgstr ""
 
-#: fpr/models.py:617
+#: fpr/models.py:643
 #, fuzzy
 #| msgid "Executing command(s)"
 msgid "verification command"
 msgstr "Executando o(s) comando(s)"
 
-#: fpr/models.py:621
+#: fpr/models.py:647
 msgid "event detail command"
 msgstr ""
 
-#: fpr/models.py:625
+#: fpr/models.py:651
 msgid "supported by"
 msgstr ""
 
-#: fpr/models.py:633
+#: fpr/models.py:659
 #, fuzzy
 #| msgid "File format"
 msgid "output file format"
 msgstr "Formato de arquivo"
 
-#: fpr/models.py:688
+#: fpr/models.py:714
 #, fuzzy
 #| msgid "Already in preservation format"
 msgid "valid preservation format"
 msgstr "Já está em formato de preservação"
 
-#: fpr/models.py:694
+#: fpr/models.py:720
 #, fuzzy
 #| msgid "Already in access format"
 msgid "valid access format"
 msgstr "Já está no formato de acesso"
 
-#: fpr/models.py:698
+#: fpr/models.py:724
 msgid "file ID type"
 msgstr ""
 
-#: fpr/models.py:723
+#: fpr/models.py:750
 msgid "classification"
 msgstr ""
 
-#: fpr/models.py:740
+#: fpr/models.py:767
 msgid "command clasification"
 msgstr ""
 
-#: fpr/models.py:745 fpr/models.py:759
+#: fpr/models.py:772 fpr/models.py:786
 #, fuzzy
 #| msgid "File UUID"
 msgid "file ID"
 msgstr "Arquivo UUID"
 
-#: fpr/models.py:761
+#: fpr/models.py:788
 msgid "tool"
 msgstr ""
 
-#: fpr/models.py:763
+#: fpr/models.py:790
 #, fuzzy
 #| msgid "AtoM/Binder version"
 msgid "tool version"
@@ -1922,12 +1986,12 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:50 templates/accounts/add.html:36
 #: templates/accounts/edit.html:40 templates/accounts/profile.html:49
 #: templates/administration/processing_edit.html:40
-#: templates/delete_request.html:19 templates/ingest/as/match.html:129
-#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:66
-#: templates/rights/rights_edit.html:290 templates/rights/rights_edit.html:292
-#: templates/rights/rights_grants_edit.html:111
-#: templates/rights/rights_grants_edit.html:113
-#: templates/simple_confirm.html:10 templates/transfer/metadata_edit.html:65
+#: templates/delete_request.html:20 templates/ingest/as/match.html:129
+#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:67
+#: templates/rights/rights_edit.html:291 templates/rights/rights_edit.html:293
+#: templates/rights/rights_grants_edit.html:112
+#: templates/rights/rights_grants_edit.html:114
+#: templates/simple_confirm.html:11 templates/transfer/metadata_edit.html:66
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -2116,18 +2180,18 @@ msgstr ""
 #: fpr/templates/fpr/idcommand/form.html:32
 #: fpr/templates/fpr/idrule/form.html:29 fpr/templates/fpr/idtool/form.html:30
 #: templates/accounts/edit.html:39 templates/accounts/profile.html:48
-#: templates/administration/api.html:36
-#: templates/administration/dips_as_edit.html:29
-#: templates/administration/dips_atom_edit.html:44
-#: templates/administration/general.html:67
-#: templates/administration/handle_config.html:24
-#: templates/administration/premis_agent.html:24
+#: templates/administration/api.html:37
+#: templates/administration/dips_as_edit.html:30
+#: templates/administration/dips_atom_edit.html:45
+#: templates/administration/general.html:68
+#: templates/administration/handle_config.html:25
+#: templates/administration/premis_agent.html:25
 #: templates/administration/processing_edit.html:39
-#: templates/administration/term_detail.html:34
-#: templates/ingest/metadata_edit.html:62 templates/rights/rights_edit.html:285
-#: templates/rights/rights_grants_edit.html:106
-#: templates/transfer/component.html:54
-#: templates/transfer/metadata_edit.html:61
+#: templates/administration/term_detail.html:35
+#: templates/ingest/metadata_edit.html:63 templates/rights/rights_edit.html:286
+#: templates/rights/rights_grants_edit.html:107
+#: templates/transfer/component.html:55
+#: templates/transfer/metadata_edit.html:62
 msgid "Save"
 msgstr "Salvar"
 
@@ -2140,11 +2204,11 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:12
 #: fpr/templates/fpr/format/group/delete.html:49
 #: fpr/templates/fpr/format/group/list.html:51 templates/accounts/list.html:42
-#: templates/administration/atom_levels_of_description.html:44
+#: templates/administration/atom_levels_of_description.html:45
 #: templates/administration/processing.html:33
-#: templates/administration/reports/failure_detail.html:31
+#: templates/administration/reports/failure_detail.html:32
 #: templates/administration/reports/failures.html:39
-#: templates/administration/term_detail.html:35
+#: templates/administration/term_detail.html:36
 #: templates/archival_storage/view.html:111
 #: templates/archival_storage/view.html:154 templates/main/access.html:25
 #: templates/rights/rights_list.html:55 templates/rights/rights_list.html:58
@@ -2463,13 +2527,6 @@ msgstr ""
 msgid "Script"
 msgstr ""
 
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:959
-#: templates/administration/reports/failures.html:25
-#: templates/rights/rights_edit.html:101 templates/rights/rights_edit.html:153
-#: templates/rights/rights_edit.html:203 templates/rights/rights_edit.html:251
-msgid "Type"
-msgstr "Tipo"
-
 #: fpr/templates/fpr/idcommand/list.html:56
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
@@ -2525,7 +2582,7 @@ msgstr "Configuração"
 #: fpr/templates/fpr/idtool/detail.html:49
 #: templates/ingest/as/_search_form.html:5 templates/ingest/as/match.html:102
 #: templates/ingest/as/match.html:120
-#: templates/ingest/as/review_matches.html:30 templates/ingest/grid.html:165
+#: templates/ingest/as/review_matches.html:31 templates/ingest/grid.html:165
 msgid "Identifier"
 msgstr "Código de referência"
 
@@ -2755,75 +2812,75 @@ msgstr ""
 "Erro ao criar pipeline: o servidor de armazenamento está em execução? Entre "
 "em contato com o administrador."
 
-#: main/models.py:243
+#: main/models.py:245
 msgid "Part of AIC"
 msgstr "Parte da AIC"
 
-#: main/models.py:244
+#: main/models.py:246
 msgid "Optional: leave blank if unsure"
 msgstr "Opcional: deixe em branco se não tiver certeza"
 
-#: main/models.py:253
+#: main/models.py:255
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr "Utilize o formato ISO 8601 (AAAA-MM-DD ou AAAA-MM-DD/AAAA-MM-DD)"
 
-#: main/models.py:263
+#: main/models.py:265
 msgid "Use ISO 639"
 msgstr "Utilize a ISO 639"
 
-#: main/models.py:281
+#: main/models.py:283
 msgid "Untitled"
 msgstr "Sem título"
 
-#: main/models.py:329
+#: main/models.py:336
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr "%(type)s evento em%(file_uuid)s (%(detail)s)"
 
-#: main/models.py:371
+#: main/models.py:381
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr "%(derived)sderivado de%(src)sem%(event)s"
 
-#: main/models.py:399
+#: main/models.py:409
 msgid "SIP"
 msgstr "SIP"
 
-#: main/models.py:400
+#: main/models.py:410
 msgid "AIC"
 msgstr "AIC"
 
-#: main/models.py:401
+#: main/models.py:411
 msgid "Reingested AIP"
 msgstr "AIP readmitido"
 
-#: main/models.py:402
+#: main/models.py:412
 msgid "Reingested AIC"
 msgstr "AIC readmitido"
 
-#: main/models.py:416
+#: main/models.py:426
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr "SIP: {path}"
 
-#: main/models.py:529
+#: main/models.py:547
 msgid "Arranged SIPs"
 msgstr "SIPs Organizados"
 
-#: main/models.py:533
+#: main/models.py:551
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr "%(original)s -> %(arrange)s"
 
-#: main/models.py:578
+#: main/models.py:596
 msgid "Identifier Type"
 msgstr "Tipo de Identificador"
 
-#: main/models.py:580
+#: main/models.py:598
 msgid "Identifier Value"
 msgstr "Valor do Identificador"
 
-#: main/models.py:582
+#: main/models.py:600
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
@@ -2831,56 +2888,56 @@ msgstr ""
 "Usado como premis:objectIdentifierType e premis:objectIdentifierValue no "
 "arquivo METS."
 
-#: main/models.py:645
+#: main/models.py:673
 #, fuzzy, python-format
 #| msgid "File %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr "Arquivo %(uuid)s:%(originallocation)sagora em %(currentlocation)s"
 
-#: main/models.py:681
+#: main/models.py:719
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr "Diretório %(uuid)s:%(originallocation)s agora em %(currentlocation)s"
 
-#: main/models.py:740
+#: main/models.py:783
 #, fuzzy, python-format
 #| msgid "File format"
 msgid "%(file)s is %(format)s"
 msgstr "Formato de arquivo"
 
-#: main/models.py:758
+#: main/models.py:801
 msgid "(Unnamed)"
 msgstr "(Sem nome)"
 
-#: main/models.py:780
+#: main/models.py:823
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: main/models.py:781
+#: main/models.py:824
 msgid "Awaiting decision"
 msgstr "Aguardando decisão"
 
-#: main/models.py:782
+#: main/models.py:825
 msgid "Completed successfully"
 msgstr "Completado com sucesso"
 
-#: main/models.py:783
+#: main/models.py:826
 msgid "Executing command(s)"
 msgstr "Executando o(s) comando(s)"
 
-#: main/models.py:784
+#: main/models.py:827
 msgid "Failed"
 msgstr "Falhou"
 
-#: main/models.py:879
+#: main/models.py:924
 msgid "Agent Identifier Type"
 msgstr "Tipo de Identificador de Agente"
 
-#: main/models.py:884
+#: main/models.py:929
 msgid "Agent Identifier Value"
 msgstr "Valor de Identificador de Agente"
 
-#: main/models.py:886
+#: main/models.py:931
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
@@ -2888,336 +2945,336 @@ msgstr ""
 "Usado como premis:agentIdentifierValue e premis:linkingAgentIdentifierValue "
 "no arquivo METS."
 
-#: main/models.py:893
+#: main/models.py:938
 msgid "Agent Name"
 msgstr "Nome do Agente"
 
-#: main/models.py:894
+#: main/models.py:939
 msgid "Used for premis:agentName in the METS file."
 msgstr "Usado como premis:agentName no arquivo METS."
 
-#: main/models.py:900
+#: main/models.py:945
 msgid "Agent Type"
 msgstr "Tipo de Agente"
 
-#: main/models.py:901
+#: main/models.py:946
 msgid "Used for premis:agentType in the METS file."
 msgstr "Usado como premis:agentType no arquivo METS."
 
-#: main/models.py:925
+#: main/models.py:970
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:927
+#: main/models.py:972
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:962 templates/rights/rights_edit.html:105
-#: templates/rights/rights_edit.html:157 templates/rights/rights_edit.html:207
-#: templates/rights/rights_edit.html:255
+#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
+#: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr "Valor"
 
-#: main/models.py:965
+#: main/models.py:1013
 msgid "Rights holder"
 msgstr "Detentor dos direitos"
 
-#: main/models.py:968
+#: main/models.py:1016
 msgid "Copyright"
 msgstr "Direitos autorais"
 
-#: main/models.py:969
+#: main/models.py:1017
 msgid "Statute"
 msgstr "Regulamento"
 
-#: main/models.py:970
+#: main/models.py:1018
 msgid "License"
 msgstr "Licença"
 
-#: main/models.py:971
+#: main/models.py:1019
 msgid "Donor"
 msgstr "Doador"
 
-#: main/models.py:972
+#: main/models.py:1020
 msgid "Policy"
 msgstr "Política"
 
-#: main/models.py:979 templates/rights/rights_list.html:34
+#: main/models.py:1027 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr "Base"
 
-#: main/models.py:991
+#: main/models.py:1039
 msgid "Rights Statement"
 msgstr "Declaração de Direitos"
 
-#: main/models.py:995
+#: main/models.py:1043
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr "%(basis)spara %(unit)s (%(id)s)"
 
-#: main/models.py:1008
+#: main/models.py:1058
 msgid "copyrighted"
 msgstr "protegido por direitos autorais"
 
-#: main/models.py:1009
+#: main/models.py:1059
 msgid "public domain"
 msgstr "domínio público"
 
-#: main/models.py:1010
+#: main/models.py:1060
 msgid "unknown"
 msgstr "desconhecido"
 
-#: main/models.py:1015
+#: main/models.py:1065
 msgid "Copyright status"
 msgstr "Status dos direitos autorais"
 
-#: main/models.py:1020
+#: main/models.py:1070
 msgid "Copyright jurisdiction"
 msgstr "Juridisção dos direitos de autor"
 
-#: main/models.py:1026
+#: main/models.py:1076
 msgid "Copyright determination date"
 msgstr "Data de determinação dos direitos autorais"
 
-#: main/models.py:1027 main/models.py:1034 main/models.py:1041
-#: main/models.py:1105 main/models.py:1112 main/models.py:1172
-#: main/models.py:1179 main/models.py:1237 main/models.py:1246
-#: main/models.py:1253 main/models.py:1321 main/models.py:1328
+#: main/models.py:1077 main/models.py:1084 main/models.py:1091
+#: main/models.py:1161 main/models.py:1168 main/models.py:1234
+#: main/models.py:1241 main/models.py:1303 main/models.py:1312
+#: main/models.py:1319 main/models.py:1391 main/models.py:1398
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr "Utilize o formato ISO 8061 (AAAA-MM-DD)"
 
-#: main/models.py:1033
+#: main/models.py:1083
 msgid "Copyright start date"
 msgstr "Data inicial dos direitos autoriais"
 
-#: main/models.py:1040
+#: main/models.py:1090
 msgid "Copyright end date"
 msgstr "Data final dos direitos autoriais"
 
-#: main/models.py:1046 main/models.py:1117 main/models.py:1186
-#: main/models.py:1258 main/models.py:1333
+#: main/models.py:1096 main/models.py:1173 main/models.py:1248
+#: main/models.py:1324 main/models.py:1403
 msgid "Open End Date"
 msgstr "Data Final Aberta"
 
-#: main/models.py:1047 main/models.py:1118 main/models.py:1187
-#: main/models.py:1259 main/models.py:1334
+#: main/models.py:1097 main/models.py:1174 main/models.py:1249
+#: main/models.py:1325 main/models.py:1404
 msgid "Indicate end date is open"
 msgstr "Indica que a data final está aberta"
 
-#: main/models.py:1052
+#: main/models.py:1102
 msgid "Rights: Copyright"
 msgstr "Direitos: Direitos autorais"
 
-#: main/models.py:1062
+#: main/models.py:1114
 msgid "Copyright document identification type"
 msgstr "Tipo de documento de identificação de direitos autorais"
 
-#: main/models.py:1066
+#: main/models.py:1118
 msgid "Copyright document identification value"
 msgstr "Valor do documento de identificação de direitos autorais"
 
-#: main/models.py:1072
+#: main/models.py:1124
 msgid "Copyright document identification role"
 msgstr "Função do documento de identificação de direitos autorais"
 
-#: main/models.py:1077
+#: main/models.py:1129
 msgid "Rights: Copyright: Docs ID"
 msgstr "Direitos: Direito Autoral: ID dos Documentos"
 
-#: main/models.py:1086 templates/rights/rights_edit.html:116
+#: main/models.py:1140 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr "Nota de direitos autorais"
 
-#: main/models.py:1091
+#: main/models.py:1145
 msgid "Rights: Copyright: Note"
 msgstr "Direitos: Direito Autoral: Nota"
 
-#: main/models.py:1098
+#: main/models.py:1154
 msgid "License terms"
 msgstr "Termos de licença"
 
-#: main/models.py:1104
+#: main/models.py:1160
 msgid "License start date"
 msgstr "Data inicial da Licença"
 
-#: main/models.py:1111
+#: main/models.py:1167
 msgid "License end date"
 msgstr "Data final da Licença"
 
-#: main/models.py:1123
+#: main/models.py:1179
 msgid "Rights: License"
 msgstr "Direitos: Licença"
 
-#: main/models.py:1133
+#: main/models.py:1191
 msgid "License documentation identification type"
 msgstr "Tipo de documento de identificação de licença"
 
-#: main/models.py:1137
+#: main/models.py:1195
 msgid "License documentation identification value"
 msgstr "Valor do documento de identificação de licença"
 
-#: main/models.py:1143
+#: main/models.py:1201
 msgid "License document identification role"
 msgstr "Função do documento de identificação de licença"
 
-#: main/models.py:1148
+#: main/models.py:1206
 msgid "Rights: License: Docs ID"
 msgstr "Direitos: Licença: ID dos Documentos"
 
-#: main/models.py:1157 templates/rights/rights_edit.html:218
+#: main/models.py:1217 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr "Nota de licença"
 
-#: main/models.py:1162
+#: main/models.py:1222
 msgid "Rights: License: Note"
 msgstr "Direitos: Licença: Nota"
 
-#: main/models.py:1171 templates/rights/rights_list.html:36
+#: main/models.py:1233 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr "Início"
 
-#: main/models.py:1178 templates/rights/rights_list.html:37
+#: main/models.py:1240 templates/rights/rights_list.html:37
 msgid "End"
 msgstr "Fim"
 
-#: main/models.py:1192
+#: main/models.py:1254
 msgid "Rights: Granted"
 msgstr "Direitos: Garantia"
 
-#: main/models.py:1203
+#: main/models.py:1266
 msgid "Rights note"
 msgstr "Nota de direitos"
 
-#: main/models.py:1208
+#: main/models.py:1271
 msgid "Rights: Granted: Note"
 msgstr "Direitos: Garantia: Nota"
 
-#: main/models.py:1222
+#: main/models.py:1286
 msgid "Rights: Granted: Restriction"
 msgstr "Direitos: Garantia: Restição"
 
-#: main/models.py:1229
+#: main/models.py:1295
 msgid "Statute jurisdiction"
 msgstr " Jurisdição do regulamento"
 
-#: main/models.py:1232
+#: main/models.py:1298
 msgid "Statute citation"
 msgstr "Citação do regulamento"
 
-#: main/models.py:1236
+#: main/models.py:1302
 msgid "Statute determination date"
 msgstr "Data de determinação do regulamento"
 
-#: main/models.py:1245
+#: main/models.py:1311
 msgid "Statute start date"
 msgstr "Data inicial do estatuto"
 
-#: main/models.py:1252
+#: main/models.py:1318
 msgid "Statute end date"
 msgstr "Data final do estatuto"
 
-#: main/models.py:1264
+#: main/models.py:1330
 msgid "Rights: Statute"
 msgstr "Direitos: Estatuto"
 
-#: main/models.py:1274 templates/rights/rights_edit.html:168
+#: main/models.py:1341 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr "Nota do estatuto"
 
-#: main/models.py:1279
+#: main/models.py:1346
 msgid "Rights: Statute: Note"
 msgstr "Direitos: Estatuto: Nota"
 
-#: main/models.py:1290
+#: main/models.py:1358
 msgid "Statute document identification type"
 msgstr "Tipo de documento de identificação de estatuto"
 
-#: main/models.py:1294
+#: main/models.py:1362
 msgid "Statute document identification value"
 msgstr "Valor do documento de identificação de estatuto"
 
-#: main/models.py:1300
+#: main/models.py:1368
 msgid "Statute document identification role"
 msgstr "Função do documento de identificação de estatuto"
 
-#: main/models.py:1305
+#: main/models.py:1373
 msgid "Rights: Statute: Docs ID"
 msgstr "Direitos: Estatuto: ID dos Documentos"
 
-#: main/models.py:1313
+#: main/models.py:1383
 msgid "Other rights basis"
 msgstr "Base de outros direitos"
 
-#: main/models.py:1320
+#: main/models.py:1390
 msgid "Other rights start date"
 msgstr "Data inicial de outros direitos"
 
-#: main/models.py:1327
+#: main/models.py:1397
 msgid "Other rights end date"
 msgstr "Data final de outros direitos"
 
-#: main/models.py:1339
+#: main/models.py:1409
 msgid "Rights: Other"
 msgstr "Direitos: Outros"
 
-#: main/models.py:1350
+#: main/models.py:1421
 msgid "Other rights document identification type"
 msgstr "Tipo de documento de identificação de outros direitos"
 
-#: main/models.py:1354
+#: main/models.py:1425
 msgid "Other right document identification value"
 msgstr "Valor do documento de identificação de outros direitos"
 
-#: main/models.py:1360
+#: main/models.py:1431
 msgid "Other rights document identification role"
 msgstr "Função do documento de identificação de outros direitos"
 
-#: main/models.py:1365
+#: main/models.py:1436
 msgid "Rights: Other: Docs ID"
 msgstr "Direitos: Outros: ID dos Documentos"
 
-#: main/models.py:1375
+#: main/models.py:1447
 msgid "Other rights note"
 msgstr "Nota de outros direitos"
 
-#: main/models.py:1380
+#: main/models.py:1452
 msgid "Rights: Other: Note"
 msgstr "Direitos: Outros: Nota"
 
-#: main/models.py:1388
+#: main/models.py:1462
 msgid "Linking Agent"
 msgstr "Agente de Ligação"
 
-#: main/models.py:1393
+#: main/models.py:1467
 msgid "Linking Agent Value"
 msgstr "Valor do Agente de Ligação"
 
-#: main/models.py:1399
+#: main/models.py:1473
 msgid "Rights: Agent"
 msgstr "Direitos: Agente"
 
-#: main/models.py:1435
+#: main/models.py:1509
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr "Semanticamente uma chave estrangeira para o SIP ou Transferência"
 
-#: main/models.py:1473
+#: main/models.py:1547
 msgid "ASDIPObjectResourcePairing"
 msgstr "ASDIPObjectResourcePairing"
 
-#: main/models.py:1488
+#: main/models.py:1562
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr "Se um SIP foi iniciado ou não usando arquivos deste objeto digital."
 
-#: main/models.py:1495
+#: main/models.py:1569
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 "ID no sistema remoto ArchivesSpace, após o objeto digital ter sido criado."
 
-#: main/models.py:1615
+#: main/models.py:1709
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr "%(sortorder)s:%(name)s"
@@ -3226,15 +3283,15 @@ msgstr "%(sortorder)s:%(name)s"
 msgid "<no API key generated>"
 msgstr "<no API key generated>"
 
-#: main/views.py:302
+#: main/views.py:299
 msgid "Added."
 msgstr "Adicionado."
 
-#: main/views.py:307
+#: main/views.py:304
 msgid "Error: no delete ID supplied."
 msgstr "Erro: não excluir ID fornecido."
 
-#: main/views.py:322
+#: main/views.py:319
 msgid "Incorrect type."
 msgstr "Tipo incorreto."
 
@@ -3266,7 +3323,7 @@ msgstr ""
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:436
+#: settings/base.py:435
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
@@ -3274,7 +3331,7 @@ msgstr ""
 "Selecione \"Aprovar transferência\" para começar a processar ou \"Rejeitar "
 "transferência\" para reiniciar."
 
-#: settings/base.py:439
+#: settings/base.py:438
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
@@ -3284,11 +3341,11 @@ msgstr ""
 "forem interrompidas ou falharem. A transferência será automaticamente "
 "excluída quando o AIP for movido para o armazenamento."
 
-#: settings/base.py:441
+#: settings/base.py:440
 msgid "Create a SIP from the transfer."
 msgstr "Crie um SIP a partir da transferência."
 
-#: settings/base.py:443
+#: settings/base.py:442
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
@@ -3298,7 +3355,7 @@ msgstr ""
 "qualquer avaliação e arranjo físico, selecione \"Criação de SIP completada\" "
 "para iniciar os  microsserviços de admissão."
 
-#: settings/base.py:446
+#: settings/base.py:445
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
@@ -3308,7 +3365,7 @@ msgstr ""
 "cópias de acesso resultará em um DIP gerado para upload em um sistema de "
 "acesso."
 
-#: settings/base.py:449
+#: settings/base.py:448
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -3322,7 +3379,7 @@ msgstr ""
 "em \"Falha na normalização de preservação\" ou \"Falha na normalização de "
 "acesso\" para visualizar a saída da ferramenta e a mensagem de erro."
 
-#: settings/base.py:452
+#: settings/base.py:451
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
@@ -3331,7 +3388,7 @@ msgstr ""
 "Selecione \"Armazenar AIP\" para mover o AIP para o armazenamento de "
 "arquivos."
 
-#: settings/base.py:455
+#: settings/base.py:454
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3370,7 +3427,7 @@ msgid "Previous"
 msgstr "Anterior"
 
 #: templates/_pager.html:35 templates/ingest/normalization_report.html:121
-#: templates/rights/rights_edit.html:287
+#: templates/rights/rights_edit.html:288
 msgid "Next"
 msgstr "Próximo"
 
@@ -3407,8 +3464,8 @@ msgstr "Usuários"
 msgid "Add new user"
 msgstr "Adicionar novo usuário"
 
-#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:64
-#: templates/installer/welcome.html:49 templates/transfer/metadata_edit.html:63
+#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:65
+#: templates/installer/welcome.html:50 templates/transfer/metadata_edit.html:64
 msgid "Create"
 msgstr "Criar"
 
@@ -3420,12 +3477,6 @@ msgstr "Usuários - Editar%(user)s"
 #: templates/accounts/list.html:23 templates/accounts/profile.html:29
 msgid "Username"
 msgstr "Nome de usuário"
-
-#: templates/accounts/list.html:24 templates/accounts/profile.html:31
-#: templates/administration/atom_levels_of_description.html:36
-#: templates/administration/reports/failures.html:26
-msgid "Name"
-msgstr "Nome"
 
 #: templates/accounts/list.html:25 templates/accounts/profile.html:33
 msgid "E-mail"
@@ -3488,14 +3539,12 @@ msgstr "Admin"
 #: templates/administration/reports/failure_detail.html:6
 #: templates/administration/reports/failures.html:5
 #: templates/administration/reports/failures.html:6
-#: templates/administration/search.html:5
-#: templates/administration/search.html:6
 #: templates/administration/taxonomy.html:5
 #: templates/administration/taxonomy.html:6
 #: templates/administration/term_detail.html:5
 #: templates/administration/term_detail.html:6
 #: templates/administration/terms.html:5 templates/administration/terms.html:6
-#: templates/layout.html:66
+#: templates/layout.html:68
 msgid "Administration"
 msgstr "Administração"
 
@@ -3528,15 +3577,15 @@ msgstr "Buscar do AtoM"
 msgid "AtoM Levels of Description"
 msgstr "AtoM Níveis de Descrição"
 
-#: templates/administration/atom_levels_of_description.html:45
+#: templates/administration/atom_levels_of_description.html:46
 msgid "Promote"
 msgstr "Promover"
 
-#: templates/administration/atom_levels_of_description.html:46
+#: templates/administration/atom_levels_of_description.html:47
 msgid "Demote"
 msgstr "Rebaixar"
 
-#: templates/administration/atom_levels_of_description.html:54
+#: templates/administration/atom_levels_of_description.html:55
 msgid "No levels found."
 msgstr "Nenhum nível encontrado."
 
@@ -3548,11 +3597,11 @@ msgstr "Upload do DIP do ArchivesSpace"
 msgid "Levels of Description"
 msgstr "Níveis de Descrição"
 
-#: templates/administration/dips_atom_edit.html:37
+#: templates/administration/dips_atom_edit.html:38
 msgid "AtoM/Binder DIP upload"
 msgstr "DIP para upload no AtoM/Binder"
 
-#: templates/administration/dips_atom_edit.html:39
+#: templates/administration/dips_atom_edit.html:40
 msgid "The settings below configure DIP uploading to AtoM/Binder."
 msgstr "As configurações abaixo definem o upload do DIP para o AtoM/Binder"
 
@@ -3571,31 +3620,31 @@ msgstr ""
 msgid "General configuration"
 msgstr "Configuração geral"
 
-#: templates/administration/general.html:39
+#: templates/administration/general.html:40
 msgid "Storage Service options"
 msgstr "Opções de serviço de armazenamento"
 
-#: templates/administration/general.html:43
+#: templates/administration/general.html:44
 msgid "Checksum algorithm"
 msgstr "Algoritmo Checksum"
 
-#: templates/administration/general.html:47
+#: templates/administration/general.html:48
 msgid "Elasticsearch Indexing"
 msgstr "Indexação do Elasticsearch"
 
-#: templates/administration/general.html:52
+#: templates/administration/general.html:53
 msgid "Transfers related indexes enabled."
 msgstr "Indexação de transferências relacionadas habilitada."
 
-#: templates/administration/general.html:54
+#: templates/administration/general.html:55
 msgid "Transfers related indexes disabled."
 msgstr "Indexação de transferências relacionadas desabilitada."
 
-#: templates/administration/general.html:59
+#: templates/administration/general.html:60
 msgid "AIPs related indexes enabled."
 msgstr "Indexação de AIPs relacionados habilitada."
 
-#: templates/administration/general.html:61
+#: templates/administration/general.html:62
 msgid "AIPs related indexes disabled."
 msgstr "Indexação de AIPs relacionados desabilitada."
 
@@ -3721,25 +3770,6 @@ msgstr "Data"
 #: templates/administration/reports/failures.html:56
 msgid "No reports found."
 msgstr "Não foram encontrados relatórios."
-
-#: templates/administration/search.html:23
-msgid "Search administration"
-msgstr "Administração de pesquisa"
-
-#: templates/administration/search.html:26
-#, python-format
-msgid ""
-"\n"
-"          %(count)s AIP files indexed.\n"
-"        "
-msgstr ""
-"\n"
-"          %(count)s Arquivos AIP indexados.\n"
-"        "
-
-#: templates/administration/search.html:33
-msgid "Flush AIP Index"
-msgstr "Índice de descarga de AIP"
 
 #: templates/administration/sidebar.html:23
 msgid "General"
@@ -3867,11 +3897,6 @@ msgid ""
 "cleared manually."
 msgstr ""
 
-#: templates/administration/usage.html:90
-#: templates/archival_storage/view.html:67
-msgid "Size"
-msgstr "Tamanho"
-
 #: templates/administration/version.html:19
 msgid "About Archivematica"
 msgstr "Sobre Archivematica"
@@ -3881,12 +3906,12 @@ msgid "Agent code"
 msgstr "Código do agente"
 
 #: templates/appraisal/appraisal.html:4 templates/appraisal/appraisal.html:5
-#: templates/layout.html:58
+#: templates/layout.html:60
 msgid "Appraisal"
 msgstr "Arranjo"
 
 #: templates/appraisal/appraisal.html:30
-#: templates/archival_storage/archival_storage.html:70
+#: templates/archival_storage/archival_storage.html:74
 #: templates/backlog/backlog.html:34
 msgid "Elasticsearch Indexing Disabled"
 msgstr "Indexação do Elasticsearch Desabilitada"
@@ -3912,23 +3937,23 @@ msgstr "Pesquisar no armazenamento de arquivo"
 
 #: templates/archival_storage/archival_storage.html:6
 #: templates/archival_storage/archival_storage.html:7
-#: templates/archival_storage/archival_storage.html:32
+#: templates/archival_storage/archival_storage.html:31
 #: templates/archival_storage/view.html:6
 #: templates/archival_storage/view.html:7
-#: templates/archival_storage/view.html:50 templates/layout.html:62
+#: templates/archival_storage/view.html:50 templates/layout.html:64
 msgid "Archival storage"
 msgstr "Armazenamento de arquivo"
 
-#: templates/archival_storage/archival_storage.html:33
+#: templates/archival_storage/archival_storage.html:32
 #: templates/ingest/as/_search_form.html:6
 msgid "Search"
 msgstr "Pesquisa"
 
-#: templates/archival_storage/archival_storage.html:41
+#: templates/archival_storage/archival_storage.html:40
 msgid "Browse archival storage"
 msgstr "Navegue no armazenamento de arquivo"
 
-#: templates/archival_storage/archival_storage.html:44
+#: templates/archival_storage/archival_storage.html:43
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -3943,7 +3968,7 @@ msgstr ""
 "            Tamanho total: %(size)s MB\n"
 "          "
 
-#: templates/archival_storage/archival_storage.html:50
+#: templates/archival_storage/archival_storage.html:49
 #, python-format
 msgid ""
 "\n"
@@ -3954,17 +3979,29 @@ msgstr ""
 "              Arquivos indexados : %(count)s\n"
 "            "
 
-#: templates/archival_storage/archival_storage.html:61
+#: templates/archival_storage/archival_storage.html:60
 msgid "Create an AIC from current search results"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:62
+#: templates/archival_storage/archival_storage.html:61
 #, fuzzy
 #| msgid "Create SIP"
 msgid "Create an AIC"
 msgstr "Criar SIP"
 
-#: templates/archival_storage/archival_storage.html:71
+#: templates/archival_storage/archival_storage.html:65
+msgid ""
+"Download all results from archival storage as a CSV (Comma-separated-values) "
+"table"
+msgstr ""
+
+#: templates/archival_storage/archival_storage.html:66
+#, fuzzy
+#| msgid "Download"
+msgid "Download CSV"
+msgstr "Download"
+
+#: templates/archival_storage/archival_storage.html:75
 msgid ""
 "Sorry, Elasticsearch indexing has been disabled for the AIPs related indexes "
 "in this Archivematica installation. The archival storage tab is non-"
@@ -3982,19 +4019,6 @@ msgstr "Pacote de informações de arquivo"
 #: templates/archival_storage/view.html:71
 msgid "Date stored"
 msgstr "Data armazenada"
-
-#: templates/archival_storage/view.html:75
-msgid "Status"
-msgstr "Status"
-
-#: templates/archival_storage/view.html:79
-msgid "Encrypted"
-msgstr "Criptografado"
-
-#: templates/archival_storage/view.html:83
-#: templates/ingest/normalization_report.html:31
-msgid "Location"
-msgstr "Localização"
 
 #: templates/archival_storage/view.html:90
 #, fuzzy
@@ -4055,7 +4079,7 @@ msgstr ""
 "relacionados a Transferências nesta instalação do Archivematica. A aba "
 "backlog não funciona quando a indexação está desligada."
 
-#: templates/delete_request.html:14
+#: templates/delete_request.html:15
 msgid "Reason for deletion:"
 msgstr "Motivo da eliminação:"
 
@@ -4107,7 +4131,7 @@ msgstr "AIP"
 #: templates/ingest/grid.html:5 templates/ingest/grid.html:6
 #: templates/ingest/metadata_add_files.html:31
 #: templates/ingest/metadata_edit.html:31
-#: templates/ingest/microservices.html:11 templates/layout.html:60
+#: templates/ingest/microservices.html:11 templates/layout.html:62
 #: templates/rights/rights_edit.html:16
 #: templates/rights/rights_grants_edit.html:16
 #: templates/rights/rights_list.html:9
@@ -4124,7 +4148,7 @@ msgstr "Inicializando ..."
 #: templates/ingest/as/resource_component.html:52
 #: templates/ingest/as/resource_detail.html:42
 #: templates/ingest/as/resource_list.html:34
-#: templates/ingest/as/review_matches.html:29
+#: templates/ingest/as/review_matches.html:30
 msgid "Title"
 msgstr "Título"
 
@@ -4168,7 +4192,7 @@ msgstr "Atribuir objetos a descrições"
 #: templates/ingest/as/resource_detail.html:30
 #: templates/ingest/as/resource_list.html:25
 #: templates/ingest/as/resource_list.html:27
-#: templates/ingest/as/review_matches.html:20
+#: templates/ingest/as/review_matches.html:21
 msgid "Restart matching"
 msgstr "Reiniciar a correspondência"
 
@@ -4194,7 +4218,7 @@ msgid "Resources"
 msgstr "Recursos"
 
 #: templates/ingest/as/match.html:100 templates/ingest/as/match.html:118
-#: templates/ingest/as/review_matches.html:28
+#: templates/ingest/as/review_matches.html:29
 msgid "Level"
 msgstr "Nível"
 
@@ -4202,7 +4226,7 @@ msgstr "Nível"
 #: templates/ingest/as/resource_component.html:53
 #: templates/ingest/as/resource_detail.html:43
 #: templates/ingest/as/resource_list.html:35
-#: templates/ingest/as/review_matches.html:31
+#: templates/ingest/as/review_matches.html:32
 msgid "Dates"
 msgstr "Datas"
 
@@ -4211,7 +4235,7 @@ msgid "Pairs"
 msgstr "Pares"
 
 #: templates/ingest/as/match.html:117
-#: templates/ingest/as/review_matches.html:27
+#: templates/ingest/as/review_matches.html:28
 msgid "File"
 msgstr "Arquivo"
 
@@ -4250,7 +4274,7 @@ msgstr "Atribuir objetos DIP a este recurso"
 msgid "Collections"
 msgstr "Coleções"
 
-#: templates/ingest/as/review_matches.html:21
+#: templates/ingest/as/review_matches.html:22
 msgid "Finish matching"
 msgstr "Finalizando correspondência"
 
@@ -4367,38 +4391,38 @@ msgstr ""
 msgid "Select a directory"
 msgstr "Selecione um diretório"
 
-#: templates/ingest/metadata_edit.html:77
-#: templates/transfer/metadata_edit.html:76
+#: templates/ingest/metadata_edit.html:78
+#: templates/transfer/metadata_edit.html:77
 msgid "A name given to the resource."
 msgstr "Um nome dado ao recurso."
 
-#: templates/ingest/metadata_edit.html:81
-#: templates/transfer/metadata_edit.html:80
+#: templates/ingest/metadata_edit.html:82
+#: templates/transfer/metadata_edit.html:81
 msgid "An entity primarily responsible for making the resource."
 msgstr "Uma entidade principal responsável por fazer o recurso"
 
-#: templates/ingest/metadata_edit.html:85
-#: templates/transfer/metadata_edit.html:84
+#: templates/ingest/metadata_edit.html:86
+#: templates/transfer/metadata_edit.html:85
 msgid "The topic of the resource."
 msgstr "O tópico do recurso."
 
-#: templates/ingest/metadata_edit.html:89
-#: templates/transfer/metadata_edit.html:88
+#: templates/ingest/metadata_edit.html:90
+#: templates/transfer/metadata_edit.html:89
 msgid "An account of the resource."
 msgstr "Uma conta do recurso."
 
-#: templates/ingest/metadata_edit.html:93
-#: templates/transfer/metadata_edit.html:92
+#: templates/ingest/metadata_edit.html:94
+#: templates/transfer/metadata_edit.html:93
 msgid "An entity responsible for making the resource available."
 msgstr "Uma entidade responsável por disponibilizar o recurso."
 
-#: templates/ingest/metadata_edit.html:97
-#: templates/transfer/metadata_edit.html:96
+#: templates/ingest/metadata_edit.html:98
+#: templates/transfer/metadata_edit.html:97
 msgid "An entity responsible for making contributions to the resource."
 msgstr "Uma entidade responsável por fazer contribuições para o recurso."
 
-#: templates/ingest/metadata_edit.html:101
-#: templates/transfer/metadata_edit.html:100
+#: templates/ingest/metadata_edit.html:102
+#: templates/transfer/metadata_edit.html:101
 msgid ""
 "A point or period of time associated with an event in the lifecycle of the "
 "resource."
@@ -4406,13 +4430,13 @@ msgstr ""
 "Um ponto ou período de tempo associado a um evento no ciclo de vida do "
 "recurso."
 
-#: templates/ingest/metadata_edit.html:106
-#: templates/transfer/metadata_edit.html:105
+#: templates/ingest/metadata_edit.html:107
+#: templates/transfer/metadata_edit.html:106
 msgid "The nature or genre of the resource."
 msgstr "A natureza ou gênero do recurso."
 
-#: templates/ingest/metadata_edit.html:108
-#: templates/transfer/metadata_edit.html:107
+#: templates/ingest/metadata_edit.html:109
+#: templates/transfer/metadata_edit.html:108
 msgid ""
 "\n"
 "        You may wish to use the DCMI type vocabulary provided here: <a href="
@@ -4426,13 +4450,13 @@ msgstr ""
 "org/documents/dcmi-type-vocabulary/</a>\n"
 "      "
 
-#: templates/ingest/metadata_edit.html:116
-#: templates/transfer/metadata_edit.html:115
+#: templates/ingest/metadata_edit.html:117
+#: templates/transfer/metadata_edit.html:116
 msgid "The file format, physical medium, or dimensions of the resource."
 msgstr "O formato do arquivo, o meio físico ou as dimensões do recurso."
 
-#: templates/ingest/metadata_edit.html:118
-#: templates/transfer/metadata_edit.html:117
+#: templates/ingest/metadata_edit.html:119
+#: templates/transfer/metadata_edit.html:118
 msgid ""
 "\n"
 "        Best practice is to use a controlled vocabulary such as the list of "
@@ -4448,29 +4472,29 @@ msgstr ""
 "assignments/media-types/</a>\n"
 "      "
 
-#: templates/ingest/metadata_edit.html:125
-#: templates/transfer/metadata_edit.html:124
+#: templates/ingest/metadata_edit.html:126
+#: templates/transfer/metadata_edit.html:125
 msgid "An unambiguous reference to the resource within a given context."
 msgstr ""
 "Uma referência inequívoca ao recurso dentro de um determinado contexto."
 
-#: templates/ingest/metadata_edit.html:129
-#: templates/transfer/metadata_edit.html:128
+#: templates/ingest/metadata_edit.html:130
+#: templates/transfer/metadata_edit.html:129
 msgid "A related resource from which the described resource is derived."
 msgstr "Um recurso relacionado a partir do qual o recurso descrito é derivado."
 
-#: templates/ingest/metadata_edit.html:133
-#: templates/transfer/metadata_edit.html:132
+#: templates/ingest/metadata_edit.html:134
+#: templates/transfer/metadata_edit.html:133
 msgid "A related resource."
 msgstr "Um recurso relacionado."
 
-#: templates/ingest/metadata_edit.html:137
-#: templates/transfer/metadata_edit.html:136
+#: templates/ingest/metadata_edit.html:138
+#: templates/transfer/metadata_edit.html:137
 msgid "A language of the resource."
 msgstr "Uma idioma do recurso."
 
-#: templates/ingest/metadata_edit.html:141
-#: templates/transfer/metadata_edit.html:140
+#: templates/ingest/metadata_edit.html:142
+#: templates/transfer/metadata_edit.html:141
 msgid ""
 "The spatial or temporal topic of the resource, the spatial applicability of "
 "the resource, or the jurisdiction under which the resource is relevant."
@@ -4478,8 +4502,8 @@ msgstr ""
 "O tópico espacial ou temporal do recurso, a aplicabilidade espacial do "
 "recurso ou a jurisdição sob a qual o recurso é relevante."
 
-#: templates/ingest/metadata_edit.html:145
-#: templates/transfer/metadata_edit.html:144
+#: templates/ingest/metadata_edit.html:146
+#: templates/transfer/metadata_edit.html:145
 msgid "Information about rights held in and over the resource."
 msgstr "Informações sobre direitos mantidos no e sobre o recurso."
 
@@ -4541,15 +4565,15 @@ msgstr ""
 "      Mostrando %(start_index)s-%(end_index)s de %(total_items)s\n"
 "    "
 
-#: templates/installer/storagesetup.html:25
+#: templates/installer/storagesetup.html:26
 msgid "Register this pipeline in the Storage Service"
 msgstr "Registre este pipeline no Storage Service"
 
-#: templates/installer/storagesetup.html:30
+#: templates/installer/storagesetup.html:31
 msgid "Dashboard UUID"
 msgstr "Painel de controle UUID"
 
-#: templates/installer/storagesetup.html:39
+#: templates/installer/storagesetup.html:40
 msgid "Register"
 msgstr "Registro"
 
@@ -4573,7 +4597,7 @@ msgstr ""
 msgid "Archivematica Dashboard"
 msgstr "Painel de controle Archivematica"
 
-#: templates/layout.html:55 templates/rights/rights_edit.html:18
+#: templates/layout.html:57 templates/rights/rights_edit.html:18
 #: templates/rights/rights_grants_edit.html:18
 #: templates/rights/rights_list.html:11 templates/transfer/component.html:10
 #: templates/transfer/detail.html:9 templates/transfer/grid.html:5
@@ -4583,19 +4607,19 @@ msgstr "Painel de controle Archivematica"
 msgid "Transfer"
 msgstr "Transferir"
 
-#: templates/layout.html:57
+#: templates/layout.html:59
 msgid "Backlog"
 msgstr "Backlog"
 
-#: templates/layout.html:64
+#: templates/layout.html:66
 msgid "Preservation planning"
 msgstr "Plano de preservação"
 
-#: templates/layout.html:74
+#: templates/layout.html:76
 msgid "Your profile"
 msgstr "Seu perfil"
 
-#: templates/layout.html:76
+#: templates/layout.html:78
 msgid "Log out"
 msgstr "Sair"
 
@@ -4710,28 +4734,28 @@ msgstr ""
 "                  Novo conteúdo adicionado: %(type)s.\n"
 "                "
 
-#: templates/rights/rights_edit.html:96
+#: templates/rights/rights_edit.html:97
 msgid "Copyright documentation identifier:"
 msgstr "Identificador da documentação de direitos autorais:"
 
-#: templates/rights/rights_edit.html:109 templates/rights/rights_edit.html:161
-#: templates/rights/rights_edit.html:211 templates/rights/rights_edit.html:259
+#: templates/rights/rights_edit.html:110 templates/rights/rights_edit.html:162
+#: templates/rights/rights_edit.html:212 templates/rights/rights_edit.html:260
 msgid "Role"
 msgstr "Função"
 
-#: templates/rights/rights_edit.html:147
+#: templates/rights/rights_edit.html:148
 msgid "Statute documentation identifier:"
 msgstr "Identificador da documentação do Estatuto:"
 
-#: templates/rights/rights_edit.html:197
+#: templates/rights/rights_edit.html:198
 msgid "License documentation identifier:"
 msgstr "Identificador da documentação da licença:"
 
-#: templates/rights/rights_edit.html:245
+#: templates/rights/rights_edit.html:246
 msgid "Documentation identifier"
 msgstr "Identificador da documentação"
 
-#: templates/rights/rights_edit.html:266
+#: templates/rights/rights_edit.html:267
 msgid "Note"
 msgstr "Nota"
 
@@ -4742,23 +4766,23 @@ msgstr ""
 "Agora, você pode acrescentar informações adicionais, como identificadores de "
 "documentos e notas."
 
-#: templates/rights/rights_grants_edit.html:79
+#: templates/rights/rights_grants_edit.html:80
 msgid "Allow"
 msgstr "Permite"
 
-#: templates/rights/rights_grants_edit.html:80
+#: templates/rights/rights_grants_edit.html:81
 msgid "Disallow"
 msgstr "Não permite"
 
-#: templates/rights/rights_grants_edit.html:81
+#: templates/rights/rights_grants_edit.html:82
 msgid "Conditional"
 msgstr "Condicional"
 
-#: templates/rights/rights_grants_edit.html:87
+#: templates/rights/rights_grants_edit.html:88
 msgid "Grant/restriction note"
 msgstr "Nota de concessão/restrição"
 
-#: templates/rights/rights_grants_edit.html:108
+#: templates/rights/rights_grants_edit.html:109
 msgid "Done"
 msgstr "Feito"
 
@@ -4789,6 +4813,21 @@ msgstr "Transferir metadados"
 #: templates/transfer/grid.html:86
 msgid "Transfer start time"
 msgstr "Hora inicial da transferência"
+
+#~ msgid "Search administration"
+#~ msgstr "Administração de pesquisa"
+
+#~ msgid ""
+#~ "\n"
+#~ "          %(count)s AIP files indexed.\n"
+#~ "        "
+#~ msgstr ""
+#~ "\n"
+#~ "          %(count)s Arquivos AIP indexados.\n"
+#~ "        "
+
+#~ msgid "Flush AIP Index"
+#~ msgstr "Índice de descarga de AIP"
 
 #~ msgid "Send transfer to quarantine"
 #~ msgstr "Enviar transferência para quarentena"

--- a/src/dashboard/src/locale/pt_BR/LC_MESSAGES/djangojs.po
+++ b/src/dashboard/src/locale/pt_BR/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 12:27-0400\n"
+"POT-Creation-Date: 2020-07-27 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Cintya Takahaschi <cintya.takahaschi@gmail.com>, 2018\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/artefactual/"
@@ -28,7 +28,7 @@ msgid "Are you sure you want to delete this level of description?"
 msgstr "Tem certeza de que deseja excluir esse nível de descrição?"
 
 #: media/js/advanced-search-query-creator.js:14 media/js/file_browser.js:59
-#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:209
+#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:211
 msgid "Delete"
 msgstr "Excluir"
 
@@ -47,7 +47,7 @@ msgid "Any"
 msgstr "Qualquer"
 
 #: media/js/archival_storage/archival_storage_search.js:61
-#: media/js/archival_storage/archival_storage_search.js:238
+#: media/js/archival_storage/archival_storage_search.js:242
 msgid "File UUID"
 msgstr "Arquivo UUID"
 
@@ -106,227 +106,233 @@ msgstr "Frase"
 msgid "Date range"
 msgstr "Intervalo de data"
 
-#: media/js/archival_storage/archival_storage_search.js:148
+#: media/js/archival_storage/archival_storage_search.js:152
 msgid "view raw"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:169
+#: media/js/archival_storage/archival_storage_search.js:173
 #: media/js/backlog/backlog-search.js:6 media/js/backlog/backlog-search.js:12
 msgid "Download"
 msgstr "Downloads"
 
-#: media/js/archival_storage/archival_storage_search.js:184
+#: media/js/archival_storage/archival_storage_search.js:188
 msgid "AIPs in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:185
+#: media/js/archival_storage/archival_storage_search.js:189
 msgid "AIP in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:188
+#: media/js/archival_storage/archival_storage_search.js:192
 #, fuzzy
 #| msgid "Part of AIC"
 msgid "Part of"
 msgstr "Parte da AIC"
 
-#: media/js/archival_storage/archival_storage_search.js:190
+#: media/js/archival_storage/archival_storage_search.js:194
 msgid "None"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:197
+#: media/js/archival_storage/archival_storage_search.js:201
 msgid "View"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "True"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "False"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 msgid "Deletion requested"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 #: media/js/backlog/backlog-search.js:19
 msgid "Stored"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:236
+#: media/js/archival_storage/archival_storage_search.js:240
 msgid "Thumbnail"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:237
+#: media/js/archival_storage/archival_storage_search.js:241
 #, fuzzy
 #| msgid "Filename"
 msgid "File"
 msgstr "Nome do arquivo"
 
-#: media/js/archival_storage/archival_storage_search.js:239
+#: media/js/archival_storage/archival_storage_search.js:243
 msgid "AIP"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:240
+#: media/js/archival_storage/archival_storage_search.js:244
 #: media/js/backlog/backlog-search.js:42 media/js/backlog/backlog-search.js:53
 #: media/js/ingest/backlog.js:37
 msgid "Accession number"
 msgstr "Número do registro de entrada"
 
-#: media/js/archival_storage/archival_storage_search.js:241
-#: media/js/archival_storage/archival_storage_search.js:254
+#: media/js/archival_storage/archival_storage_search.js:245
+#: media/js/archival_storage/archival_storage_search.js:258
 #: media/js/backlog/backlog-search.js:43 media/js/backlog/backlog-search.js:55
 msgid "Status"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:242
-#: media/js/archival_storage/archival_storage_search.js:256
+#: media/js/archival_storage/archival_storage_search.js:246
+#: media/js/archival_storage/archival_storage_search.js:261
 #: media/js/backlog/backlog-search.js:44 media/js/backlog/backlog-search.js:56
-#: media/js/ingest.js:216 media/js/transfer.js:153
+#: media/js/ingest.js:217 media/js/transfer.js:154
 msgid "Actions"
 msgstr "Ações"
 
-#: media/js/archival_storage/archival_storage_search.js:247
+#: media/js/archival_storage/archival_storage_search.js:251
 #: media/js/backlog/backlog-search.js:49
 msgid "Name"
 msgstr "Nome"
 
-#: media/js/archival_storage/archival_storage_search.js:248
+#: media/js/archival_storage/archival_storage_search.js:252
 #, fuzzy
 #| msgid "AIP UUID"
 msgid "UUID"
 msgstr "AIP UUID"
 
-#: media/js/archival_storage/archival_storage_search.js:249
+#: media/js/archival_storage/archival_storage_search.js:253
 msgid "AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:250
+#: media/js/archival_storage/archival_storage_search.js:254
 #: media/js/backlog/backlog-search.js:51
 msgid "Size"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:251
+#: media/js/archival_storage/archival_storage_search.js:255
 #: media/js/backlog/backlog-search.js:52
 msgid "File count"
 msgstr "Contagem de arquivos"
 
-#: media/js/archival_storage/archival_storage_search.js:252
+#: media/js/archival_storage/archival_storage_search.js:256
 #, fuzzy
 #| msgid "Accession number"
 msgid "Accession numbers"
 msgstr "Número do registro de entrada"
 
-#: media/js/archival_storage/archival_storage_search.js:253
+#: media/js/archival_storage/archival_storage_search.js:257
 #, fuzzy
 #| msgid "Create SIP"
 msgid "Created"
 msgstr "Criar SIP"
 
-#: media/js/archival_storage/archival_storage_search.js:255
+#: media/js/archival_storage/archival_storage_search.js:259
 msgid "Encrypted"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:309
-#: media/js/backlog/backlog-search.js:109
+#: media/js/archival_storage/archival_storage_search.js:260
+#, fuzzy
+#| msgid "Actions"
+msgid "Location"
+msgstr "Ações"
+
+#: media/js/archival_storage/archival_storage_search.js:315
+#: media/js/backlog/backlog-search.js:110
 #, fuzzy
 #| msgid "Select an action..."
 msgid "Select columns"
 msgstr "Selecione uma ação ..."
 
-#: media/js/archival_storage/archival_storage_search.js:313
-#: media/js/backlog/backlog-search.js:113
+#: media/js/archival_storage/archival_storage_search.js:319
+#: media/js/backlog/backlog-search.js:114
 msgctxt "DataTable - sEmptyTable"
 msgid "No data available in table"
 msgstr "Sem dados disponíveis na tabela"
 
-#: media/js/archival_storage/archival_storage_search.js:314
-#: media/js/backlog/backlog-search.js:114
+#: media/js/archival_storage/archival_storage_search.js:320
+#: media/js/backlog/backlog-search.js:115
 msgctxt "DataTable - sInfo"
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Mostrando _INICIAR_ para _FIM_ de entradas _TOTAL_"
 
-#: media/js/archival_storage/archival_storage_search.js:315
-#: media/js/backlog/backlog-search.js:115
+#: media/js/archival_storage/archival_storage_search.js:321
+#: media/js/backlog/backlog-search.js:116
 msgctxt "DataTable - sInfoEmpty"
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Mostrando 0 a 0 de 0 entradas"
 
-#: media/js/archival_storage/archival_storage_search.js:316
-#: media/js/backlog/backlog-search.js:116
+#: media/js/archival_storage/archival_storage_search.js:322
+#: media/js/backlog/backlog-search.js:117
 msgctxt "DataTable - sInfoFiltered"
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filtrado de _MAX_ entradas totais)"
 
-#: media/js/archival_storage/archival_storage_search.js:318
-#: media/js/backlog/backlog-search.js:118
+#: media/js/archival_storage/archival_storage_search.js:324
+#: media/js/backlog/backlog-search.js:119
 msgctxt "DataTable - sInfoThousands"
 msgid ","
 msgstr "."
 
-#: media/js/archival_storage/archival_storage_search.js:319
-#: media/js/backlog/backlog-search.js:119
+#: media/js/archival_storage/archival_storage_search.js:325
+#: media/js/backlog/backlog-search.js:120
 msgctxt "DataTable - sLengthMenu"
 msgid "Show _MENU_ entries"
 msgstr "Mostrar entradas _MENU_"
 
-#: media/js/archival_storage/archival_storage_search.js:320
-#: media/js/backlog/backlog-search.js:120
+#: media/js/archival_storage/archival_storage_search.js:326
+#: media/js/backlog/backlog-search.js:121
 msgctxt "DataTable - sLoadingRecords"
 msgid "Loading..."
 msgstr "Carregando..."
 
-#: media/js/archival_storage/archival_storage_search.js:321
-#: media/js/backlog/backlog-search.js:121
+#: media/js/archival_storage/archival_storage_search.js:327
+#: media/js/backlog/backlog-search.js:122
 msgctxt "DataTable - sProcessing"
 msgid "Processing..."
 msgstr "Em processamento..."
 
-#: media/js/archival_storage/archival_storage_search.js:322
-#: media/js/backlog/backlog-search.js:122
+#: media/js/archival_storage/archival_storage_search.js:328
+#: media/js/backlog/backlog-search.js:123
 msgctxt "DataTable - sSearch"
 msgid "Search:"
 msgstr "Busca:"
 
-#: media/js/archival_storage/archival_storage_search.js:323
-#: media/js/backlog/backlog-search.js:123
+#: media/js/archival_storage/archival_storage_search.js:329
+#: media/js/backlog/backlog-search.js:124
 msgctxt "DataTable - sZeroRecords"
 msgid "No matching records found"
 msgstr "Nenhum registro correspondente encontrado"
 
-#: media/js/archival_storage/archival_storage_search.js:325
-#: media/js/backlog/backlog-search.js:125
+#: media/js/archival_storage/archival_storage_search.js:331
+#: media/js/backlog/backlog-search.js:126
 msgctxt "DataTable - sFirst"
 msgid "First"
 msgstr "Primeiro"
 
-#: media/js/archival_storage/archival_storage_search.js:326
-#: media/js/backlog/backlog-search.js:126
+#: media/js/archival_storage/archival_storage_search.js:332
+#: media/js/backlog/backlog-search.js:127
 msgctxt "DataTable - sLast"
 msgid "Last"
 msgstr "Último"
 
-#: media/js/archival_storage/archival_storage_search.js:327
-#: media/js/backlog/backlog-search.js:127
+#: media/js/archival_storage/archival_storage_search.js:333
+#: media/js/backlog/backlog-search.js:128
 msgctxt "DataTable - sNext"
 msgid "Next"
 msgstr "Próximo"
 
-#: media/js/archival_storage/archival_storage_search.js:328
-#: media/js/backlog/backlog-search.js:128
+#: media/js/archival_storage/archival_storage_search.js:334
+#: media/js/backlog/backlog-search.js:129
 msgctxt "DataTable - sPrevious"
 msgid "Previous"
 msgstr "Anterior"
 
-#: media/js/archival_storage/archival_storage_search.js:331
-#: media/js/backlog/backlog-search.js:131
+#: media/js/archival_storage/archival_storage_search.js:337
+#: media/js/backlog/backlog-search.js:132
 msgctxt "DataTable - sSortAscending"
 msgid ": activate to sort column ascending"
 msgstr ": ativar para ordenar coluna ascendente"
 
-#: media/js/archival_storage/archival_storage_search.js:332
-#: media/js/backlog/backlog-search.js:132
+#: media/js/archival_storage/archival_storage_search.js:338
+#: media/js/backlog/backlog-search.js:133
 msgctxt "DataTable - sSortDescending"
 msgid ": activate to sort column descending"
 msgstr ": ativar para ordenar coluna descendente"
@@ -366,7 +372,7 @@ msgid "Yes"
 msgstr "Sim"
 
 #: media/js/directory_picker.js:90 media/js/file_browser.js:178
-#: media/js/ingest.js:123 media/js/jobs.js:590 media/js/jobs.js:683
+#: media/js/ingest.js:124 media/js/jobs.js:590 media/js/jobs.js:686
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -416,43 +422,43 @@ msgstr "Remover SIP"
 msgid "Confirm"
 msgstr "Confirma"
 
-#: media/js/ingest.js:145
+#: media/js/ingest.js:146
 msgid "Dublin Core metadata editor"
 msgstr "Editor de metadados do Dublin Core"
 
-#: media/js/ingest.js:152 media/js/jobs.js:535
+#: media/js/ingest.js:153 media/js/jobs.js:535
 msgid "Close"
 msgstr "Fechar"
 
-#: media/js/ingest.js:173
+#: media/js/ingest.js:174
 msgid "Error"
 msgstr "Erro"
 
-#: media/js/ingest.js:240
+#: media/js/ingest.js:241
 msgid "Report"
 msgstr "Relatório"
 
-#: media/js/ingest.js:243
+#: media/js/ingest.js:244
 msgid "Match DIP objects to resources"
 msgstr "Corresponder objetos DIP aos recursos"
 
-#: media/js/ingest.js:301
+#: media/js/ingest.js:303
 msgid "Loading..."
 msgstr "Carregando..."
 
-#: media/js/ingest/as_matcher.js:551
+#: media/js/ingest/as_matcher.js:553
 msgid "No resource selected."
 msgstr "Nenhum recurso selecionado."
 
-#: media/js/ingest/as_matcher.js:558
+#: media/js/ingest/as_matcher.js:560
 msgid "No objects selected."
 msgstr "Nenhum objeto selecionado."
 
-#: media/js/ingest/as_matcher.js:670
+#: media/js/ingest/as_matcher.js:673
 msgid "Warning"
 msgstr "Atenção"
 
-#: media/js/ingest/as_matcher.js:674
+#: media/js/ingest/as_matcher.js:677
 msgid "Dismiss"
 msgstr "Dispensar"
 
@@ -464,15 +470,15 @@ msgstr "Nome do arquivo"
 msgid "Ingest date (YYYY-MM-DD)"
 msgstr "Data de admissão (AAAA-MM-DD)"
 
-#: media/js/ingest/metadata_form.js:83
+#: media/js/ingest/metadata_form.js:84
 msgid "Browse"
 msgstr "Navegador"
 
-#: media/js/ingest/metadata_form.js:85
+#: media/js/ingest/metadata_form.js:86
 msgid "Add files"
 msgstr "Adicionar arquivos"
 
-#: media/js/ingest/metadata_form.js:124
+#: media/js/ingest/metadata_form.js:125
 msgid "Please select at least one metadata file."
 msgstr "Selecione pelo menos um arquivo de metadados."
 
@@ -501,34 +507,34 @@ msgstr ""
 msgid "Remove All Completed %ss"
 msgstr "Remover todos os concluídos%ss"
 
-#: media/js/jobs.js:661
+#: media/js/jobs.js:664
 #, javascript-format
 msgid "There were no completed %ss to remove"
 msgstr "Não há concluídos%spara remover."
 
-#: media/js/jobs.js:665
+#: media/js/jobs.js:668
 #, javascript-format
 msgid "Successfully removed the following %ss: %s"
 msgstr "Removido com sucesso o seguinte%ss: %s"
 
-#: media/js/jobs.js:671
+#: media/js/jobs.js:674
 #, javascript-format
 msgid "Failed to remove all completed %ss"
 msgstr "Falha ao remover todos os concluídos%ss"
 
-#: media/js/jobs.js:797
+#: media/js/jobs.js:800
 msgid "Previous"
 msgstr "Anterior"
 
-#: media/js/jobs.js:812
+#: media/js/jobs.js:815
 msgid "Next"
 msgstr "Próximo"
 
-#: media/js/jobs.js:850
+#: media/js/jobs.js:853
 msgid "Error trying to connect to database. Trying again..."
 msgstr "Erro ao tentar se conectar ao banco de dados. Tentando novamente..."
 
-#: media/js/jobs.js:900
+#: media/js/jobs.js:903
 msgid "Error trying to connect to MCP server. Trying again..."
 msgstr "Erro ao tentar se conectar ao servidor MCP. Tentando novamente..."
 
@@ -544,7 +550,7 @@ msgstr "Carregando"
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: media/js/repeating-ajax-data.js:215
+#: media/js/repeating-ajax-data.js:217
 msgid "Are you sure?"
 msgstr "Você tem certeza?"
 

--- a/src/dashboard/src/locale/sv/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 11:52-0400\n"
+"POT-Creation-Date: 2020-07-27 22:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: artefactual <translate@artefactual.com>, 2018\n"
 "Language-Team: Swedish (https://www.transifex.com/artefactual/teams/1506/"
@@ -19,12 +19,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: components/accounts/views.py:62 components/accounts/views.py:150
-#: components/administration/views.py:459
-#: components/administration/views.py:474
-#: components/administration/views.py:486
-#: components/administration/views.py:513
-#: components/administration/views.py:564
+#: components/accounts/views.py:61 components/accounts/views.py:149
+#: components/administration/views.py:454
+#: components/administration/views.py:469
+#: components/administration/views.py:481
+#: components/administration/views.py:508
+#: components/administration/views.py:555
 #: components/administration/views_dip_upload.py:25
 #: components/administration/views_dip_upload.py:39 fpr/views.py:106
 #: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Saved."
 msgstr "Sparad."
 
-#: components/accounts/views.py:82
+#: components/accounts/views.py:81
 #, python-format
 msgid "Your profile (%s)"
 msgstr "Din profil (%s)"
@@ -409,7 +409,7 @@ msgstr "Inbäddad"
 msgid "New"
 msgstr "Ny"
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:973
+#: components/administration/forms_dip_upload.py:21 main/models.py:1021
 msgid "Other"
 msgstr "Annat"
 
@@ -605,32 +605,32 @@ msgstr "REST API-nyckel"
 msgid "Used in metadata-only DIP upload."
 msgstr "Används vid uppladdning av DIP med enbart metadata."
 
-#: components/administration/views.py:92 components/administration/views.py:125
-#: components/ingest/views.py:293 fpr/views.py:261 main/views.py:310
+#: components/administration/views.py:89 components/administration/views.py:122
+#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
 msgid "Deleted."
 msgstr "Raderad."
 
-#: components/administration/views.py:109
+#: components/administration/views.py:106
 msgid "Promoted."
 msgstr "Upphöjt."
 
-#: components/administration/views.py:112
+#: components/administration/views.py:109
 msgid "Error attempting to promote level of description."
 msgstr "Fel under försök att befordra beskrivningsnivå"
 
-#: components/administration/views.py:116
+#: components/administration/views.py:113
 msgid "Demoted."
 msgstr "Degraderat."
 
-#: components/administration/views.py:119
+#: components/administration/views.py:116
 msgid "Error attempting to demote level of description."
 msgstr "Fel under försök att degradera beskrivningsnivå"
 
-#: components/administration/views.py:127
+#: components/administration/views.py:124
 msgid "Level of description not found."
 msgstr "Beskrivningsnivå inte funnen."
 
-#: components/administration/views.py:193
+#: components/administration/views.py:190
 msgid ""
 "Error retrieving locations: is the storage server running? Please contact an "
 "administrator."
@@ -638,69 +638,69 @@ msgstr ""
 "Fel under hämtning av platser: är lagringsservern igång? Var god kontakta en "
 "administratör."
 
-#: components/administration/views.py:202
+#: components/administration/views.py:199
 #, fuzzy
 #| msgid "AIP storage locations"
 msgid "AIP Storage"
 msgstr "AIP lagringsplatser"
 
-#: components/administration/views.py:203
+#: components/administration/views.py:200
 msgid "DIP Storage"
 msgstr ""
 
-#: components/administration/views.py:204
+#: components/administration/views.py:201
 msgid "FEDORA Deposits"
 msgstr ""
 
-#: components/administration/views.py:205
+#: components/administration/views.py:202
 #, fuzzy
 #| msgid "Search transfer backlog"
 msgid "Transfer Backlog"
 msgstr "Sök i överföringarnas backlogg"
 
-#: components/administration/views.py:206
+#: components/administration/views.py:203
 #, fuzzy
 #| msgid "Transfer source locations"
 msgid "Transfer Source"
 msgstr "Transfers ursprungsplatser"
 
-#: components/administration/views.py:207
+#: components/administration/views.py:204
 msgid "Replicator"
 msgstr ""
 
-#: components/administration/views.py:224
+#: components/administration/views.py:221
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:407
+#: components/administration/views.py:404
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:410
+#: components/administration/views.py:406
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr "Rensa"
 
-#: components/administration/views.py:436
+#: components/administration/views.py:431
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:439
+#: components/administration/views.py:434
 #, fuzzy, python-format
 #| msgid "No files or directories found under path: %(path)s"
 msgid "No such file or directory: %(path)s"
 msgstr "Inga filer eller mappar funna under sökväg: %(path)s"
 
-#: components/administration/views.py:580
+#: components/administration/views.py:571
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
 "Storage Sevice URL below.<hr />%(error)s"
 msgstr ""
 
-#: components/administration/views.py:597
+#: components/administration/views.py:588
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -708,7 +708,7 @@ msgid ""
 "%(error)s"
 msgstr ""
 
-#: components/administration/views.py:609
+#: components/administration/views.py:600
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -777,6 +777,7 @@ msgid "Please type in the UUID to confirm"
 msgstr "Var god skriv UUIDet för att bekräfta"
 
 #: components/archival_storage/forms.py:89
+#: components/archival_storage/views.py:210
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -806,25 +807,88 @@ msgstr "uuid måste specificeras"
 msgid "UUID mismatch"
 msgstr "UUID matchar inte"
 
-#: components/archival_storage/views.py:49
+#: components/archival_storage/views.py:54
 msgid "Stored"
 msgstr "Lagrad"
 
-#: components/archival_storage/views.py:50
+#: components/archival_storage/views.py:55
 msgid "Deletion requested"
 msgstr "Radering efterfrågad"
 
-#: components/archival_storage/views.py:464
+#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: templates/accounts/profile.html:31
+#: templates/administration/atom_levels_of_description.html:37
+#: templates/administration/reports/failures.html:26
+msgid "Name"
+msgstr "Namn"
+
+#: components/archival_storage/views.py:211
+msgid "AICID"
+msgstr ""
+
+#: components/archival_storage/views.py:212
+msgid "Count AIPs in AIC"
+msgstr ""
+
+#: components/archival_storage/views.py:213
+#: templates/administration/usage.html:90
+#: templates/archival_storage/view.html:67
+msgid "Size"
+msgstr "Storlek"
+
+#: components/archival_storage/views.py:214
+#, fuzzy
+#| msgid "Failure report"
+msgid "File count"
+msgstr "Rapport över misslyckanden"
+
+#: components/archival_storage/views.py:215
+#, fuzzy
+#| msgid "Access"
+msgid "Accession IDs"
+msgstr "Åtkomst"
+
+#: components/archival_storage/views.py:216
+#, fuzzy
+#| msgid "Created time"
+msgid "Created date (UTC)"
+msgstr "Tid vid uprrättande"
+
+#: components/archival_storage/views.py:217
+#: templates/archival_storage/view.html:75
+msgid "Status"
+msgstr "Status"
+
+#: components/archival_storage/views.py:218
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: templates/administration/reports/failures.html:25
+#: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
+#: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
+msgid "Type"
+msgstr "Typ"
+
+#: components/archival_storage/views.py:219
+#: templates/archival_storage/view.html:79
+msgid "Encrypted"
+msgstr "Krypterad"
+
+#: components/archival_storage/views.py:220
+#: templates/archival_storage/view.html:83
+#: templates/ingest/normalization_report.html:31
+msgid "Location"
+msgstr "Plats"
+
+#: components/archival_storage/views.py:600
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:593
+#: components/archival_storage/views.py:729
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 "Uppladdning av DIP med endast metadata misslyckades, se logg för fler "
 "detaljer."
 
-#: components/archival_storage/views.py:605
+#: components/archival_storage/views.py:741
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
@@ -832,12 +896,12 @@ msgid ""
 msgstr ""
 "Uppladdning av endast metadata DIP lyckades. Ny resurs har slug: %(slug)s"
 
-#: components/archival_storage/views.py:628
+#: components/archival_storage/views.py:764
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr "Fel under återingestering av paket: %(message)s"
 
-#: components/backlog/views.py:291
+#: components/backlog/views.py:282
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 "Kunde inte ansluta till lagringsservern. Var god kontakta din administratör."
@@ -995,7 +1059,7 @@ msgstr "AtoM:s verifieringsinställningar inte specificerade!"
 msgid "Unable to fetch levels of description from AtoM!"
 msgstr "Kunde inte hämta beskrivningsnivåer från AtoM!"
 
-#: components/ingest/views.py:87
+#: components/ingest/views.py:86
 msgid ""
 "Error retrieving originals/arrange directory locations: is the storage "
 "server running? Please contact an administrator."
@@ -1003,7 +1067,7 @@ msgstr ""
 "Det gick inte att hämta original/ordna katalog: är lagringsservern igång? "
 "Vänligen kontakta en administratör."
 
-#: components/ingest/views.py:182
+#: components/ingest/views.py:181
 msgid ""
 "Error retrieving source directories: is the storage server running? Please "
 "contact an administrator."
@@ -1011,30 +1075,30 @@ msgstr ""
 "Fel vid hämtning av källmappar: är lagringsservern igång? Var god kontakta "
 "en administratör."
 
-#: components/ingest/views.py:191
+#: components/ingest/views.py:190
 msgid ""
 "No transfer source locations are available. Please contact an administrator."
 msgstr ""
 "Inga källplatser för överföringen är tillgängliga. Var god kontakta en "
 "administratör."
 
-#: components/ingest/views.py:283
+#: components/ingest/views.py:278
 msgid "Are you sure you want to delete this metadata?"
 msgstr "Är du säker på att du vill radera denna matadata?"
 
-#: components/ingest/views.py:418
+#: components/ingest/views.py:412
 msgid "Review normalization"
 msgstr "Granska normalisering"
 
-#: components/ingest/views.py:421
+#: components/ingest/views.py:415
 msgid "Review AIP"
 msgstr "Granska AIP"
 
-#: components/ingest/views.py:424
+#: components/ingest/views.py:418
 msgid "Review DIP"
 msgstr "Granska DIP"
 
-#: components/ingest/views_as.py:327
+#: components/ingest/views_as.py:325
 msgid "Operation failed, please try again later or contact your administrator."
 msgstr ""
 
@@ -1172,20 +1236,20 @@ msgid ""
 "content."
 msgstr "Det slutdatum då licensen slutar tillämpas på innehållet."
 
-#: components/rights/views.py:277 components/rights/views.py:311
+#: components/rights/views.py:272 components/rights/views.py:306
 msgid "copyright"
 msgstr "upphovsrätt"
 
-#: components/rights/views.py:345 components/rights/views.py:379
+#: components/rights/views.py:340 components/rights/views.py:374
 msgid "license"
 msgstr "licens"
 
-#: components/rights/views.py:391 components/rights/views.py:426
-#: components/rights/views.py:466 components/rights/views.py:497
+#: components/rights/views.py:386 components/rights/views.py:421
+#: components/rights/views.py:461 components/rights/views.py:492
 msgid "statute"
 msgstr "regelverk"
 
-#: components/rights/views.py:483
+#: components/rights/views.py:478
 msgid "statue"
 msgstr "regelverk"
 
@@ -1193,11 +1257,11 @@ msgstr "regelverk"
 msgid "Error retrieving source directories"
 msgstr "Hämtning av källmappar misslyckades"
 
-#: components/transfer/views.py:210
+#: components/transfer/views.py:208
 msgid "Updated path was not provided."
 msgstr "Uppdaterad sökväg angavs ej."
 
-#: components/transfer/views.py:212
+#: components/transfer/views.py:210
 #, fuzzy
 #| msgid "Unable to update transfer metadata set: contact administrator."
 msgid "Unable to update transfer metadata set, contact administrator:"
@@ -1237,466 +1301,466 @@ msgstr ""
 msgid "the related model"
 msgstr "Tid vid uprrättande"
 
-#: fpr/models.py:51 fpr/models.py:362 fpr/models.py:560 fpr/models.py:603
-#: fpr/models.py:643 fpr/models.py:659 fpr/models.py:677 fpr/models.py:705
-#: fpr/models.py:730 fpr/models.py:749 fpr/models.py:770
+#: fpr/models.py:52 fpr/models.py:378 fpr/models.py:586 fpr/models.py:629
+#: fpr/models.py:669 fpr/models.py:685 fpr/models.py:703 fpr/models.py:731
+#: fpr/models.py:757 fpr/models.py:776 fpr/models.py:797
 msgid "enabled"
 msgstr ""
 
-#: fpr/models.py:52 fpr/models.py:601 fpr/models.py:640 fpr/models.py:657
-#: fpr/models.py:675 fpr/models.py:703 fpr/models.py:728 fpr/models.py:747
-#: fpr/models.py:768
+#: fpr/models.py:53 fpr/models.py:627 fpr/models.py:666 fpr/models.py:683
+#: fpr/models.py:701 fpr/models.py:729 fpr/models.py:755 fpr/models.py:774
+#: fpr/models.py:795
 msgid "last modified"
 msgstr ""
 
-#: fpr/models.py:141 fpr/models.py:165 fpr/models.py:182 fpr/models.py:251
-#: fpr/models.py:306 fpr/models.py:356 fpr/models.py:388 fpr/models.py:484
-#: fpr/models.py:554
+#: fpr/models.py:142 fpr/models.py:170 fpr/models.py:187 fpr/models.py:257
+#: fpr/models.py:316 fpr/models.py:372 fpr/models.py:404 fpr/models.py:506
+#: fpr/models.py:580
 #, fuzzy
 #| msgid "Identifier"
 msgid "Unique identifier"
 msgstr "Signum"
 
-#: fpr/models.py:144 fpr/models.py:167 fpr/models.py:194 fpr/models.py:254
-#: fpr/models.py:359 fpr/models.py:494 fpr/models.py:557 fpr/models.py:631
-#: fpr/models.py:652 fpr/models.py:671 fpr/models.py:686
+#: fpr/models.py:145 fpr/models.py:172 fpr/models.py:200 fpr/models.py:260
+#: fpr/models.py:375 fpr/models.py:517 fpr/models.py:583 fpr/models.py:657
+#: fpr/models.py:678 fpr/models.py:697 fpr/models.py:712
 #, fuzzy
 #| msgid "Description"
 msgid "description"
 msgstr "Beskrivning"
 
-#: fpr/models.py:144
+#: fpr/models.py:145
 msgid "Common name of format"
 msgstr ""
 
-#: fpr/models.py:147
+#: fpr/models.py:151
 #, fuzzy
 #| msgid "A related resource."
 msgid "the related group"
 msgstr "En relaterad resurs."
 
-#: fpr/models.py:149 fpr/models.py:168 fpr/models.py:364 fpr/models.py:561
+#: fpr/models.py:154 fpr/models.py:173 fpr/models.py:380 fpr/models.py:587
 msgid "slug"
 msgstr ""
 
-#: fpr/models.py:154 fpr/templates/fpr/format/version/detail.html:31
+#: fpr/models.py:159 fpr/templates/fpr/format/version/detail.html:31
 #: fpr/templates/fpr/fprule/detail.html:30
 #: fpr/templates/fpr/fprule/list.html:30 fpr/templates/fpr/idrule/list.html:28
 #: templates/ingest/normalization_report.html:32
 msgid "Format"
 msgstr "Format"
 
-#: fpr/models.py:171
+#: fpr/models.py:176
 #, fuzzy
 #| msgid "Format"
 msgid "Format group"
 msgstr "Format"
 
-#: fpr/models.py:189 fpr/models.py:312 fpr/models.py:444 fpr/models.py:713
+#: fpr/models.py:194 fpr/models.py:327 fpr/models.py:465 fpr/models.py:739
 #, fuzzy
 #| msgid "File format"
 msgid "the related format"
 msgstr "Filformat"
 
-#: fpr/models.py:191 fpr/models.py:361 fpr/models.py:559
+#: fpr/models.py:197 fpr/models.py:377 fpr/models.py:585
 #, fuzzy
 #| msgid "Version"
 msgid "version"
 msgstr "Version"
 
-#: fpr/models.py:192
+#: fpr/models.py:198
 msgid "pronom id"
 msgstr ""
 
-#: fpr/models.py:198
+#: fpr/models.py:204
 msgid "Formal name to go in the METS file."
 msgstr ""
 
-#: fpr/models.py:200
+#: fpr/models.py:206
 #, fuzzy
 #| msgid "Already in access format"
 msgid "access format"
 msgstr "Redan i åtkomstformat."
 
-#: fpr/models.py:201
+#: fpr/models.py:207
 #, fuzzy
 #| msgid "Already in preservation format"
 msgid "preservation format"
 msgstr "Redan i bevarandeformat"
 
-#: fpr/models.py:208 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
 #, fuzzy
 #| msgid "Format"
 msgid "Format version"
 msgstr "Format"
 
-#: fpr/models.py:227
+#: fpr/models.py:233
 msgid ""
 "Unable to save, an active Format Version  with this pronom id already exists."
 msgstr ""
 
-#: fpr/models.py:234
+#: fpr/models.py:240
 #, python-format
 msgid "%(format)s: %(description)s (%(pronom_id)s)"
 msgstr ""
 
-#: fpr/models.py:254
+#: fpr/models.py:260
 msgid "Name to identify script"
 msgstr ""
 
-#: fpr/models.py:257
+#: fpr/models.py:263
 msgid "PUID"
 msgstr ""
 
-#: fpr/models.py:258
+#: fpr/models.py:264
 msgid "MIME type"
 msgstr ""
 
-#: fpr/models.py:259
+#: fpr/models.py:265
 msgid "File extension"
 msgstr ""
 
-#: fpr/models.py:261
+#: fpr/models.py:267
 #, fuzzy
 #| msgid "Configuration"
 msgid "configuration"
 msgstr "Konfigurering"
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 #, fuzzy
 #| msgid "Description"
 msgid "script"
 msgstr "Beskrivning"
 
-#: fpr/models.py:263
+#: fpr/models.py:269
 msgid "Script to be executed."
 msgstr ""
 
-#: fpr/models.py:265 fpr/models.py:497
+#: fpr/models.py:271 fpr/models.py:520
 msgid "Bash script"
 msgstr ""
 
-#: fpr/models.py:266 fpr/models.py:498
+#: fpr/models.py:272 fpr/models.py:521
 msgid "Python script"
 msgstr ""
 
-#: fpr/models.py:267 fpr/models.py:499
+#: fpr/models.py:273 fpr/models.py:522
 msgid "Command line"
 msgstr ""
 
-#: fpr/models.py:268 fpr/models.py:500
+#: fpr/models.py:274 fpr/models.py:523
 msgid "No shebang needed"
 msgstr ""
 
-#: fpr/models.py:271 fpr/models.py:503
+#: fpr/models.py:277 fpr/models.py:526
 #, fuzzy
 #| msgid "Object type"
 msgid "script type"
 msgstr "Objekttyp"
 
-#: fpr/models.py:274 fpr/models.py:492
+#: fpr/models.py:283 fpr/models.py:514
 msgid "the related tool"
 msgstr ""
 
-#: fpr/models.py:278
+#: fpr/models.py:288
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "Format identification command"
 msgstr "Välj kommando för identifikation av filformat (Ingest)"
 
-#: fpr/models.py:282
+#: fpr/models.py:292
 #, python-format
 msgid "%(tool)s %(config)s runs %(command)s"
 msgstr ""
 
-#: fpr/models.py:309 fpr/models.py:441
+#: fpr/models.py:321 fpr/models.py:459
 msgid "the related command"
 msgstr ""
 
-#: fpr/models.py:315
+#: fpr/models.py:331
 msgid "command output"
 msgstr ""
 
-#: fpr/models.py:318
+#: fpr/models.py:334
 msgid "Format identification rule"
 msgstr ""
 
-#: fpr/models.py:335
+#: fpr/models.py:351
 msgid ""
 "Unable to save, a rule with this output already exists for this command."
 msgstr ""
 
-#: fpr/models.py:342
+#: fpr/models.py:358
 #, python-format
 msgid "Format identification rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:345
+#: fpr/models.py:361
 #, python-format
 msgid "%(command)s with %(output)s is %(format)s"
 msgstr ""
 
-#: fpr/models.py:359 fpr/models.py:557
+#: fpr/models.py:375 fpr/models.py:583
 msgid "Name of tool"
 msgstr ""
 
-#: fpr/models.py:368
+#: fpr/models.py:384
 msgid "Format identification tool"
 msgstr ""
 
-#: fpr/models.py:374 fpr/models.py:568
+#: fpr/models.py:390 fpr/models.py:594
 #, fuzzy, python-format
 #| msgid "Description"
 msgid "%(description)s"
 msgstr "Beskrivning"
 
-#: fpr/models.py:416 templates/layout.html:65 templates/main/access.html:4
+#: fpr/models.py:432 templates/layout.html:67 templates/main/access.html:4
 #: templates/main/access.html:5
 msgid "Access"
 msgstr "Åtkomst"
 
-#: fpr/models.py:417 fpr/models.py:514
+#: fpr/models.py:433 fpr/models.py:538
 msgid "Characterization"
 msgstr ""
 
-#: fpr/models.py:418
+#: fpr/models.py:434
 #, fuzzy
 #| msgid "Extract packages"
 msgid "Extract"
 msgstr "Extrahera packages"
 
-#: fpr/models.py:419 fpr/templates/fpr/format/version/detail.html:33
+#: fpr/models.py:435 fpr/templates/fpr/format/version/detail.html:33
 #, fuzzy
 #| msgid "Preservation planning"
 msgid "Preservation"
 msgstr "Bevarandeplanering"
 
-#: fpr/models.py:420
+#: fpr/models.py:436
 msgid "Thumbnail"
 msgstr ""
 
-#: fpr/models.py:421 fpr/models.py:518
+#: fpr/models.py:437 fpr/models.py:542
 #, fuzzy
 #| msgid "Description"
 msgid "Transcription"
 msgstr "Beskrivning"
 
-#: fpr/models.py:422 fpr/models.py:519
+#: fpr/models.py:438 fpr/models.py:543
 msgid "Validation"
 msgstr ""
 
-#: fpr/models.py:423
+#: fpr/models.py:439
 msgid "Validation against a policy"
 msgstr ""
 
-#: fpr/models.py:426
+#: fpr/models.py:442
 #, fuzzy
 #| msgid "Delete successful."
 msgid "Default access"
 msgstr "Radering lyckades."
 
-#: fpr/models.py:427
+#: fpr/models.py:443
 #, fuzzy
 #| msgid "Default location"
 msgid "Default characterization"
 msgstr "Standardplats"
 
-#: fpr/models.py:428
+#: fpr/models.py:444
 #, fuzzy
 #| msgid "Default location"
 msgid "Default thumbnail"
 msgstr "Standardplats"
 
-#: fpr/models.py:439
+#: fpr/models.py:455
 #, fuzzy
 #| msgid "Purpose"
 msgid "purpose"
 msgstr "Syfte"
 
-#: fpr/models.py:447
+#: fpr/models.py:469
 msgid "count attempts"
 msgstr ""
 
-#: fpr/models.py:448
+#: fpr/models.py:470
 msgid "count okay"
 msgstr ""
 
-#: fpr/models.py:449
+#: fpr/models.py:471
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:452 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:732
 msgid "Format policy rule"
 msgstr ""
 
-#: fpr/models.py:472
+#: fpr/models.py:494
 #, python-format
 msgid "Format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/models.py:475
+#: fpr/models.py:497
 #, python-format
 msgid "Normalize %(format)s for %(purpose)s via %(command)s"
 msgstr ""
 
-#: fpr/models.py:495 fpr/models.py:627 fpr/models.py:744
+#: fpr/models.py:518 fpr/models.py:653 fpr/models.py:771
 #, fuzzy
 #| msgid "Rsync command"
 msgid "command"
 msgstr "Rsync-kommando"
 
-#: fpr/models.py:505 fpr/models.py:629
+#: fpr/models.py:528 fpr/models.py:655
 #, fuzzy
 #| msgid "Default location"
 msgid "output location"
 msgstr "Standardplats"
 
-#: fpr/models.py:511
+#: fpr/models.py:534
 msgid "the related output format"
 msgstr ""
 
-#: fpr/models.py:515
+#: fpr/models.py:539
 msgid "Event Detail"
 msgstr ""
 
-#: fpr/models.py:516
+#: fpr/models.py:540
 #, fuzzy
 #| msgid "Duration"
 msgid "Extraction"
 msgstr "Varaktighet"
 
-#: fpr/models.py:517
+#: fpr/models.py:541
 #, fuzzy
 #| msgid "Review normalization"
 msgid "Normalization"
 msgstr "Granska normalisering"
 
-#: fpr/models.py:520
+#: fpr/models.py:544
 #, fuzzy
 #| msgid "Restriction(s)"
 msgid "Verification"
 msgstr "Begränsning(ar)"
 
-#: fpr/models.py:523 fpr/models.py:613
+#: fpr/models.py:547 fpr/models.py:639
 msgid "command usage"
 msgstr ""
 
-#: fpr/models.py:531
+#: fpr/models.py:555
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "the related verification command"
 msgstr "Välj kommando för identifikation av filformat (Ingest)"
 
-#: fpr/models.py:539
+#: fpr/models.py:564
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:543 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:731
 msgid "Format policy command"
 msgstr ""
 
-#: fpr/models.py:565
+#: fpr/models.py:591
 #, fuzzy
 #| msgid "Review normalization"
 msgid "Normalization tool"
 msgstr "Granska normalisering"
 
-#: fpr/models.py:582
+#: fpr/models.py:608
 #, fuzzy
 #| msgid "Documentation identifier"
 msgid "agent identifier type"
 msgstr "Dokumentationssignum"
 
-#: fpr/models.py:583
+#: fpr/models.py:609
 #, fuzzy
 #| msgid "Documentation identifier"
 msgid "agent identifier value"
 msgstr "Dokumentationssignum"
 
-#: fpr/models.py:584
+#: fpr/models.py:610
 #, fuzzy
 #| msgid "File name"
 msgid "agent name"
 msgstr "Filnamn"
 
-#: fpr/models.py:585
+#: fpr/models.py:611
 #, fuzzy
 #| msgid "Object type"
 msgid "agent type"
 msgstr "Objekttyp"
 
-#: fpr/models.py:586
+#: fpr/models.py:612
 msgid "client IP address"
 msgstr ""
 
-#: fpr/models.py:598 fpr/models.py:637 fpr/models.py:655 fpr/models.py:673
-#: fpr/models.py:701 fpr/models.py:726 fpr/models.py:746 fpr/models.py:766
+#: fpr/models.py:624 fpr/models.py:663 fpr/models.py:681 fpr/models.py:699
+#: fpr/models.py:727 fpr/models.py:753 fpr/models.py:773 fpr/models.py:793
 #, fuzzy
 #| msgid "Replace"
 msgid "replaces"
 msgstr "Ersätt"
 
-#: fpr/models.py:600
+#: fpr/models.py:626
 msgid "type"
 msgstr ""
 
-#: fpr/models.py:614
+#: fpr/models.py:640
 msgid "command type"
 msgstr ""
 
-#: fpr/models.py:617
+#: fpr/models.py:643
 msgid "verification command"
 msgstr ""
 
-#: fpr/models.py:621
+#: fpr/models.py:647
 msgid "event detail command"
 msgstr ""
 
-#: fpr/models.py:625
+#: fpr/models.py:651
 msgid "supported by"
 msgstr ""
 
-#: fpr/models.py:633
+#: fpr/models.py:659
 #, fuzzy
 #| msgid "File format"
 msgid "output file format"
 msgstr "Filformat"
 
-#: fpr/models.py:688
+#: fpr/models.py:714
 #, fuzzy
 #| msgid "Already in preservation format"
 msgid "valid preservation format"
 msgstr "Redan i bevarandeformat"
 
-#: fpr/models.py:694
+#: fpr/models.py:720
 #, fuzzy
 #| msgid "Already in access format"
 msgid "valid access format"
 msgstr "Redan i åtkomstformat."
 
-#: fpr/models.py:698
+#: fpr/models.py:724
 msgid "file ID type"
 msgstr ""
 
-#: fpr/models.py:723
+#: fpr/models.py:750
 msgid "classification"
 msgstr ""
 
-#: fpr/models.py:740
+#: fpr/models.py:767
 msgid "command clasification"
 msgstr ""
 
-#: fpr/models.py:745 fpr/models.py:759
+#: fpr/models.py:772 fpr/models.py:786
 #, fuzzy
 #| msgid "File UUID"
 msgid "file ID"
 msgstr "Filens UUID"
 
-#: fpr/models.py:761
+#: fpr/models.py:788
 msgid "tool"
 msgstr ""
 
-#: fpr/models.py:763
+#: fpr/models.py:790
 #, fuzzy
 #| msgid "Version"
 msgid "tool version"
@@ -1883,12 +1947,12 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:50 templates/accounts/add.html:36
 #: templates/accounts/edit.html:40 templates/accounts/profile.html:49
 #: templates/administration/processing_edit.html:40
-#: templates/delete_request.html:19 templates/ingest/as/match.html:129
-#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:66
-#: templates/rights/rights_edit.html:290 templates/rights/rights_edit.html:292
-#: templates/rights/rights_grants_edit.html:111
-#: templates/rights/rights_grants_edit.html:113
-#: templates/simple_confirm.html:10 templates/transfer/metadata_edit.html:65
+#: templates/delete_request.html:20 templates/ingest/as/match.html:129
+#: templates/ingest/grid.html:174 templates/ingest/metadata_edit.html:67
+#: templates/rights/rights_edit.html:291 templates/rights/rights_edit.html:293
+#: templates/rights/rights_grants_edit.html:112
+#: templates/rights/rights_grants_edit.html:114
+#: templates/simple_confirm.html:11 templates/transfer/metadata_edit.html:66
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -2077,18 +2141,18 @@ msgstr ""
 #: fpr/templates/fpr/idcommand/form.html:32
 #: fpr/templates/fpr/idrule/form.html:29 fpr/templates/fpr/idtool/form.html:30
 #: templates/accounts/edit.html:39 templates/accounts/profile.html:48
-#: templates/administration/api.html:36
-#: templates/administration/dips_as_edit.html:29
-#: templates/administration/dips_atom_edit.html:44
-#: templates/administration/general.html:67
-#: templates/administration/handle_config.html:24
-#: templates/administration/premis_agent.html:24
+#: templates/administration/api.html:37
+#: templates/administration/dips_as_edit.html:30
+#: templates/administration/dips_atom_edit.html:45
+#: templates/administration/general.html:68
+#: templates/administration/handle_config.html:25
+#: templates/administration/premis_agent.html:25
 #: templates/administration/processing_edit.html:39
-#: templates/administration/term_detail.html:34
-#: templates/ingest/metadata_edit.html:62 templates/rights/rights_edit.html:285
-#: templates/rights/rights_grants_edit.html:106
-#: templates/transfer/component.html:54
-#: templates/transfer/metadata_edit.html:61
+#: templates/administration/term_detail.html:35
+#: templates/ingest/metadata_edit.html:63 templates/rights/rights_edit.html:286
+#: templates/rights/rights_grants_edit.html:107
+#: templates/transfer/component.html:55
+#: templates/transfer/metadata_edit.html:62
 msgid "Save"
 msgstr "Spara"
 
@@ -2101,11 +2165,11 @@ msgstr ""
 #: fpr/templates/fpr/format/group/delete.html:12
 #: fpr/templates/fpr/format/group/delete.html:49
 #: fpr/templates/fpr/format/group/list.html:51 templates/accounts/list.html:42
-#: templates/administration/atom_levels_of_description.html:44
+#: templates/administration/atom_levels_of_description.html:45
 #: templates/administration/processing.html:33
-#: templates/administration/reports/failure_detail.html:31
+#: templates/administration/reports/failure_detail.html:32
 #: templates/administration/reports/failures.html:39
-#: templates/administration/term_detail.html:35
+#: templates/administration/term_detail.html:36
 #: templates/archival_storage/view.html:111
 #: templates/archival_storage/view.html:154 templates/main/access.html:25
 #: templates/rights/rights_list.html:55 templates/rights/rights_list.html:58
@@ -2420,13 +2484,6 @@ msgstr ""
 msgid "Script"
 msgstr ""
 
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:959
-#: templates/administration/reports/failures.html:25
-#: templates/rights/rights_edit.html:101 templates/rights/rights_edit.html:153
-#: templates/rights/rights_edit.html:203 templates/rights/rights_edit.html:251
-msgid "Type"
-msgstr "Typ"
-
 #: fpr/templates/fpr/idcommand/list.html:56
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
@@ -2480,7 +2537,7 @@ msgstr "Konfigurering"
 #: fpr/templates/fpr/idtool/detail.html:49
 #: templates/ingest/as/_search_form.html:5 templates/ingest/as/match.html:102
 #: templates/ingest/as/match.html:120
-#: templates/ingest/as/review_matches.html:30 templates/ingest/grid.html:165
+#: templates/ingest/as/review_matches.html:31 templates/ingest/grid.html:165
 msgid "Identifier"
 msgstr "Signum"
 
@@ -2698,464 +2755,464 @@ msgstr ""
 "Fel under skapelse av pipeline: Är lagringsservern igång? Var god kontakta "
 "en administratör."
 
-#: main/models.py:243
+#: main/models.py:245
 msgid "Part of AIC"
 msgstr "Del av AIC"
 
-#: main/models.py:244
+#: main/models.py:246
 msgid "Optional: leave blank if unsure"
 msgstr ""
 
-#: main/models.py:253
+#: main/models.py:255
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:263
+#: main/models.py:265
 msgid "Use ISO 639"
 msgstr ""
 
-#: main/models.py:281
+#: main/models.py:283
 msgid "Untitled"
 msgstr "Utan titel"
 
-#: main/models.py:329
+#: main/models.py:336
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr "%(type)s händekse på %(file_uuid)s (%(detail)s)"
 
-#: main/models.py:371
+#: main/models.py:381
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr "%(derived)s  bearbetad från %(src)s i %(event)s"
 
-#: main/models.py:399
+#: main/models.py:409
 msgid "SIP"
 msgstr ""
 
-#: main/models.py:400
+#: main/models.py:410
 msgid "AIC"
 msgstr "AIC"
 
-#: main/models.py:401
+#: main/models.py:411
 msgid "Reingested AIP"
 msgstr ""
 
-#: main/models.py:402
+#: main/models.py:412
 msgid "Reingested AIC"
 msgstr ""
 
-#: main/models.py:416
+#: main/models.py:426
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr "SIP: {path}"
 
-#: main/models.py:529
+#: main/models.py:547
 msgid "Arranged SIPs"
 msgstr ""
 
-#: main/models.py:533
+#: main/models.py:551
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr "%(original)s -> %(arrange)s"
 
-#: main/models.py:578
+#: main/models.py:596
 msgid "Identifier Type"
 msgstr ""
 
-#: main/models.py:580
+#: main/models.py:598
 msgid "Identifier Value"
 msgstr ""
 
-#: main/models.py:582
+#: main/models.py:600
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
 msgstr ""
 
-#: main/models.py:645
+#: main/models.py:673
 #, fuzzy, python-format
 #| msgid "File %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr "File %(uuid)s: %(originallocation)s nu på %(currentlocation)s"
 
-#: main/models.py:681
+#: main/models.py:719
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr "Sökväg %(uuid)s: %(originallocation)s nu på %(currentlocation)s"
 
-#: main/models.py:740
+#: main/models.py:783
 #, fuzzy, python-format
 #| msgid "File format"
 msgid "%(file)s is %(format)s"
 msgstr "Filformat"
 
-#: main/models.py:758
+#: main/models.py:801
 msgid "(Unnamed)"
 msgstr "(Namnlös)"
 
-#: main/models.py:780
+#: main/models.py:823
 msgid "Unknown"
 msgstr "Okänd"
 
-#: main/models.py:781
+#: main/models.py:824
 msgid "Awaiting decision"
 msgstr ""
 
-#: main/models.py:782
+#: main/models.py:825
 msgid "Completed successfully"
 msgstr ""
 
-#: main/models.py:783
+#: main/models.py:826
 msgid "Executing command(s)"
 msgstr ""
 
-#: main/models.py:784
+#: main/models.py:827
 msgid "Failed"
 msgstr ""
 
-#: main/models.py:879
+#: main/models.py:924
 msgid "Agent Identifier Type"
 msgstr ""
 
-#: main/models.py:884
+#: main/models.py:929
 msgid "Agent Identifier Value"
 msgstr ""
 
-#: main/models.py:886
+#: main/models.py:931
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
 msgstr ""
 
-#: main/models.py:893
+#: main/models.py:938
 msgid "Agent Name"
 msgstr ""
 
-#: main/models.py:894
+#: main/models.py:939
 msgid "Used for premis:agentName in the METS file."
 msgstr ""
 
-#: main/models.py:900
+#: main/models.py:945
 msgid "Agent Type"
 msgstr ""
 
-#: main/models.py:901
+#: main/models.py:946
 msgid "Used for premis:agentType in the METS file."
 msgstr ""
 
-#: main/models.py:925
+#: main/models.py:970
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:927
+#: main/models.py:972
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:962 templates/rights/rights_edit.html:105
-#: templates/rights/rights_edit.html:157 templates/rights/rights_edit.html:207
-#: templates/rights/rights_edit.html:255
+#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
+#: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr "Värde"
 
-#: main/models.py:965
+#: main/models.py:1013
 msgid "Rights holder"
 msgstr "Rättighetsinnehavare"
 
-#: main/models.py:968
+#: main/models.py:1016
 msgid "Copyright"
 msgstr "Upphovsrätt"
 
-#: main/models.py:969
+#: main/models.py:1017
 msgid "Statute"
 msgstr "Regelverk"
 
-#: main/models.py:970
+#: main/models.py:1018
 msgid "License"
 msgstr "Licens"
 
-#: main/models.py:971
+#: main/models.py:1019
 msgid "Donor"
 msgstr "Donator"
 
-#: main/models.py:972
+#: main/models.py:1020
 msgid "Policy"
 msgstr "Policy"
 
-#: main/models.py:979 templates/rights/rights_list.html:34
+#: main/models.py:1027 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr "Grund"
 
-#: main/models.py:991
+#: main/models.py:1039
 msgid "Rights Statement"
 msgstr ""
 
-#: main/models.py:995
+#: main/models.py:1043
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr "%(basis)s för %(unit)s (%(id)s)"
 
-#: main/models.py:1008
+#: main/models.py:1058
 msgid "copyrighted"
 msgstr ""
 
-#: main/models.py:1009
+#: main/models.py:1059
 msgid "public domain"
 msgstr ""
 
-#: main/models.py:1010
+#: main/models.py:1060
 msgid "unknown"
 msgstr ""
 
-#: main/models.py:1015
+#: main/models.py:1065
 msgid "Copyright status"
 msgstr "Upphovsrättsstatus"
 
-#: main/models.py:1020
+#: main/models.py:1070
 msgid "Copyright jurisdiction"
 msgstr "Upphovsrättsgrund"
 
-#: main/models.py:1026
+#: main/models.py:1076
 msgid "Copyright determination date"
 msgstr ""
 
-#: main/models.py:1027 main/models.py:1034 main/models.py:1041
-#: main/models.py:1105 main/models.py:1112 main/models.py:1172
-#: main/models.py:1179 main/models.py:1237 main/models.py:1246
-#: main/models.py:1253 main/models.py:1321 main/models.py:1328
+#: main/models.py:1077 main/models.py:1084 main/models.py:1091
+#: main/models.py:1161 main/models.py:1168 main/models.py:1234
+#: main/models.py:1241 main/models.py:1303 main/models.py:1312
+#: main/models.py:1319 main/models.py:1391 main/models.py:1398
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:1033
+#: main/models.py:1083
 msgid "Copyright start date"
 msgstr ""
 
-#: main/models.py:1040
+#: main/models.py:1090
 msgid "Copyright end date"
 msgstr ""
 
-#: main/models.py:1046 main/models.py:1117 main/models.py:1186
-#: main/models.py:1258 main/models.py:1333
+#: main/models.py:1096 main/models.py:1173 main/models.py:1248
+#: main/models.py:1324 main/models.py:1403
 msgid "Open End Date"
 msgstr ""
 
-#: main/models.py:1047 main/models.py:1118 main/models.py:1187
-#: main/models.py:1259 main/models.py:1334
+#: main/models.py:1097 main/models.py:1174 main/models.py:1249
+#: main/models.py:1325 main/models.py:1404
 msgid "Indicate end date is open"
 msgstr ""
 
-#: main/models.py:1052
+#: main/models.py:1102
 msgid "Rights: Copyright"
 msgstr ""
 
-#: main/models.py:1062
+#: main/models.py:1114
 msgid "Copyright document identification type"
 msgstr ""
 
-#: main/models.py:1066
+#: main/models.py:1118
 msgid "Copyright document identification value"
 msgstr ""
 
-#: main/models.py:1072
+#: main/models.py:1124
 msgid "Copyright document identification role"
 msgstr ""
 
-#: main/models.py:1077
+#: main/models.py:1129
 msgid "Rights: Copyright: Docs ID"
 msgstr ""
 
-#: main/models.py:1086 templates/rights/rights_edit.html:116
+#: main/models.py:1140 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr "Upphovsrättsnotering"
 
-#: main/models.py:1091
+#: main/models.py:1145
 msgid "Rights: Copyright: Note"
 msgstr ""
 
-#: main/models.py:1098
+#: main/models.py:1154
 msgid "License terms"
 msgstr "Licensvillkor"
 
-#: main/models.py:1104
+#: main/models.py:1160
 msgid "License start date"
 msgstr ""
 
-#: main/models.py:1111
+#: main/models.py:1167
 msgid "License end date"
 msgstr ""
 
-#: main/models.py:1123
+#: main/models.py:1179
 msgid "Rights: License"
 msgstr ""
 
-#: main/models.py:1133
+#: main/models.py:1191
 msgid "License documentation identification type"
 msgstr ""
 
-#: main/models.py:1137
+#: main/models.py:1195
 msgid "License documentation identification value"
 msgstr ""
 
-#: main/models.py:1143
+#: main/models.py:1201
 msgid "License document identification role"
 msgstr ""
 
-#: main/models.py:1148
+#: main/models.py:1206
 msgid "Rights: License: Docs ID"
 msgstr ""
 
-#: main/models.py:1157 templates/rights/rights_edit.html:218
+#: main/models.py:1217 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr "Licensanmärkning"
 
-#: main/models.py:1162
+#: main/models.py:1222
 msgid "Rights: License: Note"
 msgstr ""
 
-#: main/models.py:1171 templates/rights/rights_list.html:36
+#: main/models.py:1233 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr "Start"
 
-#: main/models.py:1178 templates/rights/rights_list.html:37
+#: main/models.py:1240 templates/rights/rights_list.html:37
 msgid "End"
 msgstr "Slut"
 
-#: main/models.py:1192
+#: main/models.py:1254
 msgid "Rights: Granted"
 msgstr ""
 
-#: main/models.py:1203
+#: main/models.py:1266
 msgid "Rights note"
 msgstr ""
 
-#: main/models.py:1208
+#: main/models.py:1271
 msgid "Rights: Granted: Note"
 msgstr ""
 
-#: main/models.py:1222
+#: main/models.py:1286
 msgid "Rights: Granted: Restriction"
 msgstr ""
 
-#: main/models.py:1229
+#: main/models.py:1295
 msgid "Statute jurisdiction"
 msgstr "Rättsgrund för regelverk"
 
-#: main/models.py:1232
+#: main/models.py:1298
 msgid "Statute citation"
 msgstr "Citering för regelverk"
 
-#: main/models.py:1236
+#: main/models.py:1302
 msgid "Statute determination date"
 msgstr "Beslutsdatum för regelverk"
 
-#: main/models.py:1245
+#: main/models.py:1311
 msgid "Statute start date"
 msgstr ""
 
-#: main/models.py:1252
+#: main/models.py:1318
 msgid "Statute end date"
 msgstr ""
 
-#: main/models.py:1264
+#: main/models.py:1330
 msgid "Rights: Statute"
 msgstr ""
 
-#: main/models.py:1274 templates/rights/rights_edit.html:168
+#: main/models.py:1341 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr "Regelverksanmärkning"
 
-#: main/models.py:1279
+#: main/models.py:1346
 msgid "Rights: Statute: Note"
 msgstr ""
 
-#: main/models.py:1290
+#: main/models.py:1358
 msgid "Statute document identification type"
 msgstr ""
 
-#: main/models.py:1294
+#: main/models.py:1362
 msgid "Statute document identification value"
 msgstr ""
 
-#: main/models.py:1300
+#: main/models.py:1368
 msgid "Statute document identification role"
 msgstr ""
 
-#: main/models.py:1305
+#: main/models.py:1373
 msgid "Rights: Statute: Docs ID"
 msgstr ""
 
-#: main/models.py:1313
+#: main/models.py:1383
 msgid "Other rights basis"
 msgstr ""
 
-#: main/models.py:1320
+#: main/models.py:1390
 msgid "Other rights start date"
 msgstr ""
 
-#: main/models.py:1327
+#: main/models.py:1397
 msgid "Other rights end date"
 msgstr ""
 
-#: main/models.py:1339
+#: main/models.py:1409
 msgid "Rights: Other"
 msgstr ""
 
-#: main/models.py:1350
+#: main/models.py:1421
 msgid "Other rights document identification type"
 msgstr ""
 
-#: main/models.py:1354
+#: main/models.py:1425
 msgid "Other right document identification value"
 msgstr ""
 
-#: main/models.py:1360
+#: main/models.py:1431
 msgid "Other rights document identification role"
 msgstr ""
 
-#: main/models.py:1365
+#: main/models.py:1436
 msgid "Rights: Other: Docs ID"
 msgstr ""
 
-#: main/models.py:1375
+#: main/models.py:1447
 msgid "Other rights note"
 msgstr ""
 
-#: main/models.py:1380
+#: main/models.py:1452
 msgid "Rights: Other: Note"
 msgstr ""
 
-#: main/models.py:1388
+#: main/models.py:1462
 msgid "Linking Agent"
 msgstr ""
 
-#: main/models.py:1393
+#: main/models.py:1467
 msgid "Linking Agent Value"
 msgstr ""
 
-#: main/models.py:1399
+#: main/models.py:1473
 msgid "Rights: Agent"
 msgstr ""
 
-#: main/models.py:1435
+#: main/models.py:1509
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr ""
 
-#: main/models.py:1473
+#: main/models.py:1547
 msgid "ASDIPObjectResourcePairing"
 msgstr ""
 
-#: main/models.py:1488
+#: main/models.py:1562
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr ""
 
-#: main/models.py:1495
+#: main/models.py:1569
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 
-#: main/models.py:1615
+#: main/models.py:1709
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr "%(sortorder)s: %(name)s"
@@ -3164,15 +3221,15 @@ msgstr "%(sortorder)s: %(name)s"
 msgid "<no API key generated>"
 msgstr "<no API key generated>"
 
-#: main/views.py:302
+#: main/views.py:299
 msgid "Added."
 msgstr "Tillagd."
 
-#: main/views.py:307
+#: main/views.py:304
 msgid "Error: no delete ID supplied."
 msgstr "Fel: ingen raderings ID angavs."
 
-#: main/views.py:322
+#: main/views.py:319
 msgid "Incorrect type."
 msgstr "Felaktig typ."
 
@@ -3204,7 +3261,7 @@ msgstr ""
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:436
+#: settings/base.py:435
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
@@ -3212,7 +3269,7 @@ msgstr ""
 "Välj \"Godkänn överföring\" för att påbörja bearbetning eller \"Avslå "
 "överföring\" för att starta om."
 
-#: settings/base.py:439
+#: settings/base.py:438
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
@@ -3222,11 +3279,11 @@ msgstr ""
 "eller misslyckas. Denna transfer kommer automatiskt raderas när AIP:n har "
 "flyttats till lagring."
 
-#: settings/base.py:441
+#: settings/base.py:440
 msgid "Create a SIP from the transfer."
 msgstr "Skapa SIP från transfern."
 
-#: settings/base.py:443
+#: settings/base.py:442
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
@@ -3236,7 +3293,7 @@ msgstr ""
 "bevarande- och gallringsprocess och fysiskt ordnande välj \"SIP skapelse "
 "fullföljd\" för att starta de micro-servicerna kopplade till ingest."
 
-#: settings/base.py:446
+#: settings/base.py:445
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
@@ -3246,7 +3303,7 @@ msgstr ""
 "åtkomstkopior kommer leda till att en DIP genereras för uppladdning till ett "
 "åtkomstsystem."
 
-#: settings/base.py:449
+#: settings/base.py:448
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -3261,7 +3318,7 @@ msgstr ""
 "misslyckades\" eller \"Normalisering för åtkomst misslyckades\" för att se "
 "verktygets output och felmeddelande."
 
-#: settings/base.py:452
+#: settings/base.py:451
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
@@ -3269,7 +3326,7 @@ msgstr ""
 "Om så önskas kan du klicka på \"Granska\" för visa innehållet i AIP:n. Välj "
 "\"Lagra AIP\" för att flytta AIP:n till arkivförvaring."
 
-#: settings/base.py:455
+#: settings/base.py:454
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3306,7 +3363,7 @@ msgid "Previous"
 msgstr "Föregående"
 
 #: templates/_pager.html:35 templates/ingest/normalization_report.html:121
-#: templates/rights/rights_edit.html:287
+#: templates/rights/rights_edit.html:288
 msgid "Next"
 msgstr "Nästa"
 
@@ -3343,8 +3400,8 @@ msgstr "Användare"
 msgid "Add new user"
 msgstr "Lägg till ny användare"
 
-#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:64
-#: templates/installer/welcome.html:49 templates/transfer/metadata_edit.html:63
+#: templates/accounts/add.html:35 templates/ingest/metadata_edit.html:65
+#: templates/installer/welcome.html:50 templates/transfer/metadata_edit.html:64
 msgid "Create"
 msgstr "Skapa"
 
@@ -3356,12 +3413,6 @@ msgstr "Användare - Redigera %(user)s"
 #: templates/accounts/list.html:23 templates/accounts/profile.html:29
 msgid "Username"
 msgstr "Användarnamn"
-
-#: templates/accounts/list.html:24 templates/accounts/profile.html:31
-#: templates/administration/atom_levels_of_description.html:36
-#: templates/administration/reports/failures.html:26
-msgid "Name"
-msgstr "Namn"
 
 #: templates/accounts/list.html:25 templates/accounts/profile.html:33
 msgid "E-mail"
@@ -3424,14 +3475,12 @@ msgstr "Admin"
 #: templates/administration/reports/failure_detail.html:6
 #: templates/administration/reports/failures.html:5
 #: templates/administration/reports/failures.html:6
-#: templates/administration/search.html:5
-#: templates/administration/search.html:6
 #: templates/administration/taxonomy.html:5
 #: templates/administration/taxonomy.html:6
 #: templates/administration/term_detail.html:5
 #: templates/administration/term_detail.html:6
 #: templates/administration/terms.html:5 templates/administration/terms.html:6
-#: templates/layout.html:66
+#: templates/layout.html:68
 msgid "Administration"
 msgstr "Administration"
 
@@ -3465,15 +3514,15 @@ msgstr "Hämta från AtoM"
 msgid "AtoM Levels of Description"
 msgstr "AtoM Beskrivningsnivåer"
 
-#: templates/administration/atom_levels_of_description.html:45
+#: templates/administration/atom_levels_of_description.html:46
 msgid "Promote"
 msgstr "Höj upp"
 
-#: templates/administration/atom_levels_of_description.html:46
+#: templates/administration/atom_levels_of_description.html:47
 msgid "Demote"
 msgstr "Degradera"
 
-#: templates/administration/atom_levels_of_description.html:54
+#: templates/administration/atom_levels_of_description.html:55
 msgid "No levels found."
 msgstr "Inga nivåer funna"
 
@@ -3485,11 +3534,11 @@ msgstr "Uppladdning av ArchivesSpace-DIP"
 msgid "Levels of Description"
 msgstr "Beskrivningsnivåer"
 
-#: templates/administration/dips_atom_edit.html:37
+#: templates/administration/dips_atom_edit.html:38
 msgid "AtoM/Binder DIP upload"
 msgstr ""
 
-#: templates/administration/dips_atom_edit.html:39
+#: templates/administration/dips_atom_edit.html:40
 msgid "The settings below configure DIP uploading to AtoM/Binder."
 msgstr ""
 
@@ -3508,31 +3557,31 @@ msgstr ""
 msgid "General configuration"
 msgstr "Allmän konfigurering"
 
-#: templates/administration/general.html:39
+#: templates/administration/general.html:40
 msgid "Storage Service options"
 msgstr "Inställningar för lagringstjänst"
 
-#: templates/administration/general.html:43
+#: templates/administration/general.html:44
 msgid "Checksum algorithm"
 msgstr "Chucksum algoritm"
 
-#: templates/administration/general.html:47
+#: templates/administration/general.html:48
 msgid "Elasticsearch Indexing"
 msgstr ""
 
-#: templates/administration/general.html:52
+#: templates/administration/general.html:53
 msgid "Transfers related indexes enabled."
 msgstr ""
 
-#: templates/administration/general.html:54
+#: templates/administration/general.html:55
 msgid "Transfers related indexes disabled."
 msgstr ""
 
-#: templates/administration/general.html:59
+#: templates/administration/general.html:60
 msgid "AIPs related indexes enabled."
 msgstr ""
 
-#: templates/administration/general.html:61
+#: templates/administration/general.html:62
 msgid "AIPs related indexes disabled."
 msgstr ""
 
@@ -3653,25 +3702,6 @@ msgstr "Datum"
 #: templates/administration/reports/failures.html:56
 msgid "No reports found."
 msgstr "Inga rapporter funna"
-
-#: templates/administration/search.html:23
-msgid "Search administration"
-msgstr "Sök igenom administration"
-
-#: templates/administration/search.html:26
-#, python-format
-msgid ""
-"\n"
-"          %(count)s AIP files indexed.\n"
-"        "
-msgstr ""
-"\n"
-"          %(count)s AIP filer indexerades.\n"
-"        "
-
-#: templates/administration/search.html:33
-msgid "Flush AIP Index"
-msgstr "Rensa AIP-index"
 
 #: templates/administration/sidebar.html:23
 msgid "General"
@@ -3799,11 +3829,6 @@ msgid ""
 "cleared manually."
 msgstr ""
 
-#: templates/administration/usage.html:90
-#: templates/archival_storage/view.html:67
-msgid "Size"
-msgstr "Storlek"
-
 #: templates/administration/version.html:19
 msgid "About Archivematica"
 msgstr "Om Archivematica"
@@ -3813,12 +3838,12 @@ msgid "Agent code"
 msgstr "Agent-kod"
 
 #: templates/appraisal/appraisal.html:4 templates/appraisal/appraisal.html:5
-#: templates/layout.html:58
+#: templates/layout.html:60
 msgid "Appraisal"
 msgstr "Bevarande- och gallringsprocess"
 
 #: templates/appraisal/appraisal.html:30
-#: templates/archival_storage/archival_storage.html:70
+#: templates/archival_storage/archival_storage.html:74
 #: templates/backlog/backlog.html:34
 msgid "Elasticsearch Indexing Disabled"
 msgstr ""
@@ -3841,23 +3866,23 @@ msgstr "Sök efter arkivförvaring"
 
 #: templates/archival_storage/archival_storage.html:6
 #: templates/archival_storage/archival_storage.html:7
-#: templates/archival_storage/archival_storage.html:32
+#: templates/archival_storage/archival_storage.html:31
 #: templates/archival_storage/view.html:6
 #: templates/archival_storage/view.html:7
-#: templates/archival_storage/view.html:50 templates/layout.html:62
+#: templates/archival_storage/view.html:50 templates/layout.html:64
 msgid "Archival storage"
 msgstr "Arkivförvaring"
 
-#: templates/archival_storage/archival_storage.html:33
+#: templates/archival_storage/archival_storage.html:32
 #: templates/ingest/as/_search_form.html:6
 msgid "Search"
 msgstr "Sök"
 
-#: templates/archival_storage/archival_storage.html:41
+#: templates/archival_storage/archival_storage.html:40
 msgid "Browse archival storage"
 msgstr "Bläddra i arkivförvaring"
 
-#: templates/archival_storage/archival_storage.html:44
+#: templates/archival_storage/archival_storage.html:43
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -3872,7 +3897,7 @@ msgstr ""
 "                Modul %(module)s\n"
 "              "
 
-#: templates/archival_storage/archival_storage.html:50
+#: templates/archival_storage/archival_storage.html:49
 #, python-format
 msgid ""
 "\n"
@@ -3880,17 +3905,29 @@ msgid ""
 "            "
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:61
+#: templates/archival_storage/archival_storage.html:60
 msgid "Create an AIC from current search results"
 msgstr ""
 
-#: templates/archival_storage/archival_storage.html:62
+#: templates/archival_storage/archival_storage.html:61
 #, fuzzy
 #| msgid "Create SIP"
 msgid "Create an AIC"
 msgstr "Skapa SIP"
 
-#: templates/archival_storage/archival_storage.html:71
+#: templates/archival_storage/archival_storage.html:65
+msgid ""
+"Download all results from archival storage as a CSV (Comma-separated-values) "
+"table"
+msgstr ""
+
+#: templates/archival_storage/archival_storage.html:66
+#, fuzzy
+#| msgid "Download"
+msgid "Download CSV"
+msgstr "Ladda ner"
+
+#: templates/archival_storage/archival_storage.html:75
 msgid ""
 "Sorry, Elasticsearch indexing has been disabled for the AIPs related indexes "
 "in this Archivematica installation. The archival storage tab is non-"
@@ -3904,19 +3941,6 @@ msgstr "Archival Information Package"
 #: templates/archival_storage/view.html:71
 msgid "Date stored"
 msgstr "Datum lagrad"
-
-#: templates/archival_storage/view.html:75
-msgid "Status"
-msgstr "Status"
-
-#: templates/archival_storage/view.html:79
-msgid "Encrypted"
-msgstr "Krypterad"
-
-#: templates/archival_storage/view.html:83
-#: templates/ingest/normalization_report.html:31
-msgid "Location"
-msgstr "Plats"
 
 #: templates/archival_storage/view.html:90
 #, fuzzy
@@ -3974,7 +3998,7 @@ msgid ""
 "functional when indexing is turned off."
 msgstr ""
 
-#: templates/delete_request.html:14
+#: templates/delete_request.html:15
 msgid "Reason for deletion:"
 msgstr "Orsak till radering:"
 
@@ -4024,7 +4048,7 @@ msgstr "AIP"
 #: templates/ingest/grid.html:5 templates/ingest/grid.html:6
 #: templates/ingest/metadata_add_files.html:31
 #: templates/ingest/metadata_edit.html:31
-#: templates/ingest/microservices.html:11 templates/layout.html:60
+#: templates/ingest/microservices.html:11 templates/layout.html:62
 #: templates/rights/rights_edit.html:16
 #: templates/rights/rights_grants_edit.html:16
 #: templates/rights/rights_list.html:9
@@ -4041,7 +4065,7 @@ msgstr "Initialiserar..."
 #: templates/ingest/as/resource_component.html:52
 #: templates/ingest/as/resource_detail.html:42
 #: templates/ingest/as/resource_list.html:34
-#: templates/ingest/as/review_matches.html:29
+#: templates/ingest/as/review_matches.html:30
 msgid "Title"
 msgstr "Titel"
 
@@ -4085,7 +4109,7 @@ msgstr "Förordna objekt till beskrivningar"
 #: templates/ingest/as/resource_detail.html:30
 #: templates/ingest/as/resource_list.html:25
 #: templates/ingest/as/resource_list.html:27
-#: templates/ingest/as/review_matches.html:20
+#: templates/ingest/as/review_matches.html:21
 msgid "Restart matching"
 msgstr "Starta om matchning"
 
@@ -4111,7 +4135,7 @@ msgid "Resources"
 msgstr "Resurser"
 
 #: templates/ingest/as/match.html:100 templates/ingest/as/match.html:118
-#: templates/ingest/as/review_matches.html:28
+#: templates/ingest/as/review_matches.html:29
 msgid "Level"
 msgstr "Nivå"
 
@@ -4119,7 +4143,7 @@ msgstr "Nivå"
 #: templates/ingest/as/resource_component.html:53
 #: templates/ingest/as/resource_detail.html:43
 #: templates/ingest/as/resource_list.html:35
-#: templates/ingest/as/review_matches.html:31
+#: templates/ingest/as/review_matches.html:32
 msgid "Dates"
 msgstr "Datum"
 
@@ -4128,7 +4152,7 @@ msgid "Pairs"
 msgstr "Par"
 
 #: templates/ingest/as/match.html:117
-#: templates/ingest/as/review_matches.html:27
+#: templates/ingest/as/review_matches.html:28
 msgid "File"
 msgstr "Fil"
 
@@ -4167,7 +4191,7 @@ msgstr "Tilldela DIP-objekt till denna resurs"
 msgid "Collections"
 msgstr "Samlingar"
 
-#: templates/ingest/as/review_matches.html:21
+#: templates/ingest/as/review_matches.html:22
 msgid "Finish matching"
 msgstr "Avsluta matchning"
 
@@ -4274,38 +4298,38 @@ msgstr ""
 msgid "Select a directory"
 msgstr "Välj en mapp"
 
-#: templates/ingest/metadata_edit.html:77
-#: templates/transfer/metadata_edit.html:76
+#: templates/ingest/metadata_edit.html:78
+#: templates/transfer/metadata_edit.html:77
 msgid "A name given to the resource."
 msgstr "Ett namn för denna resurs"
 
-#: templates/ingest/metadata_edit.html:81
-#: templates/transfer/metadata_edit.html:80
+#: templates/ingest/metadata_edit.html:82
+#: templates/transfer/metadata_edit.html:81
 msgid "An entity primarily responsible for making the resource."
 msgstr "En entitet som är huvudsakligt ansvarig för att skapa resursen."
 
-#: templates/ingest/metadata_edit.html:85
-#: templates/transfer/metadata_edit.html:84
+#: templates/ingest/metadata_edit.html:86
+#: templates/transfer/metadata_edit.html:85
 msgid "The topic of the resource."
 msgstr "Resursens ämne."
 
-#: templates/ingest/metadata_edit.html:89
-#: templates/transfer/metadata_edit.html:88
+#: templates/ingest/metadata_edit.html:90
+#: templates/transfer/metadata_edit.html:89
 msgid "An account of the resource."
 msgstr "En redogörelse för resursen."
 
-#: templates/ingest/metadata_edit.html:93
-#: templates/transfer/metadata_edit.html:92
+#: templates/ingest/metadata_edit.html:94
+#: templates/transfer/metadata_edit.html:93
 msgid "An entity responsible for making the resource available."
 msgstr "En entitet som ansvarar för att göra resursen tillgänglig."
 
-#: templates/ingest/metadata_edit.html:97
-#: templates/transfer/metadata_edit.html:96
+#: templates/ingest/metadata_edit.html:98
+#: templates/transfer/metadata_edit.html:97
 msgid "An entity responsible for making contributions to the resource."
 msgstr "En entitet som ansvarar för att bidra till resursen."
 
-#: templates/ingest/metadata_edit.html:101
-#: templates/transfer/metadata_edit.html:100
+#: templates/ingest/metadata_edit.html:102
+#: templates/transfer/metadata_edit.html:101
 msgid ""
 "A point or period of time associated with an event in the lifecycle of the "
 "resource."
@@ -4313,13 +4337,13 @@ msgstr ""
 "En punkt eller period av tid som associeras med en händelse i resursens "
 "livscykel."
 
-#: templates/ingest/metadata_edit.html:106
-#: templates/transfer/metadata_edit.html:105
+#: templates/ingest/metadata_edit.html:107
+#: templates/transfer/metadata_edit.html:106
 msgid "The nature or genre of the resource."
 msgstr "Resursens karaktär eller genre."
 
-#: templates/ingest/metadata_edit.html:108
-#: templates/transfer/metadata_edit.html:107
+#: templates/ingest/metadata_edit.html:109
+#: templates/transfer/metadata_edit.html:108
 msgid ""
 "\n"
 "        You may wish to use the DCMI type vocabulary provided here: <a href="
@@ -4333,13 +4357,13 @@ msgstr ""
 "\">http://dublincore.org/documents/dcmi-type-vocabulary/</a>\n"
 "      "
 
-#: templates/ingest/metadata_edit.html:116
-#: templates/transfer/metadata_edit.html:115
+#: templates/ingest/metadata_edit.html:117
+#: templates/transfer/metadata_edit.html:116
 msgid "The file format, physical medium, or dimensions of the resource."
 msgstr "Filformat, fysiskt medium eller dimensioner som resursen har."
 
-#: templates/ingest/metadata_edit.html:118
-#: templates/transfer/metadata_edit.html:117
+#: templates/ingest/metadata_edit.html:119
+#: templates/transfer/metadata_edit.html:118
 msgid ""
 "\n"
 "        Best practice is to use a controlled vocabulary such as the list of "
@@ -4355,28 +4379,28 @@ msgstr ""
 "media-types/</a>\n"
 "      "
 
-#: templates/ingest/metadata_edit.html:125
-#: templates/transfer/metadata_edit.html:124
+#: templates/ingest/metadata_edit.html:126
+#: templates/transfer/metadata_edit.html:125
 msgid "An unambiguous reference to the resource within a given context."
 msgstr "En entydig referens till resursen inom en given kontext."
 
-#: templates/ingest/metadata_edit.html:129
-#: templates/transfer/metadata_edit.html:128
+#: templates/ingest/metadata_edit.html:130
+#: templates/transfer/metadata_edit.html:129
 msgid "A related resource from which the described resource is derived."
 msgstr "En relaterad resurs från vilken den beskrivna resursen är bearbetad."
 
-#: templates/ingest/metadata_edit.html:133
-#: templates/transfer/metadata_edit.html:132
+#: templates/ingest/metadata_edit.html:134
+#: templates/transfer/metadata_edit.html:133
 msgid "A related resource."
 msgstr "En relaterad resurs."
 
-#: templates/ingest/metadata_edit.html:137
-#: templates/transfer/metadata_edit.html:136
+#: templates/ingest/metadata_edit.html:138
+#: templates/transfer/metadata_edit.html:137
 msgid "A language of the resource."
 msgstr "Ett språk för denna resurs."
 
-#: templates/ingest/metadata_edit.html:141
-#: templates/transfer/metadata_edit.html:140
+#: templates/ingest/metadata_edit.html:142
+#: templates/transfer/metadata_edit.html:141
 msgid ""
 "The spatial or temporal topic of the resource, the spatial applicability of "
 "the resource, or the jurisdiction under which the resource is relevant."
@@ -4384,8 +4408,8 @@ msgstr ""
 "Resursens rumsliga eller den tidsmässiga tema, resursens rumsliga "
 "tillämplighet, eller den jurisdiktion under vilken resursen är relevant."
 
-#: templates/ingest/metadata_edit.html:145
-#: templates/transfer/metadata_edit.html:144
+#: templates/ingest/metadata_edit.html:146
+#: templates/transfer/metadata_edit.html:145
 msgid "Information about rights held in and over the resource."
 msgstr "Information om rättigheter som lagras i och över resursen."
 
@@ -4447,15 +4471,15 @@ msgstr ""
 "      Visar %(start_index)s-%(end_index)s av %(total_items)s\n"
 "    "
 
-#: templates/installer/storagesetup.html:25
+#: templates/installer/storagesetup.html:26
 msgid "Register this pipeline in the Storage Service"
 msgstr "Registrera den pipeline i Lagringstjänsten"
 
-#: templates/installer/storagesetup.html:30
+#: templates/installer/storagesetup.html:31
 msgid "Dashboard UUID"
 msgstr "Översiktsvys UUID"
 
-#: templates/installer/storagesetup.html:39
+#: templates/installer/storagesetup.html:40
 msgid "Register"
 msgstr "Registrera"
 
@@ -4479,7 +4503,7 @@ msgstr ""
 msgid "Archivematica Dashboard"
 msgstr "Archivematica översiktsvy"
 
-#: templates/layout.html:55 templates/rights/rights_edit.html:18
+#: templates/layout.html:57 templates/rights/rights_edit.html:18
 #: templates/rights/rights_grants_edit.html:18
 #: templates/rights/rights_list.html:11 templates/transfer/component.html:10
 #: templates/transfer/detail.html:9 templates/transfer/grid.html:5
@@ -4489,19 +4513,19 @@ msgstr "Archivematica översiktsvy"
 msgid "Transfer"
 msgstr "Transfer"
 
-#: templates/layout.html:57
+#: templates/layout.html:59
 msgid "Backlog"
 msgstr "Backlogg"
 
-#: templates/layout.html:64
+#: templates/layout.html:66
 msgid "Preservation planning"
 msgstr "Bevarandeplanering"
 
-#: templates/layout.html:74
+#: templates/layout.html:76
 msgid "Your profile"
 msgstr "Din profil"
 
-#: templates/layout.html:76
+#: templates/layout.html:78
 msgid "Log out"
 msgstr "Logga ut"
 
@@ -4616,28 +4640,28 @@ msgstr ""
 "                  Nytt innehåll tillagt: %(type)s.\n"
 "                "
 
-#: templates/rights/rights_edit.html:96
+#: templates/rights/rights_edit.html:97
 msgid "Copyright documentation identifier:"
 msgstr "Copyrightdokumentations-identifierare:"
 
-#: templates/rights/rights_edit.html:109 templates/rights/rights_edit.html:161
-#: templates/rights/rights_edit.html:211 templates/rights/rights_edit.html:259
+#: templates/rights/rights_edit.html:110 templates/rights/rights_edit.html:162
+#: templates/rights/rights_edit.html:212 templates/rights/rights_edit.html:260
 msgid "Role"
 msgstr "Roll"
 
-#: templates/rights/rights_edit.html:147
+#: templates/rights/rights_edit.html:148
 msgid "Statute documentation identifier:"
 msgstr "Regelverksdokumentations-identifierare:"
 
-#: templates/rights/rights_edit.html:197
+#: templates/rights/rights_edit.html:198
 msgid "License documentation identifier:"
 msgstr "Licensdokumentations-identifierare:"
 
-#: templates/rights/rights_edit.html:245
+#: templates/rights/rights_edit.html:246
 msgid "Documentation identifier"
 msgstr "Dokumentationssignum"
 
-#: templates/rights/rights_edit.html:266
+#: templates/rights/rights_edit.html:267
 msgid "Note"
 msgstr "Anmärkning"
 
@@ -4648,23 +4672,23 @@ msgstr ""
 "Du kan nu lägga till yttreligare information så som dokumentidentifierare "
 "och kommentarer."
 
-#: templates/rights/rights_grants_edit.html:79
+#: templates/rights/rights_grants_edit.html:80
 msgid "Allow"
 msgstr "Tillåt"
 
-#: templates/rights/rights_grants_edit.html:80
+#: templates/rights/rights_grants_edit.html:81
 msgid "Disallow"
 msgstr "Neka"
 
-#: templates/rights/rights_grants_edit.html:81
+#: templates/rights/rights_grants_edit.html:82
 msgid "Conditional"
 msgstr "Villkorlig"
 
-#: templates/rights/rights_grants_edit.html:87
+#: templates/rights/rights_grants_edit.html:88
 msgid "Grant/restriction note"
 msgstr "Anmärkning om anslag/begränsning"
 
-#: templates/rights/rights_grants_edit.html:108
+#: templates/rights/rights_grants_edit.html:109
 msgid "Done"
 msgstr "Avslutad"
 
@@ -4695,6 +4719,21 @@ msgstr "Överföringens metadata"
 #: templates/transfer/grid.html:86
 msgid "Transfer start time"
 msgstr "Överföringens starttid"
+
+#~ msgid "Search administration"
+#~ msgstr "Sök igenom administration"
+
+#~ msgid ""
+#~ "\n"
+#~ "          %(count)s AIP files indexed.\n"
+#~ "        "
+#~ msgstr ""
+#~ "\n"
+#~ "          %(count)s AIP filer indexerades.\n"
+#~ "        "
+
+#~ msgid "Flush AIP Index"
+#~ msgstr "Rensa AIP-index"
 
 #~ msgid "Send transfer to quarantine"
 #~ msgstr "Skicka överföringspaketet till karantän"

--- a/src/dashboard/src/locale/sv/LC_MESSAGES/djangojs.po
+++ b/src/dashboard/src/locale/sv/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 12:27-0400\n"
+"POT-Creation-Date: 2020-07-27 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: August Frihammar <august.frihammar@arkivit.se>, 2017\n"
 "Language-Team: Swedish (https://www.transifex.com/artefactual/teams/1506/"
@@ -28,7 +28,7 @@ msgid "Are you sure you want to delete this level of description?"
 msgstr "Är du säker på att du vill radera denna beskrivningsnivå?"
 
 #: media/js/advanced-search-query-creator.js:14 media/js/file_browser.js:59
-#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:209
+#: media/js/file_browser.js:64 media/js/repeating-ajax-data.js:211
 msgid "Delete"
 msgstr "Radera"
 
@@ -47,7 +47,7 @@ msgid "Any"
 msgstr "Valfri"
 
 #: media/js/archival_storage/archival_storage_search.js:61
-#: media/js/archival_storage/archival_storage_search.js:238
+#: media/js/archival_storage/archival_storage_search.js:242
 msgid "File UUID"
 msgstr "Filens UUID"
 
@@ -106,227 +106,233 @@ msgstr "Fras"
 msgid "Date range"
 msgstr "Datumintervall"
 
-#: media/js/archival_storage/archival_storage_search.js:148
+#: media/js/archival_storage/archival_storage_search.js:152
 msgid "view raw"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:169
+#: media/js/archival_storage/archival_storage_search.js:173
 #: media/js/backlog/backlog-search.js:6 media/js/backlog/backlog-search.js:12
 msgid "Download"
 msgstr "Ladda ner"
 
-#: media/js/archival_storage/archival_storage_search.js:184
+#: media/js/archival_storage/archival_storage_search.js:188
 msgid "AIPs in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:185
+#: media/js/archival_storage/archival_storage_search.js:189
 msgid "AIP in AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:188
+#: media/js/archival_storage/archival_storage_search.js:192
 #, fuzzy
 #| msgid "Part of AIC"
 msgid "Part of"
 msgstr "Del av AIC"
 
-#: media/js/archival_storage/archival_storage_search.js:190
+#: media/js/archival_storage/archival_storage_search.js:194
 msgid "None"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:197
+#: media/js/archival_storage/archival_storage_search.js:201
 msgid "View"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "True"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:210
+#: media/js/archival_storage/archival_storage_search.js:214
 msgid "False"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 msgid "Deletion requested"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:214
+#: media/js/archival_storage/archival_storage_search.js:218
 #: media/js/backlog/backlog-search.js:19
 msgid "Stored"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:236
+#: media/js/archival_storage/archival_storage_search.js:240
 msgid "Thumbnail"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:237
+#: media/js/archival_storage/archival_storage_search.js:241
 #, fuzzy
 #| msgid "Filename"
 msgid "File"
 msgstr "Filnamn"
 
-#: media/js/archival_storage/archival_storage_search.js:239
+#: media/js/archival_storage/archival_storage_search.js:243
 msgid "AIP"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:240
+#: media/js/archival_storage/archival_storage_search.js:244
 #: media/js/backlog/backlog-search.js:42 media/js/backlog/backlog-search.js:53
 #: media/js/ingest/backlog.js:37
 msgid "Accession number"
 msgstr "Accessionsnummer"
 
-#: media/js/archival_storage/archival_storage_search.js:241
-#: media/js/archival_storage/archival_storage_search.js:254
+#: media/js/archival_storage/archival_storage_search.js:245
+#: media/js/archival_storage/archival_storage_search.js:258
 #: media/js/backlog/backlog-search.js:43 media/js/backlog/backlog-search.js:55
 msgid "Status"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:242
-#: media/js/archival_storage/archival_storage_search.js:256
+#: media/js/archival_storage/archival_storage_search.js:246
+#: media/js/archival_storage/archival_storage_search.js:261
 #: media/js/backlog/backlog-search.js:44 media/js/backlog/backlog-search.js:56
-#: media/js/ingest.js:216 media/js/transfer.js:153
+#: media/js/ingest.js:217 media/js/transfer.js:154
 msgid "Actions"
 msgstr "Åtgärder"
 
-#: media/js/archival_storage/archival_storage_search.js:247
+#: media/js/archival_storage/archival_storage_search.js:251
 #: media/js/backlog/backlog-search.js:49
 msgid "Name"
 msgstr "Namn"
 
-#: media/js/archival_storage/archival_storage_search.js:248
+#: media/js/archival_storage/archival_storage_search.js:252
 #, fuzzy
 #| msgid "AIP UUID"
 msgid "UUID"
 msgstr "AIP UUID"
 
-#: media/js/archival_storage/archival_storage_search.js:249
+#: media/js/archival_storage/archival_storage_search.js:253
 msgid "AIC"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:250
+#: media/js/archival_storage/archival_storage_search.js:254
 #: media/js/backlog/backlog-search.js:51
 msgid "Size"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:251
+#: media/js/archival_storage/archival_storage_search.js:255
 #: media/js/backlog/backlog-search.js:52
 msgid "File count"
 msgstr "Filantal"
 
-#: media/js/archival_storage/archival_storage_search.js:252
+#: media/js/archival_storage/archival_storage_search.js:256
 #, fuzzy
 #| msgid "Accession number"
 msgid "Accession numbers"
 msgstr "Accessionsnummer"
 
-#: media/js/archival_storage/archival_storage_search.js:253
+#: media/js/archival_storage/archival_storage_search.js:257
 #, fuzzy
 #| msgid "Create SIP"
 msgid "Created"
 msgstr "Skapa SIP"
 
-#: media/js/archival_storage/archival_storage_search.js:255
+#: media/js/archival_storage/archival_storage_search.js:259
 msgid "Encrypted"
 msgstr ""
 
-#: media/js/archival_storage/archival_storage_search.js:309
-#: media/js/backlog/backlog-search.js:109
+#: media/js/archival_storage/archival_storage_search.js:260
+#, fuzzy
+#| msgid "Actions"
+msgid "Location"
+msgstr "Åtgärder"
+
+#: media/js/archival_storage/archival_storage_search.js:315
+#: media/js/backlog/backlog-search.js:110
 #, fuzzy
 #| msgid "Select an action..."
 msgid "Select columns"
 msgstr "Välj en åtgärd..."
 
-#: media/js/archival_storage/archival_storage_search.js:313
-#: media/js/backlog/backlog-search.js:113
+#: media/js/archival_storage/archival_storage_search.js:319
+#: media/js/backlog/backlog-search.js:114
 msgctxt "DataTable - sEmptyTable"
 msgid "No data available in table"
 msgstr "Ingen data tillgänglig i tabellen"
 
-#: media/js/archival_storage/archival_storage_search.js:314
-#: media/js/backlog/backlog-search.js:114
+#: media/js/archival_storage/archival_storage_search.js:320
+#: media/js/backlog/backlog-search.js:115
 msgctxt "DataTable - sInfo"
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Visar _START_ till _END_ av _TOTAL_ poster"
 
-#: media/js/archival_storage/archival_storage_search.js:315
-#: media/js/backlog/backlog-search.js:115
+#: media/js/archival_storage/archival_storage_search.js:321
+#: media/js/backlog/backlog-search.js:116
 msgctxt "DataTable - sInfoEmpty"
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Visar 0 till 0 av 0 poster"
 
-#: media/js/archival_storage/archival_storage_search.js:316
-#: media/js/backlog/backlog-search.js:116
+#: media/js/archival_storage/archival_storage_search.js:322
+#: media/js/backlog/backlog-search.js:117
 msgctxt "DataTable - sInfoFiltered"
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filterat från totalt _MAX_ poster)"
 
-#: media/js/archival_storage/archival_storage_search.js:318
-#: media/js/backlog/backlog-search.js:118
+#: media/js/archival_storage/archival_storage_search.js:324
+#: media/js/backlog/backlog-search.js:119
 msgctxt "DataTable - sInfoThousands"
 msgid ","
 msgstr ","
 
-#: media/js/archival_storage/archival_storage_search.js:319
-#: media/js/backlog/backlog-search.js:119
+#: media/js/archival_storage/archival_storage_search.js:325
+#: media/js/backlog/backlog-search.js:120
 msgctxt "DataTable - sLengthMenu"
 msgid "Show _MENU_ entries"
 msgstr "Visa _MENU_ poster"
 
-#: media/js/archival_storage/archival_storage_search.js:320
-#: media/js/backlog/backlog-search.js:120
+#: media/js/archival_storage/archival_storage_search.js:326
+#: media/js/backlog/backlog-search.js:121
 msgctxt "DataTable - sLoadingRecords"
 msgid "Loading..."
 msgstr "Laddar..."
 
-#: media/js/archival_storage/archival_storage_search.js:321
-#: media/js/backlog/backlog-search.js:121
+#: media/js/archival_storage/archival_storage_search.js:327
+#: media/js/backlog/backlog-search.js:122
 msgctxt "DataTable - sProcessing"
 msgid "Processing..."
 msgstr "Bearbetar..."
 
-#: media/js/archival_storage/archival_storage_search.js:322
-#: media/js/backlog/backlog-search.js:122
+#: media/js/archival_storage/archival_storage_search.js:328
+#: media/js/backlog/backlog-search.js:123
 msgctxt "DataTable - sSearch"
 msgid "Search:"
 msgstr "Sök:"
 
-#: media/js/archival_storage/archival_storage_search.js:323
-#: media/js/backlog/backlog-search.js:123
+#: media/js/archival_storage/archival_storage_search.js:329
+#: media/js/backlog/backlog-search.js:124
 msgctxt "DataTable - sZeroRecords"
 msgid "No matching records found"
 msgstr "Inga matchande poster hittades"
 
-#: media/js/archival_storage/archival_storage_search.js:325
-#: media/js/backlog/backlog-search.js:125
+#: media/js/archival_storage/archival_storage_search.js:331
+#: media/js/backlog/backlog-search.js:126
 msgctxt "DataTable - sFirst"
 msgid "First"
 msgstr "Först"
 
-#: media/js/archival_storage/archival_storage_search.js:326
-#: media/js/backlog/backlog-search.js:126
+#: media/js/archival_storage/archival_storage_search.js:332
+#: media/js/backlog/backlog-search.js:127
 msgctxt "DataTable - sLast"
 msgid "Last"
 msgstr "Sist"
 
-#: media/js/archival_storage/archival_storage_search.js:327
-#: media/js/backlog/backlog-search.js:127
+#: media/js/archival_storage/archival_storage_search.js:333
+#: media/js/backlog/backlog-search.js:128
 msgctxt "DataTable - sNext"
 msgid "Next"
 msgstr "Nästa"
 
-#: media/js/archival_storage/archival_storage_search.js:328
-#: media/js/backlog/backlog-search.js:128
+#: media/js/archival_storage/archival_storage_search.js:334
+#: media/js/backlog/backlog-search.js:129
 msgctxt "DataTable - sPrevious"
 msgid "Previous"
 msgstr "Föregående"
 
-#: media/js/archival_storage/archival_storage_search.js:331
-#: media/js/backlog/backlog-search.js:131
+#: media/js/archival_storage/archival_storage_search.js:337
+#: media/js/backlog/backlog-search.js:132
 msgctxt "DataTable - sSortAscending"
 msgid ": activate to sort column ascending"
 msgstr ": aktivera för att sortera kolumnen stigande"
 
-#: media/js/archival_storage/archival_storage_search.js:332
-#: media/js/backlog/backlog-search.js:132
+#: media/js/archival_storage/archival_storage_search.js:338
+#: media/js/backlog/backlog-search.js:133
 msgctxt "DataTable - sSortDescending"
 msgid ": activate to sort column descending"
 msgstr ": aktivera för att sortera kolumnen fallande"
@@ -366,7 +372,7 @@ msgid "Yes"
 msgstr "Ja"
 
 #: media/js/directory_picker.js:90 media/js/file_browser.js:178
-#: media/js/ingest.js:123 media/js/jobs.js:590 media/js/jobs.js:683
+#: media/js/ingest.js:124 media/js/jobs.js:590 media/js/jobs.js:686
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -416,43 +422,43 @@ msgstr "Radera SIP"
 msgid "Confirm"
 msgstr "Bekräfta"
 
-#: media/js/ingest.js:145
+#: media/js/ingest.js:146
 msgid "Dublin Core metadata editor"
 msgstr "Dublin Core metadata redigerare"
 
-#: media/js/ingest.js:152 media/js/jobs.js:535
+#: media/js/ingest.js:153 media/js/jobs.js:535
 msgid "Close"
 msgstr "Stäng"
 
-#: media/js/ingest.js:173
+#: media/js/ingest.js:174
 msgid "Error"
 msgstr "Fel"
 
-#: media/js/ingest.js:240
+#: media/js/ingest.js:241
 msgid "Report"
 msgstr "Rapport"
 
-#: media/js/ingest.js:243
+#: media/js/ingest.js:244
 msgid "Match DIP objects to resources"
 msgstr "Matcha DIP-objekt med resurser"
 
-#: media/js/ingest.js:301
+#: media/js/ingest.js:303
 msgid "Loading..."
 msgstr "Laddar..."
 
-#: media/js/ingest/as_matcher.js:551
+#: media/js/ingest/as_matcher.js:553
 msgid "No resource selected."
 msgstr "Inga resurser valda."
 
-#: media/js/ingest/as_matcher.js:558
+#: media/js/ingest/as_matcher.js:560
 msgid "No objects selected."
 msgstr "Inga poster valda."
 
-#: media/js/ingest/as_matcher.js:670
+#: media/js/ingest/as_matcher.js:673
 msgid "Warning"
 msgstr "Varning"
 
-#: media/js/ingest/as_matcher.js:674
+#: media/js/ingest/as_matcher.js:677
 msgid "Dismiss"
 msgstr "Avfärda"
 
@@ -464,15 +470,15 @@ msgstr "Filnamn"
 msgid "Ingest date (YYYY-MM-DD)"
 msgstr "Ingestdatum (ÅÅÅÅ-MM-DD)"
 
-#: media/js/ingest/metadata_form.js:83
+#: media/js/ingest/metadata_form.js:84
 msgid "Browse"
 msgstr "Bläddra"
 
-#: media/js/ingest/metadata_form.js:85
+#: media/js/ingest/metadata_form.js:86
 msgid "Add files"
 msgstr "Lägg till filer"
 
-#: media/js/ingest/metadata_form.js:124
+#: media/js/ingest/metadata_form.js:125
 msgid "Please select at least one metadata file."
 msgstr "Välj minst en metadatafil."
 
@@ -501,34 +507,34 @@ msgstr ""
 msgid "Remove All Completed %ss"
 msgstr "Ta bort alla avslutade %s"
 
-#: media/js/jobs.js:661
+#: media/js/jobs.js:664
 #, javascript-format
 msgid "There were no completed %ss to remove"
 msgstr "Det fanns inga avslutade %s att ta bort"
 
-#: media/js/jobs.js:665
+#: media/js/jobs.js:668
 #, javascript-format
 msgid "Successfully removed the following %ss: %s"
 msgstr "Radering av följande %s: %s lyckad"
 
-#: media/js/jobs.js:671
+#: media/js/jobs.js:674
 #, javascript-format
 msgid "Failed to remove all completed %ss"
 msgstr "Avlägsning av alla avslutade %s misslyckades"
 
-#: media/js/jobs.js:797
+#: media/js/jobs.js:800
 msgid "Previous"
 msgstr "Föregående"
 
-#: media/js/jobs.js:812
+#: media/js/jobs.js:815
 msgid "Next"
 msgstr "Nästa"
 
-#: media/js/jobs.js:850
+#: media/js/jobs.js:853
 msgid "Error trying to connect to database. Trying again..."
 msgstr "Fel under anslutning till databas. Försöker igen..."
 
-#: media/js/jobs.js:900
+#: media/js/jobs.js:903
 msgid "Error trying to connect to MCP server. Trying again..."
 msgstr "Fel under anslutning till MCP-server. Försöker igen..."
 
@@ -544,7 +550,7 @@ msgstr "Laddar"
 msgid "Disconnected"
 msgstr "Frånkopplad"
 
-#: media/js/repeating-ajax-data.js:215
+#: media/js/repeating-ajax-data.js:217
 msgid "Are you sure?"
 msgstr "Är du säker?"
 

--- a/src/dashboard/src/main/management/commands/rebuild_aip_index_from_storage_service.py
+++ b/src/dashboard/src/main/management/commands/rebuild_aip_index_from_storage_service.py
@@ -231,6 +231,11 @@ class Command(DashboardCommand):
             package_info["current_path"], remove_uuid_suffix=True
         )
 
+        aip_location = package_info.get("current_location", "")
+        location_description = storageService.retrieve_storage_location_description(
+            aip_location
+        )
+
         if delete_before_reindexing:
             self.info(
                 "Deleting package {} from 'aips' and 'aipfiles' indices.".format(uuid)
@@ -249,6 +254,7 @@ class Command(DashboardCommand):
                 aip_size=package_info["size"],
                 aips_in_aic=aips_in_aic,
                 encrypted=package_info.get("encrypted", False),
+                location=location_description,
             )
             self.info("Successfully indexed package {}".format(uuid))
             os.remove(mets_download_path)

--- a/src/dashboard/src/main/management/commands/rebuild_elasticsearch_aip_index_from_files.py
+++ b/src/dashboard/src/main/management/commands/rebuild_elasticsearch_aip_index_from_files.py
@@ -145,10 +145,14 @@ def processAIPThenDeleteMETSFile(path, temp_dir, es_client, delete_existing_data
             aips_in_aic = get_aips_in_aic(root, temp_dir, path)
 
     aip_info = storage_service.get_file_info(uuid=aip_uuid)
-
     if not aip_info:
         print("Information not found in Storage Service for AIP UUID: ", aip_uuid)
         return 1
+
+    aip_location = aip_info[0].get("current_location", "")
+    location_description = storage_service.retrieve_storage_location_description(
+        aip_location
+    )
 
     return elasticSearchFunctions.index_aip_and_files(
         client=es_client,
@@ -159,6 +163,7 @@ def processAIPThenDeleteMETSFile(path, temp_dir, es_client, delete_existing_data
         aip_size=aip_info[0]["size"],
         aips_in_aic=aips_in_aic,
         identifiers=[],  # TODO get these
+        location=location_description,
     )
 
 

--- a/src/dashboard/src/media/css/archival_storage.css
+++ b/src/dashboard/src/media/css/archival_storage.css
@@ -124,3 +124,10 @@ div.search-summary p {
 #create-aic-btn {
   margin-bottom: 10px;
 }
+
+#download-csv-btn {
+  float: right;
+  border: none;
+  background: none;
+  margin-top: 10px;
+}

--- a/src/dashboard/src/requirements/base.in
+++ b/src/dashboard/src/requirements/base.in
@@ -20,6 +20,7 @@ lazy-paged-sequence
 lxml==3.5.0
 metsrw==0.3.15
 mysqlclient==1.4.6
+pandas==0.24.2
 pytz
 pyopenssl
 python-dateutil==2.6.0

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -39,16 +39,18 @@ lxml==3.5.0               # via -r base.in, metsrw
 metsrw==0.3.15            # via -r base.in
 mysqlclient==1.4.6        # via -r base.in, agentarchives
 ndg-httpsclient==0.5.1    # via -r base.in
+numpy==1.16.6             # via pandas
+pandas==0.24.2            # via -r base.in
 pathlib2==2.3.4           # via -r base.in
 prometheus-client==0.7.1  # via -r base.in, django-prometheus
 pyasn1-modules==0.2.8     # via python-ldap
 pyasn1==0.4.8             # via -r base.in, ndg-httpsclient, pyasn1-modules, python-ldap
 pycparser==2.20           # via cffi
 pyopenssl==19.1.0         # via -r base.in, ndg-httpsclient
-python-dateutil==2.6.0    # via -r base.in, django-tastypie
+python-dateutil==2.6.0    # via -r base.in, django-tastypie, pandas
 python-ldap==3.2.0        # via -r base.in, django-auth-ldap
 python-mimeparse==1.6.0   # via django-tastypie
-pytz==2020.1              # via -r base.in, django
+pytz==2020.1              # via -r base.in, django, pandas
 requests==2.21.0          # via -r base.in, agentarchives, amclient
 scandir==1.10.0           # via -r base.in, pathlib2
 six==1.15.0               # via amclient, cryptography, django-extensions, metsrw, pathlib2, pyopenssl, python-dateutil

--- a/src/dashboard/src/requirements/dev.txt
+++ b/src/dashboard/src/requirements/dev.txt
@@ -61,7 +61,9 @@ mockldap==0.2.8           # via -r test.txt
 more-itertools==5.0.0     # via -r test.txt, pytest
 mysqlclient==1.4.6        # via -r test.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r test.txt
+numpy==1.16.6             # via -r test.txt, pandas
 packaging==20.4           # via -r test.txt, pytest, tox
+pandas==0.24.2            # via -r test.txt
 pathlib2==2.3.4           # via -r test.txt, importlib-metadata, importlib-resources, ipython, pickleshare, pytest, pytest-django, virtualenv
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
@@ -82,10 +84,10 @@ pytest-django==3.9.0      # via -r test.txt
 pytest-mock==2.0.0        # via -r dev.in, -r test.txt
 pytest-pythonpath==0.7.3  # via -r test.txt
 pytest==4.6.11            # via -r dev.in, -r test.txt, pytest-cov, pytest-django, pytest-mock, pytest-pythonpath
-python-dateutil==2.6.0    # via -r test.txt, django-tastypie
+python-dateutil==2.6.0    # via -r test.txt, django-tastypie, pandas
 python-ldap==3.2.0        # via -r test.txt, django-auth-ldap, mockldap
 python-mimeparse==1.6.0   # via -r test.txt, django-tastypie
-pytz==2020.1              # via -r test.txt, django
+pytz==2020.1              # via -r test.txt, django, pandas
 pyyaml==5.3.1             # via -r test.txt, vcrpy
 requests==2.21.0          # via -r test.txt, agentarchives, amclient
 scandir==1.10.0           # via -r test.txt, pathlib2

--- a/src/dashboard/src/requirements/production.txt
+++ b/src/dashboard/src/requirements/production.txt
@@ -39,16 +39,18 @@ lxml==3.5.0               # via -r base.txt, metsrw
 metsrw==0.3.15            # via -r base.txt
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r base.txt
+numpy==1.16.6             # via -r base.txt, pandas
+pandas==0.24.2            # via -r base.txt
 pathlib2==2.3.4           # via -r base.txt
 prometheus-client==0.7.1  # via -r base.txt, django-prometheus
 pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
 pyasn1==0.4.8             # via -r base.txt, ndg-httpsclient, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r base.txt, cffi
 pyopenssl==19.1.0         # via -r base.txt, ndg-httpsclient
-python-dateutil==2.6.0    # via -r base.txt, django-tastypie
+python-dateutil==2.6.0    # via -r base.txt, django-tastypie, pandas
 python-ldap==3.2.0        # via -r base.txt, django-auth-ldap
 python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
-pytz==2020.1              # via -r base.txt, django
+pytz==2020.1              # via -r base.txt, django, pandas
 requests==2.21.0          # via -r base.txt, agentarchives, amclient
 scandir==1.10.0           # via -r base.txt, pathlib2
 six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, metsrw, pathlib2, pyopenssl, python-dateutil

--- a/src/dashboard/src/requirements/test.txt
+++ b/src/dashboard/src/requirements/test.txt
@@ -55,7 +55,9 @@ mockldap==0.2.8           # via -r test.in
 more-itertools==5.0.0     # via pytest
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r base.txt
+numpy==1.16.6             # via -r base.txt, pandas
 packaging==20.4           # via pytest, tox
+pandas==0.24.2            # via -r base.txt
 pathlib2==2.3.4           # via -r base.txt, importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
 pluggy==0.13.1            # via pytest, tox
 prometheus-client==0.7.1  # via -r base.txt, django-prometheus
@@ -70,10 +72,10 @@ pytest-django==3.9.0      # via -r test.in
 pytest-mock==2.0.0        # via -r test.in
 pytest-pythonpath==0.7.3  # via -r test.in
 pytest==4.6.11            # via -r test.in, pytest-cov, pytest-django, pytest-mock, pytest-pythonpath
-python-dateutil==2.6.0    # via -r base.txt, django-tastypie
+python-dateutil==2.6.0    # via -r base.txt, django-tastypie, pandas
 python-ldap==3.2.0        # via -r base.txt, django-auth-ldap, mockldap
 python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
-pytz==2020.1              # via -r base.txt, django
+pytz==2020.1              # via -r base.txt, django, pandas
 pyyaml==5.3.1             # via vcrpy
 requests==2.21.0          # via -r base.txt, agentarchives, amclient
 scandir==1.10.0           # via -r base.txt, pathlib2

--- a/src/dashboard/src/templates/archival_storage/archival_storage.html
+++ b/src/dashboard/src/templates/archival_storage/archival_storage.html
@@ -61,6 +61,11 @@
       {% trans "Create an AIC" %}
     </button>
 
+    <a id="download-csv-btn" class="btn btn-default fa-download fa"
+      title="{% trans 'Download all results from archival storage as a CSV (Comma-separated-values) table' %}">
+      <span class="button-text-span">{% trans "Download CSV" %}</span>
+    </a>
+
     <table id="archival-storage-entries">
     </table>
 


### PR DESCRIPTION
Enable download of complete Archival Storage Elasticsearch results as CSV and enables display of storage location

This series of commits adds two new features as well as tests to:

* Download the AIP Elasticsearch index as CSV.
* Enable display of storage location in the Archival Storage tab. 

Connected to archivematica/issues#1213
Connected to archivematica/issues#1214
Relies on https://github.com/artefactual/archivematica/pull/1625