### PR TITLE
Generate and upload coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,18 +1,20 @@
 [run]
 
 omit =
-	src/archivematicaCommon/lib/externals/
-	**/migrations/*
-	**/settings/*
-	**/wsgi.py
-	**/tests/*
-	**/manage.py
+    **/src/archivematicaCommon/lib/externals/*
+    **/migrations/*
+    **/south_migrations/*
+    **/management/commands/*
+    **/settings/*
+    **/tests/*
+    **/wsgi.py
+    **/manage.py
 
 source =
-	src/archivematicaCommon/lib/
-	src/dashboard/src/
-	src/MCPClient/lib/
-	src/MCPClient/lib/clientScripts/
-	src/MCPServer/lib/
+    **/src/archivematicaCommon/lib/
+    **/src/dashboard/src/
+    **/src/MCPClient/lib/
+    **/src/MCPClient/lib/clientScripts/
+    **/src/MCPServer/lib/
 
 branch = True

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,19 @@ jobs:
     runs-on: "ubuntu-18.04"
     strategy:
       matrix:
-        rule:
-          - mcp-server
-          - mcp-client
-          - dashboard
-          - archivematica-common
-          - storage-service
-          - checkformigrations
+        include:
+          - rule: mcp-server
+            coverage: true
+          - rule: mcp-client
+            coverage: true
+          - rule: dashboard
+            coverage: true
+          - rule: archivematica-common
+            coverage: true
+          - rule: storage-service
+            coverage: false
+          - rule: checkformigrations
+            coverage: false
     steps:
       - name: "Check out repository"
         uses: "actions/checkout@v2"
@@ -65,11 +71,27 @@ jobs:
         run: |
           make -C hack/ create-volumes
       - name: "Run make rule"
+        if: "! matrix.coverage"
         run: |
           make -C hack/ test-${{ matrix.rule }}
         env:
           TOXARGS: -vv
           PYTEST_ADDOPTS: -vv
+      - name: "Run make rule with coverage"
+        if: "matrix.coverage"
+        run: |
+          make -C hack/ test-${{ matrix.rule }}
+        env:
+          TOXARGS: -vv
+          PYTEST_ADDOPTS: -vv --cov /src/src/ --cov-config=/src/.coveragerc --cov-report xml:/src/coverage.xml
+      - name: "Upload coverage report"
+        if: matrix.coverage && github.repository == 'artefactual/archivematica'
+        uses: "codecov/codecov-action@v1"
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: true
+          verbose: true
+          name: ${{ matrix.rule }}
       - name: "Set newest docker cache"
         run: |
           rm -rf /tmp/.docker-cache-old

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Travis CI](https://travis-ci.org/artefactual/archivematica.svg?branch=qa/1.x)](https://travis-ci.org/artefactual/archivematica)
+[![codecov](https://codecov.io/gh/artefactual/archivematica/branch/qa/1.x/graph/badge.svg?token=tKlfjhmrlC)](https://codecov.io/gh/artefactual/archivematica)
 
 # [Archivematica](https://www.archivematica.org/)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+# Validate this file:
+#   curl --data-binary @codecov.yml https://codecov.io/validate
+
+comment: off
+
+coverage:
+  precision: 2
+  round: down
+  range: "25...100"
+  status:
+    project:
+      default:
+        threshold: 25%
+        if_not_found: success
+    patch:
+      default:
+        threshold: 25%
+        if_not_found: success
+
+fixes:
+  - "/src/::"


### PR DESCRIPTION
This modifies the `test` CI workflow to generate coverage reports for
the `make test-...` rules of the MCPServer, MCPClient, dashboard and
archivematicaCommon.

These reports are then uploaded and processed in codecov.io.

The `codecov.yml` configuration is a copy from enduro with an extra
fix to map the internal /src/ path of the Docker containers.

Connected to https://github.com/archivematica/Issues/issues/1434