### PR TITLE
Specifies a dedicated tab as output in which all tasks are displayed

### DIFF
--- a/src/dashboard/src/media/js/jobs.js
+++ b/src/dashboard/src/media/js/jobs.js
@@ -542,7 +542,7 @@ var BaseJobView = Backbone.View.extend({
     {
       event.preventDefault();
 
-      window.open('/tasks/' + this.model.get('uuid') + '/', '_blank');
+      window.open('/tasks/' + this.model.get('uuid') + '/', 'output');
     },
 
   /**


### PR DESCRIPTION
This will fix issue archivematica/Issues#85
specifying a dedicated output window as target to display tasks
in one single tab rather than opening one after every click on the tasks gear.