### PR TITLE
Add configurable password validation to Archivematica

### DIFF
--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -162,6 +162,30 @@ variables or in the gunicorn configuration file.
     - **Type:** `string`
     - **Default:** `127.0.0.1:4730`
 
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_PASSWORD_MINIMUM_LENGTH`**:
+    - **Description:** sets minimum length for user passwords.
+    - **Config file example:** `Dashboard.password_minimum_length`
+    - **Type:** `integer`
+    - **Default:** `8`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_PASSWORD_DISABLE_COMMON_VALIDATION`**:
+    - **Description:** disables password validation that prevents users from using passwords that occur in a [list of common passwords](https://github.com/django/django/blob/stable/1.11.x/django/contrib/auth/common-passwords.txt.gz).
+    - **Config file example:** `Dashboard.password_disable_common_validation`
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_PASSWORD_DISABLE_USER_ATTRIBUTE_SIMILARITY_VALIDATION`**:
+    - **Description:** disables password validation that prevents users from using passwords that are too similar to their username and other user attributes.
+    - **Config file example:** `Dashboard.password_disable_user_attribute_similarity_validation`
+    - **Type:** `boolean`
+    - **Default:** `false`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_PASSWORD_DISABLE_COMPLEXITY_VALIDATION`**:
+    - **Description:** disables password validation that checks that passwords contain at least three of: lower-case characters, upper-case characters, numbers, special characters.
+    - **Config file example:** `Dashboard.password_disable_complexity_validation`
+    - **Type:** `boolean`
+    - **Default:** `false`
+
 - **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_SHIBBOLETH_AUTHENTICATION`**:
     - **Description:** enables the Shibboleth authentication system.
     - **Config file example:** `Dashboard.shibboleth_authentication`

--- a/src/dashboard/src/components/accounts/validators.py
+++ b/src/dashboard/src/components/accounts/validators.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import six
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext as _
+
+
+class PasswordComplexityValidator(object):
+    """Custom password complexity validator.
+
+    To pass validation, passwords must contain at least three of:
+    - uppercase characters
+    - lowercase characters
+    - numbers
+    - special characters
+    """
+
+    HELP_TEXT = _(
+        "Your password must contain at least 3 of: uppercase characters, "
+        "lowercase characters, numbers, and special characters (symbols or "
+        "non-alphanumeric Unicode characters)."
+    )
+
+    def validate(self, password, user=None):
+        type_count = 0
+
+        has_lower = False
+        has_upper = False
+        has_number = False
+        has_special = False
+
+        unicode_password = six.ensure_text(password, errors="ignore")
+        for char in unicode_password:
+            if char.islower():
+                has_lower = True
+            elif char.isupper():
+                has_upper = True
+            elif char.isdigit():
+                has_number = True
+            else:
+                has_special = True
+
+        CHARACTER_TYPES = (has_lower, has_upper, has_number, has_special)
+        type_count = sum(val is True for val in CHARACTER_TYPES)
+
+        if type_count < 3:
+            raise ValidationError(self.HELP_TEXT, code="notcomplex")
+
+    def get_help_text(self):
+        return self.HELP_TEXT

--- a/src/dashboard/src/locale/en/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-27 22:10+0000\n"
+"POT-Creation-Date: 2021-01-12 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,17 +17,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: components/accounts/validators.py:20
+msgid ""
+"Your password must contain at least 3 of: uppercase characters, lowercase "
+"characters, numbers, and special characters (symbols or non-alphanumeric "
+"Unicode characters)."
+msgstr ""
+
 #: components/accounts/views.py:61 components/accounts/views.py:149
-#: components/administration/views.py:454
-#: components/administration/views.py:469
-#: components/administration/views.py:481
-#: components/administration/views.py:508
-#: components/administration/views.py:555
+#: components/administration/views.py:468
+#: components/administration/views.py:483
+#: components/administration/views.py:495
+#: components/administration/views.py:522
+#: components/administration/views.py:569
 #: components/administration/views_dip_upload.py:25
-#: components/administration/views_dip_upload.py:39 fpr/views.py:106
-#: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
-#: fpr/views.py:433 fpr/views.py:527 fpr/views.py:535 fpr/views.py:602
-#: fpr/views.py:656
+#: components/administration/views_dip_upload.py:39 fpr/views.py:105
+#: fpr/views.py:112 fpr/views.py:149 fpr/views.py:300 fpr/views.py:341
+#: fpr/views.py:432 fpr/views.py:526 fpr/views.py:534 fpr/views.py:601
+#: fpr/views.py:655
 msgid "Saved."
 msgstr ""
 
@@ -364,7 +371,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:1021
+#: components/administration/forms_dip_upload.py:21 main/models.py:1033
 msgid "Other"
 msgstr ""
 
@@ -548,7 +555,7 @@ msgid "Used in metadata-only DIP upload."
 msgstr ""
 
 #: components/administration/views.py:89 components/administration/views.py:122
-#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
+#: components/ingest/views.py:287 fpr/views.py:260 main/views.py:307
 msgid "Deleted."
 msgstr ""
 
@@ -606,34 +613,34 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:404
+#: components/administration/views.py:418
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:406
+#: components/administration/views.py:420
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr ""
 
-#: components/administration/views.py:431
+#: components/administration/views.py:445
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:434
+#: components/administration/views.py:448
 #, python-format
 msgid "No such file or directory: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:571
+#: components/administration/views.py:585
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
 "Storage Sevice URL below.<hr />%(error)s"
 msgstr ""
 
-#: components/administration/views.py:588
+#: components/administration/views.py:602
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -641,7 +648,7 @@ msgid ""
 "%(error)s"
 msgstr ""
 
-#: components/administration/views.py:600
+#: components/administration/views.py:614
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -710,7 +717,7 @@ msgid "Please type in the UUID to confirm"
 msgstr ""
 
 #: components/archival_storage/forms.py:89
-#: components/archival_storage/views.py:210
+#: components/archival_storage/views.py:204
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -748,84 +755,84 @@ msgstr ""
 msgid "Deletion requested"
 msgstr ""
 
-#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: components/archival_storage/views.py:203 templates/accounts/list.html:24
 #: templates/accounts/profile.html:31
 #: templates/administration/atom_levels_of_description.html:37
 #: templates/administration/reports/failures.html:26
 msgid "Name"
 msgstr ""
 
-#: components/archival_storage/views.py:211
+#: components/archival_storage/views.py:205
 msgid "AICID"
 msgstr ""
 
-#: components/archival_storage/views.py:212
+#: components/archival_storage/views.py:206
 msgid "Count AIPs in AIC"
 msgstr ""
 
-#: components/archival_storage/views.py:213
+#: components/archival_storage/views.py:207
 #: templates/administration/usage.html:90
 #: templates/archival_storage/view.html:67
 msgid "Size"
 msgstr ""
 
-#: components/archival_storage/views.py:214
+#: components/archival_storage/views.py:208
 msgid "File count"
 msgstr ""
 
-#: components/archival_storage/views.py:215
+#: components/archival_storage/views.py:209
 msgid "Accession IDs"
 msgstr ""
 
-#: components/archival_storage/views.py:216
+#: components/archival_storage/views.py:210
 msgid "Created date (UTC)"
 msgstr ""
 
-#: components/archival_storage/views.py:217
+#: components/archival_storage/views.py:211
 #: templates/archival_storage/view.html:75
 msgid "Status"
 msgstr ""
 
-#: components/archival_storage/views.py:218
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: components/archival_storage/views.py:212
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1019
 #: templates/administration/reports/failures.html:25
 #: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
 #: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
 msgid "Type"
 msgstr ""
 
-#: components/archival_storage/views.py:219
+#: components/archival_storage/views.py:213
 #: templates/archival_storage/view.html:79
 msgid "Encrypted"
 msgstr ""
 
-#: components/archival_storage/views.py:220
+#: components/archival_storage/views.py:214
 #: templates/archival_storage/view.html:83
 #: templates/ingest/normalization_report.html:31
 msgid "Location"
 msgstr ""
 
-#: components/archival_storage/views.py:600
+#: components/archival_storage/views.py:601
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:729
+#: components/archival_storage/views.py:730
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 
-#: components/archival_storage/views.py:741
+#: components/archival_storage/views.py:742
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
 "slug: %(slug)s"
 msgstr ""
 
-#: components/archival_storage/views.py:764
+#: components/archival_storage/views.py:765
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr ""
 
-#: components/backlog/views.py:282
+#: components/backlog/views.py:285
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 
@@ -868,100 +875,100 @@ msgstr ""
 msgid "Provided SIP UUID (%(uuid)s) belongs to an already-started SIP!"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:503
+#: components/filesystem_ajax/views.py:505
 #, python-format
 msgid "Provided UUID (%(uuid)s) is not a valid UUID!"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:512
+#: components/filesystem_ajax/views.py:514
 #, python-format
 msgid "%(path1)s is not in %(path2)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:518
+#: components/filesystem_ajax/views.py:520
 #, python-format
 msgid "%(path)s is not a directory"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:601
+#: components/filesystem_ajax/views.py:603
 msgid "SIP created."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:610
+#: components/filesystem_ajax/views.py:612
 msgid "All directories must be within the arrange directory."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:642
+#: components/filesystem_ajax/views.py:644
 msgid "Creation successful."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:654
+#: components/filesystem_ajax/views.py:656
 #, python-format
 msgid "%(src)s and %(dst)s must be inside %(path)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:675
+#: components/filesystem_ajax/views.py:677
 msgid "You cannot drag and drop onto a file."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:745
+#: components/filesystem_ajax/views.py:747
 msgid "GET parameter 'filepath' or 'destination' was blank."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:748
+#: components/filesystem_ajax/views.py:750
 #, python-format
 msgid "%(path)s must be in arrange directory."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:761
+#: components/filesystem_ajax/views.py:763
 #, python-format
 msgid "%(path1)s must go in a SIP, cannot be dropped onto %(path2)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:796
+#: components/filesystem_ajax/views.py:798
 #, python-format
 msgid "Storage Service failed with the message: %(messsage)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:812
+#: components/filesystem_ajax/views.py:814
 #, python-format
 msgid ""
 "No file information returned from the Storage Service for file at "
 "relative_path: %(path)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:890
+#: components/filesystem_ajax/views.py:892
 #, python-format
 msgid "%(path)s is not in base backlog path nor arrange path"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:916
+#: components/filesystem_ajax/views.py:918
 msgid "SIP files successfully moved."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:925
+#: components/filesystem_ajax/views.py:927
 msgid "Files added to the SIP."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:956
+#: components/filesystem_ajax/views.py:958
 msgid "Metadata files added successfully."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:991
+#: components/filesystem_ajax/views.py:993
 #, python-format
 msgid "Location %(location)s is not associated with this pipeline"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:1028
+#: components/filesystem_ajax/views.py:1030
 #, python-format
 msgid "The following errors occured: %(message)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:1032
+#: components/filesystem_ajax/views.py:1034
 msgid "Files added successfully."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:1102
+#: components/filesystem_ajax/views.py:1104
 #, python-format
 msgid "File with UUID %(uuid)s could not be found"
 msgstr ""
@@ -1253,7 +1260,7 @@ msgstr ""
 msgid "preservation format"
 msgstr ""
 
-#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:723
 msgid "Format version"
 msgstr ""
 
@@ -1429,7 +1436,7 @@ msgstr ""
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:474 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:728
 msgid "Format policy rule"
 msgstr ""
 
@@ -1483,7 +1490,7 @@ msgstr ""
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:569 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:727
 msgid "Format policy command"
 msgstr ""
 
@@ -2036,7 +2043,7 @@ msgstr ""
 #: fpr/templates/fpr/fpcommand/form.html:10
 #: fpr/templates/fpr/fpcommand/list.html:4
 #: fpr/templates/fpr/fpcommand/list.html:5
-#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:678
+#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:677
 msgid "Format policy commands"
 msgstr ""
 
@@ -2106,7 +2113,7 @@ msgid "Rule %(description)s"
 msgstr ""
 
 #: fpr/templates/fpr/fprule/detail.html:10
-#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:547
+#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:546
 msgid "Format policy rules"
 msgstr ""
 
@@ -2200,7 +2207,7 @@ msgstr ""
 #: fpr/templates/fpr/idcommand/form.html:10
 #: fpr/templates/fpr/idcommand/list.html:4
 #: fpr/templates/fpr/idcommand/list.html:5
-#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:445
+#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:444
 msgid "Identification commands"
 msgstr ""
 
@@ -2227,7 +2234,7 @@ msgstr ""
 #: fpr/templates/fpr/idrule/detail.html:10
 #: fpr/templates/fpr/idrule/form.html:10 fpr/templates/fpr/idrule/list.html:4
 #: fpr/templates/fpr/idrule/list.html:5 fpr/templates/fpr/idrule/list.html:9
-#: fpr/views.py:354
+#: fpr/views.py:353
 msgid "Identification rules"
 msgstr ""
 
@@ -2292,144 +2299,144 @@ msgstr ""
 msgid "No revisions exist."
 msgstr ""
 
-#: fpr/utils.py:74
+#: fpr/utils.py:85
 msgid ""
 "You are replacing the current revision with data from an older revision."
 msgstr ""
 
-#: fpr/utils.py:81
+#: fpr/utils.py:92
 msgid "You are viewing a disabled revision."
 msgstr ""
 
-#: fpr/views.py:91
+#: fpr/views.py:90
 #, python-format
 msgid "Edit format %(name)s"
 msgstr ""
 
-#: fpr/views.py:93
+#: fpr/views.py:92
 msgid "Create format"
 msgstr ""
 
-#: fpr/views.py:134
+#: fpr/views.py:133
 #, python-format
 msgid "Replace format version %(name)s"
 msgstr ""
 
-#: fpr/views.py:137 fpr/views.py:641
+#: fpr/views.py:136 fpr/views.py:640
 msgid "Create format version"
 msgstr ""
 
-#: fpr/views.py:164
+#: fpr/views.py:163
 msgid "Format versions"
 msgstr ""
 
-#: fpr/views.py:173 fpr/views.py:360 fpr/views.py:454 fpr/views.py:554
-#: fpr/views.py:687
+#: fpr/views.py:172 fpr/views.py:359 fpr/views.py:453 fpr/views.py:553
+#: fpr/views.py:686
 msgid "Disabled."
 msgstr ""
 
-#: fpr/views.py:179 fpr/views.py:363 fpr/views.py:457 fpr/views.py:557
-#: fpr/views.py:693
+#: fpr/views.py:178 fpr/views.py:362 fpr/views.py:456 fpr/views.py:556
+#: fpr/views.py:692
 msgid "Enabled."
 msgstr ""
 
-#: fpr/views.py:192
+#: fpr/views.py:191
 msgid "Enable/disable format version"
 msgstr ""
 
-#: fpr/views.py:212
+#: fpr/views.py:211
 #, python-format
 msgid "Edit format group %(name)s"
 msgstr ""
 
-#: fpr/views.py:214
+#: fpr/views.py:213
 msgid "Create format group"
 msgstr ""
 
-#: fpr/views.py:249
+#: fpr/views.py:248
 #, python-format
 msgid "%(count)d substitutions were performed."
 msgstr ""
 
-#: fpr/views.py:256
+#: fpr/views.py:255
 msgid "Please select a group to substitute for this group in member formats."
 msgstr ""
 
-#: fpr/views.py:293
+#: fpr/views.py:292
 #, python-format
 msgid "Edit identification tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:296
+#: fpr/views.py:295
 msgid "Create identification tool"
 msgstr ""
 
-#: fpr/views.py:331
+#: fpr/views.py:330
 #, python-format
 msgid "Replace identification rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:334
+#: fpr/views.py:333
 msgid "Create identification rule"
 msgstr ""
 
-#: fpr/views.py:374
+#: fpr/views.py:373
 msgid "Enable/disable identification rule"
 msgstr ""
 
-#: fpr/views.py:405
+#: fpr/views.py:404
 #, python-format
 msgid "Replace identification command %(name)s"
 msgstr ""
 
-#: fpr/views.py:410
+#: fpr/views.py:409
 msgid "Create identification command"
 msgstr ""
 
-#: fpr/views.py:467
+#: fpr/views.py:466
 msgid "Enable/disable identification command"
 msgstr ""
 
-#: fpr/views.py:509
+#: fpr/views.py:508
 #, python-format
 msgid "Replace format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:513
+#: fpr/views.py:512
 msgid "Create format policy rule"
 msgstr ""
 
-#: fpr/views.py:568
+#: fpr/views.py:567
 msgid "Enable/disable format policy registry rule"
 msgstr ""
 
-#: fpr/views.py:593
+#: fpr/views.py:592
 #, python-format
 msgid "Replace format policy registry tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:598
+#: fpr/views.py:597
 msgid "Create format policy registry tool"
 msgstr ""
 
-#: fpr/views.py:638
+#: fpr/views.py:637
 #, python-format
 msgid "Replace command %(name)s"
 msgstr ""
 
-#: fpr/views.py:704
+#: fpr/views.py:703
 msgid "Enable/disable format policy command"
 msgstr ""
 
-#: fpr/views.py:728
+#: fpr/views.py:724
 msgid "Identification tool configuration"
 msgstr ""
 
-#: fpr/views.py:729
+#: fpr/views.py:725
 msgid "Identification rule"
 msgstr ""
 
-#: fpr/views.py:730
+#: fpr/views.py:726
 msgid "Identification command"
 msgstr ""
 
@@ -2463,462 +2470,462 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: main/models.py:245
+#: main/models.py:246
 msgid "Part of AIC"
 msgstr ""
 
-#: main/models.py:246
+#: main/models.py:247
 msgid "Optional: leave blank if unsure"
 msgstr ""
 
-#: main/models.py:255
+#: main/models.py:256
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:265
+#: main/models.py:266
 msgid "Use ISO 639"
 msgstr ""
 
-#: main/models.py:283
+#: main/models.py:284
 msgid "Untitled"
 msgstr ""
 
-#: main/models.py:336
+#: main/models.py:337
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr ""
 
-#: main/models.py:381
+#: main/models.py:382
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr ""
 
-#: main/models.py:409
+#: main/models.py:410
 msgid "SIP"
 msgstr ""
 
-#: main/models.py:410
+#: main/models.py:411
 msgid "AIC"
 msgstr ""
 
-#: main/models.py:411
+#: main/models.py:412
 msgid "Reingested AIP"
 msgstr ""
 
-#: main/models.py:412
+#: main/models.py:413
 msgid "Reingested AIC"
 msgstr ""
 
-#: main/models.py:426
+#: main/models.py:427
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr ""
 
-#: main/models.py:547
+#: main/models.py:548
 msgid "Arranged SIPs"
 msgstr ""
 
-#: main/models.py:551
+#: main/models.py:552
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr ""
 
-#: main/models.py:596
+#: main/models.py:597
 msgid "Identifier Type"
 msgstr ""
 
-#: main/models.py:598
+#: main/models.py:599
 msgid "Identifier Value"
 msgstr ""
 
-#: main/models.py:600
+#: main/models.py:601
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
 msgstr ""
 
-#: main/models.py:673
+#: main/models.py:674
 #, python-format
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:719
+#: main/models.py:720
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:783
+#: main/models.py:784
 #, python-format
 msgid "%(file)s is %(format)s"
 msgstr ""
 
-#: main/models.py:801
+#: main/models.py:802
 msgid "(Unnamed)"
 msgstr ""
 
-#: main/models.py:823
+#: main/models.py:824
 msgid "Unknown"
 msgstr ""
 
-#: main/models.py:824
+#: main/models.py:825
 msgid "Awaiting decision"
 msgstr ""
 
-#: main/models.py:825
+#: main/models.py:826
 msgid "Completed successfully"
 msgstr ""
 
-#: main/models.py:826
+#: main/models.py:827
 msgid "Executing command(s)"
 msgstr ""
 
-#: main/models.py:827
+#: main/models.py:828
 msgid "Failed"
 msgstr ""
 
-#: main/models.py:924
+#: main/models.py:936
 msgid "Agent Identifier Type"
 msgstr ""
 
-#: main/models.py:929
+#: main/models.py:941
 msgid "Agent Identifier Value"
 msgstr ""
 
-#: main/models.py:931
+#: main/models.py:943
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
 msgstr ""
 
-#: main/models.py:938
+#: main/models.py:950
 msgid "Agent Name"
 msgstr ""
 
-#: main/models.py:939
+#: main/models.py:951
 msgid "Used for premis:agentName in the METS file."
 msgstr ""
 
-#: main/models.py:945
+#: main/models.py:957
 msgid "Agent Type"
 msgstr ""
 
-#: main/models.py:946
+#: main/models.py:958
 msgid "Used for premis:agentType in the METS file."
 msgstr ""
 
-#: main/models.py:970
+#: main/models.py:982
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:972
+#: main/models.py:984
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: main/models.py:1022 templates/rights/rights_edit.html:106
 #: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
 #: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr ""
 
-#: main/models.py:1013
+#: main/models.py:1025
 msgid "Rights holder"
 msgstr ""
 
-#: main/models.py:1016
+#: main/models.py:1028
 msgid "Copyright"
 msgstr ""
 
-#: main/models.py:1017
+#: main/models.py:1029
 msgid "Statute"
 msgstr ""
 
-#: main/models.py:1018
+#: main/models.py:1030
 msgid "License"
 msgstr ""
 
-#: main/models.py:1019
+#: main/models.py:1031
 msgid "Donor"
 msgstr ""
 
-#: main/models.py:1020
+#: main/models.py:1032
 msgid "Policy"
 msgstr ""
 
-#: main/models.py:1027 templates/rights/rights_list.html:34
+#: main/models.py:1039 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr ""
 
-#: main/models.py:1039
+#: main/models.py:1051
 msgid "Rights Statement"
 msgstr ""
 
-#: main/models.py:1043
+#: main/models.py:1055
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr ""
 
-#: main/models.py:1058
+#: main/models.py:1070
 msgid "copyrighted"
 msgstr ""
 
-#: main/models.py:1059
+#: main/models.py:1071
 msgid "public domain"
 msgstr ""
 
-#: main/models.py:1060
+#: main/models.py:1072
 msgid "unknown"
 msgstr ""
 
-#: main/models.py:1065
+#: main/models.py:1077
 msgid "Copyright status"
 msgstr ""
 
-#: main/models.py:1070
+#: main/models.py:1082
 msgid "Copyright jurisdiction"
 msgstr ""
 
-#: main/models.py:1076
+#: main/models.py:1088
 msgid "Copyright determination date"
 msgstr ""
 
-#: main/models.py:1077 main/models.py:1084 main/models.py:1091
-#: main/models.py:1161 main/models.py:1168 main/models.py:1234
-#: main/models.py:1241 main/models.py:1303 main/models.py:1312
-#: main/models.py:1319 main/models.py:1391 main/models.py:1398
+#: main/models.py:1089 main/models.py:1096 main/models.py:1103
+#: main/models.py:1173 main/models.py:1180 main/models.py:1246
+#: main/models.py:1253 main/models.py:1315 main/models.py:1324
+#: main/models.py:1331 main/models.py:1403 main/models.py:1410
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:1083
+#: main/models.py:1095
 msgid "Copyright start date"
 msgstr ""
 
-#: main/models.py:1090
+#: main/models.py:1102
 msgid "Copyright end date"
 msgstr ""
 
-#: main/models.py:1096 main/models.py:1173 main/models.py:1248
-#: main/models.py:1324 main/models.py:1403
+#: main/models.py:1108 main/models.py:1185 main/models.py:1260
+#: main/models.py:1336 main/models.py:1415
 msgid "Open End Date"
 msgstr ""
 
-#: main/models.py:1097 main/models.py:1174 main/models.py:1249
-#: main/models.py:1325 main/models.py:1404
+#: main/models.py:1109 main/models.py:1186 main/models.py:1261
+#: main/models.py:1337 main/models.py:1416
 msgid "Indicate end date is open"
 msgstr ""
 
-#: main/models.py:1102
+#: main/models.py:1114
 msgid "Rights: Copyright"
 msgstr ""
 
-#: main/models.py:1114
+#: main/models.py:1126
 msgid "Copyright document identification type"
 msgstr ""
 
-#: main/models.py:1118
+#: main/models.py:1130
 msgid "Copyright document identification value"
 msgstr ""
 
-#: main/models.py:1124
+#: main/models.py:1136
 msgid "Copyright document identification role"
 msgstr ""
 
-#: main/models.py:1129
+#: main/models.py:1141
 msgid "Rights: Copyright: Docs ID"
 msgstr ""
 
-#: main/models.py:1140 templates/rights/rights_edit.html:117
+#: main/models.py:1152 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr ""
 
-#: main/models.py:1145
+#: main/models.py:1157
 msgid "Rights: Copyright: Note"
 msgstr ""
 
-#: main/models.py:1154
+#: main/models.py:1166
 msgid "License terms"
 msgstr ""
 
-#: main/models.py:1160
+#: main/models.py:1172
 msgid "License start date"
 msgstr ""
 
-#: main/models.py:1167
+#: main/models.py:1179
 msgid "License end date"
 msgstr ""
 
-#: main/models.py:1179
+#: main/models.py:1191
 msgid "Rights: License"
 msgstr ""
 
-#: main/models.py:1191
+#: main/models.py:1203
 msgid "License documentation identification type"
 msgstr ""
 
-#: main/models.py:1195
+#: main/models.py:1207
 msgid "License documentation identification value"
 msgstr ""
 
-#: main/models.py:1201
+#: main/models.py:1213
 msgid "License document identification role"
 msgstr ""
 
-#: main/models.py:1206
+#: main/models.py:1218
 msgid "Rights: License: Docs ID"
 msgstr ""
 
-#: main/models.py:1217 templates/rights/rights_edit.html:219
+#: main/models.py:1229 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr ""
 
-#: main/models.py:1222
+#: main/models.py:1234
 msgid "Rights: License: Note"
 msgstr ""
 
-#: main/models.py:1233 templates/rights/rights_list.html:36
+#: main/models.py:1245 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr ""
 
-#: main/models.py:1240 templates/rights/rights_list.html:37
+#: main/models.py:1252 templates/rights/rights_list.html:37
 msgid "End"
 msgstr ""
 
-#: main/models.py:1254
+#: main/models.py:1266
 msgid "Rights: Granted"
 msgstr ""
 
-#: main/models.py:1266
+#: main/models.py:1278
 msgid "Rights note"
 msgstr ""
 
-#: main/models.py:1271
+#: main/models.py:1283
 msgid "Rights: Granted: Note"
 msgstr ""
 
-#: main/models.py:1286
+#: main/models.py:1298
 msgid "Rights: Granted: Restriction"
 msgstr ""
 
-#: main/models.py:1295
+#: main/models.py:1307
 msgid "Statute jurisdiction"
 msgstr ""
 
-#: main/models.py:1298
+#: main/models.py:1310
 msgid "Statute citation"
 msgstr ""
 
-#: main/models.py:1302
+#: main/models.py:1314
 msgid "Statute determination date"
 msgstr ""
 
-#: main/models.py:1311
+#: main/models.py:1323
 msgid "Statute start date"
 msgstr ""
 
-#: main/models.py:1318
+#: main/models.py:1330
 msgid "Statute end date"
 msgstr ""
 
-#: main/models.py:1330
+#: main/models.py:1342
 msgid "Rights: Statute"
 msgstr ""
 
-#: main/models.py:1341 templates/rights/rights_edit.html:169
+#: main/models.py:1353 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr ""
 
-#: main/models.py:1346
+#: main/models.py:1358
 msgid "Rights: Statute: Note"
 msgstr ""
 
-#: main/models.py:1358
+#: main/models.py:1370
 msgid "Statute document identification type"
 msgstr ""
 
-#: main/models.py:1362
+#: main/models.py:1374
 msgid "Statute document identification value"
 msgstr ""
 
-#: main/models.py:1368
+#: main/models.py:1380
 msgid "Statute document identification role"
 msgstr ""
 
-#: main/models.py:1373
+#: main/models.py:1385
 msgid "Rights: Statute: Docs ID"
 msgstr ""
 
-#: main/models.py:1383
+#: main/models.py:1395
 msgid "Other rights basis"
 msgstr ""
 
-#: main/models.py:1390
+#: main/models.py:1402
 msgid "Other rights start date"
 msgstr ""
 
-#: main/models.py:1397
+#: main/models.py:1409
 msgid "Other rights end date"
 msgstr ""
 
-#: main/models.py:1409
+#: main/models.py:1421
 msgid "Rights: Other"
 msgstr ""
 
-#: main/models.py:1421
+#: main/models.py:1433
 msgid "Other rights document identification type"
 msgstr ""
 
-#: main/models.py:1425
+#: main/models.py:1437
 msgid "Other right document identification value"
 msgstr ""
 
-#: main/models.py:1431
+#: main/models.py:1443
 msgid "Other rights document identification role"
 msgstr ""
 
-#: main/models.py:1436
+#: main/models.py:1448
 msgid "Rights: Other: Docs ID"
 msgstr ""
 
-#: main/models.py:1447
+#: main/models.py:1459
 msgid "Other rights note"
 msgstr ""
 
-#: main/models.py:1452
+#: main/models.py:1464
 msgid "Rights: Other: Note"
 msgstr ""
 
-#: main/models.py:1462
+#: main/models.py:1474
 msgid "Linking Agent"
 msgstr ""
 
-#: main/models.py:1467
+#: main/models.py:1479
 msgid "Linking Agent Value"
 msgstr ""
 
-#: main/models.py:1473
+#: main/models.py:1485
 msgid "Rights: Agent"
 msgstr ""
 
-#: main/models.py:1509
+#: main/models.py:1521
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr ""
 
-#: main/models.py:1547
+#: main/models.py:1559
 msgid "ASDIPObjectResourcePairing"
 msgstr ""
 
-#: main/models.py:1562
+#: main/models.py:1574
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr ""
 
-#: main/models.py:1569
+#: main/models.py:1581
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 
-#: main/models.py:1709
+#: main/models.py:1721
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr ""
@@ -2939,66 +2946,66 @@ msgstr ""
 msgid "Incorrect type."
 msgstr ""
 
-#: settings/base.py:212
+#: settings/base.py:255
 msgid "English"
 msgstr ""
 
-#: settings/base.py:213
+#: settings/base.py:256
 msgid "French"
 msgstr ""
 
-#: settings/base.py:214
+#: settings/base.py:257
 msgid "Spanish"
 msgstr ""
 
-#: settings/base.py:215
+#: settings/base.py:258
 msgid "Japanese"
 msgstr ""
 
-#: settings/base.py:216
+#: settings/base.py:259
 msgid "Portuguese"
 msgstr ""
 
-#: settings/base.py:217
+#: settings/base.py:260
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: settings/base.py:218
+#: settings/base.py:261
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:435
+#: settings/base.py:479
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
 msgstr ""
 
-#: settings/base.py:438
+#: settings/base.py:482
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
 "has been moved into storage."
 msgstr ""
 
-#: settings/base.py:440
+#: settings/base.py:484
 msgid "Create a SIP from the transfer."
 msgstr ""
 
-#: settings/base.py:442
+#: settings/base.py:486
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
 "start ingest micro-services."
 msgstr ""
 
-#: settings/base.py:445
+#: settings/base.py:489
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
 "system."
 msgstr ""
 
-#: settings/base.py:448
+#: settings/base.py:492
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -3007,13 +3014,13 @@ msgid ""
 "view the tool output and error message."
 msgstr ""
 
-#: settings/base.py:451
+#: settings/base.py:495
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
 msgstr ""
 
-#: settings/base.py:454
+#: settings/base.py:498
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3171,7 +3178,7 @@ msgid "REST API configuration"
 msgstr ""
 
 #: templates/administration/api.html:27
-msgid "IP whitelist"
+msgid "IP allowlist"
 msgstr ""
 
 #: templates/administration/api.html:29
@@ -3181,7 +3188,7 @@ msgid ""
 msgstr ""
 
 #: templates/administration/api.html:30
-msgid "If the whitelist is left empty, all IPs and hostnames will be allowed."
+msgid "If the allowlist is left empty, all IPs and hostnames will be allowed."
 msgstr ""
 
 #: templates/administration/atom_levels_of_description.html:25

--- a/src/dashboard/src/locale/es/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-27 22:10+0000\n"
+"POT-Creation-Date: 2021-01-12 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Flores (PhD.) <dfloresbr@gmail.com>, 2017\n"
 "Language-Team: Spanish (https://www.transifex.com/artefactual/teams/1506/"
@@ -19,17 +19,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: components/accounts/validators.py:20
+msgid ""
+"Your password must contain at least 3 of: uppercase characters, lowercase "
+"characters, numbers, and special characters (symbols or non-alphanumeric "
+"Unicode characters)."
+msgstr ""
+
 #: components/accounts/views.py:61 components/accounts/views.py:149
-#: components/administration/views.py:454
-#: components/administration/views.py:469
-#: components/administration/views.py:481
-#: components/administration/views.py:508
-#: components/administration/views.py:555
+#: components/administration/views.py:468
+#: components/administration/views.py:483
+#: components/administration/views.py:495
+#: components/administration/views.py:522
+#: components/administration/views.py:569
 #: components/administration/views_dip_upload.py:25
-#: components/administration/views_dip_upload.py:39 fpr/views.py:106
-#: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
-#: fpr/views.py:433 fpr/views.py:527 fpr/views.py:535 fpr/views.py:602
-#: fpr/views.py:656
+#: components/administration/views_dip_upload.py:39 fpr/views.py:105
+#: fpr/views.py:112 fpr/views.py:149 fpr/views.py:300 fpr/views.py:341
+#: fpr/views.py:432 fpr/views.py:526 fpr/views.py:534 fpr/views.py:601
+#: fpr/views.py:655
 msgid "Saved."
 msgstr "Grabado."
 
@@ -366,7 +373,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:1021
+#: components/administration/forms_dip_upload.py:21 main/models.py:1033
 msgid "Other"
 msgstr "Otro"
 
@@ -552,7 +559,7 @@ msgid "Used in metadata-only DIP upload."
 msgstr ""
 
 #: components/administration/views.py:89 components/administration/views.py:122
-#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
+#: components/ingest/views.py:287 fpr/views.py:260 main/views.py:307
 msgid "Deleted."
 msgstr "Borrado."
 
@@ -616,34 +623,34 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:404
+#: components/administration/views.py:418
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:406
+#: components/administration/views.py:420
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr "Limpiar"
 
-#: components/administration/views.py:431
+#: components/administration/views.py:445
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:434
+#: components/administration/views.py:448
 #, python-format
 msgid "No such file or directory: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:571
+#: components/administration/views.py:585
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
 "Storage Sevice URL below.<hr />%(error)s"
 msgstr ""
 
-#: components/administration/views.py:588
+#: components/administration/views.py:602
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -651,7 +658,7 @@ msgid ""
 "%(error)s"
 msgstr ""
 
-#: components/administration/views.py:600
+#: components/administration/views.py:614
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -720,7 +727,7 @@ msgid "Please type in the UUID to confirm"
 msgstr ""
 
 #: components/archival_storage/forms.py:89
-#: components/archival_storage/views.py:210
+#: components/archival_storage/views.py:204
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -758,90 +765,90 @@ msgstr ""
 msgid "Deletion requested"
 msgstr ""
 
-#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: components/archival_storage/views.py:203 templates/accounts/list.html:24
 #: templates/accounts/profile.html:31
 #: templates/administration/atom_levels_of_description.html:37
 #: templates/administration/reports/failures.html:26
 msgid "Name"
 msgstr "Nombre"
 
-#: components/archival_storage/views.py:211
+#: components/archival_storage/views.py:205
 msgid "AICID"
 msgstr ""
 
-#: components/archival_storage/views.py:212
+#: components/archival_storage/views.py:206
 msgid "Count AIPs in AIC"
 msgstr ""
 
-#: components/archival_storage/views.py:213
+#: components/archival_storage/views.py:207
 #: templates/administration/usage.html:90
 #: templates/archival_storage/view.html:67
 msgid "Size"
 msgstr "Tamaño"
 
-#: components/archival_storage/views.py:214
+#: components/archival_storage/views.py:208
 #, fuzzy
 #| msgid "Failures"
 msgid "File count"
 msgstr "Fallos"
 
-#: components/archival_storage/views.py:215
+#: components/archival_storage/views.py:209
 #, fuzzy
 #| msgid "Access"
 msgid "Accession IDs"
 msgstr "Acceso"
 
-#: components/archival_storage/views.py:216
+#: components/archival_storage/views.py:210
 #, fuzzy
 #| msgid "Create SIP"
 msgid "Created date (UTC)"
 msgstr "Crear SIP"
 
-#: components/archival_storage/views.py:217
+#: components/archival_storage/views.py:211
 #: templates/archival_storage/view.html:75
 msgid "Status"
 msgstr "Estado de elaboración"
 
-#: components/archival_storage/views.py:218
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: components/archival_storage/views.py:212
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1019
 #: templates/administration/reports/failures.html:25
 #: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
 #: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
 msgid "Type"
 msgstr "Tipo"
 
-#: components/archival_storage/views.py:219
+#: components/archival_storage/views.py:213
 #: templates/archival_storage/view.html:79
 msgid "Encrypted"
 msgstr ""
 
-#: components/archival_storage/views.py:220
+#: components/archival_storage/views.py:214
 #: templates/archival_storage/view.html:83
 #: templates/ingest/normalization_report.html:31
 msgid "Location"
 msgstr "Localización"
 
-#: components/archival_storage/views.py:600
+#: components/archival_storage/views.py:601
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:729
+#: components/archival_storage/views.py:730
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 
-#: components/archival_storage/views.py:741
+#: components/archival_storage/views.py:742
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
 "slug: %(slug)s"
 msgstr ""
 
-#: components/archival_storage/views.py:764
+#: components/archival_storage/views.py:765
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr ""
 
-#: components/backlog/views.py:282
+#: components/backlog/views.py:285
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 
@@ -884,100 +891,100 @@ msgstr ""
 msgid "Provided SIP UUID (%(uuid)s) belongs to an already-started SIP!"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:503
+#: components/filesystem_ajax/views.py:505
 #, python-format
 msgid "Provided UUID (%(uuid)s) is not a valid UUID!"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:512
+#: components/filesystem_ajax/views.py:514
 #, python-format
 msgid "%(path1)s is not in %(path2)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:518
+#: components/filesystem_ajax/views.py:520
 #, python-format
 msgid "%(path)s is not a directory"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:601
+#: components/filesystem_ajax/views.py:603
 msgid "SIP created."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:610
+#: components/filesystem_ajax/views.py:612
 msgid "All directories must be within the arrange directory."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:642
+#: components/filesystem_ajax/views.py:644
 msgid "Creation successful."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:654
+#: components/filesystem_ajax/views.py:656
 #, python-format
 msgid "%(src)s and %(dst)s must be inside %(path)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:675
+#: components/filesystem_ajax/views.py:677
 msgid "You cannot drag and drop onto a file."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:745
+#: components/filesystem_ajax/views.py:747
 msgid "GET parameter 'filepath' or 'destination' was blank."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:748
+#: components/filesystem_ajax/views.py:750
 #, python-format
 msgid "%(path)s must be in arrange directory."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:761
+#: components/filesystem_ajax/views.py:763
 #, python-format
 msgid "%(path1)s must go in a SIP, cannot be dropped onto %(path2)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:796
+#: components/filesystem_ajax/views.py:798
 #, python-format
 msgid "Storage Service failed with the message: %(messsage)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:812
+#: components/filesystem_ajax/views.py:814
 #, python-format
 msgid ""
 "No file information returned from the Storage Service for file at "
 "relative_path: %(path)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:890
+#: components/filesystem_ajax/views.py:892
 #, python-format
 msgid "%(path)s is not in base backlog path nor arrange path"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:916
+#: components/filesystem_ajax/views.py:918
 msgid "SIP files successfully moved."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:925
+#: components/filesystem_ajax/views.py:927
 msgid "Files added to the SIP."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:956
+#: components/filesystem_ajax/views.py:958
 msgid "Metadata files added successfully."
 msgstr "Ficheros con metadatos añadidos correctamente."
 
-#: components/filesystem_ajax/views.py:991
+#: components/filesystem_ajax/views.py:993
 #, python-format
 msgid "Location %(location)s is not associated with this pipeline"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:1028
+#: components/filesystem_ajax/views.py:1030
 #, python-format
 msgid "The following errors occured: %(message)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:1032
+#: components/filesystem_ajax/views.py:1034
 msgid "Files added successfully."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:1102
+#: components/filesystem_ajax/views.py:1104
 #, python-format
 msgid "File with UUID %(uuid)s could not be found"
 msgstr ""
@@ -1281,7 +1288,7 @@ msgstr ""
 msgid "preservation format"
 msgstr "Planificación de la preservación"
 
-#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:723
 #, fuzzy
 #| msgid "Format"
 msgid "Format version"
@@ -1474,7 +1481,7 @@ msgstr ""
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:474 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:728
 msgid "Format policy rule"
 msgstr ""
 
@@ -1534,7 +1541,7 @@ msgstr ""
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:569 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:727
 msgid "Format policy command"
 msgstr ""
 
@@ -2124,7 +2131,7 @@ msgstr "Nivel de descripción"
 #: fpr/templates/fpr/fpcommand/form.html:10
 #: fpr/templates/fpr/fpcommand/list.html:4
 #: fpr/templates/fpr/fpcommand/list.html:5
-#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:678
+#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:677
 msgid "Format policy commands"
 msgstr ""
 
@@ -2203,7 +2210,7 @@ msgid "Rule %(description)s"
 msgstr "Nivel de descripción"
 
 #: fpr/templates/fpr/fprule/detail.html:10
-#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:547
+#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:546
 msgid "Format policy rules"
 msgstr ""
 
@@ -2302,7 +2309,7 @@ msgstr ""
 #: fpr/templates/fpr/idcommand/form.html:10
 #: fpr/templates/fpr/idcommand/list.html:4
 #: fpr/templates/fpr/idcommand/list.html:5
-#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:445
+#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:444
 #, fuzzy
 #| msgid "Executing command(s)"
 msgid "Identification commands"
@@ -2331,7 +2338,7 @@ msgstr ""
 #: fpr/templates/fpr/idrule/detail.html:10
 #: fpr/templates/fpr/idrule/form.html:10 fpr/templates/fpr/idrule/list.html:4
 #: fpr/templates/fpr/idrule/list.html:5 fpr/templates/fpr/idrule/list.html:9
-#: fpr/views.py:354
+#: fpr/views.py:353
 #, fuzzy
 #| msgid "Identifier"
 msgid "Identification rules"
@@ -2402,150 +2409,150 @@ msgstr ""
 msgid "No revisions exist."
 msgstr ""
 
-#: fpr/utils.py:74
+#: fpr/utils.py:85
 msgid ""
 "You are replacing the current revision with data from an older revision."
 msgstr ""
 
-#: fpr/utils.py:81
+#: fpr/utils.py:92
 msgid "You are viewing a disabled revision."
 msgstr ""
 
-#: fpr/views.py:91
+#: fpr/views.py:90
 #, python-format
 msgid "Edit format %(name)s"
 msgstr ""
 
-#: fpr/views.py:93
+#: fpr/views.py:92
 #, fuzzy
 #| msgid "Create"
 msgid "Create format"
 msgstr "Crear"
 
-#: fpr/views.py:134
+#: fpr/views.py:133
 #, python-format
 msgid "Replace format version %(name)s"
 msgstr ""
 
-#: fpr/views.py:137 fpr/views.py:641
+#: fpr/views.py:136 fpr/views.py:640
 msgid "Create format version"
 msgstr ""
 
-#: fpr/views.py:164
+#: fpr/views.py:163
 msgid "Format versions"
 msgstr ""
 
-#: fpr/views.py:173 fpr/views.py:360 fpr/views.py:454 fpr/views.py:554
-#: fpr/views.py:687
+#: fpr/views.py:172 fpr/views.py:359 fpr/views.py:453 fpr/views.py:553
+#: fpr/views.py:686
 msgid "Disabled."
 msgstr ""
 
-#: fpr/views.py:179 fpr/views.py:363 fpr/views.py:457 fpr/views.py:557
-#: fpr/views.py:693
+#: fpr/views.py:178 fpr/views.py:362 fpr/views.py:456 fpr/views.py:556
+#: fpr/views.py:692
 msgid "Enabled."
 msgstr ""
 
-#: fpr/views.py:192
+#: fpr/views.py:191
 msgid "Enable/disable format version"
 msgstr ""
 
-#: fpr/views.py:212
+#: fpr/views.py:211
 #, python-format
 msgid "Edit format group %(name)s"
 msgstr ""
 
-#: fpr/views.py:214
+#: fpr/views.py:213
 msgid "Create format group"
 msgstr ""
 
-#: fpr/views.py:249
+#: fpr/views.py:248
 #, python-format
 msgid "%(count)d substitutions were performed."
 msgstr ""
 
-#: fpr/views.py:256
+#: fpr/views.py:255
 msgid "Please select a group to substitute for this group in member formats."
 msgstr ""
 
-#: fpr/views.py:293
+#: fpr/views.py:292
 #, python-format
 msgid "Edit identification tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:296
+#: fpr/views.py:295
 msgid "Create identification tool"
 msgstr ""
 
-#: fpr/views.py:331
+#: fpr/views.py:330
 #, python-format
 msgid "Replace identification rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:334
+#: fpr/views.py:333
 msgid "Create identification rule"
 msgstr ""
 
-#: fpr/views.py:374
+#: fpr/views.py:373
 msgid "Enable/disable identification rule"
 msgstr ""
 
-#: fpr/views.py:405
+#: fpr/views.py:404
 #, python-format
 msgid "Replace identification command %(name)s"
 msgstr ""
 
-#: fpr/views.py:410
+#: fpr/views.py:409
 msgid "Create identification command"
 msgstr ""
 
-#: fpr/views.py:467
+#: fpr/views.py:466
 msgid "Enable/disable identification command"
 msgstr ""
 
-#: fpr/views.py:509
+#: fpr/views.py:508
 #, python-format
 msgid "Replace format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:513
+#: fpr/views.py:512
 msgid "Create format policy rule"
 msgstr ""
 
-#: fpr/views.py:568
+#: fpr/views.py:567
 msgid "Enable/disable format policy registry rule"
 msgstr ""
 
-#: fpr/views.py:593
+#: fpr/views.py:592
 #, python-format
 msgid "Replace format policy registry tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:598
+#: fpr/views.py:597
 msgid "Create format policy registry tool"
 msgstr ""
 
-#: fpr/views.py:638
+#: fpr/views.py:637
 #, python-format
 msgid "Replace command %(name)s"
 msgstr ""
 
-#: fpr/views.py:704
+#: fpr/views.py:703
 msgid "Enable/disable format policy command"
 msgstr ""
 
-#: fpr/views.py:728
+#: fpr/views.py:724
 #, fuzzy
 #| msgid "General configuration"
 msgid "Identification tool configuration"
 msgstr "Configuración general"
 
-#: fpr/views.py:729
+#: fpr/views.py:725
 #, fuzzy
 #| msgid "Identifier"
 msgid "Identification rule"
 msgstr "Identificador"
 
-#: fpr/views.py:730
+#: fpr/views.py:726
 #, fuzzy
 #| msgid "Executing command(s)"
 msgid "Identification command"
@@ -2581,462 +2588,462 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: main/models.py:245
+#: main/models.py:246
 msgid "Part of AIC"
 msgstr ""
 
-#: main/models.py:246
+#: main/models.py:247
 msgid "Optional: leave blank if unsure"
 msgstr ""
 
-#: main/models.py:255
+#: main/models.py:256
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:265
+#: main/models.py:266
 msgid "Use ISO 639"
 msgstr ""
 
-#: main/models.py:283
+#: main/models.py:284
 msgid "Untitled"
 msgstr "Sin título"
 
-#: main/models.py:336
+#: main/models.py:337
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr ""
 
-#: main/models.py:381
+#: main/models.py:382
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr ""
 
-#: main/models.py:409
+#: main/models.py:410
 msgid "SIP"
 msgstr ""
 
-#: main/models.py:410
+#: main/models.py:411
 msgid "AIC"
 msgstr ""
 
-#: main/models.py:411
+#: main/models.py:412
 msgid "Reingested AIP"
 msgstr ""
 
-#: main/models.py:412
+#: main/models.py:413
 msgid "Reingested AIC"
 msgstr ""
 
-#: main/models.py:426
+#: main/models.py:427
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr ""
 
-#: main/models.py:547
+#: main/models.py:548
 msgid "Arranged SIPs"
 msgstr ""
 
-#: main/models.py:551
+#: main/models.py:552
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr ""
 
-#: main/models.py:596
+#: main/models.py:597
 msgid "Identifier Type"
 msgstr ""
 
-#: main/models.py:598
+#: main/models.py:599
 msgid "Identifier Value"
 msgstr ""
 
-#: main/models.py:600
+#: main/models.py:601
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
 msgstr ""
 
-#: main/models.py:673
+#: main/models.py:674
 #, python-format
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:719
+#: main/models.py:720
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:783
+#: main/models.py:784
 #, python-format
 msgid "%(file)s is %(format)s"
 msgstr ""
 
-#: main/models.py:801
+#: main/models.py:802
 msgid "(Unnamed)"
 msgstr ""
 
-#: main/models.py:823
+#: main/models.py:824
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: main/models.py:824
+#: main/models.py:825
 msgid "Awaiting decision"
 msgstr "Esperando decisión"
 
-#: main/models.py:825
+#: main/models.py:826
 msgid "Completed successfully"
 msgstr "Completado"
 
-#: main/models.py:826
+#: main/models.py:827
 msgid "Executing command(s)"
 msgstr "Ejecutando comando(s)"
 
-#: main/models.py:827
+#: main/models.py:828
 msgid "Failed"
 msgstr "Fallido"
 
-#: main/models.py:924
+#: main/models.py:936
 msgid "Agent Identifier Type"
 msgstr ""
 
-#: main/models.py:929
+#: main/models.py:941
 msgid "Agent Identifier Value"
 msgstr ""
 
-#: main/models.py:931
+#: main/models.py:943
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
 msgstr ""
 
-#: main/models.py:938
+#: main/models.py:950
 msgid "Agent Name"
 msgstr ""
 
-#: main/models.py:939
+#: main/models.py:951
 msgid "Used for premis:agentName in the METS file."
 msgstr ""
 
-#: main/models.py:945
+#: main/models.py:957
 msgid "Agent Type"
 msgstr ""
 
-#: main/models.py:946
+#: main/models.py:958
 msgid "Used for premis:agentType in the METS file."
 msgstr ""
 
-#: main/models.py:970
+#: main/models.py:982
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:972
+#: main/models.py:984
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: main/models.py:1022 templates/rights/rights_edit.html:106
 #: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
 #: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr "Valor"
 
-#: main/models.py:1013
+#: main/models.py:1025
 msgid "Rights holder"
 msgstr "Titular de derechos"
 
-#: main/models.py:1016
+#: main/models.py:1028
 msgid "Copyright"
 msgstr "Derechos de autor"
 
-#: main/models.py:1017
+#: main/models.py:1029
 msgid "Statute"
 msgstr "Normativa"
 
-#: main/models.py:1018
+#: main/models.py:1030
 msgid "License"
 msgstr "Licencia"
 
-#: main/models.py:1019
+#: main/models.py:1031
 msgid "Donor"
 msgstr "Donador"
 
-#: main/models.py:1020
+#: main/models.py:1032
 msgid "Policy"
 msgstr "Política"
 
-#: main/models.py:1027 templates/rights/rights_list.html:34
+#: main/models.py:1039 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr "Fundamento"
 
-#: main/models.py:1039
+#: main/models.py:1051
 msgid "Rights Statement"
 msgstr ""
 
-#: main/models.py:1043
+#: main/models.py:1055
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr ""
 
-#: main/models.py:1058
+#: main/models.py:1070
 msgid "copyrighted"
 msgstr ""
 
-#: main/models.py:1059
+#: main/models.py:1071
 msgid "public domain"
 msgstr ""
 
-#: main/models.py:1060
+#: main/models.py:1072
 msgid "unknown"
 msgstr ""
 
-#: main/models.py:1065
+#: main/models.py:1077
 msgid "Copyright status"
 msgstr "Régimen de derechos de autor"
 
-#: main/models.py:1070
+#: main/models.py:1082
 msgid "Copyright jurisdiction"
 msgstr "Ley del estado aplicable"
 
-#: main/models.py:1076
+#: main/models.py:1088
 msgid "Copyright determination date"
 msgstr ""
 
-#: main/models.py:1077 main/models.py:1084 main/models.py:1091
-#: main/models.py:1161 main/models.py:1168 main/models.py:1234
-#: main/models.py:1241 main/models.py:1303 main/models.py:1312
-#: main/models.py:1319 main/models.py:1391 main/models.py:1398
+#: main/models.py:1089 main/models.py:1096 main/models.py:1103
+#: main/models.py:1173 main/models.py:1180 main/models.py:1246
+#: main/models.py:1253 main/models.py:1315 main/models.py:1324
+#: main/models.py:1331 main/models.py:1403 main/models.py:1410
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:1083
+#: main/models.py:1095
 msgid "Copyright start date"
 msgstr ""
 
-#: main/models.py:1090
+#: main/models.py:1102
 msgid "Copyright end date"
 msgstr ""
 
-#: main/models.py:1096 main/models.py:1173 main/models.py:1248
-#: main/models.py:1324 main/models.py:1403
+#: main/models.py:1108 main/models.py:1185 main/models.py:1260
+#: main/models.py:1336 main/models.py:1415
 msgid "Open End Date"
 msgstr ""
 
-#: main/models.py:1097 main/models.py:1174 main/models.py:1249
-#: main/models.py:1325 main/models.py:1404
+#: main/models.py:1109 main/models.py:1186 main/models.py:1261
+#: main/models.py:1337 main/models.py:1416
 msgid "Indicate end date is open"
 msgstr ""
 
-#: main/models.py:1102
+#: main/models.py:1114
 msgid "Rights: Copyright"
 msgstr ""
 
-#: main/models.py:1114
+#: main/models.py:1126
 msgid "Copyright document identification type"
 msgstr ""
 
-#: main/models.py:1118
+#: main/models.py:1130
 msgid "Copyright document identification value"
 msgstr ""
 
-#: main/models.py:1124
+#: main/models.py:1136
 msgid "Copyright document identification role"
 msgstr ""
 
-#: main/models.py:1129
+#: main/models.py:1141
 msgid "Rights: Copyright: Docs ID"
 msgstr ""
 
-#: main/models.py:1140 templates/rights/rights_edit.html:117
+#: main/models.py:1152 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr "Nota sobre los derechos de autor"
 
-#: main/models.py:1145
+#: main/models.py:1157
 msgid "Rights: Copyright: Note"
 msgstr ""
 
-#: main/models.py:1154
+#: main/models.py:1166
 msgid "License terms"
 msgstr "Términos de licencia"
 
-#: main/models.py:1160
+#: main/models.py:1172
 msgid "License start date"
 msgstr ""
 
-#: main/models.py:1167
+#: main/models.py:1179
 msgid "License end date"
 msgstr ""
 
-#: main/models.py:1179
+#: main/models.py:1191
 msgid "Rights: License"
 msgstr ""
 
-#: main/models.py:1191
+#: main/models.py:1203
 msgid "License documentation identification type"
 msgstr ""
 
-#: main/models.py:1195
+#: main/models.py:1207
 msgid "License documentation identification value"
 msgstr ""
 
-#: main/models.py:1201
+#: main/models.py:1213
 msgid "License document identification role"
 msgstr ""
 
-#: main/models.py:1206
+#: main/models.py:1218
 msgid "Rights: License: Docs ID"
 msgstr ""
 
-#: main/models.py:1217 templates/rights/rights_edit.html:219
+#: main/models.py:1229 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr "Nota sobre la licencia"
 
-#: main/models.py:1222
+#: main/models.py:1234
 msgid "Rights: License: Note"
 msgstr ""
 
-#: main/models.py:1233 templates/rights/rights_list.html:36
+#: main/models.py:1245 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr "Inicio"
 
-#: main/models.py:1240 templates/rights/rights_list.html:37
+#: main/models.py:1252 templates/rights/rights_list.html:37
 msgid "End"
 msgstr "Fin"
 
-#: main/models.py:1254
+#: main/models.py:1266
 msgid "Rights: Granted"
 msgstr ""
 
-#: main/models.py:1266
+#: main/models.py:1278
 msgid "Rights note"
 msgstr ""
 
-#: main/models.py:1271
+#: main/models.py:1283
 msgid "Rights: Granted: Note"
 msgstr ""
 
-#: main/models.py:1286
+#: main/models.py:1298
 msgid "Rights: Granted: Restriction"
 msgstr ""
 
-#: main/models.py:1295
+#: main/models.py:1307
 msgid "Statute jurisdiction"
 msgstr "Organismo que ha dictado la norma"
 
-#: main/models.py:1298
+#: main/models.py:1310
 msgid "Statute citation"
 msgstr "Cita de la normativa"
 
-#: main/models.py:1302
+#: main/models.py:1314
 msgid "Statute determination date"
 msgstr "Fecha de entrada en vigor"
 
-#: main/models.py:1311
+#: main/models.py:1323
 msgid "Statute start date"
 msgstr ""
 
-#: main/models.py:1318
+#: main/models.py:1330
 msgid "Statute end date"
 msgstr ""
 
-#: main/models.py:1330
+#: main/models.py:1342
 msgid "Rights: Statute"
 msgstr ""
 
-#: main/models.py:1341 templates/rights/rights_edit.html:169
+#: main/models.py:1353 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr "Nota sobre la normativa"
 
-#: main/models.py:1346
+#: main/models.py:1358
 msgid "Rights: Statute: Note"
 msgstr ""
 
-#: main/models.py:1358
+#: main/models.py:1370
 msgid "Statute document identification type"
 msgstr ""
 
-#: main/models.py:1362
+#: main/models.py:1374
 msgid "Statute document identification value"
 msgstr ""
 
-#: main/models.py:1368
+#: main/models.py:1380
 msgid "Statute document identification role"
 msgstr ""
 
-#: main/models.py:1373
+#: main/models.py:1385
 msgid "Rights: Statute: Docs ID"
 msgstr ""
 
-#: main/models.py:1383
+#: main/models.py:1395
 msgid "Other rights basis"
 msgstr ""
 
-#: main/models.py:1390
+#: main/models.py:1402
 msgid "Other rights start date"
 msgstr ""
 
-#: main/models.py:1397
+#: main/models.py:1409
 msgid "Other rights end date"
 msgstr ""
 
-#: main/models.py:1409
+#: main/models.py:1421
 msgid "Rights: Other"
 msgstr ""
 
-#: main/models.py:1421
+#: main/models.py:1433
 msgid "Other rights document identification type"
 msgstr ""
 
-#: main/models.py:1425
+#: main/models.py:1437
 msgid "Other right document identification value"
 msgstr ""
 
-#: main/models.py:1431
+#: main/models.py:1443
 msgid "Other rights document identification role"
 msgstr ""
 
-#: main/models.py:1436
+#: main/models.py:1448
 msgid "Rights: Other: Docs ID"
 msgstr ""
 
-#: main/models.py:1447
+#: main/models.py:1459
 msgid "Other rights note"
 msgstr ""
 
-#: main/models.py:1452
+#: main/models.py:1464
 msgid "Rights: Other: Note"
 msgstr ""
 
-#: main/models.py:1462
+#: main/models.py:1474
 msgid "Linking Agent"
 msgstr ""
 
-#: main/models.py:1467
+#: main/models.py:1479
 msgid "Linking Agent Value"
 msgstr ""
 
-#: main/models.py:1473
+#: main/models.py:1485
 msgid "Rights: Agent"
 msgstr ""
 
-#: main/models.py:1509
+#: main/models.py:1521
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr ""
 
-#: main/models.py:1547
+#: main/models.py:1559
 msgid "ASDIPObjectResourcePairing"
 msgstr ""
 
-#: main/models.py:1562
+#: main/models.py:1574
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr ""
 
-#: main/models.py:1569
+#: main/models.py:1581
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 
-#: main/models.py:1709
+#: main/models.py:1721
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr ""
@@ -3057,66 +3064,66 @@ msgstr ""
 msgid "Incorrect type."
 msgstr "Tipo incorrecto."
 
-#: settings/base.py:212
+#: settings/base.py:255
 msgid "English"
 msgstr "Inglés"
 
-#: settings/base.py:213
+#: settings/base.py:256
 msgid "French"
 msgstr "Francés"
 
-#: settings/base.py:214
+#: settings/base.py:257
 msgid "Spanish"
 msgstr "Español"
 
-#: settings/base.py:215
+#: settings/base.py:258
 msgid "Japanese"
 msgstr ""
 
-#: settings/base.py:216
+#: settings/base.py:259
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: settings/base.py:217
+#: settings/base.py:260
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: settings/base.py:218
+#: settings/base.py:261
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:435
+#: settings/base.py:479
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
 msgstr ""
 
-#: settings/base.py:438
+#: settings/base.py:482
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
 "has been moved into storage."
 msgstr ""
 
-#: settings/base.py:440
+#: settings/base.py:484
 msgid "Create a SIP from the transfer."
 msgstr ""
 
-#: settings/base.py:442
+#: settings/base.py:486
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
 "start ingest micro-services."
 msgstr ""
 
-#: settings/base.py:445
+#: settings/base.py:489
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
 "system."
 msgstr ""
 
-#: settings/base.py:448
+#: settings/base.py:492
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -3125,13 +3132,13 @@ msgid ""
 "view the tool output and error message."
 msgstr ""
 
-#: settings/base.py:451
+#: settings/base.py:495
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
 msgstr ""
 
-#: settings/base.py:454
+#: settings/base.py:498
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3291,7 +3298,9 @@ msgid "REST API configuration"
 msgstr "Configuración del API REST"
 
 #: templates/administration/api.html:27
-msgid "IP whitelist"
+#, fuzzy
+#| msgid "IP whitelist"
+msgid "IP allowlist"
 msgstr "Lista blanca de direcciones IP"
 
 #: templates/administration/api.html:29
@@ -3301,7 +3310,7 @@ msgid ""
 msgstr ""
 
 #: templates/administration/api.html:30
-msgid "If the whitelist is left empty, all IPs and hostnames will be allowed."
+msgid "If the allowlist is left empty, all IPs and hostnames will be allowed."
 msgstr ""
 
 #: templates/administration/atom_levels_of_description.html:25

--- a/src/dashboard/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-27 22:10+0000\n"
+"POT-Creation-Date: 2021-01-12 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Nicolas Bednarz <nicolas.bednarz@ville.montreal.qc.ca>, "
 "2017\n"
@@ -20,17 +20,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
+#: components/accounts/validators.py:20
+msgid ""
+"Your password must contain at least 3 of: uppercase characters, lowercase "
+"characters, numbers, and special characters (symbols or non-alphanumeric "
+"Unicode characters)."
+msgstr ""
+
 #: components/accounts/views.py:61 components/accounts/views.py:149
-#: components/administration/views.py:454
-#: components/administration/views.py:469
-#: components/administration/views.py:481
-#: components/administration/views.py:508
-#: components/administration/views.py:555
+#: components/administration/views.py:468
+#: components/administration/views.py:483
+#: components/administration/views.py:495
+#: components/administration/views.py:522
+#: components/administration/views.py:569
 #: components/administration/views_dip_upload.py:25
-#: components/administration/views_dip_upload.py:39 fpr/views.py:106
-#: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
-#: fpr/views.py:433 fpr/views.py:527 fpr/views.py:535 fpr/views.py:602
-#: fpr/views.py:656
+#: components/administration/views_dip_upload.py:39 fpr/views.py:105
+#: fpr/views.py:112 fpr/views.py:149 fpr/views.py:300 fpr/views.py:341
+#: fpr/views.py:432 fpr/views.py:526 fpr/views.py:534 fpr/views.py:601
+#: fpr/views.py:655
 msgid "Saved."
 msgstr "Sauvé."
 
@@ -393,7 +400,7 @@ msgstr "Intégrer"
 msgid "New"
 msgstr "Nouveau"
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:1021
+#: components/administration/forms_dip_upload.py:21 main/models.py:1033
 msgid "Other"
 msgstr "Autre"
 
@@ -590,7 +597,7 @@ msgstr ""
 "Utilisé lors d'un téléchargement DIP contenant uniquement des métadonnées."
 
 #: components/administration/views.py:89 components/administration/views.py:122
-#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
+#: components/ingest/views.py:287 fpr/views.py:260 main/views.py:307
 msgid "Deleted."
 msgstr "Supprimé."
 
@@ -656,35 +663,35 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:404
+#: components/administration/views.py:418
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:406
+#: components/administration/views.py:420
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr "Effacer"
 
-#: components/administration/views.py:431
+#: components/administration/views.py:445
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:434
+#: components/administration/views.py:448
 #, fuzzy, python-format
 #| msgid "No files or directories found under path: %(path)s"
 msgid "No such file or directory: %(path)s"
 msgstr "Aucun fichier ou répertoire trouvé pour le chemin d'accès : %(path)s"
 
-#: components/administration/views.py:571
+#: components/administration/views.py:585
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
 "Storage Sevice URL below.<hr />%(error)s"
 msgstr ""
 
-#: components/administration/views.py:588
+#: components/administration/views.py:602
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -692,7 +699,7 @@ msgid ""
 "%(error)s"
 msgstr ""
 
-#: components/administration/views.py:600
+#: components/administration/views.py:614
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -761,7 +768,7 @@ msgid "Please type in the UUID to confirm"
 msgstr "Encoder l'UUID pour confirmer"
 
 #: components/archival_storage/forms.py:89
-#: components/archival_storage/views.py:210
+#: components/archival_storage/views.py:204
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -799,80 +806,80 @@ msgstr "Stocké"
 msgid "Deletion requested"
 msgstr "Suppression demandée"
 
-#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: components/archival_storage/views.py:203 templates/accounts/list.html:24
 #: templates/accounts/profile.html:31
 #: templates/administration/atom_levels_of_description.html:37
 #: templates/administration/reports/failures.html:26
 msgid "Name"
 msgstr "Nom"
 
-#: components/archival_storage/views.py:211
+#: components/archival_storage/views.py:205
 msgid "AICID"
 msgstr ""
 
-#: components/archival_storage/views.py:212
+#: components/archival_storage/views.py:206
 msgid "Count AIPs in AIC"
 msgstr ""
 
-#: components/archival_storage/views.py:213
+#: components/archival_storage/views.py:207
 #: templates/administration/usage.html:90
 #: templates/archival_storage/view.html:67
 msgid "Size"
 msgstr "Taille"
 
-#: components/archival_storage/views.py:214
+#: components/archival_storage/views.py:208
 #, fuzzy
 #| msgid "Failure report"
 msgid "File count"
 msgstr "Rapport d'échec"
 
-#: components/archival_storage/views.py:215
+#: components/archival_storage/views.py:209
 #, fuzzy
 #| msgid "Access"
 msgid "Accession IDs"
 msgstr "Accès"
 
-#: components/archival_storage/views.py:216
+#: components/archival_storage/views.py:210
 #, fuzzy
 #| msgid "Create SIP"
 msgid "Created date (UTC)"
 msgstr "Créer un SIP "
 
-#: components/archival_storage/views.py:217
+#: components/archival_storage/views.py:211
 #: templates/archival_storage/view.html:75
 msgid "Status"
 msgstr "Statut"
 
-#: components/archival_storage/views.py:218
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: components/archival_storage/views.py:212
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1019
 #: templates/administration/reports/failures.html:25
 #: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
 #: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
 msgid "Type"
 msgstr "Type"
 
-#: components/archival_storage/views.py:219
+#: components/archival_storage/views.py:213
 #: templates/archival_storage/view.html:79
 msgid "Encrypted"
 msgstr ""
 
-#: components/archival_storage/views.py:220
+#: components/archival_storage/views.py:214
 #: templates/archival_storage/view.html:83
 #: templates/ingest/normalization_report.html:31
 msgid "Location"
 msgstr "Emplacement"
 
-#: components/archival_storage/views.py:600
+#: components/archival_storage/views.py:601
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:729
+#: components/archival_storage/views.py:730
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 "Le téléchargement DIP contenant uniquement des métadonnées a échoué, "
 "consulter les journaux pour plus de détails."
 
-#: components/archival_storage/views.py:741
+#: components/archival_storage/views.py:742
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
@@ -881,12 +888,12 @@ msgstr ""
 "Le téléchargement DIP contenant uniquement des métadonnées a été complété "
 "avec succès. Identifiant (slug) de la nouvelle ressource : %(slug)s"
 
-#: components/archival_storage/views.py:764
+#: components/archival_storage/views.py:765
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr "Erreur lors de la réacquisition du paquet : %(message)s"
 
-#: components/backlog/views.py:282
+#: components/backlog/views.py:285
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 "Incapable d'établir la connexion avec le Service de stockage. Veuillez "
@@ -931,63 +938,63 @@ msgstr "Copié avec succès."
 msgid "Provided SIP UUID (%(uuid)s) belongs to an already-started SIP!"
 msgstr "L'UUID du SIP fourni (%(uuid)s) appartient déjà à un SIP en cours!"
 
-#: components/filesystem_ajax/views.py:503
+#: components/filesystem_ajax/views.py:505
 #, python-format
 msgid "Provided UUID (%(uuid)s) is not a valid UUID!"
 msgstr "L'UUID (%(uuid)s) fourni n'est pas valide!"
 
-#: components/filesystem_ajax/views.py:512
+#: components/filesystem_ajax/views.py:514
 #, python-format
 msgid "%(path1)s is not in %(path2)s"
 msgstr "%(path1)s n'est pas dans %(path2)s"
 
-#: components/filesystem_ajax/views.py:518
+#: components/filesystem_ajax/views.py:520
 #, python-format
 msgid "%(path)s is not a directory"
 msgstr "%(path)s n'est pas un répertoire"
 
-#: components/filesystem_ajax/views.py:601
+#: components/filesystem_ajax/views.py:603
 msgid "SIP created."
 msgstr "SIP créé."
 
-#: components/filesystem_ajax/views.py:610
+#: components/filesystem_ajax/views.py:612
 msgid "All directories must be within the arrange directory."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:642
+#: components/filesystem_ajax/views.py:644
 msgid "Creation successful."
 msgstr "Création avec succès."
 
-#: components/filesystem_ajax/views.py:654
+#: components/filesystem_ajax/views.py:656
 #, python-format
 msgid "%(src)s and %(dst)s must be inside %(path)s"
 msgstr "%(src)s et %(dst)s doivent se trouver à l'intérieur de %(path)s"
 
-#: components/filesystem_ajax/views.py:675
+#: components/filesystem_ajax/views.py:677
 msgid "You cannot drag and drop onto a file."
 msgstr "Il n'est pas possible de glisser-déplacer dans un dossier."
 
-#: components/filesystem_ajax/views.py:745
+#: components/filesystem_ajax/views.py:747
 msgid "GET parameter 'filepath' or 'destination' was blank."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:748
+#: components/filesystem_ajax/views.py:750
 #, python-format
 msgid "%(path)s must be in arrange directory."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:761
+#: components/filesystem_ajax/views.py:763
 #, python-format
 msgid "%(path1)s must go in a SIP, cannot be dropped onto %(path2)s"
 msgstr ""
 "%(path1)sdoit aller dans un SIP, impossible de l'ajouter dans %(path2)s"
 
-#: components/filesystem_ajax/views.py:796
+#: components/filesystem_ajax/views.py:798
 #, python-format
 msgid "Storage Service failed with the message: %(messsage)s"
 msgstr "Échec du service de stockage accompagné du message : %(messsage)s"
 
-#: components/filesystem_ajax/views.py:812
+#: components/filesystem_ajax/views.py:814
 #, python-format
 msgid ""
 "No file information returned from the Storage Service for file at "
@@ -996,38 +1003,38 @@ msgstr ""
 "Aucune information disponible auprès du Service de stockage concernant le "
 "fichier situé dans le relative_path : %(path)s"
 
-#: components/filesystem_ajax/views.py:890
+#: components/filesystem_ajax/views.py:892
 #, python-format
 msgid "%(path)s is not in base backlog path nor arrange path"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:916
+#: components/filesystem_ajax/views.py:918
 msgid "SIP files successfully moved."
 msgstr "Fichiers SIP déplacés avec succès."
 
-#: components/filesystem_ajax/views.py:925
+#: components/filesystem_ajax/views.py:927
 msgid "Files added to the SIP."
 msgstr "Fichiers ajoutés au SIP."
 
-#: components/filesystem_ajax/views.py:956
+#: components/filesystem_ajax/views.py:958
 msgid "Metadata files added successfully."
 msgstr "Les fichiers de métadonnées ont été ajoutés avec succès."
 
-#: components/filesystem_ajax/views.py:991
+#: components/filesystem_ajax/views.py:993
 #, python-format
 msgid "Location %(location)s is not associated with this pipeline"
 msgstr "L'emplacement %(location)s n'est pas associé à ce pipeline"
 
-#: components/filesystem_ajax/views.py:1028
+#: components/filesystem_ajax/views.py:1030
 #, python-format
 msgid "The following errors occured: %(message)s"
 msgstr "L'erreur suivante est survenue: %(message)s"
 
-#: components/filesystem_ajax/views.py:1032
+#: components/filesystem_ajax/views.py:1034
 msgid "Files added successfully."
 msgstr "Les fichiers ont été ajoutés avec succès."
 
-#: components/filesystem_ajax/views.py:1102
+#: components/filesystem_ajax/views.py:1104
 #, python-format
 msgid "File with UUID %(uuid)s could not be found"
 msgstr "Le fichier lié à l'UUID  %(uuid)s n'a pu être trouvé"
@@ -1367,7 +1374,7 @@ msgstr "Déjà dans un format d'accès"
 msgid "preservation format"
 msgstr "Déjà dans un format de préservation"
 
-#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:723
 #, fuzzy
 #| msgid "Format"
 msgid "Format version"
@@ -1569,7 +1576,7 @@ msgstr ""
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:474 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:728
 msgid "Format policy rule"
 msgstr ""
 
@@ -1636,7 +1643,7 @@ msgstr ""
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:569 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:727
 msgid "Format policy command"
 msgstr ""
 
@@ -2254,7 +2261,7 @@ msgstr "Niveau de description"
 #: fpr/templates/fpr/fpcommand/form.html:10
 #: fpr/templates/fpr/fpcommand/list.html:4
 #: fpr/templates/fpr/fpcommand/list.html:5
-#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:678
+#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:677
 msgid "Format policy commands"
 msgstr ""
 
@@ -2333,7 +2340,7 @@ msgid "Rule %(description)s"
 msgstr "Niveau de description"
 
 #: fpr/templates/fpr/fprule/detail.html:10
-#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:547
+#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:546
 msgid "Format policy rules"
 msgstr ""
 
@@ -2446,7 +2453,7 @@ msgstr ""
 #: fpr/templates/fpr/idcommand/form.html:10
 #: fpr/templates/fpr/idcommand/list.html:4
 #: fpr/templates/fpr/idcommand/list.html:5
-#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:445
+#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:444
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "Identification commands"
@@ -2479,7 +2486,7 @@ msgstr ""
 #: fpr/templates/fpr/idrule/detail.html:10
 #: fpr/templates/fpr/idrule/form.html:10 fpr/templates/fpr/idrule/list.html:4
 #: fpr/templates/fpr/idrule/list.html:5 fpr/templates/fpr/idrule/list.html:9
-#: fpr/views.py:354
+#: fpr/views.py:353
 #, fuzzy
 #| msgid "Identifier"
 msgid "Identification rules"
@@ -2550,158 +2557,158 @@ msgstr ""
 msgid "No revisions exist."
 msgstr ""
 
-#: fpr/utils.py:74
+#: fpr/utils.py:85
 msgid ""
 "You are replacing the current revision with data from an older revision."
 msgstr ""
 
-#: fpr/utils.py:81
+#: fpr/utils.py:92
 msgid "You are viewing a disabled revision."
 msgstr ""
 
-#: fpr/views.py:91
+#: fpr/views.py:90
 #, python-format
 msgid "Edit format %(name)s"
 msgstr ""
 
-#: fpr/views.py:93
+#: fpr/views.py:92
 #, fuzzy
 #| msgid "File format"
 msgid "Create format"
 msgstr "Format de fichier"
 
-#: fpr/views.py:134
+#: fpr/views.py:133
 #, python-format
 msgid "Replace format version %(name)s"
 msgstr ""
 
-#: fpr/views.py:137 fpr/views.py:641
+#: fpr/views.py:136 fpr/views.py:640
 msgid "Create format version"
 msgstr ""
 
-#: fpr/views.py:164
+#: fpr/views.py:163
 msgid "Format versions"
 msgstr ""
 
-#: fpr/views.py:173 fpr/views.py:360 fpr/views.py:454 fpr/views.py:554
-#: fpr/views.py:687
+#: fpr/views.py:172 fpr/views.py:359 fpr/views.py:453 fpr/views.py:553
+#: fpr/views.py:686
 msgid "Disabled."
 msgstr ""
 
-#: fpr/views.py:179 fpr/views.py:363 fpr/views.py:457 fpr/views.py:557
-#: fpr/views.py:693
+#: fpr/views.py:178 fpr/views.py:362 fpr/views.py:456 fpr/views.py:556
+#: fpr/views.py:692
 msgid "Enabled."
 msgstr ""
 
-#: fpr/views.py:192
+#: fpr/views.py:191
 msgid "Enable/disable format version"
 msgstr ""
 
-#: fpr/views.py:212
+#: fpr/views.py:211
 #, python-format
 msgid "Edit format group %(name)s"
 msgstr ""
 
-#: fpr/views.py:214
+#: fpr/views.py:213
 msgid "Create format group"
 msgstr ""
 
-#: fpr/views.py:249
+#: fpr/views.py:248
 #, python-format
 msgid "%(count)d substitutions were performed."
 msgstr ""
 
-#: fpr/views.py:256
+#: fpr/views.py:255
 msgid "Please select a group to substitute for this group in member formats."
 msgstr ""
 
-#: fpr/views.py:293
+#: fpr/views.py:292
 #, python-format
 msgid "Edit identification tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:296
+#: fpr/views.py:295
 msgid "Create identification tool"
 msgstr ""
 
-#: fpr/views.py:331
+#: fpr/views.py:330
 #, python-format
 msgid "Replace identification rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:334
+#: fpr/views.py:333
 msgid "Create identification rule"
 msgstr ""
 
-#: fpr/views.py:374
+#: fpr/views.py:373
 msgid "Enable/disable identification rule"
 msgstr ""
 
-#: fpr/views.py:405
+#: fpr/views.py:404
 #, fuzzy, python-format
 #| msgid "Select file format identification command (Ingest)"
 msgid "Replace identification command %(name)s"
 msgstr ""
 "Sélectionner la commande d'identification de format de fichier (Acquisition)"
 
-#: fpr/views.py:410
+#: fpr/views.py:409
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "Create identification command"
 msgstr ""
 "Sélectionner la commande d'identification de format de fichier (Acquisition)"
 
-#: fpr/views.py:467
+#: fpr/views.py:466
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "Enable/disable identification command"
 msgstr ""
 "Sélectionner la commande d'identification de format de fichier (Acquisition)"
 
-#: fpr/views.py:509
+#: fpr/views.py:508
 #, python-format
 msgid "Replace format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:513
+#: fpr/views.py:512
 msgid "Create format policy rule"
 msgstr ""
 
-#: fpr/views.py:568
+#: fpr/views.py:567
 msgid "Enable/disable format policy registry rule"
 msgstr ""
 
-#: fpr/views.py:593
+#: fpr/views.py:592
 #, python-format
 msgid "Replace format policy registry tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:598
+#: fpr/views.py:597
 msgid "Create format policy registry tool"
 msgstr ""
 
-#: fpr/views.py:638
+#: fpr/views.py:637
 #, python-format
 msgid "Replace command %(name)s"
 msgstr ""
 
-#: fpr/views.py:704
+#: fpr/views.py:703
 msgid "Enable/disable format policy command"
 msgstr ""
 
-#: fpr/views.py:728
+#: fpr/views.py:724
 #, fuzzy
 #| msgid "General configuration"
 msgid "Identification tool configuration"
 msgstr "Configuration générale"
 
-#: fpr/views.py:729
+#: fpr/views.py:725
 #, fuzzy
 #| msgid "Identifier"
 msgid "Identification rule"
 msgstr "Identifiant"
 
-#: fpr/views.py:730
+#: fpr/views.py:726
 msgid "Identification command"
 msgstr ""
 
@@ -2737,463 +2744,463 @@ msgstr ""
 "Une erreur s'est produite en créant le pipeline : est-ce que le Service de "
 "stockage fonctionne? Veuillez contacter votre administrateur."
 
-#: main/models.py:245
+#: main/models.py:246
 msgid "Part of AIC"
 msgstr "Partie d'une AIC"
 
-#: main/models.py:246
+#: main/models.py:247
 msgid "Optional: leave blank if unsure"
 msgstr ""
 
-#: main/models.py:255
+#: main/models.py:256
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:265
+#: main/models.py:266
 msgid "Use ISO 639"
 msgstr ""
 
-#: main/models.py:283
+#: main/models.py:284
 msgid "Untitled"
 msgstr "Sans titre"
 
-#: main/models.py:336
+#: main/models.py:337
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr ""
 
-#: main/models.py:381
+#: main/models.py:382
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr ""
 
-#: main/models.py:409
+#: main/models.py:410
 msgid "SIP"
 msgstr ""
 
-#: main/models.py:410
+#: main/models.py:411
 msgid "AIC"
 msgstr "AIC"
 
-#: main/models.py:411
+#: main/models.py:412
 msgid "Reingested AIP"
 msgstr ""
 
-#: main/models.py:412
+#: main/models.py:413
 msgid "Reingested AIC"
 msgstr ""
 
-#: main/models.py:426
+#: main/models.py:427
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr "SIP: {path}"
 
-#: main/models.py:547
+#: main/models.py:548
 msgid "Arranged SIPs"
 msgstr ""
 
-#: main/models.py:551
+#: main/models.py:552
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr "%(original)s -> %(arrange)s"
 
-#: main/models.py:596
+#: main/models.py:597
 msgid "Identifier Type"
 msgstr ""
 
-#: main/models.py:598
+#: main/models.py:599
 msgid "Identifier Value"
 msgstr ""
 
-#: main/models.py:600
+#: main/models.py:601
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
 msgstr ""
 
-#: main/models.py:673
+#: main/models.py:674
 #, python-format
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:719
+#: main/models.py:720
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:783
+#: main/models.py:784
 #, fuzzy, python-format
 #| msgid "File format"
 msgid "%(file)s is %(format)s"
 msgstr "Format de fichier"
 
-#: main/models.py:801
+#: main/models.py:802
 msgid "(Unnamed)"
 msgstr ""
 
-#: main/models.py:823
+#: main/models.py:824
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: main/models.py:824
+#: main/models.py:825
 msgid "Awaiting decision"
 msgstr ""
 
-#: main/models.py:825
+#: main/models.py:826
 msgid "Completed successfully"
 msgstr ""
 
-#: main/models.py:826
+#: main/models.py:827
 msgid "Executing command(s)"
 msgstr ""
 
-#: main/models.py:827
+#: main/models.py:828
 msgid "Failed"
 msgstr ""
 
-#: main/models.py:924
+#: main/models.py:936
 msgid "Agent Identifier Type"
 msgstr ""
 
-#: main/models.py:929
+#: main/models.py:941
 msgid "Agent Identifier Value"
 msgstr ""
 
-#: main/models.py:931
+#: main/models.py:943
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
 msgstr ""
 
-#: main/models.py:938
+#: main/models.py:950
 msgid "Agent Name"
 msgstr ""
 
-#: main/models.py:939
+#: main/models.py:951
 msgid "Used for premis:agentName in the METS file."
 msgstr ""
 
-#: main/models.py:945
+#: main/models.py:957
 msgid "Agent Type"
 msgstr ""
 
-#: main/models.py:946
+#: main/models.py:958
 msgid "Used for premis:agentType in the METS file."
 msgstr ""
 
-#: main/models.py:970
+#: main/models.py:982
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:972
+#: main/models.py:984
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: main/models.py:1022 templates/rights/rights_edit.html:106
 #: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
 #: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr "Valeur"
 
-#: main/models.py:1013
+#: main/models.py:1025
 msgid "Rights holder"
 msgstr "Détenteur de droits"
 
-#: main/models.py:1016
+#: main/models.py:1028
 msgid "Copyright"
 msgstr "Droit d'auteur"
 
-#: main/models.py:1017
+#: main/models.py:1029
 msgid "Statute"
 msgstr "Réglementation"
 
-#: main/models.py:1018
+#: main/models.py:1030
 msgid "License"
 msgstr "Licence"
 
-#: main/models.py:1019
+#: main/models.py:1031
 msgid "Donor"
 msgstr "Donateur"
 
-#: main/models.py:1020
+#: main/models.py:1032
 msgid "Policy"
 msgstr "Politique"
 
-#: main/models.py:1027 templates/rights/rights_list.html:34
+#: main/models.py:1039 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr "Base"
 
-#: main/models.py:1039
+#: main/models.py:1051
 msgid "Rights Statement"
 msgstr ""
 
-#: main/models.py:1043
+#: main/models.py:1055
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr "%(basis)s pour %(unit)s (%(id)s)"
 
-#: main/models.py:1058
+#: main/models.py:1070
 msgid "copyrighted"
 msgstr ""
 
-#: main/models.py:1059
+#: main/models.py:1071
 msgid "public domain"
 msgstr ""
 
-#: main/models.py:1060
+#: main/models.py:1072
 msgid "unknown"
 msgstr ""
 
-#: main/models.py:1065
+#: main/models.py:1077
 msgid "Copyright status"
 msgstr "Statut des droits d'auteur"
 
-#: main/models.py:1070
+#: main/models.py:1082
 msgid "Copyright jurisdiction"
 msgstr "Compétence en matière de droit d'auteur"
 
-#: main/models.py:1076
+#: main/models.py:1088
 msgid "Copyright determination date"
 msgstr ""
 
-#: main/models.py:1077 main/models.py:1084 main/models.py:1091
-#: main/models.py:1161 main/models.py:1168 main/models.py:1234
-#: main/models.py:1241 main/models.py:1303 main/models.py:1312
-#: main/models.py:1319 main/models.py:1391 main/models.py:1398
+#: main/models.py:1089 main/models.py:1096 main/models.py:1103
+#: main/models.py:1173 main/models.py:1180 main/models.py:1246
+#: main/models.py:1253 main/models.py:1315 main/models.py:1324
+#: main/models.py:1331 main/models.py:1403 main/models.py:1410
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:1083
+#: main/models.py:1095
 msgid "Copyright start date"
 msgstr ""
 
-#: main/models.py:1090
+#: main/models.py:1102
 msgid "Copyright end date"
 msgstr ""
 
-#: main/models.py:1096 main/models.py:1173 main/models.py:1248
-#: main/models.py:1324 main/models.py:1403
+#: main/models.py:1108 main/models.py:1185 main/models.py:1260
+#: main/models.py:1336 main/models.py:1415
 msgid "Open End Date"
 msgstr ""
 
-#: main/models.py:1097 main/models.py:1174 main/models.py:1249
-#: main/models.py:1325 main/models.py:1404
+#: main/models.py:1109 main/models.py:1186 main/models.py:1261
+#: main/models.py:1337 main/models.py:1416
 msgid "Indicate end date is open"
 msgstr ""
 
-#: main/models.py:1102
+#: main/models.py:1114
 msgid "Rights: Copyright"
 msgstr ""
 
-#: main/models.py:1114
+#: main/models.py:1126
 msgid "Copyright document identification type"
 msgstr ""
 
-#: main/models.py:1118
+#: main/models.py:1130
 msgid "Copyright document identification value"
 msgstr ""
 
-#: main/models.py:1124
+#: main/models.py:1136
 msgid "Copyright document identification role"
 msgstr ""
 
-#: main/models.py:1129
+#: main/models.py:1141
 msgid "Rights: Copyright: Docs ID"
 msgstr ""
 
-#: main/models.py:1140 templates/rights/rights_edit.html:117
+#: main/models.py:1152 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr "Note sur le droit d'auteur"
 
-#: main/models.py:1145
+#: main/models.py:1157
 msgid "Rights: Copyright: Note"
 msgstr ""
 
-#: main/models.py:1154
+#: main/models.py:1166
 msgid "License terms"
 msgstr "Termes de la licence"
 
-#: main/models.py:1160
+#: main/models.py:1172
 msgid "License start date"
 msgstr ""
 
-#: main/models.py:1167
+#: main/models.py:1179
 msgid "License end date"
 msgstr ""
 
-#: main/models.py:1179
+#: main/models.py:1191
 msgid "Rights: License"
 msgstr ""
 
-#: main/models.py:1191
+#: main/models.py:1203
 msgid "License documentation identification type"
 msgstr ""
 
-#: main/models.py:1195
+#: main/models.py:1207
 msgid "License documentation identification value"
 msgstr ""
 
-#: main/models.py:1201
+#: main/models.py:1213
 msgid "License document identification role"
 msgstr ""
 
-#: main/models.py:1206
+#: main/models.py:1218
 msgid "Rights: License: Docs ID"
 msgstr ""
 
-#: main/models.py:1217 templates/rights/rights_edit.html:219
+#: main/models.py:1229 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr "Note sur la licence"
 
-#: main/models.py:1222
+#: main/models.py:1234
 msgid "Rights: License: Note"
 msgstr ""
 
-#: main/models.py:1233 templates/rights/rights_list.html:36
+#: main/models.py:1245 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr "Début"
 
-#: main/models.py:1240 templates/rights/rights_list.html:37
+#: main/models.py:1252 templates/rights/rights_list.html:37
 msgid "End"
 msgstr "Fin"
 
-#: main/models.py:1254
+#: main/models.py:1266
 msgid "Rights: Granted"
 msgstr ""
 
-#: main/models.py:1266
+#: main/models.py:1278
 msgid "Rights note"
 msgstr ""
 
-#: main/models.py:1271
+#: main/models.py:1283
 msgid "Rights: Granted: Note"
 msgstr ""
 
-#: main/models.py:1286
+#: main/models.py:1298
 msgid "Rights: Granted: Restriction"
 msgstr ""
 
-#: main/models.py:1295
+#: main/models.py:1307
 msgid "Statute jurisdiction"
 msgstr "Champ d'application de la réglementation"
 
-#: main/models.py:1298
+#: main/models.py:1310
 msgid "Statute citation"
 msgstr "Mention de la réglementation"
 
-#: main/models.py:1302
+#: main/models.py:1314
 msgid "Statute determination date"
 msgstr "Date d'établissement de la réglementation"
 
-#: main/models.py:1311
+#: main/models.py:1323
 msgid "Statute start date"
 msgstr ""
 
-#: main/models.py:1318
+#: main/models.py:1330
 msgid "Statute end date"
 msgstr ""
 
-#: main/models.py:1330
+#: main/models.py:1342
 msgid "Rights: Statute"
 msgstr ""
 
-#: main/models.py:1341 templates/rights/rights_edit.html:169
+#: main/models.py:1353 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr "Note sur la réglementation"
 
-#: main/models.py:1346
+#: main/models.py:1358
 msgid "Rights: Statute: Note"
 msgstr ""
 
-#: main/models.py:1358
+#: main/models.py:1370
 msgid "Statute document identification type"
 msgstr ""
 
-#: main/models.py:1362
+#: main/models.py:1374
 msgid "Statute document identification value"
 msgstr ""
 
-#: main/models.py:1368
+#: main/models.py:1380
 msgid "Statute document identification role"
 msgstr ""
 
-#: main/models.py:1373
+#: main/models.py:1385
 msgid "Rights: Statute: Docs ID"
 msgstr ""
 
-#: main/models.py:1383
+#: main/models.py:1395
 msgid "Other rights basis"
 msgstr ""
 
-#: main/models.py:1390
+#: main/models.py:1402
 msgid "Other rights start date"
 msgstr ""
 
-#: main/models.py:1397
+#: main/models.py:1409
 msgid "Other rights end date"
 msgstr ""
 
-#: main/models.py:1409
+#: main/models.py:1421
 msgid "Rights: Other"
 msgstr ""
 
-#: main/models.py:1421
+#: main/models.py:1433
 msgid "Other rights document identification type"
 msgstr ""
 
-#: main/models.py:1425
+#: main/models.py:1437
 msgid "Other right document identification value"
 msgstr ""
 
-#: main/models.py:1431
+#: main/models.py:1443
 msgid "Other rights document identification role"
 msgstr ""
 
-#: main/models.py:1436
+#: main/models.py:1448
 msgid "Rights: Other: Docs ID"
 msgstr ""
 
-#: main/models.py:1447
+#: main/models.py:1459
 msgid "Other rights note"
 msgstr ""
 
-#: main/models.py:1452
+#: main/models.py:1464
 msgid "Rights: Other: Note"
 msgstr ""
 
-#: main/models.py:1462
+#: main/models.py:1474
 msgid "Linking Agent"
 msgstr ""
 
-#: main/models.py:1467
+#: main/models.py:1479
 msgid "Linking Agent Value"
 msgstr ""
 
-#: main/models.py:1473
+#: main/models.py:1485
 msgid "Rights: Agent"
 msgstr ""
 
-#: main/models.py:1509
+#: main/models.py:1521
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr ""
 
-#: main/models.py:1547
+#: main/models.py:1559
 msgid "ASDIPObjectResourcePairing"
 msgstr ""
 
-#: main/models.py:1562
+#: main/models.py:1574
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr ""
 
-#: main/models.py:1569
+#: main/models.py:1581
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 
-#: main/models.py:1709
+#: main/models.py:1721
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr "%(sortorder)s: %(name)s"
@@ -3214,35 +3221,35 @@ msgstr ""
 msgid "Incorrect type."
 msgstr "Type incorrect."
 
-#: settings/base.py:212
+#: settings/base.py:255
 msgid "English"
 msgstr "Anglais"
 
-#: settings/base.py:213
+#: settings/base.py:256
 msgid "French"
 msgstr "Français"
 
-#: settings/base.py:214
+#: settings/base.py:257
 msgid "Spanish"
 msgstr "Espagnol"
 
-#: settings/base.py:215
+#: settings/base.py:258
 msgid "Japanese"
 msgstr ""
 
-#: settings/base.py:216
+#: settings/base.py:259
 msgid "Portuguese"
 msgstr "Portugais"
 
-#: settings/base.py:217
+#: settings/base.py:260
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: settings/base.py:218
+#: settings/base.py:261
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:435
+#: settings/base.py:479
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
@@ -3250,32 +3257,32 @@ msgstr ""
 "Sélectionnez \"Approuver le transfert\" pour commencer le traitement ou "
 "\"Rejeter le transfert\" pour recommencer."
 
-#: settings/base.py:438
+#: settings/base.py:482
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
 "has been moved into storage."
 msgstr ""
 
-#: settings/base.py:440
+#: settings/base.py:484
 msgid "Create a SIP from the transfer."
 msgstr "Créer un SIP à partir du transfert."
 
-#: settings/base.py:442
+#: settings/base.py:486
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
 "start ingest micro-services."
 msgstr ""
 
-#: settings/base.py:445
+#: settings/base.py:489
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
 "system."
 msgstr ""
 
-#: settings/base.py:448
+#: settings/base.py:492
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -3284,7 +3291,7 @@ msgid ""
 "view the tool output and error message."
 msgstr ""
 
-#: settings/base.py:451
+#: settings/base.py:495
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
@@ -3293,7 +3300,7 @@ msgstr ""
 "Sélectionnez \"Stocker l'AIP\" pour déplacer l'AIP dans le dossier de "
 "stockage des archives."
 
-#: settings/base.py:454
+#: settings/base.py:498
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3457,7 +3464,9 @@ msgid "REST API configuration"
 msgstr "Configuration REST API"
 
 #: templates/administration/api.html:27
-msgid "IP whitelist"
+#, fuzzy
+#| msgid "IP whitelist"
+msgid "IP allowlist"
 msgstr "Liste blanche d'adresses IP"
 
 #: templates/administration/api.html:29
@@ -3467,7 +3476,7 @@ msgid ""
 msgstr ""
 
 #: templates/administration/api.html:30
-msgid "If the whitelist is left empty, all IPs and hostnames will be allowed."
+msgid "If the allowlist is left empty, all IPs and hostnames will be allowed."
 msgstr ""
 
 #: templates/administration/atom_levels_of_description.html:25

--- a/src/dashboard/src/locale/ja/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/ja/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-27 22:10+0000\n"
+"POT-Creation-Date: 2021-01-12 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: artefactual <translate@artefactual.com>, 2018\n"
 "Language-Team: Japanese (https://www.transifex.com/artefactual/teams/1506/"
@@ -19,17 +19,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#: components/accounts/validators.py:20
+msgid ""
+"Your password must contain at least 3 of: uppercase characters, lowercase "
+"characters, numbers, and special characters (symbols or non-alphanumeric "
+"Unicode characters)."
+msgstr ""
+
 #: components/accounts/views.py:61 components/accounts/views.py:149
-#: components/administration/views.py:454
-#: components/administration/views.py:469
-#: components/administration/views.py:481
-#: components/administration/views.py:508
-#: components/administration/views.py:555
+#: components/administration/views.py:468
+#: components/administration/views.py:483
+#: components/administration/views.py:495
+#: components/administration/views.py:522
+#: components/administration/views.py:569
 #: components/administration/views_dip_upload.py:25
-#: components/administration/views_dip_upload.py:39 fpr/views.py:106
-#: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
-#: fpr/views.py:433 fpr/views.py:527 fpr/views.py:535 fpr/views.py:602
-#: fpr/views.py:656
+#: components/administration/views_dip_upload.py:39 fpr/views.py:105
+#: fpr/views.py:112 fpr/views.py:149 fpr/views.py:300 fpr/views.py:341
+#: fpr/views.py:432 fpr/views.py:526 fpr/views.py:534 fpr/views.py:601
+#: fpr/views.py:655
 msgid "Saved."
 msgstr "保存しました。"
 
@@ -366,7 +373,7 @@ msgstr ""
 msgid "New"
 msgstr "New"
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:1021
+#: components/administration/forms_dip_upload.py:21 main/models.py:1033
 msgid "Other"
 msgstr "その他"
 
@@ -552,7 +559,7 @@ msgid "Used in metadata-only DIP upload."
 msgstr ""
 
 #: components/administration/views.py:89 components/administration/views.py:122
-#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
+#: components/ingest/views.py:287 fpr/views.py:260 main/views.py:307
 msgid "Deleted."
 msgstr "削除しました。"
 
@@ -614,34 +621,34 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:404
+#: components/administration/views.py:418
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:406
+#: components/administration/views.py:420
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr "クリア"
 
-#: components/administration/views.py:431
+#: components/administration/views.py:445
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:434
+#: components/administration/views.py:448
 #, python-format
 msgid "No such file or directory: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:571
+#: components/administration/views.py:585
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
 "Storage Sevice URL below.<hr />%(error)s"
 msgstr ""
 
-#: components/administration/views.py:588
+#: components/administration/views.py:602
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -649,7 +656,7 @@ msgid ""
 "%(error)s"
 msgstr ""
 
-#: components/administration/views.py:600
+#: components/administration/views.py:614
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -718,7 +725,7 @@ msgid "Please type in the UUID to confirm"
 msgstr ""
 
 #: components/archival_storage/forms.py:89
-#: components/archival_storage/views.py:210
+#: components/archival_storage/views.py:204
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -756,90 +763,90 @@ msgstr ""
 msgid "Deletion requested"
 msgstr ""
 
-#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: components/archival_storage/views.py:203 templates/accounts/list.html:24
 #: templates/accounts/profile.html:31
 #: templates/administration/atom_levels_of_description.html:37
 #: templates/administration/reports/failures.html:26
 msgid "Name"
 msgstr "名称"
 
-#: components/archival_storage/views.py:211
+#: components/archival_storage/views.py:205
 msgid "AICID"
 msgstr ""
 
-#: components/archival_storage/views.py:212
+#: components/archival_storage/views.py:206
 msgid "Count AIPs in AIC"
 msgstr ""
 
-#: components/archival_storage/views.py:213
+#: components/archival_storage/views.py:207
 #: templates/administration/usage.html:90
 #: templates/archival_storage/view.html:67
 msgid "Size"
 msgstr "サイズ"
 
-#: components/archival_storage/views.py:214
+#: components/archival_storage/views.py:208
 #, fuzzy
 #| msgid "File name"
 msgid "File count"
 msgstr "ファイル名"
 
-#: components/archival_storage/views.py:215
+#: components/archival_storage/views.py:209
 #, fuzzy
 #| msgid "Access"
 msgid "Accession IDs"
 msgstr "アクセス"
 
-#: components/archival_storage/views.py:216
+#: components/archival_storage/views.py:210
 #, fuzzy
 #| msgid "Created time"
 msgid "Created date (UTC)"
 msgstr "作成時刻"
 
-#: components/archival_storage/views.py:217
+#: components/archival_storage/views.py:211
 #: templates/archival_storage/view.html:75
 msgid "Status"
 msgstr "ステータス"
 
-#: components/archival_storage/views.py:218
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: components/archival_storage/views.py:212
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1019
 #: templates/administration/reports/failures.html:25
 #: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
 #: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
 msgid "Type"
 msgstr "種別"
 
-#: components/archival_storage/views.py:219
+#: components/archival_storage/views.py:213
 #: templates/archival_storage/view.html:79
 msgid "Encrypted"
 msgstr ""
 
-#: components/archival_storage/views.py:220
+#: components/archival_storage/views.py:214
 #: templates/archival_storage/view.html:83
 #: templates/ingest/normalization_report.html:31
 msgid "Location"
 msgstr "所在"
 
-#: components/archival_storage/views.py:600
+#: components/archival_storage/views.py:601
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:729
+#: components/archival_storage/views.py:730
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 
-#: components/archival_storage/views.py:741
+#: components/archival_storage/views.py:742
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
 "slug: %(slug)s"
 msgstr ""
 
-#: components/archival_storage/views.py:764
+#: components/archival_storage/views.py:765
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr ""
 
-#: components/backlog/views.py:282
+#: components/backlog/views.py:285
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 
@@ -881,100 +888,100 @@ msgstr "コピーが成功しました。"
 msgid "Provided SIP UUID (%(uuid)s) belongs to an already-started SIP!"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:503
+#: components/filesystem_ajax/views.py:505
 #, python-format
 msgid "Provided UUID (%(uuid)s) is not a valid UUID!"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:512
+#: components/filesystem_ajax/views.py:514
 #, python-format
 msgid "%(path1)s is not in %(path2)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:518
+#: components/filesystem_ajax/views.py:520
 #, python-format
 msgid "%(path)s is not a directory"
 msgstr "%(path)s はディレクトリではありません"
 
-#: components/filesystem_ajax/views.py:601
+#: components/filesystem_ajax/views.py:603
 msgid "SIP created."
 msgstr "SIPを作成しました。"
 
-#: components/filesystem_ajax/views.py:610
+#: components/filesystem_ajax/views.py:612
 msgid "All directories must be within the arrange directory."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:642
+#: components/filesystem_ajax/views.py:644
 msgid "Creation successful."
 msgstr "作成に成功。"
 
-#: components/filesystem_ajax/views.py:654
+#: components/filesystem_ajax/views.py:656
 #, python-format
 msgid "%(src)s and %(dst)s must be inside %(path)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:675
+#: components/filesystem_ajax/views.py:677
 msgid "You cannot drag and drop onto a file."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:745
+#: components/filesystem_ajax/views.py:747
 msgid "GET parameter 'filepath' or 'destination' was blank."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:748
+#: components/filesystem_ajax/views.py:750
 #, python-format
 msgid "%(path)s must be in arrange directory."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:761
+#: components/filesystem_ajax/views.py:763
 #, python-format
 msgid "%(path1)s must go in a SIP, cannot be dropped onto %(path2)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:796
+#: components/filesystem_ajax/views.py:798
 #, python-format
 msgid "Storage Service failed with the message: %(messsage)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:812
+#: components/filesystem_ajax/views.py:814
 #, python-format
 msgid ""
 "No file information returned from the Storage Service for file at "
 "relative_path: %(path)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:890
+#: components/filesystem_ajax/views.py:892
 #, python-format
 msgid "%(path)s is not in base backlog path nor arrange path"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:916
+#: components/filesystem_ajax/views.py:918
 msgid "SIP files successfully moved."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:925
+#: components/filesystem_ajax/views.py:927
 msgid "Files added to the SIP."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:956
+#: components/filesystem_ajax/views.py:958
 msgid "Metadata files added successfully."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:991
+#: components/filesystem_ajax/views.py:993
 #, python-format
 msgid "Location %(location)s is not associated with this pipeline"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:1028
+#: components/filesystem_ajax/views.py:1030
 #, python-format
 msgid "The following errors occured: %(message)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:1032
+#: components/filesystem_ajax/views.py:1034
 msgid "Files added successfully."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:1102
+#: components/filesystem_ajax/views.py:1104
 #, python-format
 msgid "File with UUID %(uuid)s could not be found"
 msgstr ""
@@ -1280,7 +1287,7 @@ msgstr ""
 msgid "preservation format"
 msgstr ""
 
-#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:723
 #, fuzzy
 #| msgid "Format"
 msgid "Format version"
@@ -1477,7 +1484,7 @@ msgstr ""
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:474 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:728
 msgid "Format policy rule"
 msgstr ""
 
@@ -1539,7 +1546,7 @@ msgstr ""
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:569 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:727
 msgid "Format policy command"
 msgstr ""
 
@@ -2125,7 +2132,7 @@ msgstr "記述レベル"
 #: fpr/templates/fpr/fpcommand/form.html:10
 #: fpr/templates/fpr/fpcommand/list.html:4
 #: fpr/templates/fpr/fpcommand/list.html:5
-#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:678
+#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:677
 msgid "Format policy commands"
 msgstr ""
 
@@ -2198,7 +2205,7 @@ msgid "Rule %(description)s"
 msgstr "記述レベル"
 
 #: fpr/templates/fpr/fprule/detail.html:10
-#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:547
+#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:546
 msgid "Format policy rules"
 msgstr ""
 
@@ -2296,7 +2303,7 @@ msgstr ""
 #: fpr/templates/fpr/idcommand/form.html:10
 #: fpr/templates/fpr/idcommand/list.html:4
 #: fpr/templates/fpr/idcommand/list.html:5
-#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:445
+#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:444
 msgid "Identification commands"
 msgstr ""
 
@@ -2323,7 +2330,7 @@ msgstr ""
 #: fpr/templates/fpr/idrule/detail.html:10
 #: fpr/templates/fpr/idrule/form.html:10 fpr/templates/fpr/idrule/list.html:4
 #: fpr/templates/fpr/idrule/list.html:5 fpr/templates/fpr/idrule/list.html:9
-#: fpr/views.py:354
+#: fpr/views.py:353
 #, fuzzy
 #| msgid "Identifier"
 msgid "Identification rules"
@@ -2394,150 +2401,150 @@ msgstr ""
 msgid "No revisions exist."
 msgstr ""
 
-#: fpr/utils.py:74
+#: fpr/utils.py:85
 msgid ""
 "You are replacing the current revision with data from an older revision."
 msgstr ""
 
-#: fpr/utils.py:81
+#: fpr/utils.py:92
 msgid "You are viewing a disabled revision."
 msgstr ""
 
-#: fpr/views.py:91
+#: fpr/views.py:90
 #, python-format
 msgid "Edit format %(name)s"
 msgstr ""
 
-#: fpr/views.py:93
+#: fpr/views.py:92
 #, fuzzy
 #| msgid "Created time"
 msgid "Create format"
 msgstr "作成時刻"
 
-#: fpr/views.py:134
+#: fpr/views.py:133
 #, python-format
 msgid "Replace format version %(name)s"
 msgstr ""
 
-#: fpr/views.py:137 fpr/views.py:641
+#: fpr/views.py:136 fpr/views.py:640
 msgid "Create format version"
 msgstr ""
 
-#: fpr/views.py:164
+#: fpr/views.py:163
 msgid "Format versions"
 msgstr ""
 
-#: fpr/views.py:173 fpr/views.py:360 fpr/views.py:454 fpr/views.py:554
-#: fpr/views.py:687
+#: fpr/views.py:172 fpr/views.py:359 fpr/views.py:453 fpr/views.py:553
+#: fpr/views.py:686
 msgid "Disabled."
 msgstr ""
 
-#: fpr/views.py:179 fpr/views.py:363 fpr/views.py:457 fpr/views.py:557
-#: fpr/views.py:693
+#: fpr/views.py:178 fpr/views.py:362 fpr/views.py:456 fpr/views.py:556
+#: fpr/views.py:692
 msgid "Enabled."
 msgstr ""
 
-#: fpr/views.py:192
+#: fpr/views.py:191
 msgid "Enable/disable format version"
 msgstr ""
 
-#: fpr/views.py:212
+#: fpr/views.py:211
 #, python-format
 msgid "Edit format group %(name)s"
 msgstr ""
 
-#: fpr/views.py:214
+#: fpr/views.py:213
 msgid "Create format group"
 msgstr ""
 
-#: fpr/views.py:249
+#: fpr/views.py:248
 #, python-format
 msgid "%(count)d substitutions were performed."
 msgstr ""
 
-#: fpr/views.py:256
+#: fpr/views.py:255
 msgid "Please select a group to substitute for this group in member formats."
 msgstr ""
 
-#: fpr/views.py:293
+#: fpr/views.py:292
 #, python-format
 msgid "Edit identification tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:296
+#: fpr/views.py:295
 msgid "Create identification tool"
 msgstr ""
 
-#: fpr/views.py:331
+#: fpr/views.py:330
 #, python-format
 msgid "Replace identification rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:334
+#: fpr/views.py:333
 msgid "Create identification rule"
 msgstr ""
 
-#: fpr/views.py:374
+#: fpr/views.py:373
 msgid "Enable/disable identification rule"
 msgstr ""
 
-#: fpr/views.py:405
+#: fpr/views.py:404
 #, python-format
 msgid "Replace identification command %(name)s"
 msgstr ""
 
-#: fpr/views.py:410
+#: fpr/views.py:409
 msgid "Create identification command"
 msgstr ""
 
-#: fpr/views.py:467
+#: fpr/views.py:466
 msgid "Enable/disable identification command"
 msgstr ""
 
-#: fpr/views.py:509
+#: fpr/views.py:508
 #, python-format
 msgid "Replace format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:513
+#: fpr/views.py:512
 msgid "Create format policy rule"
 msgstr ""
 
-#: fpr/views.py:568
+#: fpr/views.py:567
 msgid "Enable/disable format policy registry rule"
 msgstr ""
 
-#: fpr/views.py:593
+#: fpr/views.py:592
 #, python-format
 msgid "Replace format policy registry tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:598
+#: fpr/views.py:597
 msgid "Create format policy registry tool"
 msgstr ""
 
-#: fpr/views.py:638
+#: fpr/views.py:637
 #, python-format
 msgid "Replace command %(name)s"
 msgstr ""
 
-#: fpr/views.py:704
+#: fpr/views.py:703
 msgid "Enable/disable format policy command"
 msgstr ""
 
-#: fpr/views.py:728
+#: fpr/views.py:724
 #, fuzzy
 #| msgid "General configuration"
 msgid "Identification tool configuration"
 msgstr "一般的な設定"
 
-#: fpr/views.py:729
+#: fpr/views.py:725
 #, fuzzy
 #| msgid "Identifier"
 msgid "Identification rule"
 msgstr "識別子"
 
-#: fpr/views.py:730
+#: fpr/views.py:726
 msgid "Identification command"
 msgstr ""
 
@@ -2571,462 +2578,462 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: main/models.py:245
+#: main/models.py:246
 msgid "Part of AIC"
 msgstr "AIC部"
 
-#: main/models.py:246
+#: main/models.py:247
 msgid "Optional: leave blank if unsure"
 msgstr ""
 
-#: main/models.py:255
+#: main/models.py:256
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:265
+#: main/models.py:266
 msgid "Use ISO 639"
 msgstr ""
 
-#: main/models.py:283
+#: main/models.py:284
 msgid "Untitled"
 msgstr ""
 
-#: main/models.py:336
+#: main/models.py:337
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr ""
 
-#: main/models.py:381
+#: main/models.py:382
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr ""
 
-#: main/models.py:409
+#: main/models.py:410
 msgid "SIP"
 msgstr ""
 
-#: main/models.py:410
+#: main/models.py:411
 msgid "AIC"
 msgstr "AIC"
 
-#: main/models.py:411
+#: main/models.py:412
 msgid "Reingested AIP"
 msgstr ""
 
-#: main/models.py:412
+#: main/models.py:413
 msgid "Reingested AIC"
 msgstr ""
 
-#: main/models.py:426
+#: main/models.py:427
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr ""
 
-#: main/models.py:547
+#: main/models.py:548
 msgid "Arranged SIPs"
 msgstr ""
 
-#: main/models.py:551
+#: main/models.py:552
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr ""
 
-#: main/models.py:596
+#: main/models.py:597
 msgid "Identifier Type"
 msgstr ""
 
-#: main/models.py:598
+#: main/models.py:599
 msgid "Identifier Value"
 msgstr ""
 
-#: main/models.py:600
+#: main/models.py:601
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
 msgstr ""
 
-#: main/models.py:673
+#: main/models.py:674
 #, python-format
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:719
+#: main/models.py:720
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:783
+#: main/models.py:784
 #, python-format
 msgid "%(file)s is %(format)s"
 msgstr ""
 
-#: main/models.py:801
+#: main/models.py:802
 msgid "(Unnamed)"
 msgstr ""
 
-#: main/models.py:823
+#: main/models.py:824
 msgid "Unknown"
 msgstr "不明"
 
-#: main/models.py:824
+#: main/models.py:825
 msgid "Awaiting decision"
 msgstr ""
 
-#: main/models.py:825
+#: main/models.py:826
 msgid "Completed successfully"
 msgstr ""
 
-#: main/models.py:826
+#: main/models.py:827
 msgid "Executing command(s)"
 msgstr ""
 
-#: main/models.py:827
+#: main/models.py:828
 msgid "Failed"
 msgstr ""
 
-#: main/models.py:924
+#: main/models.py:936
 msgid "Agent Identifier Type"
 msgstr ""
 
-#: main/models.py:929
+#: main/models.py:941
 msgid "Agent Identifier Value"
 msgstr ""
 
-#: main/models.py:931
+#: main/models.py:943
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
 msgstr ""
 
-#: main/models.py:938
+#: main/models.py:950
 msgid "Agent Name"
 msgstr ""
 
-#: main/models.py:939
+#: main/models.py:951
 msgid "Used for premis:agentName in the METS file."
 msgstr ""
 
-#: main/models.py:945
+#: main/models.py:957
 msgid "Agent Type"
 msgstr ""
 
-#: main/models.py:946
+#: main/models.py:958
 msgid "Used for premis:agentType in the METS file."
 msgstr ""
 
-#: main/models.py:970
+#: main/models.py:982
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:972
+#: main/models.py:984
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: main/models.py:1022 templates/rights/rights_edit.html:106
 #: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
 #: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr ""
 
-#: main/models.py:1013
+#: main/models.py:1025
 msgid "Rights holder"
 msgstr "権利保持者"
 
-#: main/models.py:1016
+#: main/models.py:1028
 msgid "Copyright"
 msgstr "著作権"
 
-#: main/models.py:1017
+#: main/models.py:1029
 msgid "Statute"
 msgstr "法令"
 
-#: main/models.py:1018
+#: main/models.py:1030
 msgid "License"
 msgstr "ライセンス"
 
-#: main/models.py:1019
+#: main/models.py:1031
 msgid "Donor"
 msgstr "寄贈者"
 
-#: main/models.py:1020
+#: main/models.py:1032
 msgid "Policy"
 msgstr "ポリシー"
 
-#: main/models.py:1027 templates/rights/rights_list.html:34
+#: main/models.py:1039 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr ""
 
-#: main/models.py:1039
+#: main/models.py:1051
 msgid "Rights Statement"
 msgstr ""
 
-#: main/models.py:1043
+#: main/models.py:1055
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr ""
 
-#: main/models.py:1058
+#: main/models.py:1070
 msgid "copyrighted"
 msgstr ""
 
-#: main/models.py:1059
+#: main/models.py:1071
 msgid "public domain"
 msgstr ""
 
-#: main/models.py:1060
+#: main/models.py:1072
 msgid "unknown"
 msgstr ""
 
-#: main/models.py:1065
+#: main/models.py:1077
 msgid "Copyright status"
 msgstr "著作権のステータス"
 
-#: main/models.py:1070
+#: main/models.py:1082
 msgid "Copyright jurisdiction"
 msgstr "著作権法制"
 
-#: main/models.py:1076
+#: main/models.py:1088
 msgid "Copyright determination date"
 msgstr ""
 
-#: main/models.py:1077 main/models.py:1084 main/models.py:1091
-#: main/models.py:1161 main/models.py:1168 main/models.py:1234
-#: main/models.py:1241 main/models.py:1303 main/models.py:1312
-#: main/models.py:1319 main/models.py:1391 main/models.py:1398
+#: main/models.py:1089 main/models.py:1096 main/models.py:1103
+#: main/models.py:1173 main/models.py:1180 main/models.py:1246
+#: main/models.py:1253 main/models.py:1315 main/models.py:1324
+#: main/models.py:1331 main/models.py:1403 main/models.py:1410
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:1083
+#: main/models.py:1095
 msgid "Copyright start date"
 msgstr ""
 
-#: main/models.py:1090
+#: main/models.py:1102
 msgid "Copyright end date"
 msgstr ""
 
-#: main/models.py:1096 main/models.py:1173 main/models.py:1248
-#: main/models.py:1324 main/models.py:1403
+#: main/models.py:1108 main/models.py:1185 main/models.py:1260
+#: main/models.py:1336 main/models.py:1415
 msgid "Open End Date"
 msgstr ""
 
-#: main/models.py:1097 main/models.py:1174 main/models.py:1249
-#: main/models.py:1325 main/models.py:1404
+#: main/models.py:1109 main/models.py:1186 main/models.py:1261
+#: main/models.py:1337 main/models.py:1416
 msgid "Indicate end date is open"
 msgstr ""
 
-#: main/models.py:1102
+#: main/models.py:1114
 msgid "Rights: Copyright"
 msgstr ""
 
-#: main/models.py:1114
+#: main/models.py:1126
 msgid "Copyright document identification type"
 msgstr ""
 
-#: main/models.py:1118
+#: main/models.py:1130
 msgid "Copyright document identification value"
 msgstr ""
 
-#: main/models.py:1124
+#: main/models.py:1136
 msgid "Copyright document identification role"
 msgstr ""
 
-#: main/models.py:1129
+#: main/models.py:1141
 msgid "Rights: Copyright: Docs ID"
 msgstr ""
 
-#: main/models.py:1140 templates/rights/rights_edit.html:117
+#: main/models.py:1152 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr ""
 
-#: main/models.py:1145
+#: main/models.py:1157
 msgid "Rights: Copyright: Note"
 msgstr ""
 
-#: main/models.py:1154
+#: main/models.py:1166
 msgid "License terms"
 msgstr "ライセンス条件"
 
-#: main/models.py:1160
+#: main/models.py:1172
 msgid "License start date"
 msgstr ""
 
-#: main/models.py:1167
+#: main/models.py:1179
 msgid "License end date"
 msgstr ""
 
-#: main/models.py:1179
+#: main/models.py:1191
 msgid "Rights: License"
 msgstr ""
 
-#: main/models.py:1191
+#: main/models.py:1203
 msgid "License documentation identification type"
 msgstr ""
 
-#: main/models.py:1195
+#: main/models.py:1207
 msgid "License documentation identification value"
 msgstr ""
 
-#: main/models.py:1201
+#: main/models.py:1213
 msgid "License document identification role"
 msgstr ""
 
-#: main/models.py:1206
+#: main/models.py:1218
 msgid "Rights: License: Docs ID"
 msgstr ""
 
-#: main/models.py:1217 templates/rights/rights_edit.html:219
+#: main/models.py:1229 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr "ライセンス注記"
 
-#: main/models.py:1222
+#: main/models.py:1234
 msgid "Rights: License: Note"
 msgstr ""
 
-#: main/models.py:1233 templates/rights/rights_list.html:36
+#: main/models.py:1245 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr "開始"
 
-#: main/models.py:1240 templates/rights/rights_list.html:37
+#: main/models.py:1252 templates/rights/rights_list.html:37
 msgid "End"
 msgstr "終了"
 
-#: main/models.py:1254
+#: main/models.py:1266
 msgid "Rights: Granted"
 msgstr ""
 
-#: main/models.py:1266
+#: main/models.py:1278
 msgid "Rights note"
 msgstr ""
 
-#: main/models.py:1271
+#: main/models.py:1283
 msgid "Rights: Granted: Note"
 msgstr ""
 
-#: main/models.py:1286
+#: main/models.py:1298
 msgid "Rights: Granted: Restriction"
 msgstr ""
 
-#: main/models.py:1295
+#: main/models.py:1307
 msgid "Statute jurisdiction"
 msgstr "法令の管轄"
 
-#: main/models.py:1298
+#: main/models.py:1310
 msgid "Statute citation"
 msgstr "法令の引用"
 
-#: main/models.py:1302
+#: main/models.py:1314
 msgid "Statute determination date"
 msgstr "法令の制定日"
 
-#: main/models.py:1311
+#: main/models.py:1323
 msgid "Statute start date"
 msgstr ""
 
-#: main/models.py:1318
+#: main/models.py:1330
 msgid "Statute end date"
 msgstr ""
 
-#: main/models.py:1330
+#: main/models.py:1342
 msgid "Rights: Statute"
 msgstr ""
 
-#: main/models.py:1341 templates/rights/rights_edit.html:169
+#: main/models.py:1353 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr "状態注記"
 
-#: main/models.py:1346
+#: main/models.py:1358
 msgid "Rights: Statute: Note"
 msgstr ""
 
-#: main/models.py:1358
+#: main/models.py:1370
 msgid "Statute document identification type"
 msgstr ""
 
-#: main/models.py:1362
+#: main/models.py:1374
 msgid "Statute document identification value"
 msgstr ""
 
-#: main/models.py:1368
+#: main/models.py:1380
 msgid "Statute document identification role"
 msgstr ""
 
-#: main/models.py:1373
+#: main/models.py:1385
 msgid "Rights: Statute: Docs ID"
 msgstr ""
 
-#: main/models.py:1383
+#: main/models.py:1395
 msgid "Other rights basis"
 msgstr ""
 
-#: main/models.py:1390
+#: main/models.py:1402
 msgid "Other rights start date"
 msgstr ""
 
-#: main/models.py:1397
+#: main/models.py:1409
 msgid "Other rights end date"
 msgstr ""
 
-#: main/models.py:1409
+#: main/models.py:1421
 msgid "Rights: Other"
 msgstr ""
 
-#: main/models.py:1421
+#: main/models.py:1433
 msgid "Other rights document identification type"
 msgstr ""
 
-#: main/models.py:1425
+#: main/models.py:1437
 msgid "Other right document identification value"
 msgstr ""
 
-#: main/models.py:1431
+#: main/models.py:1443
 msgid "Other rights document identification role"
 msgstr ""
 
-#: main/models.py:1436
+#: main/models.py:1448
 msgid "Rights: Other: Docs ID"
 msgstr ""
 
-#: main/models.py:1447
+#: main/models.py:1459
 msgid "Other rights note"
 msgstr ""
 
-#: main/models.py:1452
+#: main/models.py:1464
 msgid "Rights: Other: Note"
 msgstr ""
 
-#: main/models.py:1462
+#: main/models.py:1474
 msgid "Linking Agent"
 msgstr ""
 
-#: main/models.py:1467
+#: main/models.py:1479
 msgid "Linking Agent Value"
 msgstr ""
 
-#: main/models.py:1473
+#: main/models.py:1485
 msgid "Rights: Agent"
 msgstr ""
 
-#: main/models.py:1509
+#: main/models.py:1521
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr ""
 
-#: main/models.py:1547
+#: main/models.py:1559
 msgid "ASDIPObjectResourcePairing"
 msgstr ""
 
-#: main/models.py:1562
+#: main/models.py:1574
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr ""
 
-#: main/models.py:1569
+#: main/models.py:1581
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 
-#: main/models.py:1709
+#: main/models.py:1721
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr "%(sortorder)s: %(name)s"
@@ -3047,66 +3054,66 @@ msgstr ""
 msgid "Incorrect type."
 msgstr ""
 
-#: settings/base.py:212
+#: settings/base.py:255
 msgid "English"
 msgstr "目次"
 
-#: settings/base.py:213
+#: settings/base.py:256
 msgid "French"
 msgstr ""
 
-#: settings/base.py:214
+#: settings/base.py:257
 msgid "Spanish"
 msgstr ""
 
-#: settings/base.py:215
+#: settings/base.py:258
 msgid "Japanese"
 msgstr ""
 
-#: settings/base.py:216
+#: settings/base.py:259
 msgid "Portuguese"
 msgstr ""
 
-#: settings/base.py:217
+#: settings/base.py:260
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: settings/base.py:218
+#: settings/base.py:261
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:435
+#: settings/base.py:479
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
 msgstr ""
 
-#: settings/base.py:438
+#: settings/base.py:482
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
 "has been moved into storage."
 msgstr ""
 
-#: settings/base.py:440
+#: settings/base.py:484
 msgid "Create a SIP from the transfer."
 msgstr ""
 
-#: settings/base.py:442
+#: settings/base.py:486
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
 "start ingest micro-services."
 msgstr ""
 
-#: settings/base.py:445
+#: settings/base.py:489
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
 "system."
 msgstr ""
 
-#: settings/base.py:448
+#: settings/base.py:492
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -3115,13 +3122,13 @@ msgid ""
 "view the tool output and error message."
 msgstr ""
 
-#: settings/base.py:451
+#: settings/base.py:495
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
 msgstr ""
 
-#: settings/base.py:454
+#: settings/base.py:498
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3279,7 +3286,9 @@ msgid "REST API configuration"
 msgstr ""
 
 #: templates/administration/api.html:27
-msgid "IP whitelist"
+#, fuzzy
+#| msgid "IP whitelist"
+msgid "IP allowlist"
 msgstr "IPホワイトリスト"
 
 #: templates/administration/api.html:29
@@ -3289,7 +3298,7 @@ msgid ""
 msgstr ""
 
 #: templates/administration/api.html:30
-msgid "If the whitelist is left empty, all IPs and hostnames will be allowed."
+msgid "If the allowlist is left empty, all IPs and hostnames will be allowed."
 msgstr ""
 
 #: templates/administration/atom_levels_of_description.html:25

--- a/src/dashboard/src/locale/pt/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/pt/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-27 22:10+0000\n"
+"POT-Creation-Date: 2021-01-12 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: artefactual <translate@artefactual.com>, 2018\n"
 "Language-Team: Portuguese (https://www.transifex.com/artefactual/teams/1506/"
@@ -19,17 +19,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: components/accounts/validators.py:20
+msgid ""
+"Your password must contain at least 3 of: uppercase characters, lowercase "
+"characters, numbers, and special characters (symbols or non-alphanumeric "
+"Unicode characters)."
+msgstr ""
+
 #: components/accounts/views.py:61 components/accounts/views.py:149
-#: components/administration/views.py:454
-#: components/administration/views.py:469
-#: components/administration/views.py:481
-#: components/administration/views.py:508
-#: components/administration/views.py:555
+#: components/administration/views.py:468
+#: components/administration/views.py:483
+#: components/administration/views.py:495
+#: components/administration/views.py:522
+#: components/administration/views.py:569
 #: components/administration/views_dip_upload.py:25
-#: components/administration/views_dip_upload.py:39 fpr/views.py:106
-#: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
-#: fpr/views.py:433 fpr/views.py:527 fpr/views.py:535 fpr/views.py:602
-#: fpr/views.py:656
+#: components/administration/views_dip_upload.py:39 fpr/views.py:105
+#: fpr/views.py:112 fpr/views.py:149 fpr/views.py:300 fpr/views.py:341
+#: fpr/views.py:432 fpr/views.py:526 fpr/views.py:534 fpr/views.py:601
+#: fpr/views.py:655
 msgid "Saved."
 msgstr ""
 
@@ -366,7 +373,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:1021
+#: components/administration/forms_dip_upload.py:21 main/models.py:1033
 msgid "Other"
 msgstr ""
 
@@ -550,7 +557,7 @@ msgid "Used in metadata-only DIP upload."
 msgstr ""
 
 #: components/administration/views.py:89 components/administration/views.py:122
-#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
+#: components/ingest/views.py:287 fpr/views.py:260 main/views.py:307
 msgid "Deleted."
 msgstr ""
 
@@ -608,34 +615,34 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:404
+#: components/administration/views.py:418
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:406
+#: components/administration/views.py:420
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr ""
 
-#: components/administration/views.py:431
+#: components/administration/views.py:445
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:434
+#: components/administration/views.py:448
 #, python-format
 msgid "No such file or directory: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:571
+#: components/administration/views.py:585
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
 "Storage Sevice URL below.<hr />%(error)s"
 msgstr ""
 
-#: components/administration/views.py:588
+#: components/administration/views.py:602
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -643,7 +650,7 @@ msgid ""
 "%(error)s"
 msgstr ""
 
-#: components/administration/views.py:600
+#: components/administration/views.py:614
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -712,7 +719,7 @@ msgid "Please type in the UUID to confirm"
 msgstr ""
 
 #: components/archival_storage/forms.py:89
-#: components/archival_storage/views.py:210
+#: components/archival_storage/views.py:204
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -750,84 +757,84 @@ msgstr ""
 msgid "Deletion requested"
 msgstr ""
 
-#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: components/archival_storage/views.py:203 templates/accounts/list.html:24
 #: templates/accounts/profile.html:31
 #: templates/administration/atom_levels_of_description.html:37
 #: templates/administration/reports/failures.html:26
 msgid "Name"
 msgstr ""
 
-#: components/archival_storage/views.py:211
+#: components/archival_storage/views.py:205
 msgid "AICID"
 msgstr ""
 
-#: components/archival_storage/views.py:212
+#: components/archival_storage/views.py:206
 msgid "Count AIPs in AIC"
 msgstr ""
 
-#: components/archival_storage/views.py:213
+#: components/archival_storage/views.py:207
 #: templates/administration/usage.html:90
 #: templates/archival_storage/view.html:67
 msgid "Size"
 msgstr ""
 
-#: components/archival_storage/views.py:214
+#: components/archival_storage/views.py:208
 msgid "File count"
 msgstr ""
 
-#: components/archival_storage/views.py:215
+#: components/archival_storage/views.py:209
 msgid "Accession IDs"
 msgstr ""
 
-#: components/archival_storage/views.py:216
+#: components/archival_storage/views.py:210
 msgid "Created date (UTC)"
 msgstr ""
 
-#: components/archival_storage/views.py:217
+#: components/archival_storage/views.py:211
 #: templates/archival_storage/view.html:75
 msgid "Status"
 msgstr ""
 
-#: components/archival_storage/views.py:218
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: components/archival_storage/views.py:212
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1019
 #: templates/administration/reports/failures.html:25
 #: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
 #: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
 msgid "Type"
 msgstr ""
 
-#: components/archival_storage/views.py:219
+#: components/archival_storage/views.py:213
 #: templates/archival_storage/view.html:79
 msgid "Encrypted"
 msgstr ""
 
-#: components/archival_storage/views.py:220
+#: components/archival_storage/views.py:214
 #: templates/archival_storage/view.html:83
 #: templates/ingest/normalization_report.html:31
 msgid "Location"
 msgstr ""
 
-#: components/archival_storage/views.py:600
+#: components/archival_storage/views.py:601
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:729
+#: components/archival_storage/views.py:730
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 
-#: components/archival_storage/views.py:741
+#: components/archival_storage/views.py:742
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
 "slug: %(slug)s"
 msgstr ""
 
-#: components/archival_storage/views.py:764
+#: components/archival_storage/views.py:765
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr ""
 
-#: components/backlog/views.py:282
+#: components/backlog/views.py:285
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 
@@ -870,100 +877,100 @@ msgstr ""
 msgid "Provided SIP UUID (%(uuid)s) belongs to an already-started SIP!"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:503
+#: components/filesystem_ajax/views.py:505
 #, python-format
 msgid "Provided UUID (%(uuid)s) is not a valid UUID!"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:512
+#: components/filesystem_ajax/views.py:514
 #, python-format
 msgid "%(path1)s is not in %(path2)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:518
+#: components/filesystem_ajax/views.py:520
 #, python-format
 msgid "%(path)s is not a directory"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:601
+#: components/filesystem_ajax/views.py:603
 msgid "SIP created."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:610
+#: components/filesystem_ajax/views.py:612
 msgid "All directories must be within the arrange directory."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:642
+#: components/filesystem_ajax/views.py:644
 msgid "Creation successful."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:654
+#: components/filesystem_ajax/views.py:656
 #, python-format
 msgid "%(src)s and %(dst)s must be inside %(path)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:675
+#: components/filesystem_ajax/views.py:677
 msgid "You cannot drag and drop onto a file."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:745
+#: components/filesystem_ajax/views.py:747
 msgid "GET parameter 'filepath' or 'destination' was blank."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:748
+#: components/filesystem_ajax/views.py:750
 #, python-format
 msgid "%(path)s must be in arrange directory."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:761
+#: components/filesystem_ajax/views.py:763
 #, python-format
 msgid "%(path1)s must go in a SIP, cannot be dropped onto %(path2)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:796
+#: components/filesystem_ajax/views.py:798
 #, python-format
 msgid "Storage Service failed with the message: %(messsage)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:812
+#: components/filesystem_ajax/views.py:814
 #, python-format
 msgid ""
 "No file information returned from the Storage Service for file at "
 "relative_path: %(path)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:890
+#: components/filesystem_ajax/views.py:892
 #, python-format
 msgid "%(path)s is not in base backlog path nor arrange path"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:916
+#: components/filesystem_ajax/views.py:918
 msgid "SIP files successfully moved."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:925
+#: components/filesystem_ajax/views.py:927
 msgid "Files added to the SIP."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:956
+#: components/filesystem_ajax/views.py:958
 msgid "Metadata files added successfully."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:991
+#: components/filesystem_ajax/views.py:993
 #, python-format
 msgid "Location %(location)s is not associated with this pipeline"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:1028
+#: components/filesystem_ajax/views.py:1030
 #, python-format
 msgid "The following errors occured: %(message)s"
 msgstr ""
 
-#: components/filesystem_ajax/views.py:1032
+#: components/filesystem_ajax/views.py:1034
 msgid "Files added successfully."
 msgstr ""
 
-#: components/filesystem_ajax/views.py:1102
+#: components/filesystem_ajax/views.py:1104
 #, python-format
 msgid "File with UUID %(uuid)s could not be found"
 msgstr ""
@@ -1255,7 +1262,7 @@ msgstr ""
 msgid "preservation format"
 msgstr ""
 
-#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:723
 msgid "Format version"
 msgstr ""
 
@@ -1431,7 +1438,7 @@ msgstr ""
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:474 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:728
 msgid "Format policy rule"
 msgstr ""
 
@@ -1487,7 +1494,7 @@ msgstr ""
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:569 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:727
 msgid "Format policy command"
 msgstr ""
 
@@ -2040,7 +2047,7 @@ msgstr ""
 #: fpr/templates/fpr/fpcommand/form.html:10
 #: fpr/templates/fpr/fpcommand/list.html:4
 #: fpr/templates/fpr/fpcommand/list.html:5
-#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:678
+#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:677
 msgid "Format policy commands"
 msgstr ""
 
@@ -2112,7 +2119,7 @@ msgid "Rule %(description)s"
 msgstr ""
 
 #: fpr/templates/fpr/fprule/detail.html:10
-#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:547
+#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:546
 msgid "Format policy rules"
 msgstr ""
 
@@ -2208,7 +2215,7 @@ msgstr ""
 #: fpr/templates/fpr/idcommand/form.html:10
 #: fpr/templates/fpr/idcommand/list.html:4
 #: fpr/templates/fpr/idcommand/list.html:5
-#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:445
+#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:444
 msgid "Identification commands"
 msgstr ""
 
@@ -2235,7 +2242,7 @@ msgstr ""
 #: fpr/templates/fpr/idrule/detail.html:10
 #: fpr/templates/fpr/idrule/form.html:10 fpr/templates/fpr/idrule/list.html:4
 #: fpr/templates/fpr/idrule/list.html:5 fpr/templates/fpr/idrule/list.html:9
-#: fpr/views.py:354
+#: fpr/views.py:353
 msgid "Identification rules"
 msgstr ""
 
@@ -2300,144 +2307,144 @@ msgstr ""
 msgid "No revisions exist."
 msgstr ""
 
-#: fpr/utils.py:74
+#: fpr/utils.py:85
 msgid ""
 "You are replacing the current revision with data from an older revision."
 msgstr ""
 
-#: fpr/utils.py:81
+#: fpr/utils.py:92
 msgid "You are viewing a disabled revision."
 msgstr ""
 
-#: fpr/views.py:91
+#: fpr/views.py:90
 #, python-format
 msgid "Edit format %(name)s"
 msgstr ""
 
-#: fpr/views.py:93
+#: fpr/views.py:92
 msgid "Create format"
 msgstr ""
 
-#: fpr/views.py:134
+#: fpr/views.py:133
 #, python-format
 msgid "Replace format version %(name)s"
 msgstr ""
 
-#: fpr/views.py:137 fpr/views.py:641
+#: fpr/views.py:136 fpr/views.py:640
 msgid "Create format version"
 msgstr ""
 
-#: fpr/views.py:164
+#: fpr/views.py:163
 msgid "Format versions"
 msgstr ""
 
-#: fpr/views.py:173 fpr/views.py:360 fpr/views.py:454 fpr/views.py:554
-#: fpr/views.py:687
+#: fpr/views.py:172 fpr/views.py:359 fpr/views.py:453 fpr/views.py:553
+#: fpr/views.py:686
 msgid "Disabled."
 msgstr ""
 
-#: fpr/views.py:179 fpr/views.py:363 fpr/views.py:457 fpr/views.py:557
-#: fpr/views.py:693
+#: fpr/views.py:178 fpr/views.py:362 fpr/views.py:456 fpr/views.py:556
+#: fpr/views.py:692
 msgid "Enabled."
 msgstr ""
 
-#: fpr/views.py:192
+#: fpr/views.py:191
 msgid "Enable/disable format version"
 msgstr ""
 
-#: fpr/views.py:212
+#: fpr/views.py:211
 #, python-format
 msgid "Edit format group %(name)s"
 msgstr ""
 
-#: fpr/views.py:214
+#: fpr/views.py:213
 msgid "Create format group"
 msgstr ""
 
-#: fpr/views.py:249
+#: fpr/views.py:248
 #, python-format
 msgid "%(count)d substitutions were performed."
 msgstr ""
 
-#: fpr/views.py:256
+#: fpr/views.py:255
 msgid "Please select a group to substitute for this group in member formats."
 msgstr ""
 
-#: fpr/views.py:293
+#: fpr/views.py:292
 #, python-format
 msgid "Edit identification tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:296
+#: fpr/views.py:295
 msgid "Create identification tool"
 msgstr ""
 
-#: fpr/views.py:331
+#: fpr/views.py:330
 #, python-format
 msgid "Replace identification rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:334
+#: fpr/views.py:333
 msgid "Create identification rule"
 msgstr ""
 
-#: fpr/views.py:374
+#: fpr/views.py:373
 msgid "Enable/disable identification rule"
 msgstr ""
 
-#: fpr/views.py:405
+#: fpr/views.py:404
 #, python-format
 msgid "Replace identification command %(name)s"
 msgstr ""
 
-#: fpr/views.py:410
+#: fpr/views.py:409
 msgid "Create identification command"
 msgstr ""
 
-#: fpr/views.py:467
+#: fpr/views.py:466
 msgid "Enable/disable identification command"
 msgstr ""
 
-#: fpr/views.py:509
+#: fpr/views.py:508
 #, python-format
 msgid "Replace format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:513
+#: fpr/views.py:512
 msgid "Create format policy rule"
 msgstr ""
 
-#: fpr/views.py:568
+#: fpr/views.py:567
 msgid "Enable/disable format policy registry rule"
 msgstr ""
 
-#: fpr/views.py:593
+#: fpr/views.py:592
 #, python-format
 msgid "Replace format policy registry tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:598
+#: fpr/views.py:597
 msgid "Create format policy registry tool"
 msgstr ""
 
-#: fpr/views.py:638
+#: fpr/views.py:637
 #, python-format
 msgid "Replace command %(name)s"
 msgstr ""
 
-#: fpr/views.py:704
+#: fpr/views.py:703
 msgid "Enable/disable format policy command"
 msgstr ""
 
-#: fpr/views.py:728
+#: fpr/views.py:724
 msgid "Identification tool configuration"
 msgstr ""
 
-#: fpr/views.py:729
+#: fpr/views.py:725
 msgid "Identification rule"
 msgstr ""
 
-#: fpr/views.py:730
+#: fpr/views.py:726
 msgid "Identification command"
 msgstr ""
 
@@ -2471,462 +2478,462 @@ msgid ""
 "administrator."
 msgstr ""
 
-#: main/models.py:245
+#: main/models.py:246
 msgid "Part of AIC"
 msgstr ""
 
-#: main/models.py:246
+#: main/models.py:247
 msgid "Optional: leave blank if unsure"
 msgstr ""
 
-#: main/models.py:255
+#: main/models.py:256
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:265
+#: main/models.py:266
 msgid "Use ISO 639"
 msgstr ""
 
-#: main/models.py:283
+#: main/models.py:284
 msgid "Untitled"
 msgstr ""
 
-#: main/models.py:336
+#: main/models.py:337
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr ""
 
-#: main/models.py:381
+#: main/models.py:382
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr ""
 
-#: main/models.py:409
+#: main/models.py:410
 msgid "SIP"
 msgstr ""
 
-#: main/models.py:410
+#: main/models.py:411
 msgid "AIC"
 msgstr ""
 
-#: main/models.py:411
+#: main/models.py:412
 msgid "Reingested AIP"
 msgstr ""
 
-#: main/models.py:412
+#: main/models.py:413
 msgid "Reingested AIC"
 msgstr ""
 
-#: main/models.py:426
+#: main/models.py:427
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr ""
 
-#: main/models.py:547
+#: main/models.py:548
 msgid "Arranged SIPs"
 msgstr ""
 
-#: main/models.py:551
+#: main/models.py:552
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr ""
 
-#: main/models.py:596
+#: main/models.py:597
 msgid "Identifier Type"
 msgstr ""
 
-#: main/models.py:598
+#: main/models.py:599
 msgid "Identifier Value"
 msgstr ""
 
-#: main/models.py:600
+#: main/models.py:601
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
 msgstr ""
 
-#: main/models.py:673
+#: main/models.py:674
 #, python-format
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:719
+#: main/models.py:720
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr ""
 
-#: main/models.py:783
+#: main/models.py:784
 #, python-format
 msgid "%(file)s is %(format)s"
 msgstr ""
 
-#: main/models.py:801
+#: main/models.py:802
 msgid "(Unnamed)"
 msgstr ""
 
-#: main/models.py:823
+#: main/models.py:824
 msgid "Unknown"
 msgstr ""
 
-#: main/models.py:824
+#: main/models.py:825
 msgid "Awaiting decision"
 msgstr ""
 
-#: main/models.py:825
+#: main/models.py:826
 msgid "Completed successfully"
 msgstr ""
 
-#: main/models.py:826
+#: main/models.py:827
 msgid "Executing command(s)"
 msgstr ""
 
-#: main/models.py:827
+#: main/models.py:828
 msgid "Failed"
 msgstr ""
 
-#: main/models.py:924
+#: main/models.py:936
 msgid "Agent Identifier Type"
 msgstr ""
 
-#: main/models.py:929
+#: main/models.py:941
 msgid "Agent Identifier Value"
 msgstr ""
 
-#: main/models.py:931
+#: main/models.py:943
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
 msgstr ""
 
-#: main/models.py:938
+#: main/models.py:950
 msgid "Agent Name"
 msgstr ""
 
-#: main/models.py:939
+#: main/models.py:951
 msgid "Used for premis:agentName in the METS file."
 msgstr ""
 
-#: main/models.py:945
+#: main/models.py:957
 msgid "Agent Type"
 msgstr ""
 
-#: main/models.py:946
+#: main/models.py:958
 msgid "Used for premis:agentType in the METS file."
 msgstr ""
 
-#: main/models.py:970
+#: main/models.py:982
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:972
+#: main/models.py:984
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: main/models.py:1022 templates/rights/rights_edit.html:106
 #: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
 #: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr ""
 
-#: main/models.py:1013
+#: main/models.py:1025
 msgid "Rights holder"
 msgstr "Proprietário dos direitos"
 
-#: main/models.py:1016
+#: main/models.py:1028
 msgid "Copyright"
 msgstr "Direitos de autor"
 
-#: main/models.py:1017
+#: main/models.py:1029
 msgid "Statute"
 msgstr "Estatuto"
 
-#: main/models.py:1018
+#: main/models.py:1030
 msgid "License"
 msgstr "Licença"
 
-#: main/models.py:1019
+#: main/models.py:1031
 msgid "Donor"
 msgstr "Doador"
 
-#: main/models.py:1020
+#: main/models.py:1032
 msgid "Policy"
 msgstr "Política"
 
-#: main/models.py:1027 templates/rights/rights_list.html:34
+#: main/models.py:1039 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr ""
 
-#: main/models.py:1039
+#: main/models.py:1051
 msgid "Rights Statement"
 msgstr ""
 
-#: main/models.py:1043
+#: main/models.py:1055
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr ""
 
-#: main/models.py:1058
+#: main/models.py:1070
 msgid "copyrighted"
 msgstr ""
 
-#: main/models.py:1059
+#: main/models.py:1071
 msgid "public domain"
 msgstr ""
 
-#: main/models.py:1060
+#: main/models.py:1072
 msgid "unknown"
 msgstr ""
 
-#: main/models.py:1065
+#: main/models.py:1077
 msgid "Copyright status"
 msgstr "Estado dos direitos de autor"
 
-#: main/models.py:1070
+#: main/models.py:1082
 msgid "Copyright jurisdiction"
 msgstr "Jurisdição dos direitos de autor"
 
-#: main/models.py:1076
+#: main/models.py:1088
 msgid "Copyright determination date"
 msgstr ""
 
-#: main/models.py:1077 main/models.py:1084 main/models.py:1091
-#: main/models.py:1161 main/models.py:1168 main/models.py:1234
-#: main/models.py:1241 main/models.py:1303 main/models.py:1312
-#: main/models.py:1319 main/models.py:1391 main/models.py:1398
+#: main/models.py:1089 main/models.py:1096 main/models.py:1103
+#: main/models.py:1173 main/models.py:1180 main/models.py:1246
+#: main/models.py:1253 main/models.py:1315 main/models.py:1324
+#: main/models.py:1331 main/models.py:1403 main/models.py:1410
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:1083
+#: main/models.py:1095
 msgid "Copyright start date"
 msgstr ""
 
-#: main/models.py:1090
+#: main/models.py:1102
 msgid "Copyright end date"
 msgstr ""
 
-#: main/models.py:1096 main/models.py:1173 main/models.py:1248
-#: main/models.py:1324 main/models.py:1403
+#: main/models.py:1108 main/models.py:1185 main/models.py:1260
+#: main/models.py:1336 main/models.py:1415
 msgid "Open End Date"
 msgstr ""
 
-#: main/models.py:1097 main/models.py:1174 main/models.py:1249
-#: main/models.py:1325 main/models.py:1404
+#: main/models.py:1109 main/models.py:1186 main/models.py:1261
+#: main/models.py:1337 main/models.py:1416
 msgid "Indicate end date is open"
 msgstr ""
 
-#: main/models.py:1102
+#: main/models.py:1114
 msgid "Rights: Copyright"
 msgstr ""
 
-#: main/models.py:1114
+#: main/models.py:1126
 msgid "Copyright document identification type"
 msgstr ""
 
-#: main/models.py:1118
+#: main/models.py:1130
 msgid "Copyright document identification value"
 msgstr ""
 
-#: main/models.py:1124
+#: main/models.py:1136
 msgid "Copyright document identification role"
 msgstr ""
 
-#: main/models.py:1129
+#: main/models.py:1141
 msgid "Rights: Copyright: Docs ID"
 msgstr ""
 
-#: main/models.py:1140 templates/rights/rights_edit.html:117
+#: main/models.py:1152 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr ""
 
-#: main/models.py:1145
+#: main/models.py:1157
 msgid "Rights: Copyright: Note"
 msgstr ""
 
-#: main/models.py:1154
+#: main/models.py:1166
 msgid "License terms"
 msgstr "Termos da licença"
 
-#: main/models.py:1160
+#: main/models.py:1172
 msgid "License start date"
 msgstr ""
 
-#: main/models.py:1167
+#: main/models.py:1179
 msgid "License end date"
 msgstr ""
 
-#: main/models.py:1179
+#: main/models.py:1191
 msgid "Rights: License"
 msgstr ""
 
-#: main/models.py:1191
+#: main/models.py:1203
 msgid "License documentation identification type"
 msgstr ""
 
-#: main/models.py:1195
+#: main/models.py:1207
 msgid "License documentation identification value"
 msgstr ""
 
-#: main/models.py:1201
+#: main/models.py:1213
 msgid "License document identification role"
 msgstr ""
 
-#: main/models.py:1206
+#: main/models.py:1218
 msgid "Rights: License: Docs ID"
 msgstr ""
 
-#: main/models.py:1217 templates/rights/rights_edit.html:219
+#: main/models.py:1229 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr ""
 
-#: main/models.py:1222
+#: main/models.py:1234
 msgid "Rights: License: Note"
 msgstr ""
 
-#: main/models.py:1233 templates/rights/rights_list.html:36
+#: main/models.py:1245 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr ""
 
-#: main/models.py:1240 templates/rights/rights_list.html:37
+#: main/models.py:1252 templates/rights/rights_list.html:37
 msgid "End"
 msgstr ""
 
-#: main/models.py:1254
+#: main/models.py:1266
 msgid "Rights: Granted"
 msgstr ""
 
-#: main/models.py:1266
+#: main/models.py:1278
 msgid "Rights note"
 msgstr ""
 
-#: main/models.py:1271
+#: main/models.py:1283
 msgid "Rights: Granted: Note"
 msgstr ""
 
-#: main/models.py:1286
+#: main/models.py:1298
 msgid "Rights: Granted: Restriction"
 msgstr ""
 
-#: main/models.py:1295
+#: main/models.py:1307
 msgid "Statute jurisdiction"
 msgstr "Jurisdição do estatuto"
 
-#: main/models.py:1298
+#: main/models.py:1310
 msgid "Statute citation"
 msgstr "Citação do estatuto"
 
-#: main/models.py:1302
+#: main/models.py:1314
 msgid "Statute determination date"
 msgstr "Data de atribuição do estatuto"
 
-#: main/models.py:1311
+#: main/models.py:1323
 msgid "Statute start date"
 msgstr ""
 
-#: main/models.py:1318
+#: main/models.py:1330
 msgid "Statute end date"
 msgstr ""
 
-#: main/models.py:1330
+#: main/models.py:1342
 msgid "Rights: Statute"
 msgstr ""
 
-#: main/models.py:1341 templates/rights/rights_edit.html:169
+#: main/models.py:1353 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr ""
 
-#: main/models.py:1346
+#: main/models.py:1358
 msgid "Rights: Statute: Note"
 msgstr ""
 
-#: main/models.py:1358
+#: main/models.py:1370
 msgid "Statute document identification type"
 msgstr ""
 
-#: main/models.py:1362
+#: main/models.py:1374
 msgid "Statute document identification value"
 msgstr ""
 
-#: main/models.py:1368
+#: main/models.py:1380
 msgid "Statute document identification role"
 msgstr ""
 
-#: main/models.py:1373
+#: main/models.py:1385
 msgid "Rights: Statute: Docs ID"
 msgstr ""
 
-#: main/models.py:1383
+#: main/models.py:1395
 msgid "Other rights basis"
 msgstr ""
 
-#: main/models.py:1390
+#: main/models.py:1402
 msgid "Other rights start date"
 msgstr ""
 
-#: main/models.py:1397
+#: main/models.py:1409
 msgid "Other rights end date"
 msgstr ""
 
-#: main/models.py:1409
+#: main/models.py:1421
 msgid "Rights: Other"
 msgstr ""
 
-#: main/models.py:1421
+#: main/models.py:1433
 msgid "Other rights document identification type"
 msgstr ""
 
-#: main/models.py:1425
+#: main/models.py:1437
 msgid "Other right document identification value"
 msgstr ""
 
-#: main/models.py:1431
+#: main/models.py:1443
 msgid "Other rights document identification role"
 msgstr ""
 
-#: main/models.py:1436
+#: main/models.py:1448
 msgid "Rights: Other: Docs ID"
 msgstr ""
 
-#: main/models.py:1447
+#: main/models.py:1459
 msgid "Other rights note"
 msgstr ""
 
-#: main/models.py:1452
+#: main/models.py:1464
 msgid "Rights: Other: Note"
 msgstr ""
 
-#: main/models.py:1462
+#: main/models.py:1474
 msgid "Linking Agent"
 msgstr ""
 
-#: main/models.py:1467
+#: main/models.py:1479
 msgid "Linking Agent Value"
 msgstr ""
 
-#: main/models.py:1473
+#: main/models.py:1485
 msgid "Rights: Agent"
 msgstr ""
 
-#: main/models.py:1509
+#: main/models.py:1521
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr ""
 
-#: main/models.py:1547
+#: main/models.py:1559
 msgid "ASDIPObjectResourcePairing"
 msgstr ""
 
-#: main/models.py:1562
+#: main/models.py:1574
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr ""
 
-#: main/models.py:1569
+#: main/models.py:1581
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 
-#: main/models.py:1709
+#: main/models.py:1721
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr ""
@@ -2947,66 +2954,66 @@ msgstr ""
 msgid "Incorrect type."
 msgstr ""
 
-#: settings/base.py:212
+#: settings/base.py:255
 msgid "English"
 msgstr ""
 
-#: settings/base.py:213
+#: settings/base.py:256
 msgid "French"
 msgstr ""
 
-#: settings/base.py:214
+#: settings/base.py:257
 msgid "Spanish"
 msgstr ""
 
-#: settings/base.py:215
+#: settings/base.py:258
 msgid "Japanese"
 msgstr ""
 
-#: settings/base.py:216
+#: settings/base.py:259
 msgid "Portuguese"
 msgstr ""
 
-#: settings/base.py:217
+#: settings/base.py:260
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: settings/base.py:218
+#: settings/base.py:261
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:435
+#: settings/base.py:479
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
 msgstr ""
 
-#: settings/base.py:438
+#: settings/base.py:482
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
 "has been moved into storage."
 msgstr ""
 
-#: settings/base.py:440
+#: settings/base.py:484
 msgid "Create a SIP from the transfer."
 msgstr ""
 
-#: settings/base.py:442
+#: settings/base.py:486
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
 "start ingest micro-services."
 msgstr ""
 
-#: settings/base.py:445
+#: settings/base.py:489
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
 "system."
 msgstr ""
 
-#: settings/base.py:448
+#: settings/base.py:492
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -3015,13 +3022,13 @@ msgid ""
 "view the tool output and error message."
 msgstr ""
 
-#: settings/base.py:451
+#: settings/base.py:495
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
 msgstr ""
 
-#: settings/base.py:454
+#: settings/base.py:498
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3179,7 +3186,7 @@ msgid "REST API configuration"
 msgstr ""
 
 #: templates/administration/api.html:27
-msgid "IP whitelist"
+msgid "IP allowlist"
 msgstr ""
 
 #: templates/administration/api.html:29
@@ -3189,7 +3196,7 @@ msgid ""
 msgstr ""
 
 #: templates/administration/api.html:30
-msgid "If the whitelist is left empty, all IPs and hostnames will be allowed."
+msgid "If the allowlist is left empty, all IPs and hostnames will be allowed."
 msgstr ""
 
 #: templates/administration/atom_levels_of_description.html:25

--- a/src/dashboard/src/locale/pt_BR/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/pt_BR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-27 22:10+0000\n"
+"POT-Creation-Date: 2021-01-12 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: artefactual <translate@artefactual.com>, 2018\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/artefactual/"
@@ -19,17 +19,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
+#: components/accounts/validators.py:20
+msgid ""
+"Your password must contain at least 3 of: uppercase characters, lowercase "
+"characters, numbers, and special characters (symbols or non-alphanumeric "
+"Unicode characters)."
+msgstr ""
+
 #: components/accounts/views.py:61 components/accounts/views.py:149
-#: components/administration/views.py:454
-#: components/administration/views.py:469
-#: components/administration/views.py:481
-#: components/administration/views.py:508
-#: components/administration/views.py:555
+#: components/administration/views.py:468
+#: components/administration/views.py:483
+#: components/administration/views.py:495
+#: components/administration/views.py:522
+#: components/administration/views.py:569
 #: components/administration/views_dip_upload.py:25
-#: components/administration/views_dip_upload.py:39 fpr/views.py:106
-#: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
-#: fpr/views.py:433 fpr/views.py:527 fpr/views.py:535 fpr/views.py:602
-#: fpr/views.py:656
+#: components/administration/views_dip_upload.py:39 fpr/views.py:105
+#: fpr/views.py:112 fpr/views.py:149 fpr/views.py:300 fpr/views.py:341
+#: fpr/views.py:432 fpr/views.py:526 fpr/views.py:534 fpr/views.py:601
+#: fpr/views.py:655
 msgid "Saved."
 msgstr "Salvo."
 
@@ -416,7 +423,7 @@ msgstr "Embutir"
 msgid "New"
 msgstr "Novo"
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:1021
+#: components/administration/forms_dip_upload.py:21 main/models.py:1033
 msgid "Other"
 msgstr "Outro"
 
@@ -617,7 +624,7 @@ msgid "Used in metadata-only DIP upload."
 msgstr "Usado no upload de DIP somente para metadata."
 
 #: components/administration/views.py:89 components/administration/views.py:122
-#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
+#: components/ingest/views.py:287 fpr/views.py:260 main/views.py:307
 msgid "Deleted."
 msgstr "Apagado."
 
@@ -683,28 +690,28 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:404
+#: components/administration/views.py:418
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:406
+#: components/administration/views.py:420
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr "Esvaziar"
 
-#: components/administration/views.py:431
+#: components/administration/views.py:445
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:434
+#: components/administration/views.py:448
 #, fuzzy, python-format
 #| msgid "No files or directories found under path: %(path)s"
 msgid "No such file or directory: %(path)s"
 msgstr "Nenhum arquivo ou diretório encontrado no caminho: %(path)s"
 
-#: components/administration/views.py:571
+#: components/administration/views.py:585
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
@@ -714,7 +721,7 @@ msgstr ""
 "com um administrador ou atualize a URL no Serviço de Armazenamento abaixo."
 "<hr />%(error)s"
 
-#: components/administration/views.py:588
+#: components/administration/views.py:602
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -725,7 +732,7 @@ msgstr ""
 "se a pipeline existir mas estiver desabilitada. Por favor, entre em contato "
 "com um administrador.<hr />%(error)s"
 
-#: components/administration/views.py:600
+#: components/administration/views.py:614
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -798,7 +805,7 @@ msgid "Please type in the UUID to confirm"
 msgstr "Digite o UUID para confirmar"
 
 #: components/archival_storage/forms.py:89
-#: components/archival_storage/views.py:210
+#: components/archival_storage/views.py:204
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -836,80 +843,80 @@ msgstr "Armazenado"
 msgid "Deletion requested"
 msgstr "Eliminação solicitada"
 
-#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: components/archival_storage/views.py:203 templates/accounts/list.html:24
 #: templates/accounts/profile.html:31
 #: templates/administration/atom_levels_of_description.html:37
 #: templates/administration/reports/failures.html:26
 msgid "Name"
 msgstr "Nome"
 
-#: components/archival_storage/views.py:211
+#: components/archival_storage/views.py:205
 msgid "AICID"
 msgstr ""
 
-#: components/archival_storage/views.py:212
+#: components/archival_storage/views.py:206
 msgid "Count AIPs in AIC"
 msgstr ""
 
-#: components/archival_storage/views.py:213
+#: components/archival_storage/views.py:207
 #: templates/administration/usage.html:90
 #: templates/archival_storage/view.html:67
 msgid "Size"
 msgstr "Tamanho"
 
-#: components/archival_storage/views.py:214
+#: components/archival_storage/views.py:208
 #, fuzzy
 #| msgid "Failure report"
 msgid "File count"
 msgstr "Relatório de falha:"
 
-#: components/archival_storage/views.py:215
+#: components/archival_storage/views.py:209
 #, fuzzy
 #| msgid "Access"
 msgid "Accession IDs"
 msgstr "Acesso"
 
-#: components/archival_storage/views.py:216
+#: components/archival_storage/views.py:210
 #, fuzzy
 #| msgid "Created time"
 msgid "Created date (UTC)"
 msgstr "Tempo criado"
 
-#: components/archival_storage/views.py:217
+#: components/archival_storage/views.py:211
 #: templates/archival_storage/view.html:75
 msgid "Status"
 msgstr "Status"
 
-#: components/archival_storage/views.py:218
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: components/archival_storage/views.py:212
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1019
 #: templates/administration/reports/failures.html:25
 #: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
 #: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
 msgid "Type"
 msgstr "Tipo"
 
-#: components/archival_storage/views.py:219
+#: components/archival_storage/views.py:213
 #: templates/archival_storage/view.html:79
 msgid "Encrypted"
 msgstr "Criptografado"
 
-#: components/archival_storage/views.py:220
+#: components/archival_storage/views.py:214
 #: templates/archival_storage/view.html:83
 #: templates/ingest/normalization_report.html:31
 msgid "Location"
 msgstr "Localização"
 
-#: components/archival_storage/views.py:600
+#: components/archival_storage/views.py:601
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:729
+#: components/archival_storage/views.py:730
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 "O upload DIP somente de metadados falhou, verifique os logs para obter mais "
 "detalhes"
 
-#: components/archival_storage/views.py:741
+#: components/archival_storage/views.py:742
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
@@ -918,12 +925,12 @@ msgstr ""
 "O upload DIP somente de metadados foi concluído com sucesso. Novo recurso "
 "tem slug: %(slug)s"
 
-#: components/archival_storage/views.py:764
+#: components/archival_storage/views.py:765
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr "Erro ao readmitir o pacote: %(message)s"
 
-#: components/backlog/views.py:282
+#: components/backlog/views.py:285
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 "Não é possível conectar ao servidor de armazenamento. Entre em contato com o "
@@ -968,64 +975,64 @@ msgstr "Cópia bem sucedida."
 msgid "Provided SIP UUID (%(uuid)s) belongs to an already-started SIP!"
 msgstr "O SIP UUID fornecido (%(uuid)s) pertence a um SIP já iniciado!"
 
-#: components/filesystem_ajax/views.py:503
+#: components/filesystem_ajax/views.py:505
 #, python-format
 msgid "Provided UUID (%(uuid)s) is not a valid UUID!"
 msgstr "O UUID fornecido (%(uuid)s) não é um UUID válido!"
 
-#: components/filesystem_ajax/views.py:512
+#: components/filesystem_ajax/views.py:514
 #, python-format
 msgid "%(path1)s is not in %(path2)s"
 msgstr "%(path1)s não está em %(path2)s"
 
-#: components/filesystem_ajax/views.py:518
+#: components/filesystem_ajax/views.py:520
 #, python-format
 msgid "%(path)s is not a directory"
 msgstr "%(path)snão é um diretório"
 
-#: components/filesystem_ajax/views.py:601
+#: components/filesystem_ajax/views.py:603
 msgid "SIP created."
 msgstr "SIP criado."
 
-#: components/filesystem_ajax/views.py:610
+#: components/filesystem_ajax/views.py:612
 #, fuzzy
 #| msgid "Directory is not within the arrange directory."
 msgid "All directories must be within the arrange directory."
 msgstr "O diretório não está dentro do diretório de arranjo."
 
-#: components/filesystem_ajax/views.py:642
+#: components/filesystem_ajax/views.py:644
 msgid "Creation successful."
 msgstr "Criação bem sucedida."
 
-#: components/filesystem_ajax/views.py:654
+#: components/filesystem_ajax/views.py:656
 #, python-format
 msgid "%(src)s and %(dst)s must be inside %(path)s"
 msgstr "%(src)se %(dst)sdeve estar dentro %(path)s"
 
-#: components/filesystem_ajax/views.py:675
+#: components/filesystem_ajax/views.py:677
 msgid "You cannot drag and drop onto a file."
 msgstr "Você não pode arrastar e soltar em um arquivo."
 
-#: components/filesystem_ajax/views.py:745
+#: components/filesystem_ajax/views.py:747
 msgid "GET parameter 'filepath' or 'destination' was blank."
 msgstr "GET parâmetro 'caminho do arquivo' ou 'destino' estava em branco."
 
-#: components/filesystem_ajax/views.py:748
+#: components/filesystem_ajax/views.py:750
 #, python-format
 msgid "%(path)s must be in arrange directory."
 msgstr "%(path)sdeve estar no diretório de arranjo."
 
-#: components/filesystem_ajax/views.py:761
+#: components/filesystem_ajax/views.py:763
 #, python-format
 msgid "%(path1)s must go in a SIP, cannot be dropped onto %(path2)s"
 msgstr "%(path1)sdeve entrar em um SIP, não pode ser descartado %(path2)s"
 
-#: components/filesystem_ajax/views.py:796
+#: components/filesystem_ajax/views.py:798
 #, python-format
 msgid "Storage Service failed with the message: %(messsage)s"
 msgstr "O serviço de armazenamento falhou com a mensagem: %(messsage)s"
 
-#: components/filesystem_ajax/views.py:812
+#: components/filesystem_ajax/views.py:814
 #, python-format
 msgid ""
 "No file information returned from the Storage Service for file at "
@@ -1034,38 +1041,38 @@ msgstr ""
 "Nenhuma informação de arquivo retornada do Storage Service para arquivo em "
 "relative_path:%(path)s"
 
-#: components/filesystem_ajax/views.py:890
+#: components/filesystem_ajax/views.py:892
 #, python-format
 msgid "%(path)s is not in base backlog path nor arrange path"
 msgstr "%(path)snão está no caminho base backlog  nem no caminho de arranjo"
 
-#: components/filesystem_ajax/views.py:916
+#: components/filesystem_ajax/views.py:918
 msgid "SIP files successfully moved."
 msgstr "Os arquivos SIP foram movidos com sucesso"
 
-#: components/filesystem_ajax/views.py:925
+#: components/filesystem_ajax/views.py:927
 msgid "Files added to the SIP."
 msgstr "Arquivos adicionados ao SIP."
 
-#: components/filesystem_ajax/views.py:956
+#: components/filesystem_ajax/views.py:958
 msgid "Metadata files added successfully."
 msgstr "Arquivos de metadados adicionados com sucesso."
 
-#: components/filesystem_ajax/views.py:991
+#: components/filesystem_ajax/views.py:993
 #, python-format
 msgid "Location %(location)s is not associated with this pipeline"
 msgstr "Localização%(location)snão está associado a este pipeline"
 
-#: components/filesystem_ajax/views.py:1028
+#: components/filesystem_ajax/views.py:1030
 #, python-format
 msgid "The following errors occured: %(message)s"
 msgstr "Os seguintes erros ocorreram:%(message)s"
 
-#: components/filesystem_ajax/views.py:1032
+#: components/filesystem_ajax/views.py:1034
 msgid "Files added successfully."
 msgstr "Arquivos adicionados com sucesso."
 
-#: components/filesystem_ajax/views.py:1102
+#: components/filesystem_ajax/views.py:1104
 #, python-format
 msgid "File with UUID %(uuid)s could not be found"
 msgstr "Arquivo com UUID%(uuid)snão pode ser achado"
@@ -1420,7 +1427,7 @@ msgstr "Já está no formato de acesso"
 msgid "preservation format"
 msgstr "Já está em formato de preservação"
 
-#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:723
 #, fuzzy
 #| msgid "AtoM/Binder version"
 msgid "Format version"
@@ -1626,7 +1633,7 @@ msgstr ""
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:474 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:728
 msgid "Format policy rule"
 msgstr ""
 
@@ -1692,7 +1699,7 @@ msgstr "Selecione o comando de identificação do formato de arquivo (Admissão)
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:569 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:727
 msgid "Format policy command"
 msgstr ""
 
@@ -2316,7 +2323,7 @@ msgstr "Nível de descriçao"
 #: fpr/templates/fpr/fpcommand/form.html:10
 #: fpr/templates/fpr/fpcommand/list.html:4
 #: fpr/templates/fpr/fpcommand/list.html:5
-#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:678
+#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:677
 msgid "Format policy commands"
 msgstr ""
 
@@ -2399,7 +2406,7 @@ msgid "Rule %(description)s"
 msgstr "Nível de descriçao"
 
 #: fpr/templates/fpr/fprule/detail.html:10
-#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:547
+#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:546
 msgid "Format policy rules"
 msgstr ""
 
@@ -2512,7 +2519,7 @@ msgstr "Selecione o comando de identificação do formato de arquivo (Admissão)
 #: fpr/templates/fpr/idcommand/form.html:10
 #: fpr/templates/fpr/idcommand/list.html:4
 #: fpr/templates/fpr/idcommand/list.html:5
-#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:445
+#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:444
 #, fuzzy
 #| msgid "Executing command(s)"
 msgid "Identification commands"
@@ -2543,7 +2550,7 @@ msgstr ""
 #: fpr/templates/fpr/idrule/detail.html:10
 #: fpr/templates/fpr/idrule/form.html:10 fpr/templates/fpr/idrule/list.html:4
 #: fpr/templates/fpr/idrule/list.html:5 fpr/templates/fpr/idrule/list.html:9
-#: fpr/views.py:354
+#: fpr/views.py:353
 #, fuzzy
 #| msgid "Identifier Value"
 msgid "Identification rules"
@@ -2618,163 +2625,163 @@ msgstr ""
 msgid "No revisions exist."
 msgstr ""
 
-#: fpr/utils.py:74
+#: fpr/utils.py:85
 msgid ""
 "You are replacing the current revision with data from an older revision."
 msgstr ""
 
-#: fpr/utils.py:81
+#: fpr/utils.py:92
 msgid "You are viewing a disabled revision."
 msgstr ""
 
-#: fpr/views.py:91
+#: fpr/views.py:90
 #, python-format
 msgid "Edit format %(name)s"
 msgstr ""
 
-#: fpr/views.py:93
+#: fpr/views.py:92
 #, fuzzy
 #| msgid "File format"
 msgid "Create format"
 msgstr "Formato de arquivo"
 
-#: fpr/views.py:134
+#: fpr/views.py:133
 #, python-format
 msgid "Replace format version %(name)s"
 msgstr ""
 
-#: fpr/views.py:137 fpr/views.py:641
+#: fpr/views.py:136 fpr/views.py:640
 msgid "Create format version"
 msgstr ""
 
-#: fpr/views.py:164
+#: fpr/views.py:163
 msgid "Format versions"
 msgstr ""
 
-#: fpr/views.py:173 fpr/views.py:360 fpr/views.py:454 fpr/views.py:554
-#: fpr/views.py:687
+#: fpr/views.py:172 fpr/views.py:359 fpr/views.py:453 fpr/views.py:553
+#: fpr/views.py:686
 msgid "Disabled."
 msgstr ""
 
-#: fpr/views.py:179 fpr/views.py:363 fpr/views.py:457 fpr/views.py:557
-#: fpr/views.py:693
+#: fpr/views.py:178 fpr/views.py:362 fpr/views.py:456 fpr/views.py:556
+#: fpr/views.py:692
 msgid "Enabled."
 msgstr ""
 
-#: fpr/views.py:192
+#: fpr/views.py:191
 msgid "Enable/disable format version"
 msgstr ""
 
-#: fpr/views.py:212
+#: fpr/views.py:211
 #, python-format
 msgid "Edit format group %(name)s"
 msgstr ""
 
-#: fpr/views.py:214
+#: fpr/views.py:213
 msgid "Create format group"
 msgstr ""
 
-#: fpr/views.py:249
+#: fpr/views.py:248
 #, python-format
 msgid "%(count)d substitutions were performed."
 msgstr ""
 
-#: fpr/views.py:256
+#: fpr/views.py:255
 msgid "Please select a group to substitute for this group in member formats."
 msgstr ""
 
-#: fpr/views.py:293
+#: fpr/views.py:292
 #, fuzzy, python-format
 #| msgid "License document identification role"
 msgid "Edit identification tool %(name)s"
 msgstr "Função do documento de identificação de licença"
 
-#: fpr/views.py:296
+#: fpr/views.py:295
 #, fuzzy
 #| msgid "Copyright document identification role"
 msgid "Create identification tool"
 msgstr "Função do documento de identificação de direitos autorais"
 
-#: fpr/views.py:331
+#: fpr/views.py:330
 #, fuzzy, python-format
 #| msgid "License document identification role"
 msgid "Replace identification rule %(uuid)s"
 msgstr "Função do documento de identificação de licença"
 
-#: fpr/views.py:334
+#: fpr/views.py:333
 #, fuzzy
 #| msgid "Copyright document identification role"
 msgid "Create identification rule"
 msgstr "Função do documento de identificação de direitos autorais"
 
-#: fpr/views.py:374
+#: fpr/views.py:373
 #, fuzzy
 #| msgid "License document identification role"
 msgid "Enable/disable identification rule"
 msgstr "Função do documento de identificação de licença"
 
-#: fpr/views.py:405
+#: fpr/views.py:404
 #, fuzzy, python-format
 #| msgid "Select file format identification command (Ingest)"
 msgid "Replace identification command %(name)s"
 msgstr "Selecione o comando de identificação do formato de arquivo (Admissão)"
 
-#: fpr/views.py:410
+#: fpr/views.py:409
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "Create identification command"
 msgstr "Selecione o comando de identificação do formato de arquivo (Admissão)"
 
-#: fpr/views.py:467
+#: fpr/views.py:466
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "Enable/disable identification command"
 msgstr "Selecione o comando de identificação do formato de arquivo (Admissão)"
 
-#: fpr/views.py:509
+#: fpr/views.py:508
 #, python-format
 msgid "Replace format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:513
+#: fpr/views.py:512
 msgid "Create format policy rule"
 msgstr ""
 
-#: fpr/views.py:568
+#: fpr/views.py:567
 msgid "Enable/disable format policy registry rule"
 msgstr ""
 
-#: fpr/views.py:593
+#: fpr/views.py:592
 #, python-format
 msgid "Replace format policy registry tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:598
+#: fpr/views.py:597
 msgid "Create format policy registry tool"
 msgstr ""
 
-#: fpr/views.py:638
+#: fpr/views.py:637
 #, python-format
 msgid "Replace command %(name)s"
 msgstr ""
 
-#: fpr/views.py:704
+#: fpr/views.py:703
 msgid "Enable/disable format policy command"
 msgstr ""
 
-#: fpr/views.py:728
+#: fpr/views.py:724
 #, fuzzy
 #| msgid "General configuration"
 msgid "Identification tool configuration"
 msgstr "Configuração geral"
 
-#: fpr/views.py:729
+#: fpr/views.py:725
 #, fuzzy
 #| msgid "Identifier Value"
 msgid "Identification rule"
 msgstr "Valor do Identificador"
 
-#: fpr/views.py:730
+#: fpr/views.py:726
 #, fuzzy
 #| msgid "Executing command(s)"
 msgid "Identification command"
@@ -2812,75 +2819,75 @@ msgstr ""
 "Erro ao criar pipeline: o servidor de armazenamento está em execução? Entre "
 "em contato com o administrador."
 
-#: main/models.py:245
+#: main/models.py:246
 msgid "Part of AIC"
 msgstr "Parte da AIC"
 
-#: main/models.py:246
+#: main/models.py:247
 msgid "Optional: leave blank if unsure"
 msgstr "Opcional: deixe em branco se não tiver certeza"
 
-#: main/models.py:255
+#: main/models.py:256
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr "Utilize o formato ISO 8601 (AAAA-MM-DD ou AAAA-MM-DD/AAAA-MM-DD)"
 
-#: main/models.py:265
+#: main/models.py:266
 msgid "Use ISO 639"
 msgstr "Utilize a ISO 639"
 
-#: main/models.py:283
+#: main/models.py:284
 msgid "Untitled"
 msgstr "Sem título"
 
-#: main/models.py:336
+#: main/models.py:337
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr "%(type)s evento em%(file_uuid)s (%(detail)s)"
 
-#: main/models.py:381
+#: main/models.py:382
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr "%(derived)sderivado de%(src)sem%(event)s"
 
-#: main/models.py:409
+#: main/models.py:410
 msgid "SIP"
 msgstr "SIP"
 
-#: main/models.py:410
+#: main/models.py:411
 msgid "AIC"
 msgstr "AIC"
 
-#: main/models.py:411
+#: main/models.py:412
 msgid "Reingested AIP"
 msgstr "AIP readmitido"
 
-#: main/models.py:412
+#: main/models.py:413
 msgid "Reingested AIC"
 msgstr "AIC readmitido"
 
-#: main/models.py:426
+#: main/models.py:427
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr "SIP: {path}"
 
-#: main/models.py:547
+#: main/models.py:548
 msgid "Arranged SIPs"
 msgstr "SIPs Organizados"
 
-#: main/models.py:551
+#: main/models.py:552
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr "%(original)s -> %(arrange)s"
 
-#: main/models.py:596
+#: main/models.py:597
 msgid "Identifier Type"
 msgstr "Tipo de Identificador"
 
-#: main/models.py:598
+#: main/models.py:599
 msgid "Identifier Value"
 msgstr "Valor do Identificador"
 
-#: main/models.py:600
+#: main/models.py:601
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
@@ -2888,56 +2895,56 @@ msgstr ""
 "Usado como premis:objectIdentifierType e premis:objectIdentifierValue no "
 "arquivo METS."
 
-#: main/models.py:673
+#: main/models.py:674
 #, fuzzy, python-format
 #| msgid "File %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr "Arquivo %(uuid)s:%(originallocation)sagora em %(currentlocation)s"
 
-#: main/models.py:719
+#: main/models.py:720
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr "Diretório %(uuid)s:%(originallocation)s agora em %(currentlocation)s"
 
-#: main/models.py:783
+#: main/models.py:784
 #, fuzzy, python-format
 #| msgid "File format"
 msgid "%(file)s is %(format)s"
 msgstr "Formato de arquivo"
 
-#: main/models.py:801
+#: main/models.py:802
 msgid "(Unnamed)"
 msgstr "(Sem nome)"
 
-#: main/models.py:823
+#: main/models.py:824
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: main/models.py:824
+#: main/models.py:825
 msgid "Awaiting decision"
 msgstr "Aguardando decisão"
 
-#: main/models.py:825
+#: main/models.py:826
 msgid "Completed successfully"
 msgstr "Completado com sucesso"
 
-#: main/models.py:826
+#: main/models.py:827
 msgid "Executing command(s)"
 msgstr "Executando o(s) comando(s)"
 
-#: main/models.py:827
+#: main/models.py:828
 msgid "Failed"
 msgstr "Falhou"
 
-#: main/models.py:924
+#: main/models.py:936
 msgid "Agent Identifier Type"
 msgstr "Tipo de Identificador de Agente"
 
-#: main/models.py:929
+#: main/models.py:941
 msgid "Agent Identifier Value"
 msgstr "Valor de Identificador de Agente"
 
-#: main/models.py:931
+#: main/models.py:943
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
@@ -2945,336 +2952,336 @@ msgstr ""
 "Usado como premis:agentIdentifierValue e premis:linkingAgentIdentifierValue "
 "no arquivo METS."
 
-#: main/models.py:938
+#: main/models.py:950
 msgid "Agent Name"
 msgstr "Nome do Agente"
 
-#: main/models.py:939
+#: main/models.py:951
 msgid "Used for premis:agentName in the METS file."
 msgstr "Usado como premis:agentName no arquivo METS."
 
-#: main/models.py:945
+#: main/models.py:957
 msgid "Agent Type"
 msgstr "Tipo de Agente"
 
-#: main/models.py:946
+#: main/models.py:958
 msgid "Used for premis:agentType in the METS file."
 msgstr "Usado como premis:agentType no arquivo METS."
 
-#: main/models.py:970
+#: main/models.py:982
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:972
+#: main/models.py:984
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: main/models.py:1022 templates/rights/rights_edit.html:106
 #: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
 #: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr "Valor"
 
-#: main/models.py:1013
+#: main/models.py:1025
 msgid "Rights holder"
 msgstr "Detentor dos direitos"
 
-#: main/models.py:1016
+#: main/models.py:1028
 msgid "Copyright"
 msgstr "Direitos autorais"
 
-#: main/models.py:1017
+#: main/models.py:1029
 msgid "Statute"
 msgstr "Regulamento"
 
-#: main/models.py:1018
+#: main/models.py:1030
 msgid "License"
 msgstr "Licença"
 
-#: main/models.py:1019
+#: main/models.py:1031
 msgid "Donor"
 msgstr "Doador"
 
-#: main/models.py:1020
+#: main/models.py:1032
 msgid "Policy"
 msgstr "Política"
 
-#: main/models.py:1027 templates/rights/rights_list.html:34
+#: main/models.py:1039 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr "Base"
 
-#: main/models.py:1039
+#: main/models.py:1051
 msgid "Rights Statement"
 msgstr "Declaração de Direitos"
 
-#: main/models.py:1043
+#: main/models.py:1055
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr "%(basis)spara %(unit)s (%(id)s)"
 
-#: main/models.py:1058
+#: main/models.py:1070
 msgid "copyrighted"
 msgstr "protegido por direitos autorais"
 
-#: main/models.py:1059
+#: main/models.py:1071
 msgid "public domain"
 msgstr "domínio público"
 
-#: main/models.py:1060
+#: main/models.py:1072
 msgid "unknown"
 msgstr "desconhecido"
 
-#: main/models.py:1065
+#: main/models.py:1077
 msgid "Copyright status"
 msgstr "Status dos direitos autorais"
 
-#: main/models.py:1070
+#: main/models.py:1082
 msgid "Copyright jurisdiction"
 msgstr "Juridisção dos direitos de autor"
 
-#: main/models.py:1076
+#: main/models.py:1088
 msgid "Copyright determination date"
 msgstr "Data de determinação dos direitos autorais"
 
-#: main/models.py:1077 main/models.py:1084 main/models.py:1091
-#: main/models.py:1161 main/models.py:1168 main/models.py:1234
-#: main/models.py:1241 main/models.py:1303 main/models.py:1312
-#: main/models.py:1319 main/models.py:1391 main/models.py:1398
+#: main/models.py:1089 main/models.py:1096 main/models.py:1103
+#: main/models.py:1173 main/models.py:1180 main/models.py:1246
+#: main/models.py:1253 main/models.py:1315 main/models.py:1324
+#: main/models.py:1331 main/models.py:1403 main/models.py:1410
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr "Utilize o formato ISO 8061 (AAAA-MM-DD)"
 
-#: main/models.py:1083
+#: main/models.py:1095
 msgid "Copyright start date"
 msgstr "Data inicial dos direitos autoriais"
 
-#: main/models.py:1090
+#: main/models.py:1102
 msgid "Copyright end date"
 msgstr "Data final dos direitos autoriais"
 
-#: main/models.py:1096 main/models.py:1173 main/models.py:1248
-#: main/models.py:1324 main/models.py:1403
+#: main/models.py:1108 main/models.py:1185 main/models.py:1260
+#: main/models.py:1336 main/models.py:1415
 msgid "Open End Date"
 msgstr "Data Final Aberta"
 
-#: main/models.py:1097 main/models.py:1174 main/models.py:1249
-#: main/models.py:1325 main/models.py:1404
+#: main/models.py:1109 main/models.py:1186 main/models.py:1261
+#: main/models.py:1337 main/models.py:1416
 msgid "Indicate end date is open"
 msgstr "Indica que a data final está aberta"
 
-#: main/models.py:1102
+#: main/models.py:1114
 msgid "Rights: Copyright"
 msgstr "Direitos: Direitos autorais"
 
-#: main/models.py:1114
+#: main/models.py:1126
 msgid "Copyright document identification type"
 msgstr "Tipo de documento de identificação de direitos autorais"
 
-#: main/models.py:1118
+#: main/models.py:1130
 msgid "Copyright document identification value"
 msgstr "Valor do documento de identificação de direitos autorais"
 
-#: main/models.py:1124
+#: main/models.py:1136
 msgid "Copyright document identification role"
 msgstr "Função do documento de identificação de direitos autorais"
 
-#: main/models.py:1129
+#: main/models.py:1141
 msgid "Rights: Copyright: Docs ID"
 msgstr "Direitos: Direito Autoral: ID dos Documentos"
 
-#: main/models.py:1140 templates/rights/rights_edit.html:117
+#: main/models.py:1152 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr "Nota de direitos autorais"
 
-#: main/models.py:1145
+#: main/models.py:1157
 msgid "Rights: Copyright: Note"
 msgstr "Direitos: Direito Autoral: Nota"
 
-#: main/models.py:1154
+#: main/models.py:1166
 msgid "License terms"
 msgstr "Termos de licença"
 
-#: main/models.py:1160
+#: main/models.py:1172
 msgid "License start date"
 msgstr "Data inicial da Licença"
 
-#: main/models.py:1167
+#: main/models.py:1179
 msgid "License end date"
 msgstr "Data final da Licença"
 
-#: main/models.py:1179
+#: main/models.py:1191
 msgid "Rights: License"
 msgstr "Direitos: Licença"
 
-#: main/models.py:1191
+#: main/models.py:1203
 msgid "License documentation identification type"
 msgstr "Tipo de documento de identificação de licença"
 
-#: main/models.py:1195
+#: main/models.py:1207
 msgid "License documentation identification value"
 msgstr "Valor do documento de identificação de licença"
 
-#: main/models.py:1201
+#: main/models.py:1213
 msgid "License document identification role"
 msgstr "Função do documento de identificação de licença"
 
-#: main/models.py:1206
+#: main/models.py:1218
 msgid "Rights: License: Docs ID"
 msgstr "Direitos: Licença: ID dos Documentos"
 
-#: main/models.py:1217 templates/rights/rights_edit.html:219
+#: main/models.py:1229 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr "Nota de licença"
 
-#: main/models.py:1222
+#: main/models.py:1234
 msgid "Rights: License: Note"
 msgstr "Direitos: Licença: Nota"
 
-#: main/models.py:1233 templates/rights/rights_list.html:36
+#: main/models.py:1245 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr "Início"
 
-#: main/models.py:1240 templates/rights/rights_list.html:37
+#: main/models.py:1252 templates/rights/rights_list.html:37
 msgid "End"
 msgstr "Fim"
 
-#: main/models.py:1254
+#: main/models.py:1266
 msgid "Rights: Granted"
 msgstr "Direitos: Garantia"
 
-#: main/models.py:1266
+#: main/models.py:1278
 msgid "Rights note"
 msgstr "Nota de direitos"
 
-#: main/models.py:1271
+#: main/models.py:1283
 msgid "Rights: Granted: Note"
 msgstr "Direitos: Garantia: Nota"
 
-#: main/models.py:1286
+#: main/models.py:1298
 msgid "Rights: Granted: Restriction"
 msgstr "Direitos: Garantia: Restição"
 
-#: main/models.py:1295
+#: main/models.py:1307
 msgid "Statute jurisdiction"
 msgstr " Jurisdição do regulamento"
 
-#: main/models.py:1298
+#: main/models.py:1310
 msgid "Statute citation"
 msgstr "Citação do regulamento"
 
-#: main/models.py:1302
+#: main/models.py:1314
 msgid "Statute determination date"
 msgstr "Data de determinação do regulamento"
 
-#: main/models.py:1311
+#: main/models.py:1323
 msgid "Statute start date"
 msgstr "Data inicial do estatuto"
 
-#: main/models.py:1318
+#: main/models.py:1330
 msgid "Statute end date"
 msgstr "Data final do estatuto"
 
-#: main/models.py:1330
+#: main/models.py:1342
 msgid "Rights: Statute"
 msgstr "Direitos: Estatuto"
 
-#: main/models.py:1341 templates/rights/rights_edit.html:169
+#: main/models.py:1353 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr "Nota do estatuto"
 
-#: main/models.py:1346
+#: main/models.py:1358
 msgid "Rights: Statute: Note"
 msgstr "Direitos: Estatuto: Nota"
 
-#: main/models.py:1358
+#: main/models.py:1370
 msgid "Statute document identification type"
 msgstr "Tipo de documento de identificação de estatuto"
 
-#: main/models.py:1362
+#: main/models.py:1374
 msgid "Statute document identification value"
 msgstr "Valor do documento de identificação de estatuto"
 
-#: main/models.py:1368
+#: main/models.py:1380
 msgid "Statute document identification role"
 msgstr "Função do documento de identificação de estatuto"
 
-#: main/models.py:1373
+#: main/models.py:1385
 msgid "Rights: Statute: Docs ID"
 msgstr "Direitos: Estatuto: ID dos Documentos"
 
-#: main/models.py:1383
+#: main/models.py:1395
 msgid "Other rights basis"
 msgstr "Base de outros direitos"
 
-#: main/models.py:1390
+#: main/models.py:1402
 msgid "Other rights start date"
 msgstr "Data inicial de outros direitos"
 
-#: main/models.py:1397
+#: main/models.py:1409
 msgid "Other rights end date"
 msgstr "Data final de outros direitos"
 
-#: main/models.py:1409
+#: main/models.py:1421
 msgid "Rights: Other"
 msgstr "Direitos: Outros"
 
-#: main/models.py:1421
+#: main/models.py:1433
 msgid "Other rights document identification type"
 msgstr "Tipo de documento de identificação de outros direitos"
 
-#: main/models.py:1425
+#: main/models.py:1437
 msgid "Other right document identification value"
 msgstr "Valor do documento de identificação de outros direitos"
 
-#: main/models.py:1431
+#: main/models.py:1443
 msgid "Other rights document identification role"
 msgstr "Função do documento de identificação de outros direitos"
 
-#: main/models.py:1436
+#: main/models.py:1448
 msgid "Rights: Other: Docs ID"
 msgstr "Direitos: Outros: ID dos Documentos"
 
-#: main/models.py:1447
+#: main/models.py:1459
 msgid "Other rights note"
 msgstr "Nota de outros direitos"
 
-#: main/models.py:1452
+#: main/models.py:1464
 msgid "Rights: Other: Note"
 msgstr "Direitos: Outros: Nota"
 
-#: main/models.py:1462
+#: main/models.py:1474
 msgid "Linking Agent"
 msgstr "Agente de Ligação"
 
-#: main/models.py:1467
+#: main/models.py:1479
 msgid "Linking Agent Value"
 msgstr "Valor do Agente de Ligação"
 
-#: main/models.py:1473
+#: main/models.py:1485
 msgid "Rights: Agent"
 msgstr "Direitos: Agente"
 
-#: main/models.py:1509
+#: main/models.py:1521
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr "Semanticamente uma chave estrangeira para o SIP ou Transferência"
 
-#: main/models.py:1547
+#: main/models.py:1559
 msgid "ASDIPObjectResourcePairing"
 msgstr "ASDIPObjectResourcePairing"
 
-#: main/models.py:1562
+#: main/models.py:1574
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr "Se um SIP foi iniciado ou não usando arquivos deste objeto digital."
 
-#: main/models.py:1569
+#: main/models.py:1581
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 "ID no sistema remoto ArchivesSpace, após o objeto digital ter sido criado."
 
-#: main/models.py:1709
+#: main/models.py:1721
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr "%(sortorder)s:%(name)s"
@@ -3295,35 +3302,35 @@ msgstr "Erro: não excluir ID fornecido."
 msgid "Incorrect type."
 msgstr "Tipo incorreto."
 
-#: settings/base.py:212
+#: settings/base.py:255
 msgid "English"
 msgstr "Inglês"
 
-#: settings/base.py:213
+#: settings/base.py:256
 msgid "French"
 msgstr "Francês"
 
-#: settings/base.py:214
+#: settings/base.py:257
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: settings/base.py:215
+#: settings/base.py:258
 msgid "Japanese"
 msgstr ""
 
-#: settings/base.py:216
+#: settings/base.py:259
 msgid "Portuguese"
 msgstr "Português"
 
-#: settings/base.py:217
+#: settings/base.py:260
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: settings/base.py:218
+#: settings/base.py:261
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:435
+#: settings/base.py:479
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
@@ -3331,7 +3338,7 @@ msgstr ""
 "Selecione \"Aprovar transferência\" para começar a processar ou \"Rejeitar "
 "transferência\" para reiniciar."
 
-#: settings/base.py:438
+#: settings/base.py:482
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
@@ -3341,11 +3348,11 @@ msgstr ""
 "forem interrompidas ou falharem. A transferência será automaticamente "
 "excluída quando o AIP for movido para o armazenamento."
 
-#: settings/base.py:440
+#: settings/base.py:484
 msgid "Create a SIP from the transfer."
 msgstr "Crie um SIP a partir da transferência."
 
-#: settings/base.py:442
+#: settings/base.py:486
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
@@ -3355,7 +3362,7 @@ msgstr ""
 "qualquer avaliação e arranjo físico, selecione \"Criação de SIP completada\" "
 "para iniciar os  microsserviços de admissão."
 
-#: settings/base.py:445
+#: settings/base.py:489
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
@@ -3365,7 +3372,7 @@ msgstr ""
 "cópias de acesso resultará em um DIP gerado para upload em um sistema de "
 "acesso."
 
-#: settings/base.py:448
+#: settings/base.py:492
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -3379,7 +3386,7 @@ msgstr ""
 "em \"Falha na normalização de preservação\" ou \"Falha na normalização de "
 "acesso\" para visualizar a saída da ferramenta e a mensagem de erro."
 
-#: settings/base.py:451
+#: settings/base.py:495
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
@@ -3388,7 +3395,7 @@ msgstr ""
 "Selecione \"Armazenar AIP\" para mover o AIP para o armazenamento de "
 "arquivos."
 
-#: settings/base.py:454
+#: settings/base.py:498
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3553,7 +3560,9 @@ msgid "REST API configuration"
 msgstr "Configuração do REST API "
 
 #: templates/administration/api.html:27
-msgid "IP whitelist"
+#, fuzzy
+#| msgid "IP whitelist"
+msgid "IP allowlist"
 msgstr "Lista branca do IP"
 
 #: templates/administration/api.html:29
@@ -3564,7 +3573,10 @@ msgstr ""
 "Digite uma lista separada de IPs ou nomes de host permitidos para usar a API."
 
 #: templates/administration/api.html:30
-msgid "If the whitelist is left empty, all IPs and hostnames will be allowed."
+#, fuzzy
+#| msgid ""
+#| "If the whitelist is left empty, all IPs and hostnames will be allowed."
+msgid "If the allowlist is left empty, all IPs and hostnames will be allowed."
 msgstr ""
 "Se a lista branca for deixada vazia, todos os IPs e nomes de host serão "
 "permitidos."

--- a/src/dashboard/src/locale/sv/LC_MESSAGES/django.po
+++ b/src/dashboard/src/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-27 22:10+0000\n"
+"POT-Creation-Date: 2021-01-12 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: artefactual <translate@artefactual.com>, 2018\n"
 "Language-Team: Swedish (https://www.transifex.com/artefactual/teams/1506/"
@@ -19,17 +19,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: components/accounts/validators.py:20
+msgid ""
+"Your password must contain at least 3 of: uppercase characters, lowercase "
+"characters, numbers, and special characters (symbols or non-alphanumeric "
+"Unicode characters)."
+msgstr ""
+
 #: components/accounts/views.py:61 components/accounts/views.py:149
-#: components/administration/views.py:454
-#: components/administration/views.py:469
-#: components/administration/views.py:481
-#: components/administration/views.py:508
-#: components/administration/views.py:555
+#: components/administration/views.py:468
+#: components/administration/views.py:483
+#: components/administration/views.py:495
+#: components/administration/views.py:522
+#: components/administration/views.py:569
 #: components/administration/views_dip_upload.py:25
-#: components/administration/views_dip_upload.py:39 fpr/views.py:106
-#: fpr/views.py:113 fpr/views.py:150 fpr/views.py:301 fpr/views.py:342
-#: fpr/views.py:433 fpr/views.py:527 fpr/views.py:535 fpr/views.py:602
-#: fpr/views.py:656
+#: components/administration/views_dip_upload.py:39 fpr/views.py:105
+#: fpr/views.py:112 fpr/views.py:149 fpr/views.py:300 fpr/views.py:341
+#: fpr/views.py:432 fpr/views.py:526 fpr/views.py:534 fpr/views.py:601
+#: fpr/views.py:655
 msgid "Saved."
 msgstr "Sparad."
 
@@ -409,7 +416,7 @@ msgstr "Inbäddad"
 msgid "New"
 msgstr "Ny"
 
-#: components/administration/forms_dip_upload.py:21 main/models.py:1021
+#: components/administration/forms_dip_upload.py:21 main/models.py:1033
 msgid "Other"
 msgstr "Annat"
 
@@ -606,7 +613,7 @@ msgid "Used in metadata-only DIP upload."
 msgstr "Används vid uppladdning av DIP med enbart metadata."
 
 #: components/administration/views.py:89 components/administration/views.py:122
-#: components/ingest/views.py:287 fpr/views.py:261 main/views.py:307
+#: components/ingest/views.py:287 fpr/views.py:260 main/views.py:307
 msgid "Deleted."
 msgstr "Raderad."
 
@@ -672,35 +679,35 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: components/administration/views.py:404
+#: components/administration/views.py:418
 #, python-format
 msgid "Clear %(dir)s?"
 msgstr ""
 
-#: components/administration/views.py:406
+#: components/administration/views.py:420
 #: templates/administration/usage.html:103
 msgid "Clear"
 msgstr "Rensa"
 
-#: components/administration/views.py:431
+#: components/administration/views.py:445
 #, python-format
 msgid "Cleared: %(path)s"
 msgstr ""
 
-#: components/administration/views.py:434
+#: components/administration/views.py:448
 #, fuzzy, python-format
 #| msgid "No files or directories found under path: %(path)s"
 msgid "No such file or directory: %(path)s"
 msgstr "Inga filer eller mappar funna under sökväg: %(path)s"
 
-#: components/administration/views.py:571
+#: components/administration/views.py:585
 #, python-format
 msgid ""
 "Storage Service inaccessible. Please contact an administrator or update the "
 "Storage Sevice URL below.<hr />%(error)s"
 msgstr ""
 
-#: components/administration/views.py:588
+#: components/administration/views.py:602
 #, python-format
 msgid ""
 "Storage Service failed to create the pipeline. This can happen if the "
@@ -708,7 +715,7 @@ msgid ""
 "%(error)s"
 msgstr ""
 
-#: components/administration/views.py:600
+#: components/administration/views.py:614
 msgid ""
 "Storage Service returned a 404 error. Has the pipeline been disabled or is "
 "it not registered yet? Submitting form will attempt to register the pipeline."
@@ -777,7 +784,7 @@ msgid "Please type in the UUID to confirm"
 msgstr "Var god skriv UUIDet för att bekräfta"
 
 #: components/archival_storage/forms.py:89
-#: components/archival_storage/views.py:210
+#: components/archival_storage/views.py:204
 #: fpr/templates/fpr/format/detail.html:23
 #: fpr/templates/fpr/format/version/detail.html:27
 #: fpr/templates/fpr/fpcommand/detail.html:26
@@ -815,80 +822,80 @@ msgstr "Lagrad"
 msgid "Deletion requested"
 msgstr "Radering efterfrågad"
 
-#: components/archival_storage/views.py:209 templates/accounts/list.html:24
+#: components/archival_storage/views.py:203 templates/accounts/list.html:24
 #: templates/accounts/profile.html:31
 #: templates/administration/atom_levels_of_description.html:37
 #: templates/administration/reports/failures.html:26
 msgid "Name"
 msgstr "Namn"
 
-#: components/archival_storage/views.py:211
+#: components/archival_storage/views.py:205
 msgid "AICID"
 msgstr ""
 
-#: components/archival_storage/views.py:212
+#: components/archival_storage/views.py:206
 msgid "Count AIPs in AIC"
 msgstr ""
 
-#: components/archival_storage/views.py:213
+#: components/archival_storage/views.py:207
 #: templates/administration/usage.html:90
 #: templates/archival_storage/view.html:67
 msgid "Size"
 msgstr "Storlek"
 
-#: components/archival_storage/views.py:214
+#: components/archival_storage/views.py:208
 #, fuzzy
 #| msgid "Failure report"
 msgid "File count"
 msgstr "Rapport över misslyckanden"
 
-#: components/archival_storage/views.py:215
+#: components/archival_storage/views.py:209
 #, fuzzy
 #| msgid "Access"
 msgid "Accession IDs"
 msgstr "Åtkomst"
 
-#: components/archival_storage/views.py:216
+#: components/archival_storage/views.py:210
 #, fuzzy
 #| msgid "Created time"
 msgid "Created date (UTC)"
 msgstr "Tid vid uprrättande"
 
-#: components/archival_storage/views.py:217
+#: components/archival_storage/views.py:211
 #: templates/archival_storage/view.html:75
 msgid "Status"
 msgstr "Status"
 
-#: components/archival_storage/views.py:218
-#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1007
+#: components/archival_storage/views.py:212
+#: fpr/templates/fpr/idcommand/list.html:29 main/models.py:1019
 #: templates/administration/reports/failures.html:25
 #: templates/rights/rights_edit.html:102 templates/rights/rights_edit.html:154
 #: templates/rights/rights_edit.html:204 templates/rights/rights_edit.html:252
 msgid "Type"
 msgstr "Typ"
 
-#: components/archival_storage/views.py:219
+#: components/archival_storage/views.py:213
 #: templates/archival_storage/view.html:79
 msgid "Encrypted"
 msgstr "Krypterad"
 
-#: components/archival_storage/views.py:220
+#: components/archival_storage/views.py:214
 #: templates/archival_storage/view.html:83
 #: templates/ingest/normalization_report.html:31
 msgid "Location"
 msgstr "Plats"
 
-#: components/archival_storage/views.py:600
+#: components/archival_storage/views.py:601
 msgid "The AIP package containing the requested METS cannot be found"
 msgstr ""
 
-#: components/archival_storage/views.py:729
+#: components/archival_storage/views.py:730
 msgid "Metadata-only DIP upload failed, check the logs for more details"
 msgstr ""
 "Uppladdning av DIP med endast metadata misslyckades, se logg för fler "
 "detaljer."
 
-#: components/archival_storage/views.py:741
+#: components/archival_storage/views.py:742
 #, python-format
 msgid ""
 "Metadata-only DIP upload has been completed successfully. New resource has "
@@ -896,12 +903,12 @@ msgid ""
 msgstr ""
 "Uppladdning av endast metadata DIP lyckades. Ny resurs har slug: %(slug)s"
 
-#: components/archival_storage/views.py:764
+#: components/archival_storage/views.py:765
 #, python-format
 msgid "Error re-ingesting package: %(message)s"
 msgstr "Fel under återingestering av paket: %(message)s"
 
-#: components/backlog/views.py:282
+#: components/backlog/views.py:285
 msgid "Unable to connect to storage server. Please contact your administrator."
 msgstr ""
 "Kunde inte ansluta till lagringsservern. Var god kontakta din administratör."
@@ -945,64 +952,64 @@ msgstr "Kopiering lyckades."
 msgid "Provided SIP UUID (%(uuid)s) belongs to an already-started SIP!"
 msgstr "Tillhandahållen SIP UUID (%(uuid)s) hör till en redan startad SIP!"
 
-#: components/filesystem_ajax/views.py:503
+#: components/filesystem_ajax/views.py:505
 #, python-format
 msgid "Provided UUID (%(uuid)s) is not a valid UUID!"
 msgstr "Tillhandahållen UUID (%(uuid)s) är inte en giltigt UUID!"
 
-#: components/filesystem_ajax/views.py:512
+#: components/filesystem_ajax/views.py:514
 #, python-format
 msgid "%(path1)s is not in %(path2)s"
 msgstr "%(path1)s är inte in %(path2)s"
 
-#: components/filesystem_ajax/views.py:518
+#: components/filesystem_ajax/views.py:520
 #, python-format
 msgid "%(path)s is not a directory"
 msgstr "%(path)s är inte i mappen"
 
-#: components/filesystem_ajax/views.py:601
+#: components/filesystem_ajax/views.py:603
 msgid "SIP created."
 msgstr "SIP skapad."
 
-#: components/filesystem_ajax/views.py:610
+#: components/filesystem_ajax/views.py:612
 #, fuzzy
 #| msgid "Directory is not within the arrange directory."
 msgid "All directories must be within the arrange directory."
 msgstr "Katalogen finns inte i ordningskatalogen."
 
-#: components/filesystem_ajax/views.py:642
+#: components/filesystem_ajax/views.py:644
 msgid "Creation successful."
 msgstr "Skapande lyckades."
 
-#: components/filesystem_ajax/views.py:654
+#: components/filesystem_ajax/views.py:656
 #, python-format
 msgid "%(src)s and %(dst)s must be inside %(path)s"
 msgstr "%(src)s och %(dst)s måste vara i %(path)s"
 
-#: components/filesystem_ajax/views.py:675
+#: components/filesystem_ajax/views.py:677
 msgid "You cannot drag and drop onto a file."
 msgstr "Du kan inte dra och släppa till en fil."
 
-#: components/filesystem_ajax/views.py:745
+#: components/filesystem_ajax/views.py:747
 msgid "GET parameter 'filepath' or 'destination' was blank."
 msgstr "GET parameter 'filepath' eller 'destination' var tom."
 
-#: components/filesystem_ajax/views.py:748
+#: components/filesystem_ajax/views.py:750
 #, python-format
 msgid "%(path)s must be in arrange directory."
 msgstr "%(path)s måste finnas i ordningskatalogen."
 
-#: components/filesystem_ajax/views.py:761
+#: components/filesystem_ajax/views.py:763
 #, python-format
 msgid "%(path1)s must go in a SIP, cannot be dropped onto %(path2)s"
 msgstr "%(path1)s måste gå till en SIP, kan inte dras till %(path2)s"
 
-#: components/filesystem_ajax/views.py:796
+#: components/filesystem_ajax/views.py:798
 #, python-format
 msgid "Storage Service failed with the message: %(messsage)s"
 msgstr "Lagringsservern misslyckades med felmeddelande: %(messsage)s"
 
-#: components/filesystem_ajax/views.py:812
+#: components/filesystem_ajax/views.py:814
 #, python-format
 msgid ""
 "No file information returned from the Storage Service for file at "
@@ -1011,38 +1018,38 @@ msgstr ""
 "Ingen filinformation hämtades från lagringstjänsten för fil på "
 "relative_path: %(path)s"
 
-#: components/filesystem_ajax/views.py:890
+#: components/filesystem_ajax/views.py:892
 #, python-format
 msgid "%(path)s is not in base backlog path nor arrange path"
 msgstr "%(path)s finns inte i bas backlogsökvägen eller i ordningsmappen."
 
-#: components/filesystem_ajax/views.py:916
+#: components/filesystem_ajax/views.py:918
 msgid "SIP files successfully moved."
 msgstr "Flyttning av SIP-filer lyckades."
 
-#: components/filesystem_ajax/views.py:925
+#: components/filesystem_ajax/views.py:927
 msgid "Files added to the SIP."
 msgstr "Filer tillagda till SIP:en."
 
-#: components/filesystem_ajax/views.py:956
+#: components/filesystem_ajax/views.py:958
 msgid "Metadata files added successfully."
 msgstr "Tilläggande av metadatafiler lyckades."
 
-#: components/filesystem_ajax/views.py:991
+#: components/filesystem_ajax/views.py:993
 #, python-format
 msgid "Location %(location)s is not associated with this pipeline"
 msgstr "Platsen %(location)s är inte associerad med denna pipeline"
 
-#: components/filesystem_ajax/views.py:1028
+#: components/filesystem_ajax/views.py:1030
 #, python-format
 msgid "The following errors occured: %(message)s"
 msgstr "Följande fel uppstod: %(message)s"
 
-#: components/filesystem_ajax/views.py:1032
+#: components/filesystem_ajax/views.py:1034
 msgid "Files added successfully."
 msgstr "Tilläggande av filer lyckades."
 
-#: components/filesystem_ajax/views.py:1102
+#: components/filesystem_ajax/views.py:1104
 #, python-format
 msgid "File with UUID %(uuid)s could not be found"
 msgstr "Fil med UUID %(uuid)s kunde inte hittas"
@@ -1388,7 +1395,7 @@ msgstr "Redan i åtkomstformat."
 msgid "preservation format"
 msgstr "Redan i bevarandeformat"
 
-#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:727
+#: fpr/models.py:214 fpr/templates/fpr/idrule/detail.html:28 fpr/views.py:723
 #, fuzzy
 #| msgid "Format"
 msgid "Format version"
@@ -1589,7 +1596,7 @@ msgstr ""
 msgid "count not okay"
 msgstr ""
 
-#: fpr/models.py:474 fpr/views.py:732
+#: fpr/models.py:474 fpr/views.py:728
 msgid "Format policy rule"
 msgstr ""
 
@@ -1655,7 +1662,7 @@ msgstr "Välj kommando för identifikation av filformat (Ingest)"
 msgid "the related event detail command"
 msgstr ""
 
-#: fpr/models.py:569 fpr/views.py:731
+#: fpr/models.py:569 fpr/views.py:727
 msgid "Format policy command"
 msgstr ""
 
@@ -2277,7 +2284,7 @@ msgstr "Beskrivningsnivå"
 #: fpr/templates/fpr/fpcommand/form.html:10
 #: fpr/templates/fpr/fpcommand/list.html:4
 #: fpr/templates/fpr/fpcommand/list.html:5
-#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:678
+#: fpr/templates/fpr/fpcommand/list.html:9 fpr/views.py:677
 msgid "Format policy commands"
 msgstr ""
 
@@ -2356,7 +2363,7 @@ msgid "Rule %(description)s"
 msgstr "Beskrivningsnivå"
 
 #: fpr/templates/fpr/fprule/detail.html:10
-#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:547
+#: fpr/templates/fpr/fprule/form.html:10 fpr/views.py:546
 msgid "Format policy rules"
 msgstr ""
 
@@ -2469,7 +2476,7 @@ msgstr "Välj kommando för identifikation av filformat (Ingest)"
 #: fpr/templates/fpr/idcommand/form.html:10
 #: fpr/templates/fpr/idcommand/list.html:4
 #: fpr/templates/fpr/idcommand/list.html:5
-#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:445
+#: fpr/templates/fpr/idcommand/list.html:9 fpr/views.py:444
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "Identification commands"
@@ -2500,7 +2507,7 @@ msgstr ""
 #: fpr/templates/fpr/idrule/detail.html:10
 #: fpr/templates/fpr/idrule/form.html:10 fpr/templates/fpr/idrule/list.html:4
 #: fpr/templates/fpr/idrule/list.html:5 fpr/templates/fpr/idrule/list.html:9
-#: fpr/views.py:354
+#: fpr/views.py:353
 #, fuzzy
 #| msgid "Identifier"
 msgid "Identification rules"
@@ -2571,155 +2578,155 @@ msgstr ""
 msgid "No revisions exist."
 msgstr ""
 
-#: fpr/utils.py:74
+#: fpr/utils.py:85
 msgid ""
 "You are replacing the current revision with data from an older revision."
 msgstr ""
 
-#: fpr/utils.py:81
+#: fpr/utils.py:92
 msgid "You are viewing a disabled revision."
 msgstr ""
 
-#: fpr/views.py:91
+#: fpr/views.py:90
 #, python-format
 msgid "Edit format %(name)s"
 msgstr ""
 
-#: fpr/views.py:93
+#: fpr/views.py:92
 #, fuzzy
 #| msgid "File format"
 msgid "Create format"
 msgstr "Filformat"
 
-#: fpr/views.py:134
+#: fpr/views.py:133
 #, python-format
 msgid "Replace format version %(name)s"
 msgstr ""
 
-#: fpr/views.py:137 fpr/views.py:641
+#: fpr/views.py:136 fpr/views.py:640
 msgid "Create format version"
 msgstr ""
 
-#: fpr/views.py:164
+#: fpr/views.py:163
 msgid "Format versions"
 msgstr ""
 
-#: fpr/views.py:173 fpr/views.py:360 fpr/views.py:454 fpr/views.py:554
-#: fpr/views.py:687
+#: fpr/views.py:172 fpr/views.py:359 fpr/views.py:453 fpr/views.py:553
+#: fpr/views.py:686
 msgid "Disabled."
 msgstr ""
 
-#: fpr/views.py:179 fpr/views.py:363 fpr/views.py:457 fpr/views.py:557
-#: fpr/views.py:693
+#: fpr/views.py:178 fpr/views.py:362 fpr/views.py:456 fpr/views.py:556
+#: fpr/views.py:692
 msgid "Enabled."
 msgstr ""
 
-#: fpr/views.py:192
+#: fpr/views.py:191
 msgid "Enable/disable format version"
 msgstr ""
 
-#: fpr/views.py:212
+#: fpr/views.py:211
 #, python-format
 msgid "Edit format group %(name)s"
 msgstr ""
 
-#: fpr/views.py:214
+#: fpr/views.py:213
 msgid "Create format group"
 msgstr ""
 
-#: fpr/views.py:249
+#: fpr/views.py:248
 #, python-format
 msgid "%(count)d substitutions were performed."
 msgstr ""
 
-#: fpr/views.py:256
+#: fpr/views.py:255
 msgid "Please select a group to substitute for this group in member formats."
 msgstr ""
 
-#: fpr/views.py:293
+#: fpr/views.py:292
 #, python-format
 msgid "Edit identification tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:296
+#: fpr/views.py:295
 msgid "Create identification tool"
 msgstr ""
 
-#: fpr/views.py:331
+#: fpr/views.py:330
 #, python-format
 msgid "Replace identification rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:334
+#: fpr/views.py:333
 msgid "Create identification rule"
 msgstr ""
 
-#: fpr/views.py:374
+#: fpr/views.py:373
 msgid "Enable/disable identification rule"
 msgstr ""
 
-#: fpr/views.py:405
+#: fpr/views.py:404
 #, fuzzy, python-format
 #| msgid "Select file format identification command (Ingest)"
 msgid "Replace identification command %(name)s"
 msgstr "Välj kommando för identifikation av filformat (Ingest)"
 
-#: fpr/views.py:410
+#: fpr/views.py:409
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "Create identification command"
 msgstr "Välj kommando för identifikation av filformat (Ingest)"
 
-#: fpr/views.py:467
+#: fpr/views.py:466
 #, fuzzy
 #| msgid "Select file format identification command (Ingest)"
 msgid "Enable/disable identification command"
 msgstr "Välj kommando för identifikation av filformat (Ingest)"
 
-#: fpr/views.py:509
+#: fpr/views.py:508
 #, python-format
 msgid "Replace format policy rule %(uuid)s"
 msgstr ""
 
-#: fpr/views.py:513
+#: fpr/views.py:512
 msgid "Create format policy rule"
 msgstr ""
 
-#: fpr/views.py:568
+#: fpr/views.py:567
 msgid "Enable/disable format policy registry rule"
 msgstr ""
 
-#: fpr/views.py:593
+#: fpr/views.py:592
 #, python-format
 msgid "Replace format policy registry tool %(name)s"
 msgstr ""
 
-#: fpr/views.py:598
+#: fpr/views.py:597
 msgid "Create format policy registry tool"
 msgstr ""
 
-#: fpr/views.py:638
+#: fpr/views.py:637
 #, python-format
 msgid "Replace command %(name)s"
 msgstr ""
 
-#: fpr/views.py:704
+#: fpr/views.py:703
 msgid "Enable/disable format policy command"
 msgstr ""
 
-#: fpr/views.py:728
+#: fpr/views.py:724
 #, fuzzy
 #| msgid "General configuration"
 msgid "Identification tool configuration"
 msgstr "Allmän konfigurering"
 
-#: fpr/views.py:729
+#: fpr/views.py:725
 #, fuzzy
 #| msgid "Identifier"
 msgid "Identification rule"
 msgstr "Signum"
 
-#: fpr/views.py:730
+#: fpr/views.py:726
 msgid "Identification command"
 msgstr ""
 
@@ -2755,464 +2762,464 @@ msgstr ""
 "Fel under skapelse av pipeline: Är lagringsservern igång? Var god kontakta "
 "en administratör."
 
-#: main/models.py:245
+#: main/models.py:246
 msgid "Part of AIC"
 msgstr "Del av AIC"
 
-#: main/models.py:246
+#: main/models.py:247
 msgid "Optional: leave blank if unsure"
 msgstr ""
 
-#: main/models.py:255
+#: main/models.py:256
 msgid "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:265
+#: main/models.py:266
 msgid "Use ISO 639"
 msgstr ""
 
-#: main/models.py:283
+#: main/models.py:284
 msgid "Untitled"
 msgstr "Utan titel"
 
-#: main/models.py:336
+#: main/models.py:337
 #, python-format
 msgid "%(type)s event on %(file_uuid)s (%(detail)s)"
 msgstr "%(type)s händekse på %(file_uuid)s (%(detail)s)"
 
-#: main/models.py:381
+#: main/models.py:382
 #, python-format
 msgid "%(derived)s derived from %(src)s in %(event)s"
 msgstr "%(derived)s  bearbetad från %(src)s i %(event)s"
 
-#: main/models.py:409
+#: main/models.py:410
 msgid "SIP"
 msgstr ""
 
-#: main/models.py:410
+#: main/models.py:411
 msgid "AIC"
 msgstr "AIC"
 
-#: main/models.py:411
+#: main/models.py:412
 msgid "Reingested AIP"
 msgstr ""
 
-#: main/models.py:412
+#: main/models.py:413
 msgid "Reingested AIC"
 msgstr ""
 
-#: main/models.py:426
+#: main/models.py:427
 #, python-brace-format
 msgid "SIP: {path}"
 msgstr "SIP: {path}"
 
-#: main/models.py:547
+#: main/models.py:548
 msgid "Arranged SIPs"
 msgstr ""
 
-#: main/models.py:551
+#: main/models.py:552
 #, python-format
 msgid "%(original)s -> %(arrange)s"
 msgstr "%(original)s -> %(arrange)s"
 
-#: main/models.py:596
+#: main/models.py:597
 msgid "Identifier Type"
 msgstr ""
 
-#: main/models.py:598
+#: main/models.py:599
 msgid "Identifier Value"
 msgstr ""
 
-#: main/models.py:600
+#: main/models.py:601
 msgid ""
 "Used for premis:objectIdentifierType and premis:objectIdentifierValue in the "
 "METS file."
 msgstr ""
 
-#: main/models.py:673
+#: main/models.py:674
 #, fuzzy, python-format
 #| msgid "File %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgid "File %(uuid)s:%(originallocation)s now at %(currentlocation)s"
 msgstr "File %(uuid)s: %(originallocation)s nu på %(currentlocation)s"
 
-#: main/models.py:719
+#: main/models.py:720
 #, python-format
 msgid "Directory %(uuid)s: %(originallocation)s now at %(currentlocation)s"
 msgstr "Sökväg %(uuid)s: %(originallocation)s nu på %(currentlocation)s"
 
-#: main/models.py:783
+#: main/models.py:784
 #, fuzzy, python-format
 #| msgid "File format"
 msgid "%(file)s is %(format)s"
 msgstr "Filformat"
 
-#: main/models.py:801
+#: main/models.py:802
 msgid "(Unnamed)"
 msgstr "(Namnlös)"
 
-#: main/models.py:823
+#: main/models.py:824
 msgid "Unknown"
 msgstr "Okänd"
 
-#: main/models.py:824
+#: main/models.py:825
 msgid "Awaiting decision"
 msgstr ""
 
-#: main/models.py:825
+#: main/models.py:826
 msgid "Completed successfully"
 msgstr ""
 
-#: main/models.py:826
+#: main/models.py:827
 msgid "Executing command(s)"
 msgstr ""
 
-#: main/models.py:827
+#: main/models.py:828
 msgid "Failed"
 msgstr ""
 
-#: main/models.py:924
+#: main/models.py:936
 msgid "Agent Identifier Type"
 msgstr ""
 
-#: main/models.py:929
+#: main/models.py:941
 msgid "Agent Identifier Value"
 msgstr ""
 
-#: main/models.py:931
+#: main/models.py:943
 msgid ""
 "Used for premis:agentIdentifierValue and premis:linkingAgentIdentifierValue "
 "in the METS file."
 msgstr ""
 
-#: main/models.py:938
+#: main/models.py:950
 msgid "Agent Name"
 msgstr ""
 
-#: main/models.py:939
+#: main/models.py:951
 msgid "Used for premis:agentName in the METS file."
 msgstr ""
 
-#: main/models.py:945
+#: main/models.py:957
 msgid "Agent Type"
 msgstr ""
 
-#: main/models.py:946
+#: main/models.py:958
 msgid "Used for premis:agentType in the METS file."
 msgstr ""
 
-#: main/models.py:970
+#: main/models.py:982
 msgid ""
 "If checked, this user will receive system emails, such as Transfer Fail and "
 "Normalization Reports."
 msgstr ""
 
-#: main/models.py:972
+#: main/models.py:984
 msgid "Send system emails?"
 msgstr ""
 
-#: main/models.py:1010 templates/rights/rights_edit.html:106
+#: main/models.py:1022 templates/rights/rights_edit.html:106
 #: templates/rights/rights_edit.html:158 templates/rights/rights_edit.html:208
 #: templates/rights/rights_edit.html:256
 msgid "Value"
 msgstr "Värde"
 
-#: main/models.py:1013
+#: main/models.py:1025
 msgid "Rights holder"
 msgstr "Rättighetsinnehavare"
 
-#: main/models.py:1016
+#: main/models.py:1028
 msgid "Copyright"
 msgstr "Upphovsrätt"
 
-#: main/models.py:1017
+#: main/models.py:1029
 msgid "Statute"
 msgstr "Regelverk"
 
-#: main/models.py:1018
+#: main/models.py:1030
 msgid "License"
 msgstr "Licens"
 
-#: main/models.py:1019
+#: main/models.py:1031
 msgid "Donor"
 msgstr "Donator"
 
-#: main/models.py:1020
+#: main/models.py:1032
 msgid "Policy"
 msgstr "Policy"
 
-#: main/models.py:1027 templates/rights/rights_list.html:34
+#: main/models.py:1039 templates/rights/rights_list.html:34
 msgid "Basis"
 msgstr "Grund"
 
-#: main/models.py:1039
+#: main/models.py:1051
 msgid "Rights Statement"
 msgstr ""
 
-#: main/models.py:1043
+#: main/models.py:1055
 #, python-format
 msgid "%(basis)s for %(unit)s (%(id)s)"
 msgstr "%(basis)s för %(unit)s (%(id)s)"
 
-#: main/models.py:1058
+#: main/models.py:1070
 msgid "copyrighted"
 msgstr ""
 
-#: main/models.py:1059
+#: main/models.py:1071
 msgid "public domain"
 msgstr ""
 
-#: main/models.py:1060
+#: main/models.py:1072
 msgid "unknown"
 msgstr ""
 
-#: main/models.py:1065
+#: main/models.py:1077
 msgid "Copyright status"
 msgstr "Upphovsrättsstatus"
 
-#: main/models.py:1070
+#: main/models.py:1082
 msgid "Copyright jurisdiction"
 msgstr "Upphovsrättsgrund"
 
-#: main/models.py:1076
+#: main/models.py:1088
 msgid "Copyright determination date"
 msgstr ""
 
-#: main/models.py:1077 main/models.py:1084 main/models.py:1091
-#: main/models.py:1161 main/models.py:1168 main/models.py:1234
-#: main/models.py:1241 main/models.py:1303 main/models.py:1312
-#: main/models.py:1319 main/models.py:1391 main/models.py:1398
+#: main/models.py:1089 main/models.py:1096 main/models.py:1103
+#: main/models.py:1173 main/models.py:1180 main/models.py:1246
+#: main/models.py:1253 main/models.py:1315 main/models.py:1324
+#: main/models.py:1331 main/models.py:1403 main/models.py:1410
 msgid "Use ISO 8061 (YYYY-MM-DD)"
 msgstr ""
 
-#: main/models.py:1083
+#: main/models.py:1095
 msgid "Copyright start date"
 msgstr ""
 
-#: main/models.py:1090
+#: main/models.py:1102
 msgid "Copyright end date"
 msgstr ""
 
-#: main/models.py:1096 main/models.py:1173 main/models.py:1248
-#: main/models.py:1324 main/models.py:1403
+#: main/models.py:1108 main/models.py:1185 main/models.py:1260
+#: main/models.py:1336 main/models.py:1415
 msgid "Open End Date"
 msgstr ""
 
-#: main/models.py:1097 main/models.py:1174 main/models.py:1249
-#: main/models.py:1325 main/models.py:1404
+#: main/models.py:1109 main/models.py:1186 main/models.py:1261
+#: main/models.py:1337 main/models.py:1416
 msgid "Indicate end date is open"
 msgstr ""
 
-#: main/models.py:1102
+#: main/models.py:1114
 msgid "Rights: Copyright"
 msgstr ""
 
-#: main/models.py:1114
+#: main/models.py:1126
 msgid "Copyright document identification type"
 msgstr ""
 
-#: main/models.py:1118
+#: main/models.py:1130
 msgid "Copyright document identification value"
 msgstr ""
 
-#: main/models.py:1124
+#: main/models.py:1136
 msgid "Copyright document identification role"
 msgstr ""
 
-#: main/models.py:1129
+#: main/models.py:1141
 msgid "Rights: Copyright: Docs ID"
 msgstr ""
 
-#: main/models.py:1140 templates/rights/rights_edit.html:117
+#: main/models.py:1152 templates/rights/rights_edit.html:117
 msgid "Copyright note"
 msgstr "Upphovsrättsnotering"
 
-#: main/models.py:1145
+#: main/models.py:1157
 msgid "Rights: Copyright: Note"
 msgstr ""
 
-#: main/models.py:1154
+#: main/models.py:1166
 msgid "License terms"
 msgstr "Licensvillkor"
 
-#: main/models.py:1160
+#: main/models.py:1172
 msgid "License start date"
 msgstr ""
 
-#: main/models.py:1167
+#: main/models.py:1179
 msgid "License end date"
 msgstr ""
 
-#: main/models.py:1179
+#: main/models.py:1191
 msgid "Rights: License"
 msgstr ""
 
-#: main/models.py:1191
+#: main/models.py:1203
 msgid "License documentation identification type"
 msgstr ""
 
-#: main/models.py:1195
+#: main/models.py:1207
 msgid "License documentation identification value"
 msgstr ""
 
-#: main/models.py:1201
+#: main/models.py:1213
 msgid "License document identification role"
 msgstr ""
 
-#: main/models.py:1206
+#: main/models.py:1218
 msgid "Rights: License: Docs ID"
 msgstr ""
 
-#: main/models.py:1217 templates/rights/rights_edit.html:219
+#: main/models.py:1229 templates/rights/rights_edit.html:219
 msgid "License note"
 msgstr "Licensanmärkning"
 
-#: main/models.py:1222
+#: main/models.py:1234
 msgid "Rights: License: Note"
 msgstr ""
 
-#: main/models.py:1233 templates/rights/rights_list.html:36
+#: main/models.py:1245 templates/rights/rights_list.html:36
 msgid "Start"
 msgstr "Start"
 
-#: main/models.py:1240 templates/rights/rights_list.html:37
+#: main/models.py:1252 templates/rights/rights_list.html:37
 msgid "End"
 msgstr "Slut"
 
-#: main/models.py:1254
+#: main/models.py:1266
 msgid "Rights: Granted"
 msgstr ""
 
-#: main/models.py:1266
+#: main/models.py:1278
 msgid "Rights note"
 msgstr ""
 
-#: main/models.py:1271
+#: main/models.py:1283
 msgid "Rights: Granted: Note"
 msgstr ""
 
-#: main/models.py:1286
+#: main/models.py:1298
 msgid "Rights: Granted: Restriction"
 msgstr ""
 
-#: main/models.py:1295
+#: main/models.py:1307
 msgid "Statute jurisdiction"
 msgstr "Rättsgrund för regelverk"
 
-#: main/models.py:1298
+#: main/models.py:1310
 msgid "Statute citation"
 msgstr "Citering för regelverk"
 
-#: main/models.py:1302
+#: main/models.py:1314
 msgid "Statute determination date"
 msgstr "Beslutsdatum för regelverk"
 
-#: main/models.py:1311
+#: main/models.py:1323
 msgid "Statute start date"
 msgstr ""
 
-#: main/models.py:1318
+#: main/models.py:1330
 msgid "Statute end date"
 msgstr ""
 
-#: main/models.py:1330
+#: main/models.py:1342
 msgid "Rights: Statute"
 msgstr ""
 
-#: main/models.py:1341 templates/rights/rights_edit.html:169
+#: main/models.py:1353 templates/rights/rights_edit.html:169
 msgid "Statute note"
 msgstr "Regelverksanmärkning"
 
-#: main/models.py:1346
+#: main/models.py:1358
 msgid "Rights: Statute: Note"
 msgstr ""
 
-#: main/models.py:1358
+#: main/models.py:1370
 msgid "Statute document identification type"
 msgstr ""
 
-#: main/models.py:1362
+#: main/models.py:1374
 msgid "Statute document identification value"
 msgstr ""
 
-#: main/models.py:1368
+#: main/models.py:1380
 msgid "Statute document identification role"
 msgstr ""
 
-#: main/models.py:1373
+#: main/models.py:1385
 msgid "Rights: Statute: Docs ID"
 msgstr ""
 
-#: main/models.py:1383
+#: main/models.py:1395
 msgid "Other rights basis"
 msgstr ""
 
-#: main/models.py:1390
+#: main/models.py:1402
 msgid "Other rights start date"
 msgstr ""
 
-#: main/models.py:1397
+#: main/models.py:1409
 msgid "Other rights end date"
 msgstr ""
 
-#: main/models.py:1409
+#: main/models.py:1421
 msgid "Rights: Other"
 msgstr ""
 
-#: main/models.py:1421
+#: main/models.py:1433
 msgid "Other rights document identification type"
 msgstr ""
 
-#: main/models.py:1425
+#: main/models.py:1437
 msgid "Other right document identification value"
 msgstr ""
 
-#: main/models.py:1431
+#: main/models.py:1443
 msgid "Other rights document identification role"
 msgstr ""
 
-#: main/models.py:1436
+#: main/models.py:1448
 msgid "Rights: Other: Docs ID"
 msgstr ""
 
-#: main/models.py:1447
+#: main/models.py:1459
 msgid "Other rights note"
 msgstr ""
 
-#: main/models.py:1452
+#: main/models.py:1464
 msgid "Rights: Other: Note"
 msgstr ""
 
-#: main/models.py:1462
+#: main/models.py:1474
 msgid "Linking Agent"
 msgstr ""
 
-#: main/models.py:1467
+#: main/models.py:1479
 msgid "Linking Agent Value"
 msgstr ""
 
-#: main/models.py:1473
+#: main/models.py:1485
 msgid "Rights: Agent"
 msgstr ""
 
-#: main/models.py:1509
+#: main/models.py:1521
 msgid "Semantically a foreign key to SIP or Transfer"
 msgstr ""
 
-#: main/models.py:1547
+#: main/models.py:1559
 msgid "ASDIPObjectResourcePairing"
 msgstr ""
 
-#: main/models.py:1562
+#: main/models.py:1574
 msgid ""
 "Whether or not a SIP has been started using files in this digital object."
 msgstr ""
 
-#: main/models.py:1569
+#: main/models.py:1581
 msgid ""
 "ID in the remote ArchivesSpace system, after digital object has been created."
 msgstr ""
 
-#: main/models.py:1709
+#: main/models.py:1721
 #, python-format
 msgid "%(sortorder)s: %(name)s"
 msgstr "%(sortorder)s: %(name)s"
@@ -3233,35 +3240,35 @@ msgstr "Fel: ingen raderings ID angavs."
 msgid "Incorrect type."
 msgstr "Felaktig typ."
 
-#: settings/base.py:212
+#: settings/base.py:255
 msgid "English"
 msgstr "Engelska"
 
-#: settings/base.py:213
+#: settings/base.py:256
 msgid "French"
 msgstr "Franska"
 
-#: settings/base.py:214
+#: settings/base.py:257
 msgid "Spanish"
 msgstr "Spanska"
 
-#: settings/base.py:215
+#: settings/base.py:258
 msgid "Japanese"
 msgstr ""
 
-#: settings/base.py:216
+#: settings/base.py:259
 msgid "Portuguese"
 msgstr "Portugisiska"
 
-#: settings/base.py:217
+#: settings/base.py:260
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: settings/base.py:218
+#: settings/base.py:261
 msgid "Swedish"
 msgstr ""
 
-#: settings/base.py:435
+#: settings/base.py:479
 msgid ""
 "Select \"Approve transfer\" to begin processing or \"Reject transfer\" to "
 "start over again."
@@ -3269,7 +3276,7 @@ msgstr ""
 "Välj \"Godkänn överföring\" för att påbörja bearbetning eller \"Avslå "
 "överföring\" för att starta om."
 
-#: settings/base.py:438
+#: settings/base.py:482
 msgid ""
 "Create a complete backup of the transfer in case transfer/ingest are "
 "interrupted or fail. The transfer will automatically be deleted once the AIP "
@@ -3279,11 +3286,11 @@ msgstr ""
 "eller misslyckas. Denna transfer kommer automatiskt raderas när AIP:n har "
 "flyttats till lagring."
 
-#: settings/base.py:440
+#: settings/base.py:484
 msgid "Create a SIP from the transfer."
 msgstr "Skapa SIP från transfern."
 
-#: settings/base.py:442
+#: settings/base.py:486
 msgid ""
 "Once you have added files from the transfer to the SIP and have completed "
 "any appraisal and physical arrangement, select \"SIP creation complete\" to "
@@ -3293,7 +3300,7 @@ msgstr ""
 "bevarande- och gallringsprocess och fysiskt ordnande välj \"SIP skapelse "
 "fullföljd\" för att starta de micro-servicerna kopplade till ingest."
 
-#: settings/base.py:445
+#: settings/base.py:489
 msgid ""
 "Create preservation and/or access copies of files if desired. Creating "
 "access copies will result in a DIP being generated for upload into an access "
@@ -3303,7 +3310,7 @@ msgstr ""
 "åtkomstkopior kommer leda till att en DIP genereras för uppladdning till ett "
 "åtkomstsystem."
 
-#: settings/base.py:448
+#: settings/base.py:492
 msgid ""
 "If desired, click \"review\" to view the normalized files. To see a report "
 "summarizing the normalization results, click on the report icon next to the "
@@ -3318,7 +3325,7 @@ msgstr ""
 "misslyckades\" eller \"Normalisering för åtkomst misslyckades\" för att se "
 "verktygets output och felmeddelande."
 
-#: settings/base.py:451
+#: settings/base.py:495
 msgid ""
 "If desired, click \"review\" to view AIP contents. Select \"Store AIP\" to "
 "move the AIP into archival storage."
@@ -3326,7 +3333,7 @@ msgstr ""
 "Om så önskas kan du klicka på \"Granska\" för visa innehållet i AIP:n. Välj "
 "\"Lagra AIP\" för att flytta AIP:n till arkivförvaring."
 
-#: settings/base.py:454
+#: settings/base.py:498
 msgid ""
 "If desired, select \"Upload DIP\" to upload the DIP to the access system."
 msgstr ""
@@ -3489,7 +3496,9 @@ msgid "REST API configuration"
 msgstr "Inställningar för REST API"
 
 #: templates/administration/api.html:27
-msgid "IP whitelist"
+#, fuzzy
+#| msgid "IP whitelist"
+msgid "IP allowlist"
 msgstr "Lista över godkända IP-adresser"
 
 #: templates/administration/api.html:29
@@ -3501,7 +3510,10 @@ msgstr ""
 "tillåtelse att använda API:n."
 
 #: templates/administration/api.html:30
-msgid "If the whitelist is left empty, all IPs and hostnames will be allowed."
+#, fuzzy
+#| msgid ""
+#| "If the whitelist is left empty, all IPs and hostnames will be allowed."
+msgid "If the allowlist is left empty, all IPs and hostnames will be allowed."
 msgstr ""
 "Om listan med godkända IP-adresser lämnas tom så kommer alla IP-adresser och "
 "värddatornamn tillåtas."

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -63,6 +63,26 @@ CONFIG_MAPPING = {
         "option": "gearman_server",
         "type": "string",
     },
+    "password_minimum_length": {
+        "section": "Dashboard",
+        "option": "password_minimum_length",
+        "type": "int",
+    },
+    "password_disable_common_validation": {
+        "section": "Dashboard",
+        "option": "password_disable_common_validation",
+        "type": "boolean",
+    },
+    "password_disable_user_attribute_similarity_validation": {
+        "section": "Dashboard",
+        "option": "password_disable_user_attribute_similarity_validation",
+        "type": "boolean",
+    },
+    "password_disable_complexity_validation": {
+        "section": "Dashboard",
+        "option": "password_disable_complexity_validation",
+        "type": "boolean",
+    },
     "shibboleth_authentication": {
         "section": "Dashboard",
         "option": "shibboleth_authentication",
@@ -140,6 +160,10 @@ elasticsearch_server = 127.0.0.1:9200
 elasticsearch_timeout = 10
 search_enabled = true
 gearman_server = 127.0.0.1:4730
+password_minimum_length = 8
+password_disable_common_validation = False
+password_disable_user_attribute_similarity_validation = False
+password_disable_complexity_validation = False
 shibboleth_authentication = False
 cas_authentication = False
 ldap_authentication = False
@@ -344,6 +368,8 @@ MIDDLEWARE = [
 
 AUTHENTICATION_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
 
+# Import basic authentication settings from component module.
+from .components.auth import *  # noqa
 
 ROOT_URLCONF = "urls"
 

--- a/src/dashboard/src/settings/components/auth.py
+++ b/src/dashboard/src/settings/components/auth.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+"""Settings for basic user authentication."""
+
+from settings.base import config
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "OPTIONS": {"min_length": config.get("password_minimum_length")},
+    }
+]
+
+DISABLE_PASSWORD_COMMON_VALIDATION = config.get("password_disable_common_validation")
+if not DISABLE_PASSWORD_COMMON_VALIDATION:
+    AUTH_PASSWORD_VALIDATORS.append(
+        {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"}
+    )
+
+DISABLE_PASSWORD_USER_ATTRIBUTE_SIMILARITY_VALIDATION = config.get(
+    "password_disable_user_attribute_similarity_validation"
+)
+if not DISABLE_PASSWORD_USER_ATTRIBUTE_SIMILARITY_VALIDATION:
+    AUTH_PASSWORD_VALIDATORS.append(
+        {
+            "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+        }
+    )
+
+DISABLE_PASSWORD_COMPLEXITY_VALIDATION = config.get(
+    "password_disable_complexity_validation"
+)
+if not DISABLE_PASSWORD_COMPLEXITY_VALIDATION:
+    AUTH_PASSWORD_VALIDATORS.append(
+        {"NAME": "components.accounts.validators.PasswordComplexityValidator"}
+    )

--- a/src/dashboard/src/settings/local.py
+++ b/src/dashboard/src/settings/local.py
@@ -30,6 +30,9 @@ from .base import *
 DEBUG = True
 TEMPLATES[0]["OPTIONS"]["debug"] = True
 
+# Disable password validation in local development environment.
+AUTH_PASSWORD_VALIDATORS = []
+
 # Fixture directories are only configured in local and test environments.
 # In Django 1.8, if you create a fixture named initial_data.[xml/yaml/json],
 # that fixture will be loaded every time you run migrate, which is something we

--- a/src/dashboard/tests/test_password_validation.py
+++ b/src/dashboard/tests/test_password_validation.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import pytest
+
+from django.contrib.auth.password_validation import (
+    get_password_validators,
+    validate_password,
+)
+from django.core.exceptions import ValidationError
+
+
+@pytest.mark.parametrize(
+    "password,raises_exception",
+    [
+        # Passwords with only one type raise ValidationError.
+        ("abcdefghijk", True),
+        ("ABCDEFGHIJK", True),
+        ("12345678", True),
+        ("@#!_-=^$", True),
+        # Passwords with only two types raise ValidationError. Accented upper
+        # and lower case letters are treated as their ASCII equivalents and do
+        # not count as a special character.
+        ("abcdeFGHIJK", True),
+        ("ABÇDEF1234", True),
+        ("àbcdef!$@", True),
+        # Passwords with three types pass validation.
+        ("abcdef123!@#", False),
+        ("ABCdef12345", False),
+        ("#@!abcdefGHIJK", False),
+        # Passwords with all four types pass validation.
+        ("abcDEF123!@#", False),
+        ("#l33t#PASSWORD!", False),
+    ],
+)
+def test_password_complexity_validator(password, raises_exception):
+    VALIDATOR_CONFIG = [
+        {"NAME": "components.accounts.validators.PasswordComplexityValidator"}
+    ]
+    validators = get_password_validators(VALIDATOR_CONFIG)
+
+    if raises_exception:
+        with pytest.raises(ValidationError):
+            _ = validate_password(password, password_validators=validators)
+    else:
+        _ = validate_password(password, password_validators=validators)


### PR DESCRIPTION
Connected to https://github.com/archivematica/Issues/issues/1332

This PR adds password validation to the Archivematica dashboard. The validators employed include:
- Django's MinimumLengthValidator (default length: 8 characters)
- Django's CommonPasswordValidator
- Django's UserAttributeSimilarityValidator
- A custom PasswordComplexityValidator, which checks that passwords contain at least 3 of: lower-case characters, upper-case characters, numbers, special characters.

The validators are enabled by default but can be disabled individually via the environment. Since the client requirement for password complexity is not universally seen as a positive and some clients may want to disable it (see for instance the newest [NIST password guidelines](https://en.wikipedia.org/wiki/Password_policy#NIST_guidelines), which discourage composition rules), we decided to make each validator individually configurable rather than providing one option to enable/disable all of them at once.

Password validation is enforced by Django when creating or editing users in the dashboard GUI as well as through the `createsuperuser` and `changepassword` management commands.

Commit a4be60c disables password validation for the local environment. To test that password validation is working in a Docker development environment, either drop that commit locally or comment out `AUTH_PASSWORD_VALIDATORS = []` in ` src/dashboard/src/settings/local.py`.

See also the accompanying PR for the Archivematica Storage Service: https://github.com/artefactual/archivematica-storage-service/pull/553.