### PR TITLE
Fix bugs in new task for reindexing AIPs from Storage Service

### DIFF
--- a/src/archivematicaCommon/lib/archivematicaFunctions.py
+++ b/src/archivematicaCommon/lib/archivematicaFunctions.py
@@ -534,26 +534,3 @@ def relative_path_to_aip_mets_file(uuid, current_path):
     mets_name = "METS.{}.xml".format(uuid)
     mets_path = "{}/data/{}".format(package_name_without_extensions, mets_name)
     return mets_path
-
-
-def filter_packages_by_status_and_pipeline(
-    package_list, valid_statuses=("UPLOADED", "DEL_REQ"), pipeline_uuid=None
-):
-    """Filter packages by status and origin pipeline.
-
-    :param package_list: List of package info returned by Storage
-    Service (list).
-    :param valid_statuses: Acceptable statuses for filter (tuple).
-    :param pipeline_uuid: Acceptable pipeline UUID for filter (str).
-
-    :returns: Filtered package list.
-    """
-    if pipeline_uuid is None:
-        pipeline_uuid = get_dashboard_uuid()
-    origin_pipeline = "/api/v2/pipeline/{}/".format(pipeline_uuid)
-    return [
-        package
-        for package in package_list
-        if package["status"] in valid_statuses
-        and package["origin_pipeline"] == origin_pipeline
-    ]

--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -562,3 +562,44 @@ def download_package(package_uuid, download_directory):
     if local_filename is None:
         raise Error("Unable to download package {}".format(local_filename))
     return local_filename
+
+
+def filter_packages(
+    package_list,
+    statuses=("UPLOADED", "DEL_REQ"),
+    package_types=("AIP", "AIC", "transfer", "DIP"),
+    pipeline_uuid=None,
+    filter_replicas=False,
+):
+    """Filter packages by status and origin pipeline.
+
+    :param package_list: List of package info returned by Storage
+    Service (list).
+    :param statuses: Acceptable statuses for filter (tuple). Defaults
+    to filtering out deleted packages.
+    :param package_types: Acceptable package types for filter (tuple).
+    :param pipeline_uuid: Acceptable pipeline UUID for filter (str).
+    :param filter_replicas: Option to filter out replicas (bool).
+
+    :returns: Filtered package list.
+    """
+    if pipeline_uuid is None:
+        pipeline_uuid = am.get_dashboard_uuid()
+    origin_pipeline = "/api/v2/pipeline/{}/".format(pipeline_uuid)
+
+    if filter_replicas:
+        return [
+            package
+            for package in package_list
+            if package["status"] in statuses
+            and package["package_type"] in package_types
+            and package["origin_pipeline"] == origin_pipeline
+            and package["replicated_package"] is None
+        ]
+    return [
+        package
+        for package in package_list
+        if package["status"] in statuses
+        and package["package_type"] in package_types
+        and package["origin_pipeline"] == origin_pipeline
+    ]

--- a/src/dashboard/src/main/management/commands/__init__.py
+++ b/src/dashboard/src/main/management/commands/__init__.py
@@ -57,7 +57,7 @@ def setup_es_for_aip_reindexing(cmd, delete_all=False):
     except ElasticsearchException as err:
         raise CommandError("Unable to connect to Elasticsearch: %s".format(err))
 
-    if delete_all is True:
+    if delete_all:
         cmd.info("Deleting all AIPs in the 'aips' and 'aipfiles' indices")
         time.sleep(3)  # Time for the user to panic and kill the process.
         indices = [es.AIPS_INDEX, es.AIP_FILES_INDEX]

--- a/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
+++ b/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
@@ -219,7 +219,7 @@ class Command(DashboardCommand):
         :returns: None
         """
         transfers = storageService.get_file_info(package_type="transfer")
-        filtered_transfers = am.filter_packages_by_status_and_pipeline(
+        filtered_transfers = storageService.filter_packages(
             transfers, pipeline_uuid=pipeline_uuid
         )
         processed = 0


### PR DESCRIPTION
Fixes two bugs in the new AIP reindexing command added in commit 443fc2e66a101a0160951f06fa2f3a01717c9ce0:

* The task was not previously filtering out replicated AIPs, which was leading to a `lxml.etree.XMLSyntaxError` error for replicated AIPs during indexing (specifically, in the `index_aips_and_files` function in `elasticSearchFunctions.py`)
* The `--uuid` flag to reindex a single AIP was throwing an `AttributeError` because it was trying to get a property from a list, rather than from the first member of that list, and was incorrectly expecting `process_package` to return a tuple rather than a boolean.

Bugs addressed in this PR:
* https://github.com/archivematica/Issues/issues/1262
* https://github.com/archivematica/Issues/issues/1263

Connected to https://github.com/archivematica/issues/issues/734