### PR TITLE
fpr: stop using get_all_related_objects

### DIFF
--- a/src/dashboard/src/fpr/tests/test_views.py
+++ b/src/dashboard/src/fpr/tests/test_views.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.test import TestCase
 
 from components import helpers
-from fpr.models import FPTool, IDTool
+from fpr.models import FPTool, IDTool, FPCommand
 
 
 class TestViews(TestCase):
@@ -48,3 +48,14 @@ class TestViews(TestCase):
 
         resp = self.client.get(url, {"parent": tool.uuid})
         self.assertEqual(resp.context["form"].initial["tool"], tool)
+
+    def test_fpcommand_delete(self):
+        fpcommand_id = "0fd7935a-ed0d-4f67-aa25-1b44684f6aca"
+        url = reverse("fpr:fpcommand_delete", args=[fpcommand_id])
+
+        self.assertEqual(FPCommand.active.filter(uuid=fpcommand_id).exists(), True)
+
+        resp = self.client.post(url, follow=True, data={"disable": True})
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(FPCommand.active.filter(uuid=fpcommand_id).exists(), False)

--- a/src/dashboard/src/fpr/utils.py
+++ b/src/dashboard/src/fpr/utils.py
@@ -11,7 +11,12 @@ from django.utils.translation import ugettext as _
 
 def dependent_objects(object_):
     """ Returns all the objects that rely on 'object_'. """
-    links = [rel.get_accessor_name() for rel in object_._meta.get_all_related_objects()]
+    related_objects = [
+        f
+        for f in object_._meta.get_fields()
+        if (f.one_to_many or f.one_to_one) and f.auto_created and not f.concrete
+    ]
+    links = [rel.get_accessor_name() for rel in related_objects]
     dependent_objects = []
     for link in links:
         linked_objects = getattr(object_, link).all()


### PR DESCRIPTION
Django 1.10 removed a number of methods from Model._meta (fair since it was a private API). We were using `get_all_related_objects`, now gone, but this commit replaces it as described in the migration guide.

https://docs.djangoproject.com/en/1.10/ref/models/meta/#migrating-from-the-old-api
> **`MyModel._meta.get_all_related_objects()`** becomes:
> ```
> [
>    f for f in MyModel._meta.get_fields()
>    if (f.one_to_many or f.one_to_one)
>    and f.auto_created and not f.concrete
> ]
> ```

Fixes https://github.com/archivematica/Issues/issues/1276.