### PR TITLE
Pin the gearman version in the requirements file

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -43,7 +43,7 @@ funcsigs==1.0.2           # via mock, pytest
 functools32==3.2.3.post2  # via -r requirements.txt, jsonschema
 future==0.18.2            # via -r requirements.txt, metsrw
 futures==3.3.0 ; python_version < "3.2"  # via -r requirements.txt
-gearman==2.0.2            # via -r requirements.txt
+gearman==2.0.2 ; python_version < "3"  # via -r requirements.txt
 gevent==1.3.6             # via -r requirements.txt
 greenlet==1.0.0           # via -r requirements.txt, gevent
 gunicorn==19.9.0          # via -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,8 @@ django-tastypie==0.13.2
 elasticsearch>=6.0.0,<7.0.0
 enum34==1.1.6; python_version < "3.4" # required by inotify_simple
 futures==3.3.0; python_version < "3.2"
-gearman==2.0.2
+gearman==2.0.2; python_version < "3"
+gearman3==0.2.0; python_version > "3"
 gevent==1.3.6  # used by gunicorn's async workers
 gunicorn==19.9.0
 inotify_simple==1.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ enum34==1.1.6 ; python_version < "3.4"  # via -r requirements.in, cryptography
 functools32==3.2.3.post2  # via jsonschema
 future==0.18.2            # via metsrw
 futures==3.3.0 ; python_version < "3.2"  # via -r requirements.in
-gearman==2.0.2            # via -r requirements.in
+gearman==2.0.2 ; python_version < "3"  # via -r requirements.in
 gevent==1.3.6             # via -r requirements.in
 greenlet==1.0.0           # via gevent
 gunicorn==19.9.0          # via -r requirements.in


### PR DESCRIPTION
This pins different gearman versions for Python 2 and 3 which will
allow us to keep the current functionality with `gearman 2.0.2` in the
Python 2 environments and use `gearman3 0.2.0` for the Python 3
porting work.

Connected to https://github.com/archivematica/Issues/issues/845