### PR TITLE
Fix docs for pulling submodules

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -133,8 +133,7 @@ For more information, please consult the Elasticsearch `6.x`
 If you haven't already, create a directory to store this repository using git
 clone, and pull all the submodules:
 
-    $ git clone https://github.com/artefactual/archivematica.git
-    $ git submodule update --init --recursive
+    $ git clone https://github.com/artefactual/archivematica.git --branch qa/1.x --recurse-submodules
 
 Run the installation (and all Docker Compose) commands from within the hack
 directory:

--- a/hack/README.md
+++ b/hack/README.md
@@ -133,7 +133,8 @@ For more information, please consult the Elasticsearch `6.x`
 If you haven't already, create a directory to store this repository using git
 clone, and pull all the submodules:
 
-    $ git clone https://github.com/artefactual/archivematica.git --recurse-submodules
+    $ git clone https://github.com/artefactual/archivematica.git
+    $ git submodule update --init --recursive
 
 Run the installation (and all Docker Compose) commands from within the hack
 directory:


### PR DESCRIPTION
Setting up my new Archivematica development environment today, I noticed that the included instructions for pulling submodules don't work (at least when cloning over ssh, I didn't try https). My submodule dirs were all uninitialized/empty when the clone completed. This commit reverts the instructions to their previous form, which fixed it for me locally.

Connects to https://github.com/archivematica/Issues/issues/392.