### PR TITLE
Use py27-compatible pip

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -43,9 +43,9 @@ RUN set -ex \
 # Download ClamAV virus signatures
 RUN freshclam --quiet
 
-# Install Node.js and Yarn
+# Install pip, Node.js and Yarn
 RUN set -ex \
-	&& curl -s https://bootstrap.pypa.io/get-pip.py | python \
+	&& curl -s https://bootstrap.pypa.io/2.7/get-pip.py | python \
 	&& curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 	&& add-apt-repository --yes "deb https://dl.yarnpkg.com/debian/ stable main" \
 	&& apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Connects to https://github.com/archivematica/Issues/issues/1344.

Must be cherry-picked onto previous release branches.