### PR TITLE
MCPServer: enqueue next job after decisions are processed

### DIFF
--- a/src/MCPServer/lib/server/queues.py
+++ b/src/MCPServer/lib/server/queues.py
@@ -229,6 +229,7 @@ class PackageQueue(object):
             return
         elif isinstance(next_job, DecisionJob) and next_job.awaiting_decision:
             self.await_decision(next_job)
+            self.queue_next_job()
         else:
             self.schedule_job(next_job)
 
@@ -349,7 +350,7 @@ class PackageQueue(object):
             return self.waiting_choices.copy()
 
     def decide(self, job_uuid, choice, user_id=None):
-        """Make a decsion on a job waiting for user input.
+        """Make a decision on a job waiting for user input.
         """
         job_uuid = six.text_type(job_uuid)
 


### PR DESCRIPTION
This commit updates the job completion callback so work can be continued when another package is awaiting.

It needs to be tested before merging.

Connects to https://github.com/archivematica/Issues/issues/1306.