### PR TITLE
Remove transfer directory once SIP is stored

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -184,7 +184,7 @@ compile-requirements-ss:  ## Run pip-compile for Storage Service
 			-c "make clean && make all"
 
 db:  ## Connect to the MySQL server using the CLI.
-	docker-compose exec -T mysql mysql -hlocalhost -uroot -p12345
+	docker-compose exec mysql mysql -hlocalhost -uroot -p12345
 
 flush: flush-shared-dir flush-search bootstrap restart-am-services  ## Delete ALL user data.
 


### PR DESCRIPTION
This commit removes the original transfer directory that Archivematica
leaves under `sharedDirectory/currentlyProcessing`. It does not truncate
related database entries, that's being tackled as part of issue 1239.

Connects to https://github.com/archivematica/Issues/issues/1239.
Connects to https://github.com/archivematica/Issues/issues/1113.