### PR TITLE
Stream transfer files from local disk if available

### DIFF
--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -209,7 +209,7 @@ def get_first_location(**kwargs):
         kwargs_string = ", ".join(
             "%s=%r" % (key, value) for (key, value) in kwargs.items()
         )
-        raise Exception(
+        raise ResourceNotFound(
             "No locations found for %s.  Please check your storage service config."
             % kwargs_string
         )


### PR DESCRIPTION
This PR changes the `filesystem_ajax` component's `download_by_uuid` view to stream transfer files from the local disk whenever possible, and only request them from the Storage Service if they're not locally available. This resolves an issue where transfer files were not able to be previewed or downloaded when the transfer backlog was on a pipeline local filesystem and the Storage Service was on a remote machine, and lowers the overhead for some file requests by skipping the need to rsync a transfer to the Storage Service in order to stream a single file to the client.

Connected to https://github.com/archivematica/Issues/issues/1333