### PR TITLE
Report size even if du returns non-zero exit code

### DIFF
--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -392,12 +392,16 @@ def _usage_get_directory_used_bytes(path):
         # the archivematica user doesn't have permissions. In this case
         # du still prints an output to stdout so we try to catch it
         # from CalledProcessError.output.
-        logger.warning(
-            "Non-zero exit code while determining usage of %s. Some directories may be missing from total.",
-            path,
-        )
-        byte_count = err.output.split("\t")[0]
-        return byte_count if byte_count else 0
+        byte_count = 0
+        try:
+            byte_count = int(err.output.split("\t")[0])
+            logger.warning(
+                "Non-zero exit code while determining usage of %s. Some directories may be missing from total.",
+                path,
+            )
+        except (AttributeError, ValueError):
+            logger.exception("Unable to determine usage of %s.", path)
+        return byte_count
 
 
 def _usage_clear_context(request, dir_id):

--- a/src/dashboard/src/components/administration/views.py
+++ b/src/dashboard/src/components/administration/views.py
@@ -396,7 +396,8 @@ def _usage_get_directory_used_bytes(path):
         try:
             byte_count = int(err.output.split("\t")[0])
             logger.warning(
-                "Non-zero exit code while determining usage of %s. Some directories may be missing from total.",
+                "Non-zero exit code while determining usage of %s. "
+                "Some directories may be missing from total.",
                 path,
             )
         except (AttributeError, ValueError):


### PR DESCRIPTION
When `du` encounters directories for which it doesn't have permissions it returns an exit code of 1, causing `subprocess.check_output` to throw a `CalledProcessError`. This results in `usage_get_directory_used_bytes` returning 0 when run against a directory containing any files or sudirectories for which the `archivematica` user doesn't have permissions, and ultimately in the Dashboard's "Processing storage usage" page reporting that 0 bytes are used on disk:

![image](https://user-images.githubusercontent.com/6758804/90160663-16f56000-dd60-11ea-9d94-015282647c1e.png)

This commit modifies how a non-zero `du` exit code is handled. Now, a warning is logged but the bytes reported by `du` are read from `CalledProcessError.output` so that the total number of bytes in directories the archivematica user can access is still reported in the "Processing storage usage" page. We default to 0 only if `du` did not print a byte count to stdout.

Note that that directories and files for which `archivematica` doesn't have permissions won't be included in the total, meaning that the size reported won't be 100% accurate. Changes to deployments (namely, mounting storage at a directory such as `/var/archivematica` rather than at root) may also be required to circumvent this problem fully.

Connected to https://github.com/archivematica/Issues/issues/1281