### PR TITLE
Fix SIP arrangement when pkgs share the same name

### DIFF
--- a/src/dashboard/frontend/app/arrangement/arrangement.controller.js
+++ b/src/dashboard/frontend/app/arrangement/arrangement.controller.js
@@ -271,9 +271,15 @@ controller('ArrangementController', ['$scope', 'gettextCatalog', '$uibModal', '$
     };
 
     var on_failure = error => {
+      var message = gettextCatalog.getString('SIP could not be started! Check dashboard logs.');
+
+      if (error.hasOwnProperty("data") && error.data.hasOwnProperty("code") && "ERR_NO_FILES" == error.data.code) {
+        message = gettextCatalog.getString('It is not possible to create an empty SIP.');
+      }
+
       Alert.alerts.push({
         'type': 'danger',
-        'message': gettextCatalog.getString('SIP could not be started! Check dashboard logs.'),
+        'message': message,
       });
     };
 

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -395,7 +395,8 @@ def _create_arranged_sip(staging_sip_path, files, sip_uuid):
         sip = models.SIP.objects.get(uuid=sip_uuid)
     except models.SIP.DoesNotExist:
         # Create a SIP object if none exists
-        databaseFunctions.createSIP(currentpath, sip_uuid, diruuids=diruuids)
+        path = os.path.join(sip_path.replace(shared_dir, "%sharedPath%", 1), "")
+        databaseFunctions.createSIP(path, sip_uuid, diruuids=diruuids)
         sip = models.SIP.objects.get(uuid=sip_uuid)
     else:
         # Update the already-created SIP with its path
@@ -506,7 +507,8 @@ def copy_from_arrange_to_completed_common(filepath, sip_uuid, sip_name):
                 % {"uuid": sip_uuid},
                 "error": True,
             }
-            return helpers.json_response(response, status_code=400)
+            status_code = 400
+            return status_code, response
 
     # Error checking
     if not filepath.startswith(DEFAULT_ARRANGE_PATH):
@@ -568,6 +570,15 @@ def copy_from_arrange_to_completed_common(filepath, sip_uuid, sip_name):
                 }
                 if file_ not in files:
                     files.append(file_)
+
+        if not files:
+            status_code = 400
+            response = {
+                "message": _("No files were selected"),
+                "code": "ERR_NO_FILES",
+                "error": True,
+            }
+            return status_code, response
 
         logger.debug("copy_from_arrange_to_completed: files: %s", files)
         # Move files from backlog to local staging path


### PR DESCRIPTION
This commit fixes SIP arrangement when two or more SIPs are using the same
name. It ensures that the SIP object that we store in the database is using the
new path that we have assigned after the name clash was identified, i.e.
"../Foobar_1" as opposed to "../Foobar". Not doing this was causing the
MCPServer to create a whole new SIP, cuasing the `MultipleObjectsReturned`
error seen in our logs.

It also introduces a change that shows a warning to the user when an
empty SIP is being arranged since that is not a workflow that we
support.

Connects to https://github.com/archivematica/Issues/issues/1423.