### PR TITLE
Save the failure report under any condition

### DIFF
--- a/src/MCPClient/lib/clientScripts/email_fail_report.py
+++ b/src/MCPClient/lib/clientScripts/email_fail_report.py
@@ -227,6 +227,9 @@ def call(jobs):
             try:
                 args = parser.parse_args(job.args[1:])
 
+                # Each report will be stored in the DB
+                reports_to_store.append(args)
+
                 to = get_emails_from_dashboard_users()
                 if not to:
                     logger.error(
@@ -249,8 +252,6 @@ def call(jobs):
                 if args.stdout:
                     job.pyprint(content)
 
-                # Each successfully generated report will be stored in the DB
-                reports_to_store.append(args)
             except Exception as e:
                 logger.exception(e)
                 job.set_status(1)

--- a/src/MCPClient/tests/test_email_fail_report.py
+++ b/src/MCPClient/tests/test_email_fail_report.py
@@ -12,7 +12,7 @@ import pytest
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.abspath(os.path.join(THIS_DIR, "../lib/clientScripts")))
 
-from email_fail_report import send_email
+import email_fail_report
 
 
 def fake_send_email_with_exception(
@@ -33,7 +33,9 @@ def fake_send_email_with_exception(
 
 def test_send_email_ok(settings):
     settings.DEFAULT_FROM_EMAIL = "foo@bar.tld"
-    total = send_email("Foobar", ["to@domain.tld"], "<html>...</html>")
+    total = email_fail_report.send_email(
+        "Foobar", ["to@domain.tld"], "<html>...</html>"
+    )
 
     assert total == 1
     assert len(mail.outbox) == 1
@@ -50,4 +52,69 @@ def test_send_email_err(monkeypatch):
         "django.core.mail.send_mail.func_code", fake_send_email_with_exception.func_code
     )
     with pytest.raises(SMTPException):
-        send_email("Foobar", ["to@domain.tld"], "<html>...</html>")
+        email_fail_report.send_email("Foobar", ["to@domain.tld"], "<html>...</html>")
+
+
+@pytest.fixture
+def args(mocker):
+    args_mock = mocker.Mock(
+        unit_type="Transfer", unit_name="My transfer", unit_uuid="uuid", stdout=False
+    )
+    mocker.patch(
+        "argparse.ArgumentParser",
+        return_value=mocker.Mock(**{"parse_args.return_value": args_mock}),
+    )
+    return args_mock
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "users": [],
+            "send_email_result": None,
+            "send_email_calls": [],
+            "set_status_calls": [(1,)],
+        },
+        {
+            "users": ["User 1"],
+            "send_email_result": None,
+            "send_email_calls": [
+                (
+                    "Archivematica Fail Report for Transfer: My transfer-uuid",
+                    ["User 1"],
+                    "my report",
+                )
+            ],
+            "set_status_calls": [],
+        },
+        {
+            "users": ["User 1"],
+            "send_email_result": Exception("error sending email"),
+            "send_email_calls": [],
+            "set_status_calls": [(1,)],
+        },
+    ],
+    ids=["no-users-exist", "users-exist", "send-email-fails"],
+)
+def test_report_is_always_stored(transactional_db, mocker, args, test_case):
+    mocker.patch(
+        "email_fail_report.get_emails_from_dashboard_users",
+        return_value=test_case["users"],
+    )
+    mocker.patch("email_fail_report.get_content_for", return_value="my report")
+    send_email_mock = mocker.patch(
+        "email_fail_report.send_email", side_effect=test_case["send_email_result"]
+    )
+    store_report_mock = mocker.patch("email_fail_report.store_report")
+    job = mocker.MagicMock()
+    email_fail_report.call([job])
+    store_report_mock.assert_called_once_with(
+        "my report", args.unit_type, args.unit_name, args.unit_uuid
+    )
+    send_email_mock.assert_has_calls(
+        [mocker.call(*a) for a in test_case["send_email_calls"]]
+    )
+    job.set_status.assert_has_calls(
+        [mocker.call(*a) for a in test_case["set_status_calls"]]
+    )


### PR DESCRIPTION
This updates the `email_fail_report` client script to always store the
failure report even when the following conditions are met:

- there are no active users
- all users have chosen not to receive system emails
- sending the report email fails

Connected to https://github.com/archivematica/Issues/issues/1033
Connected to https://github.com/archivematica/Issues/issues/1397