### PR TITLE
Pass extra parameters for AtoM DO creation

### DIFF
--- a/src/archivematicaCommon/requirements/base.in
+++ b/src/archivematicaCommon/requirements/base.in
@@ -1,4 +1,4 @@
-agentarchives==0.6.0
+agentarchives==0.7.0
 bagit==1.7.0
 Django>=1.11,<2
 elasticsearch>=6.0.0,<7.0.0

--- a/src/archivematicaCommon/requirements/base.txt
+++ b/src/archivematicaCommon/requirements/base.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=base.txt base.in
 #
-agentarchives==0.6.0      # via -r base.in
+agentarchives==0.7.0      # via -r base.in
 bagit==1.7.0              # via -r base.in
-certifi==2020.6.20        # via requests
+certifi==2020.12.5        # via requests
 chardet==3.0.4            # via requests
 django==1.11.29           # via -r base.in
 elasticsearch==6.8.1      # via -r base.in
@@ -15,7 +15,7 @@ mysqlclient==1.4.6        # via -r base.in, agentarchives
 pathlib2==2.3.4 ; python_version < "3"  # via -r base.in
 prometheus_client==0.7.1  # via -r base.in
 python-dateutil==2.6.0    # via -r base.in
-pytz==2020.1              # via django
+pytz==2020.5              # via django
 requests==2.21.0          # via -r base.in, agentarchives
 scandir==1.10.0           # via pathlib2
 six==1.14.0               # via -r base.in, pathlib2, python-dateutil

--- a/src/archivematicaCommon/requirements/dev.txt
+++ b/src/archivematicaCommon/requirements/dev.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=dev.txt dev.in
 #
-agentarchives==0.6.0      # via -r test.txt
+agentarchives==0.7.0      # via -r test.txt
 appdirs==1.4.4            # via -r test.txt, virtualenv
 atomicwrites==1.4.0       # via -r test.txt, pytest
-attrs==19.3.0             # via -r test.txt, pytest
+attrs==20.3.0             # via -r test.txt, pytest
 backports.functools-lru-cache==1.6.1  # via -r test.txt, wcwidth
 bagit==1.7.0              # via -r test.txt
-certifi==2020.6.20        # via -r test.txt, requests
+certifi==2020.12.5        # via -r test.txt, requests
 chardet==3.0.4            # via -r test.txt, requests
 click==7.1.2              # via pip-tools
 configparser==4.0.2       # via -r test.txt, importlib-metadata
@@ -21,34 +21,34 @@ elasticsearch==6.8.1      # via -r test.txt
 filelock==3.0.12          # via -r test.txt, tox, virtualenv
 funcsigs==1.0.2           # via -r test.txt, mock, pytest
 idna==2.8                 # via -r test.txt, requests
-importlib-metadata==1.7.0  # via -r test.txt, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via -r test.txt, virtualenv
+importlib-metadata==2.1.1  # via -r test.txt, pluggy, pytest, tox, virtualenv
+importlib-resources==3.3.1  # via -r test.txt, virtualenv
 mock==3.0.5               # via -r test.txt, vcrpy
 more-itertools==5.0.0     # via -r test.txt, pytest
 mysqlclient==1.4.6        # via -r test.txt, agentarchives
-packaging==20.4           # via -r test.txt, pytest, tox
+packaging==20.8           # via -r test.txt, pytest, tox
 pathlib2==2.3.4 ; python_version < "3"  # via -r test.txt, importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
 pip-tools==5.1.2          # via -r dev.in
 pluggy==0.13.1            # via -r test.txt, pytest, tox
 prometheus_client==0.7.1  # via -r test.txt
-py==1.9.0                 # via -r test.txt, pytest, tox
+py==1.10.0                # via -r test.txt, pytest, tox
 pyparsing==2.4.7          # via -r test.txt, packaging
-pytest-django==3.9.0      # via -r test.txt
+pytest-django==3.10.0     # via -r test.txt
 pytest-pythonpath==0.7.3  # via -r test.txt
 pytest==4.6.11            # via -r test.txt, pytest-django, pytest-pythonpath
 python-dateutil==2.6.0    # via -r test.txt
-pytz==2020.1              # via -r test.txt, django
+pytz==2020.5              # via -r test.txt, django
 pyyaml==5.3.1             # via -r test.txt, vcrpy
 requests==2.21.0          # via -r test.txt, agentarchives
 scandir==1.10.0           # via -r test.txt, pathlib2
 singledispatch==3.4.0.3   # via -r test.txt, importlib-resources
-six==1.14.0               # via -r test.txt, mock, more-itertools, packaging, pathlib2, pip-tools, pytest, python-dateutil, singledispatch, tox, vcrpy, virtualenv
-toml==0.10.1              # via -r test.txt, tox
-tox==3.19.0               # via -r test.txt
+six==1.14.0               # via -r test.txt, mock, more-itertools, pathlib2, pip-tools, pytest, python-dateutil, singledispatch, tox, vcrpy, virtualenv
+toml==0.10.2              # via -r test.txt, tox
+tox==3.21.0               # via -r test.txt
 typing==3.7.4.3           # via -r test.txt, importlib-resources
 urllib3==1.24.3           # via -r test.txt, elasticsearch, requests
 vcrpy==1.13.0             # via -r test.txt
-virtualenv==20.0.30       # via -r test.txt, tox
+virtualenv==20.2.2        # via -r test.txt, tox
 wcwidth==0.2.5            # via -r test.txt, pytest
 wrapt==1.12.1             # via -r test.txt, vcrpy
 zipp==1.2.0               # via -r test.txt, importlib-metadata, importlib-resources

--- a/src/archivematicaCommon/requirements/production.txt
+++ b/src/archivematicaCommon/requirements/production.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=production.txt production.in
 #
-agentarchives==0.6.0      # via -r base.txt
+agentarchives==0.7.0      # via -r base.txt
 bagit==1.7.0              # via -r base.txt
-certifi==2020.6.20        # via -r base.txt, requests
+certifi==2020.12.5        # via -r base.txt, requests
 chardet==3.0.4            # via -r base.txt, requests
 django==1.11.29           # via -r base.txt
 elasticsearch==6.8.1      # via -r base.txt
@@ -15,7 +15,7 @@ mysqlclient==1.4.6        # via -r base.txt, agentarchives
 pathlib2==2.3.4 ; python_version < "3"  # via -r base.txt
 prometheus_client==0.7.1  # via -r base.txt
 python-dateutil==2.6.0    # via -r base.txt
-pytz==2020.1              # via -r base.txt, django
+pytz==2020.5              # via -r base.txt, django
 requests==2.21.0          # via -r base.txt, agentarchives
 scandir==1.10.0           # via -r base.txt, pathlib2
 six==1.14.0               # via -r base.txt, pathlib2, python-dateutil

--- a/src/archivematicaCommon/requirements/test.txt
+++ b/src/archivematicaCommon/requirements/test.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=test.txt test.in
 #
-agentarchives==0.6.0      # via -r base.txt
+agentarchives==0.7.0      # via -r base.txt
 appdirs==1.4.4            # via virtualenv
 atomicwrites==1.4.0       # via pytest
-attrs==19.3.0             # via pytest
+attrs==20.3.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via wcwidth
 bagit==1.7.0              # via -r base.txt
-certifi==2020.6.20        # via -r base.txt, requests
+certifi==2020.12.5        # via -r base.txt, requests
 chardet==3.0.4            # via -r base.txt, requests
 configparser==4.0.2       # via importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, vcrpy, zipp
@@ -20,33 +20,33 @@ elasticsearch==6.8.1      # via -r base.txt
 filelock==3.0.12          # via tox, virtualenv
 funcsigs==1.0.2           # via mock, pytest
 idna==2.8                 # via -r base.txt, requests
-importlib-metadata==1.7.0  # via pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
+importlib-metadata==2.1.1  # via pluggy, pytest, tox, virtualenv
+importlib-resources==3.3.1  # via virtualenv
 mock==3.0.5               # via -r test.in, vcrpy
 more-itertools==5.0.0     # via pytest
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
-packaging==20.4           # via pytest, tox
+packaging==20.8           # via pytest, tox
 pathlib2==2.3.4 ; python_version < "3"  # via -r base.txt, importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
 pluggy==0.13.1            # via pytest, tox
 prometheus_client==0.7.1  # via -r base.txt
-py==1.9.0                 # via pytest, tox
+py==1.10.0                # via pytest, tox
 pyparsing==2.4.7          # via packaging
-pytest-django==3.9.0      # via -r test.in
+pytest-django==3.10.0     # via -r test.in
 pytest-pythonpath==0.7.3  # via -r test.in
 pytest==4.6.11            # via -r test.in, pytest-django, pytest-pythonpath
 python-dateutil==2.6.0    # via -r base.txt
-pytz==2020.1              # via -r base.txt, django
+pytz==2020.5              # via -r base.txt, django
 pyyaml==5.3.1             # via vcrpy
 requests==2.21.0          # via -r base.txt, agentarchives
 scandir==1.10.0           # via -r base.txt, pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
-six==1.14.0               # via -r base.txt, mock, more-itertools, packaging, pathlib2, pytest, python-dateutil, tox, vcrpy, virtualenv
-toml==0.10.1              # via tox
-tox==3.19.0               # via -r test.in
+six==1.14.0               # via -r base.txt, mock, more-itertools, pathlib2, pytest, python-dateutil, tox, vcrpy, virtualenv
+toml==0.10.2              # via tox
+tox==3.21.0               # via -r test.in
 typing==3.7.4.3           # via importlib-resources
 urllib3==1.24.3           # via -r base.txt, elasticsearch, requests
 vcrpy==1.13.0             # via -r test.in
-virtualenv==20.0.30       # via tox
+virtualenv==20.2.2        # via tox
 wcwidth==0.2.5            # via pytest
 wrapt==1.12.1             # via vcrpy
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/src/dashboard/src/components/archival_storage/atom.py
+++ b/src/dashboard/src/components/archival_storage/atom.py
@@ -108,6 +108,8 @@ def upload_dip_metadata_to_atom(aip_name, aip_uuid, parent_slug):
                 "usage": "Offline",
                 "file_uuid": item.file_uuid,
                 "aip_uuid": aip_uuid,
+                "aip_name": aip_name,
+                "relative_path_within_aip": item.path,
             }
             _load_premis(attrs, item)
             title = os.path.basename(item.path)

--- a/src/dashboard/src/requirements/base.in
+++ b/src/dashboard/src/requirements/base.in
@@ -1,6 +1,6 @@
 # Base requirements - for all installations
 amclient==1.1.1
-agentarchives==0.6.0
+agentarchives==0.7.0
 bagit==1.7.0
 brotli==0.5.2  # Better compression library for WhiteNoise
 Django>=1.11,<2

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -5,14 +5,14 @@
 #    pip-compile --output-file=base.txt base.in
 #
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.in
-agentarchives==0.6.0      # via -r base.in
+agentarchives==0.7.0      # via -r base.in
 amclient==1.1.1           # via -r base.in
 bagit==1.7.0              # via -r base.in
 brotli==0.5.2             # via -r base.in
-certifi==2020.6.20        # via requests
-cffi==1.14.1              # via cryptography
+certifi==2020.12.5        # via requests
+cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==3.0         # via josepy, mozilla-django-oidc, pyopenssl
+cryptography==3.3.1       # via josepy, mozilla-django-oidc, pyopenssl
 django-auth-ldap==1.3.0   # via -r base.in
 django-autoslug==1.9.3    # via -r base.in
 django-braces==1.0.0      # via -r base.in
@@ -29,16 +29,16 @@ future==0.18.2            # via metsrw
 futures==3.3.0 ; python_version < "3.0"  # via -r base.in
 gearman==2.0.2            # via -r base.in
 gevent==1.3.6             # via -r base.in
-greenlet==0.4.16          # via gevent
+greenlet==0.4.17          # via gevent
 gunicorn==19.9.0          # via -r base.in
 idna==2.8                 # via requests
 ipaddress==1.0.23         # via cryptography
-josepy==1.3.0             # via mozilla-django-oidc
+josepy==1.5.0             # via mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r base.in
 logutils==0.3.3           # via -r base.in
 lxml==3.5.0               # via -r base.in, metsrw, python-cas
 metsrw==0.3.15            # via -r base.in
-mozilla-django-oidc==1.2.3  # via -r base.in
+mozilla-django-oidc==1.2.4  # via -r base.in
 mysqlclient==1.4.6        # via -r base.in, agentarchives
 ndg-httpsclient==0.5.1    # via -r base.in
 numpy==1.16.6             # via pandas
@@ -48,12 +48,12 @@ prometheus-client==0.7.1  # via -r base.in, django-prometheus
 pyasn1-modules==0.2.8     # via python-ldap
 pyasn1==0.4.8             # via -r base.in, ndg-httpsclient, pyasn1-modules, python-ldap
 pycparser==2.20           # via cffi
-pyopenssl==19.1.0         # via -r base.in, josepy, ndg-httpsclient
+pyopenssl==20.0.1         # via -r base.in, josepy, ndg-httpsclient
 python-cas==1.5.0         # via django-cas-ng
 python-dateutil==2.6.0    # via -r base.in, django-tastypie, pandas
 python-ldap==3.2.0        # via -r base.in, django-auth-ldap
 python-mimeparse==1.6.0   # via django-tastypie
-pytz==2020.1              # via -r base.in, django, pandas
+pytz==2020.5              # via -r base.in, django, pandas
 requests==2.21.0          # via -r base.in, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r base.in, pathlib2
 six==1.15.0               # via amclient, cryptography, django-extensions, josepy, metsrw, mozilla-django-oidc, pathlib2, pyopenssl, python-cas, python-dateutil

--- a/src/dashboard/src/requirements/dev.txt
+++ b/src/dashboard/src/requirements/dev.txt
@@ -5,23 +5,23 @@
 #    pip-compile --output-file=dev.txt dev.in
 #
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r test.txt
-agentarchives==0.6.0      # via -r test.txt
+agentarchives==0.7.0      # via -r test.txt
 amclient==1.1.1           # via -r test.txt
 appdirs==1.4.4            # via -r test.txt, virtualenv
 atomicwrites==1.4.0       # via -r test.txt, pytest
-attrs==19.3.0             # via -r test.txt, pytest
+attrs==20.3.0             # via -r test.txt, pytest
 backports.functools-lru-cache==1.6.1  # via -r test.txt, wcwidth
 backports.shutil-get-terminal-size==1.0.0  # via ipython
 bagit==1.7.0              # via -r test.txt
 brotli==0.5.2             # via -r test.txt
-certifi==2020.6.20        # via -r test.txt, requests
-cffi==1.14.1              # via -r test.txt, cryptography
+certifi==2020.12.5        # via -r test.txt, requests
+cffi==1.14.4              # via -r test.txt, cryptography
 chardet==3.0.4            # via -r test.txt, requests
 click==7.1.2              # via pip-tools
 configparser==4.0.2       # via -r test.txt, importlib-metadata
 contextlib2==0.6.0.post1  # via -r test.txt, importlib-metadata, importlib-resources, vcrpy, zipp
 coverage==4.2             # via -r test.txt, pytest-cov
-cryptography==3.0         # via -r test.txt, josepy, mozilla-django-oidc, pyopenssl
+cryptography==3.3.1       # via -r test.txt, josepy, mozilla-django-oidc, pyopenssl
 decorator==4.4.2          # via ipython, traitlets
 distlib==0.3.1            # via -r test.txt, virtualenv
 django-auth-ldap==1.3.0   # via -r test.txt
@@ -43,16 +43,16 @@ future==0.18.2            # via -r test.txt, metsrw
 futures==3.3.0 ; python_version < "3.0"  # via -r test.txt
 gearman==2.0.2            # via -r test.txt
 gevent==1.3.6             # via -r test.txt
-greenlet==0.4.16          # via -r test.txt, gevent
+greenlet==0.4.17          # via -r test.txt, gevent
 gunicorn==19.9.0          # via -r test.txt
 idna==2.8                 # via -r test.txt, requests
-importlib-metadata==1.7.0  # via -r test.txt, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via -r test.txt, virtualenv
+importlib-metadata==2.1.1  # via -r test.txt, pluggy, pytest, tox, virtualenv
+importlib-resources==3.3.1  # via -r test.txt, virtualenv
 ipaddress==1.0.23         # via -r test.txt, cryptography
-ipdb==0.13.3              # via -r dev.in
+ipdb==0.13.4              # via -r dev.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==5.10.0           # via -r dev.in, ipdb
-josepy==1.3.0             # via -r test.txt, mozilla-django-oidc
+josepy==1.5.0             # via -r test.txt, mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r test.txt
 logutils==0.3.3           # via -r test.txt
 lxml==3.5.0               # via -r test.txt, metsrw, python-cas
@@ -60,11 +60,11 @@ metsrw==0.3.15            # via -r test.txt
 mock==3.0.5               # via -r test.txt, mockldap, pytest-mock, vcrpy
 mockldap==0.2.8           # via -r test.txt
 more-itertools==5.0.0     # via -r test.txt, pytest
-mozilla-django-oidc==1.2.3  # via -r test.txt
+mozilla-django-oidc==1.2.4  # via -r test.txt
 mysqlclient==1.4.6        # via -r test.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r test.txt
 numpy==1.16.6             # via -r test.txt, pandas
-packaging==20.4           # via -r test.txt, pytest, tox
+packaging==20.8           # via -r test.txt, pytest, tox
 pandas==0.24.2            # via -r test.txt
 pathlib2==2.3.4           # via -r test.txt, importlib-metadata, importlib-resources, ipython, pickleshare, pytest, pytest-django, virtualenv
 pexpect==4.8.0            # via ipython
@@ -73,16 +73,16 @@ pip-tools==5.1.2          # via -r dev.in
 pluggy==0.13.1            # via -r test.txt, pytest, tox
 prometheus-client==0.7.1  # via -r test.txt, django-prometheus
 prompt-toolkit==1.0.18    # via ipython
-ptyprocess==0.6.0         # via pexpect
-py==1.9.0                 # via -r test.txt, pytest, tox
+ptyprocess==0.7.0         # via pexpect
+py==1.10.0                # via -r test.txt, pytest, tox
 pyasn1-modules==0.2.8     # via -r test.txt, python-ldap
 pyasn1==0.4.8             # via -r test.txt, ndg-httpsclient, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r test.txt, cffi
 pygments==2.5.2           # via ipython
-pyopenssl==19.1.0         # via -r test.txt, josepy, ndg-httpsclient
+pyopenssl==20.0.1         # via -r test.txt, josepy, ndg-httpsclient
 pyparsing==2.4.7          # via -r test.txt, packaging
 pytest-cov==2.4.0         # via -r test.txt
-pytest-django==3.9.0      # via -r test.txt
+pytest-django==3.10.0     # via -r test.txt
 pytest-mock==2.0.0        # via -r dev.in, -r test.txt
 pytest-pythonpath==0.7.3  # via -r test.txt
 pytest==4.6.11            # via -r dev.in, -r test.txt, pytest-cov, pytest-django, pytest-mock, pytest-pythonpath
@@ -90,20 +90,20 @@ python-cas==1.5.0         # via -r test.txt, django-cas-ng
 python-dateutil==2.6.0    # via -r test.txt, django-tastypie, pandas
 python-ldap==3.2.0        # via -r test.txt, django-auth-ldap, mockldap
 python-mimeparse==1.6.0   # via -r test.txt, django-tastypie
-pytz==2020.1              # via -r test.txt, django, pandas
+pytz==2020.5              # via -r test.txt, django, pandas
 pyyaml==5.3.1             # via -r test.txt, vcrpy
 requests==2.21.0          # via -r test.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r test.txt, pathlib2
 simplegeneric==0.8.1      # via ipython
 singledispatch==3.4.0.3   # via -r test.txt, importlib-resources
-six==1.15.0               # via -r test.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, mozilla-django-oidc, packaging, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pytest, python-cas, python-dateutil, singledispatch, tox, traitlets, vcrpy, virtualenv
-toml==0.10.1              # via -r test.txt, tox
-tox==3.19.0               # via -r test.txt
+six==1.15.0               # via -r test.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, mozilla-django-oidc, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pytest, python-cas, python-dateutil, singledispatch, tox, traitlets, vcrpy, virtualenv
+toml==0.10.2              # via -r test.txt, tox
+tox==3.21.0               # via -r test.txt
 traitlets==4.3.3          # via ipython
 typing==3.7.4.3           # via -r test.txt, importlib-resources
 urllib3==1.24.3           # via -r test.txt, amclient, elasticsearch, requests
 vcrpy==1.13.0             # via -r test.txt
-virtualenv==20.0.30       # via -r test.txt, tox
+virtualenv==20.2.2        # via -r test.txt, tox
 wcwidth==0.2.5            # via -r test.txt, prompt-toolkit, pytest
 whitenoise==3.3.0         # via -r test.txt
 wrapt==1.12.1             # via -r test.txt, vcrpy

--- a/src/dashboard/src/requirements/production.txt
+++ b/src/dashboard/src/requirements/production.txt
@@ -5,14 +5,14 @@
 #    pip-compile --output-file=production.txt production.in
 #
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.txt
-agentarchives==0.6.0      # via -r base.txt
+agentarchives==0.7.0      # via -r base.txt
 amclient==1.1.1           # via -r base.txt
 bagit==1.7.0              # via -r base.txt
 brotli==0.5.2             # via -r base.txt
-certifi==2020.6.20        # via -r base.txt, requests
-cffi==1.14.1              # via -r base.txt, cryptography
+certifi==2020.12.5        # via -r base.txt, requests
+cffi==1.14.4              # via -r base.txt, cryptography
 chardet==3.0.4            # via -r base.txt, requests
-cryptography==3.0         # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
+cryptography==3.3.1       # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
 django-auth-ldap==1.3.0   # via -r base.txt
 django-autoslug==1.9.3    # via -r base.txt
 django-braces==1.0.0      # via -r base.txt
@@ -29,16 +29,16 @@ future==0.18.2            # via -r base.txt, metsrw
 futures==3.3.0 ; python_version < "3.0"  # via -r base.txt
 gearman==2.0.2            # via -r base.txt
 gevent==1.3.6             # via -r base.txt
-greenlet==0.4.16          # via -r base.txt, gevent
+greenlet==0.4.17          # via -r base.txt, gevent
 gunicorn==19.9.0          # via -r base.txt
 idna==2.8                 # via -r base.txt, requests
 ipaddress==1.0.23         # via -r base.txt, cryptography
-josepy==1.3.0             # via -r base.txt, mozilla-django-oidc
+josepy==1.5.0             # via -r base.txt, mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r base.txt
 logutils==0.3.3           # via -r base.txt
 lxml==3.5.0               # via -r base.txt, metsrw, python-cas
 metsrw==0.3.15            # via -r base.txt
-mozilla-django-oidc==1.2.3  # via -r base.txt
+mozilla-django-oidc==1.2.4  # via -r base.txt
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r base.txt
 numpy==1.16.6             # via -r base.txt, pandas
@@ -48,12 +48,12 @@ prometheus-client==0.7.1  # via -r base.txt, django-prometheus
 pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
 pyasn1==0.4.8             # via -r base.txt, ndg-httpsclient, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r base.txt, cffi
-pyopenssl==19.1.0         # via -r base.txt, josepy, ndg-httpsclient
+pyopenssl==20.0.1         # via -r base.txt, josepy, ndg-httpsclient
 python-cas==1.5.0         # via -r base.txt, django-cas-ng
 python-dateutil==2.6.0    # via -r base.txt, django-tastypie, pandas
 python-ldap==3.2.0        # via -r base.txt, django-auth-ldap
 python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
-pytz==2020.1              # via -r base.txt, django, pandas
+pytz==2020.5              # via -r base.txt, django, pandas
 requests==2.21.0          # via -r base.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r base.txt, pathlib2
 six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, josepy, metsrw, mozilla-django-oidc, pathlib2, pyopenssl, python-cas, python-dateutil

--- a/src/dashboard/src/requirements/test.txt
+++ b/src/dashboard/src/requirements/test.txt
@@ -5,21 +5,21 @@
 #    pip-compile --output-file=test.txt test.in
 #
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r base.txt
-agentarchives==0.6.0      # via -r base.txt
+agentarchives==0.7.0      # via -r base.txt
 amclient==1.1.1           # via -r base.txt
 appdirs==1.4.4            # via virtualenv
 atomicwrites==1.4.0       # via pytest
-attrs==19.3.0             # via pytest
+attrs==20.3.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via wcwidth
 bagit==1.7.0              # via -r base.txt
 brotli==0.5.2             # via -r base.txt
-certifi==2020.6.20        # via -r base.txt, requests
-cffi==1.14.1              # via -r base.txt, cryptography
+certifi==2020.12.5        # via -r base.txt, requests
+cffi==1.14.4              # via -r base.txt, cryptography
 chardet==3.0.4            # via -r base.txt, requests
 configparser==4.0.2       # via importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, vcrpy, zipp
 coverage==4.2             # via -r test.in, pytest-cov
-cryptography==3.0         # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
+cryptography==3.3.1       # via -r base.txt, josepy, mozilla-django-oidc, pyopenssl
 distlib==0.3.1            # via virtualenv
 django-auth-ldap==1.3.0   # via -r base.txt
 django-autoslug==1.9.3    # via -r base.txt
@@ -40,13 +40,13 @@ future==0.18.2            # via -r base.txt, metsrw
 futures==3.3.0 ; python_version < "3.0"  # via -r base.txt
 gearman==2.0.2            # via -r base.txt
 gevent==1.3.6             # via -r base.txt
-greenlet==0.4.16          # via -r base.txt, gevent
+greenlet==0.4.17          # via -r base.txt, gevent
 gunicorn==19.9.0          # via -r base.txt
 idna==2.8                 # via -r base.txt, requests
-importlib-metadata==1.7.0  # via pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
+importlib-metadata==2.1.1  # via pluggy, pytest, tox, virtualenv
+importlib-resources==3.3.1  # via virtualenv
 ipaddress==1.0.23         # via -r base.txt, cryptography
-josepy==1.3.0             # via -r base.txt, mozilla-django-oidc
+josepy==1.5.0             # via -r base.txt, mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r base.txt
 logutils==0.3.3           # via -r base.txt
 lxml==3.5.0               # via -r base.txt, metsrw, python-cas
@@ -54,23 +54,23 @@ metsrw==0.3.15            # via -r base.txt
 mock==3.0.5               # via mockldap, pytest-mock, vcrpy
 mockldap==0.2.8           # via -r test.in
 more-itertools==5.0.0     # via pytest
-mozilla-django-oidc==1.2.3  # via -r base.txt
+mozilla-django-oidc==1.2.4  # via -r base.txt
 mysqlclient==1.4.6        # via -r base.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r base.txt
 numpy==1.16.6             # via -r base.txt, pandas
-packaging==20.4           # via pytest, tox
+packaging==20.8           # via pytest, tox
 pandas==0.24.2            # via -r base.txt
 pathlib2==2.3.4           # via -r base.txt, importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
 pluggy==0.13.1            # via pytest, tox
 prometheus-client==0.7.1  # via -r base.txt, django-prometheus
-py==1.9.0                 # via pytest, tox
+py==1.10.0                # via pytest, tox
 pyasn1-modules==0.2.8     # via -r base.txt, python-ldap
 pyasn1==0.4.8             # via -r base.txt, ndg-httpsclient, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r base.txt, cffi
-pyopenssl==19.1.0         # via -r base.txt, josepy, ndg-httpsclient
+pyopenssl==20.0.1         # via -r base.txt, josepy, ndg-httpsclient
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.4.0         # via -r test.in
-pytest-django==3.9.0      # via -r test.in
+pytest-django==3.10.0     # via -r test.in
 pytest-mock==2.0.0        # via -r test.in
 pytest-pythonpath==0.7.3  # via -r test.in
 pytest==4.6.11            # via -r test.in, pytest-cov, pytest-django, pytest-mock, pytest-pythonpath
@@ -78,18 +78,18 @@ python-cas==1.5.0         # via -r base.txt, django-cas-ng
 python-dateutil==2.6.0    # via -r base.txt, django-tastypie, pandas
 python-ldap==3.2.0        # via -r base.txt, django-auth-ldap, mockldap
 python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
-pytz==2020.1              # via -r base.txt, django, pandas
+pytz==2020.5              # via -r base.txt, django, pandas
 pyyaml==5.3.1             # via vcrpy
 requests==2.21.0          # via -r base.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r base.txt, pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
-six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, mozilla-django-oidc, packaging, pathlib2, pyopenssl, pytest, python-cas, python-dateutil, tox, vcrpy, virtualenv
-toml==0.10.1              # via tox
-tox==3.19.0               # via -r test.in
+six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, mozilla-django-oidc, pathlib2, pyopenssl, pytest, python-cas, python-dateutil, tox, vcrpy, virtualenv
+toml==0.10.2              # via tox
+tox==3.21.0               # via -r test.in
 typing==3.7.4.3           # via importlib-resources
 urllib3==1.24.3           # via -r base.txt, amclient, elasticsearch, requests
 vcrpy==1.13.0             # via -r test.in
-virtualenv==20.0.30       # via tox
+virtualenv==20.2.2        # via tox
 wcwidth==0.2.5            # via pytest
 whitenoise==3.3.0         # via -r base.txt
 wrapt==1.12.1             # via vcrpy


### PR DESCRIPTION
This sends the AIP name and relative path of the file that are needed
by AtoM's extract file action for metadata-only DIP uploads from
Archivematica.

It also bumps the `agentarchives` version for a [related change](https://github.com/artefactual-labs/agentarchives/pull/57).

Connected to https://github.com/archivematica/Issues/issues/1334