### PR TITLE
Lower-case transfer package_type

### DIFF
--- a/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
+++ b/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
@@ -218,7 +218,7 @@ class Command(DashboardCommand):
 
         :returns: None
         """
-        transfers = storageService.get_file_info(package_type="Transfer")
+        transfers = storageService.get_file_info(package_type="transfer")
         filtered_transfers = am.filter_packages_by_status_and_pipeline(
             transfers, pipeline_uuid=pipeline_uuid
         )


### PR DESCRIPTION
Fixes a typo introduced in PR https://github.com/artefactual/archivematica/pull/1624 which was preventing rebuild_transfer_index from returning package information from the Storage Service when run with the `--from-storage-service` argument.

Connected to https://github.com/archivematica/issues/issues/734.