### PR TITLE
Avoid TransactionTestCase where unneeded

### DIFF
--- a/src/MCPClient/tests/test_email_fail_report.py
+++ b/src/MCPClient/tests/test_email_fail_report.py
@@ -97,7 +97,8 @@ def args(mocker):
     ],
     ids=["no-users-exist", "users-exist", "send-email-fails"],
 )
-def test_report_is_always_stored(transactional_db, mocker, args, test_case):
+@pytest.mark.django_db
+def test_report_is_always_stored(mocker, args, test_case):
     mocker.patch(
         "email_fail_report.get_emails_from_dashboard_users",
         return_value=test_case["users"],


### PR DESCRIPTION
`django.test.TestCase`'s rolling back mechanism seems enough in this
case and it is significantly faster.

With `django.test.TransactionTestCase`:

    3.43s teardown src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[users-exist]
    3.40s teardown src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[send-email-fails]
    3.40s teardown src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[no-users-exist]
    0.68s setup    src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[no-users-exist]
    0.02s call     src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[users-exist]
    0.02s call     src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[send-email-fails]
    0.01s setup    src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[users-exist]
    0.01s setup    src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[send-email-fails]
    0.01s call     src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[no-users-exist]

With `django.test.TestCase`:

    0.66s setup    src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[no-users-exist]
    0.01s call     src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[send-email-fails]
    0.01s call     src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[no-users-exist]
    0.01s call     src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[users-exist]
    0.00s setup    src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[send-email-fails]
    0.00s setup    src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[users-exist]
    0.00s teardown src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[send-email-fails]
    0.00s teardown src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[users-exist]
    0.00s teardown src/MCPClient/tests/test_email_fail_report.py::test_report_is_always_stored[no-users-exist]

Connected to https://github.com/archivematica/Issues/issues/1033 and https://github.com/archivematica/Issues/issues/1397.