### PR TITLE
Convert links to full reference links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,9 @@ us assess your changes faster and makes it easier for us to merge your
 submission!
 
 There are many ways to contribute: writing tutorials or blog posts about your
-experience, improving the
-[documentation](https://github.com/artefactual/archivematica-docs/), submitting
-bug reports, answering questions on the
-[mailing list](https://groups.google.com/forum/#!forum/archivematica), or
-writing code which can be incorporated into Archivematica itself.
+experience, improving the [documentation], submitting bug reports, answering 
+questions on the [mailing list], or writing code which can be incorporated into 
+Archivematica itself.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -48,16 +46,13 @@ writing code which can be incorporated into Archivematica itself.
 If you find a security vulnerability, do NOT open an issue. Email
 info@artefactual.com instead.
 
-Issues can be filed using GitHub Issues in the
-[Archivematica Issues repo](https://github.com/archivematica/Issues). It is
-recommended to file issues there rather than in any of the Archivematica-related
-code repositories. Artefactual staff also use GitHub issues for any work they do
-on the Archivematica project.
+Issues can be filed using GitHub Issues in the [Archivematica Issues repo]. 
+It is recommended to file issues there rather than in any of the 
+Archivematica-related code repositories. Artefactual staff also use GitHub 
+issues for any work they do on the Archivematica project.
 
-You can also post in our
-[user](https://groups.google.com/forum/#!forum/archivematica) mailing list.
-A post to the mailing list is always welcome, especially if you're unsure if
-it's a bug or a local problem!
+You can also post in our [user] mailing list. A post to the mailing list is 
+always welcome, especially if you're unsure if it's a bug or a local problem!
 
 Useful questions to answer if you're having problems include:
 
@@ -74,14 +69,12 @@ Useful questions to answer if you're having problems include:
 ## Submitting enhancement ideas
 
 Similar to submitting bugs, you are welcome to submit ideas for enhancements or
-new features in the
-[Archivematica Issues repo](https://github.com/archivematica/Issues). This is
-also where Artefactual staff record upcoming enhancements when they have been
-sponsored for inclusion either by Artefactual Systems or by a client.
+new features in the [Archivematica Issues repo]. This is  also where Artefactual 
+staff record upcoming enhancements when they have been sponsored for inclusion
+either by Artefactual Systems or by a client.
 
-Please feel free also to use the
-[Issues repo wiki](https://github.com/archivematica/Issues/wiki) as a space for
-gathering and collaborating on ideas. If you are not already a member of the
+Please feel free also to use the [Issues repo wiki] as a space for gathering and 
+collaborating on ideas. If you are not already a member of the 
 Archivematica repo (required for editing the wiki), file an issue there with
 the title "Request membership."
 
@@ -94,7 +87,7 @@ outside contributors.
 Here's an outline of the contribution process:
 
 1. File an issue in the
-   [Archivematica Issues repo](https://github.com/archivematica/Issues).
+   [Archivematica Issues repo].
 2. Fork the Artefactual project on GitHub, and commit your changes to a branch
    in your fork.
 3. Open a pull request.
@@ -107,9 +100,8 @@ Here's an outline of the contribution process:
 
 ### Permalinks
 
-Issues can be enhanced by using GitHub's permalink features for
-[files](https://help.github.com/articles/getting-permanent-links-to-files/) and
-[code snippets](https://help.github.com/articles/creating-a-permanent-link-to-a-code-snippet/).
+Issues can be enhanced by using GitHub's permalink features for [files] and
+[code snippets].
 Permalinks allow users to look back over old issues and pull requests and see
 what the code looked like at a certain point in time. This can be useful where
 lines may now have been added or removed but the topic of the conversation may
@@ -119,19 +111,17 @@ still be relevant or of interest to the reader.
 
 So you have something to contribute to an Artefactual project. Great!
 
-To install Archivematica, see our
-[development installation](https://wiki.archivematica.org/Getting_started#Installation)
-instructions.
+To install Archivematica, see our [development installation] instructions.
 
-Artefactual uses [GitHub](https://github.com/)'s pull request feature for code
-review. Every change being submitted to an Artefactual project should be
+Artefactual uses [GitHub]'s pull request feature for code review. Every change 
+being submitted to an Artefactual project should be
 submitted as a pull request to the appropriate repository. A branch being
 submitted for code review should contain commits covering a related section of
 code. Try not to bundle unrelated changes together in one branch; it makes
 review harder.
 
 If you're not familiar with forking repositories and creating branches in
-GitHub, consult their [guide](https://help.github.com/articles/fork-a-repo).
+GitHub, consult their [guide].
 
 ### When to submit code for review?
 
@@ -143,7 +133,7 @@ shy about submitting early.
 
 ### Opening the pull request
 
-GitHub has an [excellent](https://help.github.com/articles/using-pull-requests)
+GitHub has an [excellent]
 guide on using the pull request feature.
 
 ### Discussion
@@ -154,7 +144,7 @@ a great place to have in-depth conversation on the issue.
 
 Do make use of GitHub's line comment feature!
 
-![Line comment](http://i.imgur.com/FsWppGN.png)
+![Line comment]
 
 By viewing the "Files changed", you can leave a comment on any line of the
 diff. This is a great way to scope discussion to a particular part of a diff.
@@ -167,42 +157,51 @@ have something to contribute on another pull request, even if you're not the
 one who opened it.
 
 For more details about code review in particular, look at our
-[code review guidelines](code_review.md).
+[code review guidelines].
 
 ### Cleaning up the commit history
 
 Once code review is finished or nearly finished, and no further development is
 planned on the branch, the branch's commit history should be cleaned up.
 You can alter the commit history of a branch using git's powerful
-[interactive rebase feature](http://www.git-scm.com/book/en/Git-Tools-Rewriting-History).
+[interactive rebase feature].
 
 ## Contributor's Agreement
 
 In order for the Archivematica development team to accept any patches or code
-commits, contributors must first sign this
-[Contributor's Agreement](https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf).
+commits, contributors must first sign this [Contributor's Agreement].
 The Archivematica contributor's agreement is based almost verbatim on the
-[Apache Foundation](http://apache.org )'s individual
-[contributor license](http://www.apache.org/licenses/icla.txt).
+[Apache Foundation]'s individual [contributor license].
 
 If you have any questions or concerns about the Contributor's Agreement,
 please email us at agreement@artefactual.com to discuss them.
 
 ### Why do I have to sign a Contributor's Agreement?
 
-One of the key challenges for open source software is to support a collaborative development environment while protecting the rights of contributors and users over the long-term.
-Unifying Archivematica copyrights through contributor agreements is the best way to protect the availability and sustainability of Archivematica over the long-term as free and open-source software.
-In all cases, contributors who sign the Contributor's Agreement retain full rights to use their original contributions for any other purpose outside of Archivematica, while enabling Artefactual Systems, any successor organization which may eventually take over responsibility for Archivematica, and the wider Archivematica community to benefit from their collaboration and contributions in this open source project.
+One of the key challenges for open source software is to support a collaborative
+development environment while protecting the rights of contributors and users 
+over the long-term.
+Unifying Archivematica copyrights through contributor agreements is the best way
+to protect the availability and sustainability of Archivematica over the 
+long-term as free and open-source software.
+In all cases, contributors who sign the Contributor's Agreement retain full 
+rights to use their original contributions for any other purpose outside of 
+Archivematica, while enabling Artefactual Systems, any successor organization 
+which may eventually take over responsibility for Archivematica, and the wider 
+Archivematica community to benefit from their collaboration and contributions 
+in this open source project.
 
-[Artefactual Systems](http://artefactual.com) has made the decision and has a proven track record of making our intellectual property available to the community at large.
-By standardizing contributions on these agreements the Archivematica intellectual property position does not become too complicated.
-This ensures our resources are devoted to making our project the best they can be, rather than fighting legal battles over contributions.
+[Artefactual Systems] has made the decision and has a proven track record of 
+making our intellectual property available to the community at large.
+By standardizing contributions on these agreements the Archivematica 
+intellectual property position does not become too complicated.
+This ensures our resources are devoted to making our project the best they can 
+be, rather than fighting legal battles over contributions.
 
 ### How do I send in an agreement?
 
-Please read and sign the
-[contributor agreement](https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf)
-and email it to agreement@artefactual.com.
+Please read and sign the [Contributor's Agreement] and email it to 
+agreement@artefactual.com.
 
 Alternatively, you may send a printed, signed agreement to:
 
@@ -215,27 +214,23 @@ Alternatively, you may send a printed, signed agreement to:
 
 ### Style
 
-Archivematica uses the Python [PEP8](https://www.python.org/dev/peps/pep-0008/)
-community style guidelines. Newly-written code should conform to PEP-8 style.
-PEP8 is a daunting document, but there are very good linters available that you
-can run to check style in your code.
+Archivematica uses the Python [PEP8] community style guidelines. Newly-written 
+code should conform to PEP-8 style. PEP8 is a daunting document, but there are 
+very good linters available that you can run to check style in your code.
 
-* The [Black](https://github.com/ambv/black) tool formats the code
-  automatically. The output is deterministic for any given input. Editor
-  integration is possible.
+* The [Black] tool formats the code automatically. The output is deterministic 
+  for any given input. Editor integration is possible.
 
-* The [flake8](https://pypi.python.org/pypi/flake8) tool checks for style
-  problems as well as errors and complexity. It can be used at the command line
-  or as a plugin in your preferred text editor/IDE. The Archivematica
-  [continuous integration system](https://travis-ci.org/artefactual/archivematica)
-  will currently check code for compliance against flake8.
+* The [flake8] tool checks for style problems as well as errors and complexity. 
+  It can be used at the command line or as a plugin in your preferred text 
+  editor/IDE. The Archivematica [continuous integration system] will currently 
+  check code for compliance against flake8.
 
 We have integrated these tools with our CI, i.e. pull requests will fail to
 build when the tools above report errors.
 
-Additionally [Pylint](https://www.pylint.org/) is used by developers internally
-at Artefactual to highlight other potential areas of improvement during
-code-review.
+Additionally [Pylint] is used by developers internally at Artefactual to 
+highlight other potential areas of improvement during code-review.
 
 #### Some extra notes
 
@@ -280,34 +275,27 @@ behaviour should be maintained.
 ### Documentation
 
 New classes and functions should generally be documented using
-[docstrings](https://en.wikipedia.org/wiki/Docstring#Python); these help in
-providing clarity, and can also be used to generate API documentation later.
-Generally any function which isn't obvious (any function longer than a line or
-two) should have a docstring. When in doubt: document! Python's
-[PEP 257](https://www.python.org/dev/peps/pep-0257/) document provides a useful
-guideline for docstring style. Generally, prefer using
-[Sphinx-compatible docstrings](http://pythonhosted.org/an_example_pypi_project/sphinx.html#function-definitions). More
-[examples](http://sphinx-doc.org/domains.html#info-field-lists) and
-[attributes to use](http://sphinx-doc.org/domains.html#the-python-domain) can
+[docstrings]; these help in providing clarity, and can also be used to generate 
+API documentation later. Generally any function which isn't obvious 
+(any function longer than a line or two) should have a docstring. 
+When in doubt: document! Python's [PEP 257] document provides a useful
+guideline for docstring style. Generally, prefer using 
+[Sphinx-compatible docstrings]. More [examples] and [attributes to use] can
 be found on the Sphinx website.
 
 ### Tests
 
-New code should also have unit tests. Tests are written in
-[unittest](https://docs.python.org/2/library/unittest.html) style and run with
-[py.test](http://pytest.org). For tests requiring the Django ORM, we use the
-Django-provided
-[TestCase](https://docs.djangoproject.com/en/1.8/topics/testing/tools/#django.test.TestCase)
-, which extends `unittest.TestCase`.
+New code should also have unit tests. Tests are written in [unittest] style 
+and run with [py.test]. For tests requiring the Django ORM, we use the 
+Django-provided[TestCase], which extends `unittest.TestCase`.
 
 Tests are found in the `tests` directory, a sibling of the directory containing
 the code. `test_foo.py` contains tests for `foo.py`. For clarity, group tests
 for the same function and similar tests into the same class within that file.
 This will also allow you to share setup and teardown code.
 
-If you are testing code that makes HTTP requests, using
-[VCR.py](https://github.com/kevin1024/vcrpy) is highly recommended. It should
-already be a development dependency.
+If you are testing code that makes HTTP requests, using [VCR.py] is highly 
+recommended. It should already be a development dependency.
 
 ### Commit History
 
@@ -341,9 +329,8 @@ that git-bisect stays reliable for tracking down bugs.
 ### Commit messages
 
 The Archivematica project follows Chris Beams' guidelines on
-[How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/),
-and specifically the
-[seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules):
+[How to Write a Git Commit Message], and specifically the
+[seven rules of a great Git commit message]:
 
 1. Separate subject from body with a blank line
 2. Limit the subject line to 50 characters
@@ -376,9 +363,8 @@ Unclear commit summaries:
 The unclear messages make it hard to tell at a glance what changed, and that
 makes browsing the commit history harder.
 
-A commit message should use the
-[imperative mood](https://chris.beams.io/posts/git-commit/#imperative) which
-should always be able to complete the following sentence:
+A commit message should use the [imperative mood] which should always be able to
+complete the following sentence:
 
     If applied, this commit will <your subject line here>
 
@@ -411,3 +397,39 @@ two together.
 
 Further content comes after a blank line.
 ```
+[documentation]: https://github.com/artefactual/archivematica-docs/
+[mailing list]: https://groups.google.com/forum/#!forum/archivematica
+[Archivematica Issues repo]: https://github.com/archivematica/Issues
+[user]: https://groups.google.com/forum/#!forum/archivematica
+[Archivematica Issues repo]: https://github.com/archivematica/Issues
+[Issues repo wiki]: https://github.com/archivematica/Issues/wiki 
+[files]: https://help.github.com/articles/getting-permanent-links-to-files/
+[code snippets]: https://help.github.com/articles/creating-a-permanent-link-to-a-code-snippet/
+[development installation]: https://wiki.archivematica.org/Getting_started#Installation
+[GitHub]: https://github.com/
+[guide]: https://help.github.com/articles/fork-a-repo
+[excellent]: https://help.github.com/articles/using-pull-requests
+[Line comment]: http://i.imgur.com/FsWppGN.png
+[code review guidelines]: code_review.md
+[interactive rebase feature]: http://www.git-scm.com/book/en/Git-Tools-Rewriting-History
+[Contributor's Agreement]: https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf
+[Apache Foundation]: http://apache.org
+[contributor license]: http://www.apache.org/licenses/icla.txt
+[Artefactual Systems]: http://artefactual.com
+[PEP8]: https://www.python.org/dev/peps/pep-0008/
+[Black]: https://github.com/ambv/black
+[flake8]: https://pypi.python.org/pypi/flake8
+[continuous integration system]: https://travis-ci.org/artefactual/archivematica
+[Pylint]: https://www.pylint.org/
+[docstrings]: https://en.wikipedia.org/wiki/Docstring#Python
+[PEP 257]: https://www.python.org/dev/peps/pep-0257/
+[Sphinx-compatible docstrings]: http://pythonhosted.org/an_example_pypi_project/sphinx.html#function-definitions
+[examples]: http://sphinx-doc.org/domains.html#info-field-lists
+[attributes to use]: http://sphinx-doc.org/domains.html#the-python-domain
+[unittest]: https://docs.python.org/2/library/unittest.html
+[py.test]: http://pytest.org
+[TestCase]: https://docs.djangoproject.com/en/1.8/topics/testing/tools/#django.test.TestCase
+[VCR.py]: https://github.com/kevin1024/vcrpy
+[How to Write a Git Commit Message]: https://chris.beams.io/posts/git-commit/
+[seven rules of a great Git commit message]: https://chris.beams.io/posts/git-commit/#seven-rules
+[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative


### PR DESCRIPTION
This will resolve the issue https://github.com/archivematica/Issues/issues/1370 by using
full reference links and reformatting the file to comply with the style guide. 