### PR TITLE
Isolate test_sanitize tests

### DIFF
--- a/src/MCPClient/tests/fixtures/dublincore.json
+++ b/src/MCPClient/tests/fixtures/dublincore.json
@@ -73,32 +73,5 @@
         "subject": "Glaives",
         "status": "UPDATED"
     }
-},
-{
-    "pk": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
-    "model": "main.metadataappliestotype",
-    "fields": {
-        "lastmodified": "2012-10-01T17:25:05Z",
-        "replaces": null,
-        "description": "SIP"
-    }
-},
-{
-    "pk": "45696327-44c5-4e78-849b-e027a189bf4d",
-    "model": "main.metadataappliestotype",
-    "fields": {
-        "lastmodified": "2012-10-01T17:25:05Z",
-        "replaces": null,
-        "description": "Transfer"
-    }
-},
-{
-    "pk": "7f04d9d4-92c2-44a5-93dc-b7bfdf0c1f17",
-    "model": "main.metadataappliestotype",
-    "fields": {
-        "lastmodified": "2012-10-01T17:25:05Z",
-        "replaces": null,
-        "description": "File"
-    }
 }
 ]

--- a/src/MCPClient/tests/fixtures/metadata_applies_to_type.json
+++ b/src/MCPClient/tests/fixtures/metadata_applies_to_type.json
@@ -1,0 +1,29 @@
+[
+{
+    "pk": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
+    "model": "main.metadataappliestotype",
+    "fields": {
+        "lastmodified": "2012-10-01T17:25:05Z",
+        "replaces": null,
+        "description": "SIP"
+    }
+},
+{
+    "pk": "45696327-44c5-4e78-849b-e027a189bf4d",
+    "model": "main.metadataappliestotype",
+    "fields": {
+        "lastmodified": "2012-10-01T17:25:05Z",
+        "replaces": null,
+        "description": "Transfer"
+    }
+},
+{
+    "pk": "7f04d9d4-92c2-44a5-93dc-b7bfdf0c1f17",
+    "model": "main.metadataappliestotype",
+    "fields": {
+        "lastmodified": "2012-10-01T17:25:05Z",
+        "replaces": null,
+        "description": "File"
+    }
+}
+]

--- a/src/MCPClient/tests/test_create_aip_mets.py
+++ b/src/MCPClient/tests/test_create_aip_mets.py
@@ -82,7 +82,7 @@ class TestNormativeStructMap(TempDirMixin, TestCase):
 class TestDublinCore(TestCase):
     """Test creation of dmdSecs containing Dublin Core."""
 
-    fixture_files = ["dublincore.json"]
+    fixture_files = ["metadata_applies_to_type.json", "dublincore.json"]
     fixtures = [os.path.join(THIS_DIR, "fixtures", p) for p in fixture_files]
     sipuuid = "8b891d7c-5bd2-4249-84a1-2f00f725b981"
     siptypeuuid = "3e48343d-e2d2-4956-aaa3-b54d26eb9761"
@@ -567,7 +567,13 @@ class TestCSVMetadata(TempDirMixin, TestCase):
 class TestCreateDigiprovMD(TestCase):
     """ Test creating PREMIS:EVENTS and PREMIS:AGENTS """
 
-    fixture_files = ["agents.json", "sip.json", "files.json", "events-transfer.json"]
+    fixture_files = [
+        "metadata_applies_to_type.json",
+        "agents.json",
+        "sip.json",
+        "files.json",
+        "events-transfer.json",
+    ]
     fixtures = [os.path.join(THIS_DIR, "fixtures", p) for p in fixture_files]
 
     def test_creates_events(self):

--- a/src/MCPClient/tests/test_move_to_backlog.py
+++ b/src/MCPClient/tests/test_move_to_backlog.py
@@ -66,7 +66,7 @@ def test_premis_event_data():
 
 
 @pytest.mark.django_db
-def test_transfer_agents(django_db_setup, transaction=True):
+def test_transfer_agents():
     transfer = Transfer.objects.create(uuid="756db89c-1380-459d-83bc-d3772f1e7dd8")
     user = User.objects.create(id=1)
     transfer.update_active_agent(user_id=user.id)

--- a/src/MCPClient/tests/test_parse_mets_to_db.py
+++ b/src/MCPClient/tests/test_parse_mets_to_db.py
@@ -18,7 +18,7 @@ from main import models
 class TestParseDublinCore(TestCase):
     """ Test parsing SIP-level DublinCore from a METS file into the DB. """
 
-    fixture_files = ["dublincore.json"]
+    fixture_files = ["metadata_applies_to_type.json", "dublincore.json"]
     fixtures = [os.path.join(THIS_DIR, "fixtures", p) for p in fixture_files]
 
     def test_none_found(self):
@@ -130,7 +130,7 @@ class TestParseDublinCore(TestCase):
 class TestParsePremisRights(TestCase):
     """ Test parsing PREMIS:RIGHTS from a METS file into the DB. """
 
-    fixture_files = ["dublincore.json"]
+    fixture_files = ["metadata_applies_to_type.json", "dublincore.json"]
     fixtures = [os.path.join(THIS_DIR, "fixtures", p) for p in fixture_files]
 
     def test_none_found(self):

--- a/src/MCPClient/tests/test_reingest_mets.py
+++ b/src/MCPClient/tests/test_reingest_mets.py
@@ -40,11 +40,7 @@ class TestUpdateObject(TestCase):
 
     def load_fixture(self, fixture_paths):
         try:
-            call_command(
-                "loaddata",
-                *fixture_paths,
-                **{"verbosity": 0, "commit": False, "skip_checks": True}
-            )
+            call_command("loaddata", *fixture_paths, **{"verbosity": 0})
         except Exception:
             self._fixture_teardown()
             raise
@@ -561,7 +557,7 @@ class TestUpdateObject(TestCase):
 class TestUpdateDublinCore(TestCase):
     """ Test updating SIP-level DublinCore. (update_dublincore) """
 
-    fixture_files = ["dublincore.json"]
+    fixture_files = ["metadata_applies_to_type.json", "dublincore.json"]
     fixtures = [os.path.join(FIXTURES_DIR, p) for p in fixture_files]
 
     sip_uuid_none = "dnedne7c-5bd2-4249-84a1-2f00f725b981"
@@ -924,7 +920,7 @@ class TestUpdateDublinCore(TestCase):
 class TestUpdateRights(TestCase):
     """ Test updating PREMIS:RIGHTS. (update_rights and add_rights_elements) """
 
-    fixture_files = ["rights.json"]
+    fixture_files = ["metadata_applies_to_type.json", "rights.json"]
     fixtures = [os.path.join(FIXTURES_DIR, p) for p in fixture_files]
 
     sip_uuid_none = "dnedne7c-5bd2-4249-84a1-2f00f725b981"

--- a/src/MCPClient/tests/test_rights_from_csv.py
+++ b/src/MCPClient/tests/test_rights_from_csv.py
@@ -29,7 +29,11 @@ class TestRightsImportFromCsvBase(TestCase):
 class TestRightsImportFromCsv(TestRightsImportFromCsvBase):
     """Test rights importing from CSV files."""
 
-    fixture_files = ["transfer.json", "files-transfer.json"]
+    fixture_files = [
+        "metadata_applies_to_type.json",
+        "transfer.json",
+        "files-transfer.json",
+    ]
     fixtures = [os.path.join(THIS_DIR, "fixtures", p) for p in fixture_files]
 
     def test_rows_processed_and_database_content(self):
@@ -390,7 +394,11 @@ class TestRightsImportFromCsv(TestRightsImportFromCsvBase):
 
 class TestRightsImportFromCsvWithUnicode(TestRightsImportFromCsvBase):
 
-    fixture_files = ["transfer.json", "files-transfer-unicode.json"]
+    fixture_files = [
+        "metadata_applies_to_type.json",
+        "transfer.json",
+        "files-transfer-unicode.json",
+    ]
     fixtures = [os.path.join(THIS_DIR, "fixtures", p) for p in fixture_files]
 
     def test_rows_processed_and_database_content_with_unicode_filepath(self):


### PR DESCRIPTION
TestSanitize class, part of the test_sanitize module, was leaving database
records behind after running. Inadvertently, we wrote other tests depending on
these records. This commit updates the way that fixtures are loaded to
ensure proper isolation.

Connects to https://github.com/archivematica/Issues/issues/383.