### PR TITLE
Add audit log middleware to dashboard

### DIFF
--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -242,6 +242,12 @@ variables or in the gunicorn configuration file.
     - **Type:** `boolean`
     - **Default:** `False`
 
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_AUDIT_LOG_MIDDLEWARE`**:
+    - **Description:** enables X-Username header with authenticated HTTP responses.
+    - **Config file example:** `Dashboard.audit_log_middleware`
+    - **Type:** `boolean`
+    - **Default:** `False`
+
 - **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_SITE_URL`**:
     - **Description:** the public address of this service.
     - **Config file example:** `Dashboard.site_url`

--- a/src/dashboard/src/middleware/common.py
+++ b/src/dashboard/src/middleware/common.py
@@ -76,6 +76,19 @@ class ElasticsearchMiddleware(MiddlewareMixin):
             )
 
 
+class AuditLogMiddleware(object):
+    """Add X-Username header with authenticated user to responses."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if request.user.is_authenticated:
+            response["X-Username"] = request.user.get_username()
+        return response
+
+
 SHIBBOLETH_REMOTE_USER_HEADER = getattr(
     settings, "SHIBBOLETH_REMOTE_USER_HEADER", "REMOTE_USER"
 )

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -128,6 +128,11 @@ CONFIG_MAPPING = {
         "option": "prometheus_enabled",
         "type": "boolean",
     },
+    "audit_log_middleware": {
+        "section": "Dashboard",
+        "option": "audit_log_middleware",
+        "type": "boolean",
+    },
     "site_url": {"section": "Dashboard", "option": "site_url", "type": "string"},
     "time_zone": {"section": "Dashboard", "option": "time_zone", "type": "string"},
     # [Dashboard] (MANDATORY in production)
@@ -172,6 +177,7 @@ storage_service_client_timeout = 86400
 storage_service_client_quick_timeout = 5
 agentarchives_client_timeout = 300
 prometheus_enabled = False
+audit_log_middleware = False
 polling_interval = 10
 site_url =
 time_zone = UTC
@@ -366,6 +372,10 @@ MIDDLEWARE = [
     "middleware.common.SpecificExceptionErrorPageResponseMiddleware",
     "middleware.common.ElasticsearchMiddleware",
 ]
+
+AUDIT_LOG_MIDDLEWARE = config.get("audit_log_middleware")
+if AUDIT_LOG_MIDDLEWARE:
+    MIDDLEWARE.append("middleware.common.AuditLogMiddleware")
 
 AUTHENTICATION_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
 


### PR DESCRIPTION
This commit adds middleware which adds an `X-Username` header with the name of the authenticated user to each response sent from the dashboard. This provides a mechanism for audit logging of user behaviour via the nginx access logs.

Connected to: https://github.com/archivematica/Issues/issues/1341