### PR TITLE
Restore indexAIP arguments in workflow.json

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -4801,7 +4801,7 @@
             "config": {
                 "@manager": "linkTaskManagerDirectories",
                 "@model": "StandardTaskConfig",
-                "arguments": "\"%SIPUUID%\" \"%SIPName%\" \"%SIPDirectory%\" \"%SIPType%\"",
+                "arguments": "\"%SIPUUID%\" \"%SIPName%\" \"%SIPDirectory%\" \"%SIPType%\" \"%AIPsStore%\" ",
                 "execute": "indexAIP_v0.0",
                 "filter_file_end": null,
                 "filter_file_start": null,


### PR DESCRIPTION
The `Index AIP` job is failing because its arguments were modified on https://github.com/artefactual/archivematica/commit/ff4d9860d82ab54da1d12935abe3be2493a76ea9

![Screenshot_2021-01-22 Archivematica Dashboard -](https://user-images.githubusercontent.com/560781/105499373-0211e680-5c87-11eb-96b7-f739c71dc0d5.png)
