### PR TITLE
Improve password validation UX

### DIFF
--- a/src/dashboard/src/media/css/style.css
+++ b/src/dashboard/src/media/css/style.css
@@ -492,6 +492,17 @@ textarea {
   line-height: 35px;
 }
 
+/* Error help messages are coded bright red to ensure that they stand
+ * out on the page for users. */
+div.has-error div span.error-msg {
+  color: red;
+}
+
+div.has-error div p.help-block {
+  color: red;
+}
+
+
 /*
  * Reset jQuery UI dialog
  */


### PR DESCRIPTION
Connected to https://github.com/archivematica/issues/issues/1332

This pull request consists of a commit with UX improvements identified during internal QA for the password validation feature. The fixes consist of:

- Style form error messages bright red to make them more visible for users.
- Ensure that password mismatch message only displays when accurate for `UserCreationForm` and `UserChangeForm` (i.e. not if error is just that password doesn't match validation criteria).
- Make form behaviour more consistent between forms with respect to where and how error messages appear for invalid passwords and non-matching passwords.

The code in this commit is heavily based on [the `UserCreationForm` and `UserChangeForm` code in the Django source code](https://github.com/django/django/blob/master/django/contrib/auth/forms.py).

Here's what it looks like in practice:

## Add user screen

### Invalid password

![Screenshot - Add new user - invalid password](https://user-images.githubusercontent.com/6758804/104535495-4dbbf480-55e4-11eb-9ce6-6c2a4090fd61.png)

### Passwords don't match

![Screenshot - Add new user - passwords don't match](https://user-images.githubusercontent.com/6758804/104535510-56acc600-55e4-11eb-8d10-47096a4fca98.png)

### Invalid password AND passwords don't match

![Screenshot - Add new user - invalid password and passwords don't match](https://user-images.githubusercontent.com/6758804/104535586-7643ee80-55e4-11eb-9b4f-4db6acb57ea3.png)

## Edit user screen

### Invalid password

![Screenshot - Edit user - invalid password](https://user-images.githubusercontent.com/6758804/104535691-ab504100-55e4-11eb-970c-63823edd6bcf.png)

### Passwords don't match

![Screenshot - Edit user - passwords don't match](https://user-images.githubusercontent.com/6758804/104537321-c1abcc00-55e7-11eb-88ed-7ea920237334.png)

### Invalid password AND passwords don't match

![Screenshot - Edit user - invalid password and password's don't match](https://user-images.githubusercontent.com/6758804/104537374-db4d1380-55e7-11eb-8636-361717dd6bf9.png)








