### PR TITLE
Fix arrangement of transfers with BagIt logs/metadata

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/urls.py
+++ b/src/dashboard/src/components/filesystem_ajax/urls.py
@@ -40,6 +40,10 @@ urlpatterns = [
         name="create_directory_within_arrange",
     ),
     url(r"^copy_to_arrange/$", views.copy_to_arrange, name="copy_to_arrange"),
-    url(r"^copy_from_arrange/$", views.copy_from_arrange_to_completed),
+    url(
+        r"^copy_from_arrange/$",
+        views.copy_from_arrange_to_completed,
+        name="copy_from_arrange",
+    ),
     url(r"^copy_metadata_files/$", views.copy_metadata_files),
 ]

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -474,7 +474,9 @@ def copy_from_arrange_to_completed(
     """
     if filepath is None:
         filepath = b64decode_string(request.POST.get("filepath", ""))
-    logger.info("copy_from_arrange_to_completed: filepath: %s", filepath)
+    logger.info(
+        "copy_from_arrange_to_completed: filepath: %s, sip_uuid: %s", filepath, sip_uuid
+    )
     # can optionally pass in the UUID to an unstarted SIP entity
     if sip_uuid is None:
         sip_uuid = request.POST.get("uuid")
@@ -549,14 +551,14 @@ def copy_from_arrange_to_completed_common(filepath, sip_uuid, sip_name):
             ).split("/", 1)
             transfer_name = transfer_parts[0]
             # Determine if the transfer is a BagIt package
-            is_bagit = True if transfer_parts[1].startswith(u"data/objects") else False
+            is_bagit = transfer_parts[1].startswith(u"data/")
             # Copy metadata & logs to tmp/, where later scripts expect
             for directory in ("logs", "metadata"):
-                source = [DEFAULT_BACKLOG_PATH, transfer_name, directory]
+                source = [DEFAULT_BACKLOG_PATH, transfer_name, directory, "."]
                 if is_bagit:
                     source.insert(2, "data")
                 file_ = {
-                    "source": os.path.join(os.path.sep.join(source), "."),
+                    "source": os.path.join(*source),
                     "destination": os.path.join(
                         "tmp",
                         "transfer-{}".format(arranged_file.transfer_uuid),

--- a/src/dashboard/tests/test_cas.py
+++ b/src/dashboard/tests/test_cas.py
@@ -7,11 +7,7 @@ from django.test import TestCase, RequestFactory
 from django.test.client import Client
 from django.urls import reverse
 import pytest
-
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+import mock
 
 from components import helpers
 from components.accounts.backends import CustomCASBackend


### PR DESCRIPTION
`copy_from_arrange_to_completed_common` commands Storage Service to copy the
arranged contents into a new SIP. Additionally, this function copies the
corresponding logs and metadata contents from the original transfers. The latter
requires to know whether the transfer(s) are in BagIt format since the accessor
would be different, i.e. BagIt packages include a payload directory (data) not
used in old-style transfers.

`data/objects/forkleaf-sundew.jpg` or `data/objects/roundleaf-sundew.jpg` are
two examples of files that this function successfully identifies as members of
BagIt transfers because they're found inside the "data" payload directory.
However, this function fails to identify BagIt transfers when arranging files
such `data/logs/BagIt/bagit.txt` or `data/metadata/manifest-md5.txt`, which can
be found in transfers originally submitted to Archivematica in BagIt format.

This commit fixes the identification routine so the format of the transfer is
identified consistently.

Fixes https://github.com/archivematica/Issues/issues/1267.