### PR TITLE
Update lxml and cryptography

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ attrs==20.3.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via wcwidth
 bagit==1.7.0              # via -r requirements.txt
 brotli==0.5.2             # via -r requirements.txt
-certifi==2020.11.8        # via -r requirements.txt, requests
+certifi==2020.12.5        # via -r requirements.txt, requests
 cffi==1.14.4              # via -r requirements.txt, cryptography
 chardet==3.0.4            # via -r requirements.txt, requests
 clamd==1.0.2              # via -r requirements.txt
@@ -22,7 +22,7 @@ configparser==4.0.2       # via importlib-metadata
 contextdecorator==0.10.0 ; python_version < "3.2"  # via -r requirements.txt
 contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, vcrpy, zipp
 coverage==4.2             # via -r requirements-dev.in, pytest-cov
-cryptography==3.2.1       # via -r requirements.txt, josepy, mozilla-django-oidc, pyopenssl
+cryptography==3.3.1       # via -r requirements.txt, josepy, mozilla-django-oidc, pyopenssl
 distlib==0.3.1            # via virtualenv
 django-auth-ldap==1.3.0   # via -r requirements.txt
 django-autoslug==1.9.3    # via -r requirements.txt
@@ -45,18 +45,18 @@ future==0.18.2            # via -r requirements.txt, metsrw
 futures==3.3.0 ; python_version < "3.2"  # via -r requirements.txt
 gearman==2.0.2            # via -r requirements.txt
 gevent==1.3.6             # via -r requirements.txt
-greenlet==0.4.17          # via -r requirements.txt, gevent
+greenlet==1.0.0           # via -r requirements.txt, gevent
 gunicorn==19.9.0          # via -r requirements.txt
 idna==2.8                 # via -r requirements.txt, requests
-importlib-metadata==2.1.0  # via pluggy, pytest, tox, virtualenv
-importlib-resources==3.3.0  # via virtualenv
+importlib-metadata==2.1.1  # via pluggy, pytest, tox, virtualenv
+importlib-resources==3.3.1  # via virtualenv
 inotify_simple==1.1.8     # via -r requirements.txt
 ipaddress==1.0.23         # via -r requirements.txt, cryptography
-josepy==1.5.0             # via -r requirements.txt, mozilla-django-oidc
+josepy==1.6.0             # via -r requirements.txt, mozilla-django-oidc
 jsonschema==2.6.0         # via -r requirements.txt
 lazy-paged-sequence==0.3  # via -r requirements.txt
 logutils==0.3.3           # via -r requirements.txt
-lxml==3.5.0               # via -r requirements.txt, ammcpc, metsrw, python-cas
+lxml==4.6.2               # via -r requirements.txt, ammcpc, metsrw, python-cas
 metsrw==0.3.15            # via -r requirements.txt
 mock==3.0.5               # via -r requirements-dev.in, mockldap, pytest-mock, vcrpy
 mockldap==0.2.8           # via -r requirements-dev.in
@@ -67,17 +67,17 @@ ndg-httpsclient==0.5.1    # via -r requirements.txt
 numpy==1.16.6             # via -r requirements.txt, pandas
 olefile==0.46             # via -r requirements.txt, opf-fido
 opf-fido==1.4.1           # via -r requirements.txt
-packaging==20.4           # via pytest, tox
+packaging==20.8           # via pytest, tox
 pandas==0.24.2            # via -r requirements.txt
 pathlib2==2.3.4 ; python_version < "3"  # via -r requirements.txt, importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
 pip-tools==5.4.0          # via -r requirements.txt
 pluggy==0.13.1            # via pytest, tox
 prometheus-client==0.7.1  # via -r requirements.txt, django-prometheus
-py==1.9.0                 # via pytest, tox
+py==1.10.0                # via pytest, tox
 pyasn1-modules==0.2.8     # via -r requirements.txt, python-ldap
 pyasn1==0.4.8             # via -r requirements.txt, ndg-httpsclient, pyasn1-modules, python-ldap
 pycparser==2.20           # via -r requirements.txt, cffi
-pyopenssl==19.1.0         # via -r requirements.txt, josepy, ndg-httpsclient
+pyopenssl==20.0.1         # via -r requirements.txt, josepy, ndg-httpsclient
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.4.0         # via -r requirements-dev.in
 pytest-django==3.10.0     # via -r requirements-dev.in
@@ -88,19 +88,19 @@ python-cas==1.5.0         # via -r requirements.txt, django-cas-ng
 python-dateutil==2.6.0    # via -r requirements.txt, django-tastypie, pandas
 python-ldap==3.2.0        # via -r requirements.txt, django-auth-ldap, mockldap
 python-mimeparse==1.6.0   # via -r requirements.txt, django-tastypie
-pytz==2020.4              # via -r requirements.txt, django, pandas
-pyyaml==5.3.1             # via vcrpy
+pytz==2020.5              # via -r requirements.txt, django, pandas
+pyyaml==5.4.1             # via vcrpy
 requests==2.21.0          # via -r requirements.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r requirements.txt, pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
-six==1.14.0               # via -r requirements.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, mozilla-django-oidc, opf-fido, packaging, pathlib2, pip-tools, pyopenssl, pytest, python-cas, python-dateutil, tox, vcrpy, virtualenv
+six==1.14.0               # via -r requirements.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, mozilla-django-oidc, opf-fido, pathlib2, pip-tools, pyopenssl, pytest, python-cas, python-dateutil, tox, vcrpy, virtualenv
 toml==0.10.2              # via tox
-tox==3.20.1               # via -r requirements-dev.in
+tox==3.21.3               # via -r requirements-dev.in
 typing==3.7.4.3           # via importlib-resources
 unidecode==0.04.19        # via -r requirements.txt
 urllib3==1.24.3           # via -r requirements.txt, amclient, elasticsearch, requests
 vcrpy==1.13.0             # via -r requirements-dev.in
-virtualenv==20.2.1        # via tox
+virtualenv==20.4.0        # via tox
 wcwidth==0.2.5            # via pytest
 whitenoise==3.3.0         # via -r requirements.txt
 wrapt==1.12.1             # via vcrpy

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ inotify_simple==1.1.8
 jsonschema==2.6.0
 lazy-paged-sequence
 logutils==0.3.3
-lxml==3.5.0
+lxml~=4.6
 metsrw==0.3.15
 mysqlclient==1.4.6
 ndg-httpsclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,13 +9,13 @@ amclient==1.1.1           # via -r requirements.in
 ammcpc==0.1.3             # via -r requirements.in
 bagit==1.7.0              # via -r requirements.in
 brotli==0.5.2             # via -r requirements.in
-certifi==2020.11.8        # via requests
+certifi==2020.12.5        # via requests
 cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
 clamd==1.0.2              # via -r requirements.in
 click==7.1.2              # via pip-tools
 contextdecorator==0.10.0 ; python_version < "3.2"  # via -r requirements.in
-cryptography==3.2.1       # via josepy, mozilla-django-oidc, pyopenssl
+cryptography==3.3.1       # via josepy, mozilla-django-oidc, pyopenssl
 django-auth-ldap==1.3.0   # via -r requirements.in
 django-autoslug==1.9.3    # via -r requirements.in
 django-braces==1.0.0      # via -r requirements.in
@@ -34,16 +34,16 @@ future==0.18.2            # via metsrw
 futures==3.3.0 ; python_version < "3.2"  # via -r requirements.in
 gearman==2.0.2            # via -r requirements.in
 gevent==1.3.6             # via -r requirements.in
-greenlet==0.4.17          # via gevent
+greenlet==1.0.0           # via gevent
 gunicorn==19.9.0          # via -r requirements.in
 idna==2.8                 # via requests
 inotify_simple==1.1.8     # via -r requirements.in
 ipaddress==1.0.23         # via cryptography
-josepy==1.5.0             # via mozilla-django-oidc
+josepy==1.6.0             # via mozilla-django-oidc
 jsonschema==2.6.0         # via -r requirements.in
 lazy-paged-sequence==0.3  # via -r requirements.in
 logutils==0.3.3           # via -r requirements.in
-lxml==3.5.0               # via -r requirements.in, ammcpc, metsrw, python-cas
+lxml==4.6.2               # via -r requirements.in, ammcpc, metsrw, python-cas
 metsrw==0.3.15            # via -r requirements.in
 mozilla-django-oidc==1.2.4  # via -r requirements.in
 mysqlclient==1.4.6        # via -r requirements.in, agentarchives
@@ -58,12 +58,12 @@ prometheus-client==0.7.1  # via -r requirements.in, django-prometheus
 pyasn1-modules==0.2.8     # via python-ldap
 pyasn1==0.4.8             # via -r requirements.in, ndg-httpsclient, pyasn1-modules, python-ldap
 pycparser==2.20           # via cffi
-pyopenssl==19.1.0         # via -r requirements.in, josepy, ndg-httpsclient
+pyopenssl==20.0.1         # via -r requirements.in, josepy, ndg-httpsclient
 python-cas==1.5.0         # via django-cas-ng
 python-dateutil==2.6.0    # via -r requirements.in, django-tastypie, pandas
 python-ldap==3.2.0        # via -r requirements.in, django-auth-ldap
 python-mimeparse==1.6.0   # via django-tastypie
-pytz==2020.4              # via -r requirements.in, django, pandas
+pytz==2020.5              # via -r requirements.in, django, pandas
 requests==2.21.0          # via -r requirements.in, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r requirements.in, pathlib2
 six==1.14.0               # via -r requirements.in, amclient, cryptography, django-extensions, josepy, metsrw, mozilla-django-oidc, opf-fido, pathlib2, pip-tools, pyopenssl, python-cas, python-dateutil

--- a/src/MCPClient/requirements/base.in
+++ b/src/MCPClient/requirements/base.in
@@ -6,7 +6,7 @@ django-extensions==1.7.9
 django-tastypie==0.13.2
 mysqlclient==1.4.6
 gearman==2.0.2
-lxml==3.5.0
+lxml~=4.6
 metsrw==0.3.15
 requests==2.21.0
 unidecode==0.04.19

--- a/src/MCPClient/requirements/base.txt
+++ b/src/MCPClient/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 ammcpc==0.1.3             # via -r base.in
 bagit==1.7.0              # via -r base.in
-certifi==2020.6.20        # via requests
+certifi==2020.12.5        # via requests
 chardet==3.0.4            # via requests
 clamd==1.0.2              # via -r base.in
 django-extensions==1.7.9  # via -r base.in
@@ -15,7 +15,7 @@ django==1.11.29           # via -r base.in
 future==0.18.2            # via metsrw
 gearman==2.0.2            # via -r base.in
 idna==2.8                 # via requests
-lxml==3.5.0               # via -r base.in, ammcpc, metsrw
+lxml==4.6.2               # via -r base.in, ammcpc, metsrw
 metsrw==0.3.15            # via -r base.in
 mysqlclient==1.4.6        # via -r base.in
 olefile==0.46             # via opf-fido
@@ -23,7 +23,7 @@ opf-fido==1.4.1           # via -r base.in
 prometheus_client==0.7.1  # via -r base.in
 python-dateutil==2.8.1    # via django-tastypie
 python-mimeparse==1.6.0   # via django-tastypie
-pytz==2020.1              # via django
+pytz==2020.5              # via django
 requests==2.21.0          # via -r base.in
 scandir==1.10.0           # via -r base.in
 six==1.15.0               # via django-extensions, metsrw, opf-fido, python-dateutil

--- a/src/MCPClient/requirements/dev.txt
+++ b/src/MCPClient/requirements/dev.txt
@@ -7,10 +7,10 @@
 ammcpc==0.1.3             # via -r test.txt
 appdirs==1.4.4            # via -r test.txt, virtualenv
 atomicwrites==1.4.0       # via -r test.txt, pytest
-attrs==19.3.0             # via -r test.txt, pytest
+attrs==20.3.0             # via -r test.txt, pytest
 backports.functools-lru-cache==1.6.1  # via -r test.txt, wcwidth
 bagit==1.7.0              # via -r test.txt
-certifi==2020.6.20        # via -r test.txt, requests
+certifi==2020.12.5        # via -r test.txt, requests
 chardet==3.0.4            # via -r test.txt, requests
 clamd==1.0.2              # via -r test.txt
 click==7.1.2              # via pip-tools
@@ -25,39 +25,39 @@ funcsigs==1.0.2           # via -r test.txt, mock, pytest
 future==0.18.2            # via -r test.txt, metsrw
 gearman==2.0.2            # via -r test.txt
 idna==2.8                 # via -r test.txt, requests
-importlib-metadata==1.7.0  # via -r test.txt, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via -r test.txt, virtualenv
-lxml==3.5.0               # via -r test.txt, ammcpc, metsrw
+importlib-metadata==2.1.1  # via -r test.txt, pluggy, pytest, tox, virtualenv
+importlib-resources==3.3.1  # via -r test.txt, virtualenv
+lxml==4.6.2               # via -r test.txt, ammcpc, metsrw
 metsrw==0.3.15            # via -r test.txt
 mock==3.0.5               # via -r test.txt, pytest-mock
 more-itertools==5.0.0     # via -r test.txt, pytest
 mysqlclient==1.4.6        # via -r test.txt
 olefile==0.46             # via -r test.txt, opf-fido
 opf-fido==1.4.1           # via -r test.txt
-packaging==20.4           # via -r test.txt, pytest, tox
+packaging==20.8           # via -r test.txt, pytest, tox
 pathlib2==2.3.5           # via -r test.txt, importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
 pip-tools==5.1.2          # via -r dev.in
 pluggy==0.13.1            # via -r test.txt, pytest, tox
 prometheus_client==0.7.1  # via -r test.txt
-py==1.9.0                 # via -r test.txt, pytest, tox
+py==1.10.0                # via -r test.txt, pytest, tox
 pyparsing==2.4.7          # via -r test.txt, packaging
-pytest-django==3.9.0      # via -r test.txt
+pytest-django==3.10.0     # via -r test.txt
 pytest-mock==1.13.0       # via -r test.txt
 pytest-pythonpath==0.7.3  # via -r test.txt
 pytest==4.6.11            # via -r test.txt, pytest-django, pytest-mock, pytest-pythonpath
 python-dateutil==2.8.1    # via -r test.txt, django-tastypie
 python-mimeparse==1.6.0   # via -r test.txt, django-tastypie
-pytz==2020.1              # via -r test.txt, django
+pytz==2020.5              # via -r test.txt, django
 requests==2.21.0          # via -r test.txt
 scandir==1.10.0           # via -r test.txt, pathlib2
 singledispatch==3.4.0.3   # via -r test.txt, importlib-resources
-six==1.15.0               # via -r test.txt, django-extensions, metsrw, mock, more-itertools, opf-fido, packaging, pathlib2, pip-tools, pytest, python-dateutil, singledispatch, tox, virtualenv
-toml==0.10.1              # via -r test.txt, tox
-tox==3.19.0               # via -r test.txt
+six==1.15.0               # via -r test.txt, django-extensions, metsrw, mock, more-itertools, opf-fido, pathlib2, pip-tools, pytest, python-dateutil, singledispatch, tox, virtualenv
+toml==0.10.2              # via -r test.txt, tox
+tox==3.21.3               # via -r test.txt
 typing==3.7.4.3           # via -r test.txt, importlib-resources
 unidecode==0.04.19        # via -r test.txt
 urllib3==1.24.3           # via -r test.txt, requests
-virtualenv==20.0.30       # via -r test.txt, tox
+virtualenv==20.4.0        # via -r test.txt, tox
 wcwidth==0.2.5            # via -r test.txt, pytest
 zipp==1.2.0               # via -r test.txt, importlib-metadata, importlib-resources
 

--- a/src/MCPClient/requirements/production.txt
+++ b/src/MCPClient/requirements/production.txt
@@ -6,7 +6,7 @@
 #
 ammcpc==0.1.3             # via -r base.txt
 bagit==1.7.0              # via -r base.txt
-certifi==2020.6.20        # via -r base.txt, requests
+certifi==2020.12.5        # via -r base.txt, requests
 chardet==3.0.4            # via -r base.txt, requests
 clamd==1.0.2              # via -r base.txt
 django-extensions==1.7.9  # via -r base.txt
@@ -15,7 +15,7 @@ django==1.11.29           # via -r base.txt
 future==0.18.2            # via -r base.txt, metsrw
 gearman==2.0.2            # via -r base.txt
 idna==2.8                 # via -r base.txt, requests
-lxml==3.5.0               # via -r base.txt, ammcpc, metsrw
+lxml==4.6.2               # via -r base.txt, ammcpc, metsrw
 metsrw==0.3.15            # via -r base.txt
 mysqlclient==1.4.6        # via -r base.txt
 olefile==0.46             # via -r base.txt, opf-fido
@@ -23,7 +23,7 @@ opf-fido==1.4.1           # via -r base.txt
 prometheus_client==0.7.1  # via -r base.txt
 python-dateutil==2.8.1    # via -r base.txt, django-tastypie
 python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
-pytz==2020.1              # via -r base.txt, django
+pytz==2020.5              # via -r base.txt, django
 requests==2.21.0          # via -r base.txt
 scandir==1.10.0           # via -r base.txt
 six==1.15.0               # via -r base.txt, django-extensions, metsrw, opf-fido, python-dateutil

--- a/src/MCPClient/requirements/test.txt
+++ b/src/MCPClient/requirements/test.txt
@@ -7,10 +7,10 @@
 ammcpc==0.1.3             # via -r base.txt
 appdirs==1.4.4            # via virtualenv
 atomicwrites==1.4.0       # via pytest
-attrs==19.3.0             # via pytest
+attrs==20.3.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via wcwidth
 bagit==1.7.0              # via -r base.txt
-certifi==2020.6.20        # via -r base.txt, requests
+certifi==2020.12.5        # via -r base.txt, requests
 chardet==3.0.4            # via -r base.txt, requests
 clamd==1.0.2              # via -r base.txt
 configparser==4.0.2       # via importlib-metadata
@@ -24,38 +24,38 @@ funcsigs==1.0.2           # via mock, pytest
 future==0.18.2            # via -r base.txt, metsrw
 gearman==2.0.2            # via -r base.txt
 idna==2.8                 # via -r base.txt, requests
-importlib-metadata==1.7.0  # via pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
-lxml==3.5.0               # via -r base.txt, ammcpc, metsrw
+importlib-metadata==2.1.1  # via pluggy, pytest, tox, virtualenv
+importlib-resources==3.3.1  # via virtualenv
+lxml==4.6.2               # via -r base.txt, ammcpc, metsrw
 metsrw==0.3.15            # via -r base.txt
 mock==3.0.5               # via pytest-mock
 more-itertools==5.0.0     # via pytest
 mysqlclient==1.4.6        # via -r base.txt
 olefile==0.46             # via -r base.txt, opf-fido
 opf-fido==1.4.1           # via -r base.txt
-packaging==20.4           # via pytest, tox
+packaging==20.8           # via pytest, tox
 pathlib2==2.3.5           # via importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
 pluggy==0.13.1            # via pytest, tox
 prometheus_client==0.7.1  # via -r base.txt
-py==1.9.0                 # via pytest, tox
+py==1.10.0                # via pytest, tox
 pyparsing==2.4.7          # via packaging
-pytest-django==3.9.0      # via -r test.in
+pytest-django==3.10.0     # via -r test.in
 pytest-mock==1.13.0       # via -r test.in
 pytest-pythonpath==0.7.3  # via -r test.in
 pytest==4.6.11            # via -r test.in, pytest-django, pytest-mock, pytest-pythonpath
 python-dateutil==2.8.1    # via -r base.txt, django-tastypie
 python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
-pytz==2020.1              # via -r base.txt, django
+pytz==2020.5              # via -r base.txt, django
 requests==2.21.0          # via -r base.txt
 scandir==1.10.0           # via -r base.txt, pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
-six==1.15.0               # via -r base.txt, django-extensions, metsrw, mock, more-itertools, opf-fido, packaging, pathlib2, pytest, python-dateutil, tox, virtualenv
-toml==0.10.1              # via tox
-tox==3.19.0               # via -r test.in
+six==1.15.0               # via -r base.txt, django-extensions, metsrw, mock, more-itertools, opf-fido, pathlib2, pytest, python-dateutil, tox, virtualenv
+toml==0.10.2              # via tox
+tox==3.21.3               # via -r test.in
 typing==3.7.4.3           # via importlib-resources
 unidecode==0.04.19        # via -r base.txt
 urllib3==1.24.3           # via -r base.txt, requests
-virtualenv==20.0.30       # via tox
+virtualenv==20.4.0        # via tox
 wcwidth==0.2.5            # via pytest
 zipp==1.2.0               # via importlib-metadata, importlib-resources
 

--- a/src/MCPServer/requirements/base.in
+++ b/src/MCPServer/requirements/base.in
@@ -2,7 +2,7 @@ Django>=1.11,<2
 django-extensions==1.7.9
 mysqlclient==1.4.6
 gearman==2.0.2
-lxml==3.5.0
+lxml~=4.6
 prometheus_client==0.7.1
 jsonschema==2.6.0
 inotify_simple==1.1.8

--- a/src/MCPServer/requirements/base.txt
+++ b/src/MCPServer/requirements/base.txt
@@ -13,10 +13,10 @@ futures==3.3.0 ; python_version < "3.2"  # via -r base.in
 gearman==2.0.2            # via -r base.in
 inotify_simple==1.1.8     # via -r base.in
 jsonschema==2.6.0         # via -r base.in
-lxml==3.5.0               # via -r base.in
+lxml==4.6.2               # via -r base.in
 mysqlclient==1.4.6        # via -r base.in
 pathlib2==2.3.4 ; python_version < "3"  # via -r base.in
 prometheus_client==0.7.1  # via -r base.in
-pytz==2020.1              # via django
+pytz==2020.5              # via django
 scandir==1.10.0           # via pathlib2
 six==1.15.0               # via django-extensions, pathlib2

--- a/src/MCPServer/requirements/dev.txt
+++ b/src/MCPServer/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 appdirs==1.4.4            # via -r test.txt, virtualenv
 atomicwrites==1.4.0       # via -r test.txt, pytest
-attrs==19.3.0             # via -r test.txt, pytest
+attrs==20.3.0             # via -r test.txt, pytest
 backports.functools-lru-cache==1.6.1  # via -r test.txt, wcwidth
 click==7.1.2              # via pip-tools
 configparser==4.0.2       # via -r test.txt, importlib-metadata
@@ -21,33 +21,33 @@ funcsigs==1.0.2           # via -r test.txt, mock, pytest
 functools32==3.2.3.post2  # via -r test.txt, jsonschema
 futures==3.3.0 ; python_version < "3.2"  # via -r test.txt
 gearman==2.0.2            # via -r test.txt
-importlib-metadata==1.7.0  # via -r test.txt, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via -r test.txt, virtualenv
+importlib-metadata==2.1.1  # via -r test.txt, pluggy, pytest, tox, virtualenv
+importlib-resources==3.3.1  # via -r test.txt, virtualenv
 inotify_simple==1.1.8     # via -r test.txt
 jsonschema==2.6.0         # via -r test.txt
-lxml==3.5.0               # via -r test.txt
+lxml==4.6.2               # via -r test.txt
 mock==3.0.5               # via -r test.txt, pytest-mock
 more-itertools==5.0.0     # via -r test.txt, pytest
 mysqlclient==1.4.6        # via -r test.txt
-packaging==20.4           # via -r test.txt, pytest, tox
+packaging==20.8           # via -r test.txt, pytest, tox
 pathlib2==2.3.4 ; python_version < "3"  # via -r test.txt, importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
 pip-tools==5.1.2          # via -r dev.in
 pluggy==0.13.1            # via -r test.txt, pytest, tox
 prometheus_client==0.7.1  # via -r test.txt
-py==1.9.0                 # via -r test.txt, pytest, tox
+py==1.10.0                # via -r test.txt, pytest, tox
 pyparsing==2.4.7          # via -r test.txt, packaging
-pytest-django==3.9.0      # via -r test.txt
+pytest-django==3.10.0     # via -r test.txt
 pytest-mock==1.13.0       # via -r test.txt
 pytest-pythonpath==0.7.3  # via -r test.txt
 pytest==4.6.11            # via -r test.txt, pytest-django, pytest-mock, pytest-pythonpath
-pytz==2020.1              # via -r test.txt, django
+pytz==2020.5              # via -r test.txt, django
 scandir==1.10.0           # via -r test.txt, pathlib2
 singledispatch==3.4.0.3   # via -r test.txt, importlib-resources
-six==1.15.0               # via -r test.txt, django-extensions, mock, more-itertools, packaging, pathlib2, pip-tools, pytest, singledispatch, tox, virtualenv
-toml==0.10.1              # via -r test.txt, tox
-tox==3.19.0               # via -r test.txt
+six==1.15.0               # via -r test.txt, django-extensions, mock, more-itertools, pathlib2, pip-tools, pytest, singledispatch, tox, virtualenv
+toml==0.10.2              # via -r test.txt, tox
+tox==3.21.3               # via -r test.txt
 typing==3.7.4.3           # via -r test.txt, importlib-resources
-virtualenv==20.0.30       # via -r test.txt, tox
+virtualenv==20.4.0        # via -r test.txt, tox
 wcwidth==0.2.5            # via -r test.txt, pytest
 zipp==1.2.0               # via -r test.txt, importlib-metadata, importlib-resources
 

--- a/src/MCPServer/requirements/production.txt
+++ b/src/MCPServer/requirements/production.txt
@@ -13,10 +13,10 @@ futures==3.3.0 ; python_version < "3.2"  # via -r base.txt
 gearman==2.0.2            # via -r base.txt
 inotify_simple==1.1.8     # via -r base.txt
 jsonschema==2.6.0         # via -r base.txt
-lxml==3.5.0               # via -r base.txt
+lxml==4.6.2               # via -r base.txt
 mysqlclient==1.4.6        # via -r base.txt
 pathlib2==2.3.4 ; python_version < "3"  # via -r base.txt
 prometheus_client==0.7.1  # via -r base.txt
-pytz==2020.1              # via -r base.txt, django
+pytz==2020.5              # via -r base.txt, django
 scandir==1.10.0           # via -r base.txt, pathlib2
 six==1.15.0               # via -r base.txt, django-extensions, pathlib2

--- a/src/MCPServer/requirements/test.txt
+++ b/src/MCPServer/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 appdirs==1.4.4            # via virtualenv
 atomicwrites==1.4.0       # via pytest
-attrs==19.3.0             # via pytest
+attrs==20.3.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via wcwidth
 configparser==4.0.2       # via importlib-metadata
 contextdecorator==0.10.0 ; python_version < "3.2"  # via -r base.txt
@@ -20,31 +20,31 @@ funcsigs==1.0.2           # via mock, pytest
 functools32==3.2.3.post2  # via -r base.txt, jsonschema
 futures==3.3.0 ; python_version < "3.2"  # via -r base.txt
 gearman==2.0.2            # via -r base.txt
-importlib-metadata==1.7.0  # via pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
+importlib-metadata==2.1.1  # via pluggy, pytest, tox, virtualenv
+importlib-resources==3.3.1  # via virtualenv
 inotify_simple==1.1.8     # via -r base.txt
 jsonschema==2.6.0         # via -r base.txt
-lxml==3.5.0               # via -r base.txt
+lxml==4.6.2               # via -r base.txt
 mock==3.0.5               # via pytest-mock
 more-itertools==5.0.0     # via pytest
 mysqlclient==1.4.6        # via -r base.txt
-packaging==20.4           # via pytest, tox
+packaging==20.8           # via pytest, tox
 pathlib2==2.3.4 ; python_version < "3"  # via -r base.txt, importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
 pluggy==0.13.1            # via pytest, tox
 prometheus_client==0.7.1  # via -r base.txt
-py==1.9.0                 # via pytest, tox
+py==1.10.0                # via pytest, tox
 pyparsing==2.4.7          # via packaging
-pytest-django==3.9.0      # via -r test.in
+pytest-django==3.10.0     # via -r test.in
 pytest-mock==1.13.0       # via -r test.in
 pytest-pythonpath==0.7.3  # via -r test.in
 pytest==4.6.11            # via -r test.in, pytest-django, pytest-mock, pytest-pythonpath
-pytz==2020.1              # via -r base.txt, django
+pytz==2020.5              # via -r base.txt, django
 scandir==1.10.0           # via -r base.txt, pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
-six==1.15.0               # via -r base.txt, django-extensions, mock, more-itertools, packaging, pathlib2, pytest, tox, virtualenv
-toml==0.10.1              # via tox
-tox==3.19.0               # via -r test.in
+six==1.15.0               # via -r base.txt, django-extensions, mock, more-itertools, pathlib2, pytest, tox, virtualenv
+toml==0.10.2              # via tox
+tox==3.21.3               # via -r test.in
 typing==3.7.4.3           # via importlib-resources
-virtualenv==20.0.30       # via tox
+virtualenv==20.4.0        # via tox
 wcwidth==0.2.5            # via pytest
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/src/archivematicaCommon/requirements/dev.txt
+++ b/src/archivematicaCommon/requirements/dev.txt
@@ -38,17 +38,17 @@ pytest-pythonpath==0.7.3  # via -r test.txt
 pytest==4.6.11            # via -r test.txt, pytest-django, pytest-pythonpath
 python-dateutil==2.6.0    # via -r test.txt
 pytz==2020.5              # via -r test.txt, django
-pyyaml==5.3.1             # via -r test.txt, vcrpy
+pyyaml==5.4.1             # via -r test.txt, vcrpy
 requests==2.21.0          # via -r test.txt, agentarchives
 scandir==1.10.0           # via -r test.txt, pathlib2
 singledispatch==3.4.0.3   # via -r test.txt, importlib-resources
 six==1.14.0               # via -r test.txt, mock, more-itertools, pathlib2, pip-tools, pytest, python-dateutil, singledispatch, tox, vcrpy, virtualenv
 toml==0.10.2              # via -r test.txt, tox
-tox==3.21.0               # via -r test.txt
+tox==3.21.3               # via -r test.txt
 typing==3.7.4.3           # via -r test.txt, importlib-resources
 urllib3==1.24.3           # via -r test.txt, elasticsearch, requests
 vcrpy==1.13.0             # via -r test.txt
-virtualenv==20.2.2        # via -r test.txt, tox
+virtualenv==20.4.0        # via -r test.txt, tox
 wcwidth==0.2.5            # via -r test.txt, pytest
 wrapt==1.12.1             # via -r test.txt, vcrpy
 zipp==1.2.0               # via -r test.txt, importlib-metadata, importlib-resources

--- a/src/archivematicaCommon/requirements/test.txt
+++ b/src/archivematicaCommon/requirements/test.txt
@@ -36,17 +36,17 @@ pytest-pythonpath==0.7.3  # via -r test.in
 pytest==4.6.11            # via -r test.in, pytest-django, pytest-pythonpath
 python-dateutil==2.6.0    # via -r base.txt
 pytz==2020.5              # via -r base.txt, django
-pyyaml==5.3.1             # via vcrpy
+pyyaml==5.4.1             # via vcrpy
 requests==2.21.0          # via -r base.txt, agentarchives
 scandir==1.10.0           # via -r base.txt, pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
 six==1.14.0               # via -r base.txt, mock, more-itertools, pathlib2, pytest, python-dateutil, tox, vcrpy, virtualenv
 toml==0.10.2              # via tox
-tox==3.21.0               # via -r test.in
+tox==3.21.3               # via -r test.in
 typing==3.7.4.3           # via importlib-resources
 urllib3==1.24.3           # via -r base.txt, elasticsearch, requests
 vcrpy==1.13.0             # via -r test.in
-virtualenv==20.2.2        # via tox
+virtualenv==20.4.0        # via tox
 wcwidth==0.2.5            # via pytest
 wrapt==1.12.1             # via vcrpy
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/src/dashboard/src/requirements/base.in
+++ b/src/dashboard/src/requirements/base.in
@@ -17,7 +17,7 @@ gevent==1.3.6  # used by gunicorn's async workers
 gunicorn==19.9.0
 futures==3.3.0; python_version < '3.0'  # used by gunicorn's async workers
 lazy-paged-sequence
-lxml==3.5.0
+lxml~=4.6
 metsrw==0.3.15
 mysqlclient==1.4.6
 pandas==0.24.2

--- a/src/dashboard/src/requirements/base.txt
+++ b/src/dashboard/src/requirements/base.txt
@@ -29,14 +29,14 @@ future==0.18.2            # via metsrw
 futures==3.3.0 ; python_version < "3.0"  # via -r base.in
 gearman==2.0.2            # via -r base.in
 gevent==1.3.6             # via -r base.in
-greenlet==0.4.17          # via gevent
+greenlet==1.0.0           # via gevent
 gunicorn==19.9.0          # via -r base.in
 idna==2.8                 # via requests
 ipaddress==1.0.23         # via cryptography
-josepy==1.5.0             # via mozilla-django-oidc
+josepy==1.6.0             # via mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r base.in
 logutils==0.3.3           # via -r base.in
-lxml==3.5.0               # via -r base.in, metsrw, python-cas
+lxml==4.6.2               # via -r base.in, metsrw, python-cas
 metsrw==0.3.15            # via -r base.in
 mozilla-django-oidc==1.2.4  # via -r base.in
 mysqlclient==1.4.6        # via -r base.in, agentarchives

--- a/src/dashboard/src/requirements/dev.txt
+++ b/src/dashboard/src/requirements/dev.txt
@@ -43,7 +43,7 @@ future==0.18.2            # via -r test.txt, metsrw
 futures==3.3.0 ; python_version < "3.0"  # via -r test.txt
 gearman==2.0.2            # via -r test.txt
 gevent==1.3.6             # via -r test.txt
-greenlet==0.4.17          # via -r test.txt, gevent
+greenlet==1.0.0           # via -r test.txt, gevent
 gunicorn==19.9.0          # via -r test.txt
 idna==2.8                 # via -r test.txt, requests
 importlib-metadata==2.1.1  # via -r test.txt, pluggy, pytest, tox, virtualenv
@@ -52,10 +52,10 @@ ipaddress==1.0.23         # via -r test.txt, cryptography
 ipdb==0.13.4              # via -r dev.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==5.10.0           # via -r dev.in, ipdb
-josepy==1.5.0             # via -r test.txt, mozilla-django-oidc
+josepy==1.6.0             # via -r test.txt, mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r test.txt
 logutils==0.3.3           # via -r test.txt
-lxml==3.5.0               # via -r test.txt, metsrw, python-cas
+lxml==4.6.2               # via -r test.txt, metsrw, python-cas
 metsrw==0.3.15            # via -r test.txt
 mock==3.0.5               # via -r test.txt, mockldap, pytest-mock, vcrpy
 mockldap==0.2.8           # via -r test.txt
@@ -91,19 +91,19 @@ python-dateutil==2.6.0    # via -r test.txt, django-tastypie, pandas
 python-ldap==3.2.0        # via -r test.txt, django-auth-ldap, mockldap
 python-mimeparse==1.6.0   # via -r test.txt, django-tastypie
 pytz==2020.5              # via -r test.txt, django, pandas
-pyyaml==5.3.1             # via -r test.txt, vcrpy
+pyyaml==5.4.1             # via -r test.txt, vcrpy
 requests==2.21.0          # via -r test.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r test.txt, pathlib2
 simplegeneric==0.8.1      # via ipython
 singledispatch==3.4.0.3   # via -r test.txt, importlib-resources
 six==1.15.0               # via -r test.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, mozilla-django-oidc, pathlib2, pip-tools, prompt-toolkit, pyopenssl, pytest, python-cas, python-dateutil, singledispatch, tox, traitlets, vcrpy, virtualenv
 toml==0.10.2              # via -r test.txt, tox
-tox==3.21.0               # via -r test.txt
+tox==3.21.3               # via -r test.txt
 traitlets==4.3.3          # via ipython
 typing==3.7.4.3           # via -r test.txt, importlib-resources
 urllib3==1.24.3           # via -r test.txt, amclient, elasticsearch, requests
 vcrpy==1.13.0             # via -r test.txt
-virtualenv==20.2.2        # via -r test.txt, tox
+virtualenv==20.4.0        # via -r test.txt, tox
 wcwidth==0.2.5            # via -r test.txt, prompt-toolkit, pytest
 whitenoise==3.3.0         # via -r test.txt
 wrapt==1.12.1             # via -r test.txt, vcrpy

--- a/src/dashboard/src/requirements/production.txt
+++ b/src/dashboard/src/requirements/production.txt
@@ -29,14 +29,14 @@ future==0.18.2            # via -r base.txt, metsrw
 futures==3.3.0 ; python_version < "3.0"  # via -r base.txt
 gearman==2.0.2            # via -r base.txt
 gevent==1.3.6             # via -r base.txt
-greenlet==0.4.17          # via -r base.txt, gevent
+greenlet==1.0.0           # via -r base.txt, gevent
 gunicorn==19.9.0          # via -r base.txt
 idna==2.8                 # via -r base.txt, requests
 ipaddress==1.0.23         # via -r base.txt, cryptography
-josepy==1.5.0             # via -r base.txt, mozilla-django-oidc
+josepy==1.6.0             # via -r base.txt, mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r base.txt
 logutils==0.3.3           # via -r base.txt
-lxml==3.5.0               # via -r base.txt, metsrw, python-cas
+lxml==4.6.2               # via -r base.txt, metsrw, python-cas
 metsrw==0.3.15            # via -r base.txt
 mozilla-django-oidc==1.2.4  # via -r base.txt
 mysqlclient==1.4.6        # via -r base.txt, agentarchives

--- a/src/dashboard/src/requirements/test.txt
+++ b/src/dashboard/src/requirements/test.txt
@@ -40,16 +40,16 @@ future==0.18.2            # via -r base.txt, metsrw
 futures==3.3.0 ; python_version < "3.0"  # via -r base.txt
 gearman==2.0.2            # via -r base.txt
 gevent==1.3.6             # via -r base.txt
-greenlet==0.4.17          # via -r base.txt, gevent
+greenlet==1.0.0           # via -r base.txt, gevent
 gunicorn==19.9.0          # via -r base.txt
 idna==2.8                 # via -r base.txt, requests
 importlib-metadata==2.1.1  # via pluggy, pytest, tox, virtualenv
 importlib-resources==3.3.1  # via virtualenv
 ipaddress==1.0.23         # via -r base.txt, cryptography
-josepy==1.5.0             # via -r base.txt, mozilla-django-oidc
+josepy==1.6.0             # via -r base.txt, mozilla-django-oidc
 lazy-paged-sequence==0.3  # via -r base.txt
 logutils==0.3.3           # via -r base.txt
-lxml==3.5.0               # via -r base.txt, metsrw, python-cas
+lxml==4.6.2               # via -r base.txt, metsrw, python-cas
 metsrw==0.3.15            # via -r base.txt
 mock==3.0.5               # via mockldap, pytest-mock, vcrpy
 mockldap==0.2.8           # via -r test.in
@@ -79,17 +79,17 @@ python-dateutil==2.6.0    # via -r base.txt, django-tastypie, pandas
 python-ldap==3.2.0        # via -r base.txt, django-auth-ldap, mockldap
 python-mimeparse==1.6.0   # via -r base.txt, django-tastypie
 pytz==2020.5              # via -r base.txt, django, pandas
-pyyaml==5.3.1             # via vcrpy
+pyyaml==5.4.1             # via vcrpy
 requests==2.21.0          # via -r base.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r base.txt, pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
 six==1.15.0               # via -r base.txt, amclient, cryptography, django-extensions, josepy, metsrw, mock, more-itertools, mozilla-django-oidc, pathlib2, pyopenssl, pytest, python-cas, python-dateutil, tox, vcrpy, virtualenv
 toml==0.10.2              # via tox
-tox==3.21.0               # via -r test.in
+tox==3.21.3               # via -r test.in
 typing==3.7.4.3           # via importlib-resources
 urllib3==1.24.3           # via -r base.txt, amclient, elasticsearch, requests
 vcrpy==1.13.0             # via -r test.in
-virtualenv==20.2.2        # via tox
+virtualenv==20.4.0        # via tox
 wcwidth==0.2.5            # via pytest
 whitenoise==3.3.0         # via -r base.txt
 wrapt==1.12.1             # via vcrpy


### PR DESCRIPTION
Using "lxml~=4.6". Other dependencies without fixed constrains are updated too.

Connects to https://github.com/archivematica/Issues/issues/1317.