### PR TITLE
Cherry Pick `d60f60` target: 1.12.1 (Fix the use of the Dashboard's polling interval)

### DIFF
--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -204,6 +204,14 @@ variables or in the gunicorn configuration file.
     - **Type:** `float`
     - **Default:** `300`
 
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_POLLING_INTERVAL`**:
+    - **Description:** describes the interval (in seconds) at which the
+    dashboard client will request an update from the server, e.g. to refresh
+    the microservice jobs display.
+    - **Config file example:** `Dashboard.polling_interval`
+    - **Type:** `integer`
+    - **Default:** `10`
+
 - **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_PROMETHEUS_ENABLED`**:
     - **Description:** Determines if Prometheus metrics should be collected.
     - **Config file example:** `Dashboard.prometheus_enabled`
@@ -363,7 +371,7 @@ variables or in the gunicorn configuration file.
 - **`AM_GUNICORN_WORKERS`**:
     - **Description:** Number of gunicorn worker processes to run.  Note that since Archivematica
     installations typically run many processes on the same system, a lower number of workers than
-    Gunicorn recommends should be used. See [WORKERS](http://docs.gunicorn.org/en/stable/settings.html#workers) and [How Many Workers?](https://docs.gunicorn.org/en/stable/design.html#how-many-workers) for more details. 
+    Gunicorn recommends should be used. See [WORKERS](http://docs.gunicorn.org/en/stable/settings.html#workers) and [How Many Workers?](https://docs.gunicorn.org/en/stable/design.html#how-many-workers) for more details.
     - **Type:** `integer`
     - **Default:** `3`
 

--- a/src/dashboard/src/media/js/jobs.js
+++ b/src/dashboard/src/media/js/jobs.js
@@ -586,8 +586,30 @@ var BaseJobView = Backbone.View.extend({
           // clone action selector
           var $proxySelect = $select.clone().css({'width': '100%'});
 
+          modalDlg = `
+            <div class="modal" id="big-choice-select-modal">
+              <div class="modal-dialog">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <button type="button" class="close" id="big-choice-select-close" data-dismiss="modal">×</button>
+                    <h3>
+          ` + gettext('Select an action...') + `
+                    </h3>
+                  </div>
+                  <div class="modal-body" id="big-choice-select-body">
+                  </div>
+                  <div class="modal-footer">
+                    <a href="#" class="btn btn-default" data-dismiss="modal" id="big-choice-select-cancel">
+          ` + gettext('Cancel') + `
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          `;
+
           // display action selector in modal window
-          $('<div class="modal" id="big-choice-select-modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="close" id="big-choice-select-close" data-dismiss="modal">×</button><h3>' + gettext('Select an action...') + '</h3></div><div class="modal-body" id="big-choice-select-body"></div><div class="modal-footer"><a href="#" class="btn btn-default" data-dismiss="modal" id="big-choice-select-cancel">' + gettext('Cancel') + '</a></div></div></div></div>').modal({show: true, backdrop: 'static'});
+          $(modalDlg).modal({show: true, backdrop: 'static'});
           $('#big-choice-select-body').append($proxySelect);
 
           // style clone as Select2
@@ -621,8 +643,6 @@ var BaseJobView = Backbone.View.extend({
 });
 
 BaseAppView = Backbone.View.extend({
-
-  interval: window.pollingInterval ? window.pollingInterval * 1000: 5000,
 
   idle: false,
 
@@ -693,6 +713,12 @@ BaseAppView = Backbone.View.extend({
 
   initialize: function(options)
     {
+      const milliseconds = 1000;
+      const defaultPollingInterval = 10000;
+
+      this.interval = window.pollingInterval ? window.pollingInterval * milliseconds : defaultPollingInterval;
+      console.log("".concat("Polling interval configured as: ", this.interval));
+
       this.statusUrl = options.statusUrl;
 
       _.bindAll(this, 'add', 'remove');

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -98,6 +98,11 @@ CONFIG_MAPPING = {
         "option": "agentarchives_client_timeout",
         "type": "float",
     },
+    "polling_interval": {
+        "section": "Dashboard",
+        "option": "polling_interval",
+        "type": "int",
+    },
     "prometheus_enabled": {
         "section": "Dashboard",
         "option": "prometheus_enabled",
@@ -143,6 +148,7 @@ storage_service_client_timeout = 86400
 storage_service_client_quick_timeout = 5
 agentarchives_client_timeout = 300
 prometheus_enabled = False
+polling_interval = 10
 site_url =
 time_zone = UTC
 
@@ -437,8 +443,8 @@ else:
 
 # Dashboard internal settings
 GEARMAN_SERVER = config.get("gearman_server")
-POLLING_INTERVAL = 5  # Seconds
-STATUS_POLLING_INTERVAL = 5  # Seconds
+POLLING_INTERVAL = config.get("polling_interval")
+
 TASKS_PER_PAGE = 10  # for paging in tasks dialog
 UUID_REGEX = "[\w]{8}(-[\w]{4}){3}-[\w]{12}"
 


### PR DESCRIPTION
This fix collects a number of smaller commits that work toward
improving how often the Dashboard communicates  with the
Archivematica back-end to request information.

We now use the jobs.js constructor to set Jobs polling interval.
The class constructor is called after the window is ready which means
that we can safely use it to set the polling interval where
previously the change in the dashboard to the Django setting
POLLING_INTERVAL would have no effect.

The modal dialog has been cleaned up. As this is a good opportunity
to do that while testing.

A previously unused application setting was removed. Per the original
ticket archivematica/issues#1017 and with a full search of the code,
this setting is unused and looks to be the remnants of a past
long-gone 🦕.

The polling interval default has been upped to 10 and can now be
configured in the system's environment. The README has been
updated to reflect this.

Connected to archivematica/issues#1017