### PR TITLE
Include time in premis:dateCreatedByApplication

### DIFF
--- a/src/MCPClient/lib/clientScripts/create_mets_v2.py
+++ b/src/MCPClient/lib/clientScripts/create_mets_v2.py
@@ -541,7 +541,7 @@ def create_premis_object(fileUUID):
     creatingApplication = etree.Element(ns.premisBNS + "creatingApplication")
     etree.SubElement(
         creatingApplication, ns.premisBNS + "dateCreatedByApplication"
-    ).text = f.modificationtime.strftime("%Y-%m-%d")
+    ).text = f.modificationtime.strftime("%Y-%m-%dT%H:%M:%SZ")
     objectCharacteristics.append(creatingApplication)
 
     for elem in create_premis_object_characteristics_extensions(fileUUID):

--- a/src/MCPClient/lib/clientScripts/create_transfer_mets.py
+++ b/src/MCPClient/lib/clientScripts/create_transfer_mets.py
@@ -628,7 +628,7 @@ def file_obj_to_premis(file_obj):
             "creating_application",
             (
                 "date_created_by_application",
-                file_obj.modificationtime.strftime("%Y-%m-%d"),
+                file_obj.modificationtime.strftime("%Y-%m-%dT%H:%M:%SZ"),
             ),
         ),
     )


### PR DESCRIPTION
Connected to https://github.com/archivematica/Issues/issues/1427

The [PREMIS 3 XML schema](https://github.com/LibraryOfCongress/premis-v3-0/blob/master/xsd#L1185) specifies that `dateCreatedByApplication` should use the "Extended Date/Time Definition, proposed to be adopted into ISO 8601 Part 2". The [EDTF specification](https://www.loc.gov/standards/datetime/) in turn includes the following example for how to format a datetime in UTC (which is how modification dates are captured in the "Store file modification dates" job):

```
[dateI][“T”][time][“Z”]
Complete representations for calendar date and UTC time of day
Example 2       ‘1985-04-12T23:20:30Z’ refers to the date 1985 April 12th at 23:20:30 UTC time.
```
As a result, the string format implemented in this PR for the transfer and AIP METS files is `"%Y-%m-%dT%H:%M:%SZ"`.

This change doesn't appear to affect reingest - the black box AMAUATs still pass (with the exception of a virus-scanning related failure which is the result of another recent change), and I also successfully reingested a few AIPs created with this branch.

Other effects/related concerns:
1. The value of `dateCreatedByApplication` in some of our existing fixtures is `"%Y-%m-%d"`. This doesn't appear to break any tests so I'm not sure if creating new fixtures or manually patching them is worth the effort.
2. There will be a downsteam change needed in AIPscan, which [currently assumes that the value in this field will be timezone-neutral](https://github.com/artefactual-labs/AIPscan/blob/main/AIPscan/Aggregator/database_helpers.py#L181-L183). This is due to assumptions made about the value of `premis:dateCreatedByApplication` in AIPscan's Aggregator code, not a breaking change in `metsrw`.
