### PR TITLE
Add make rules for running the tests in Python 3.6

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -219,17 +219,26 @@ test-build:  ## Build archivematica-tests image.
 		--build-arg TARGET=archivematica-tests \
 			../
 
-__TOXENVS_MCPSERVER := mcpserver
+__TOXENVS_MCPSERVER := py27-mcpserver
 test-mcp-server: start-mysql  ## Run MCPServer tests.
 	$(call run_toxenvs,$(__TOXENVS_MCPSERVER))
 
-__TOXENVS_MCPCLIENT = mcpclient mcpclient-ensure-no-mutable-globals
+test-mcp-server-py36: start-mysql  ## Run MCPServer tests in Python 3.6.
+	$(call run_toxenvs,py36-mcpserver)
+
+__TOXENVS_MCPCLIENT = py27-mcpclient mcpclient-ensure-no-mutable-globals
 test-mcp-client: start-mysql  ## Run MCPClient tests.
 	$(call run_toxenvs,$(__TOXENVS_MCPCLIENT))
 
-__TOXENVS_DASHBOARD = dashboard
+test-mcp-client-py36: start-mysql  ## Run MCPClient tests in Python 3.6.
+	$(call run_toxenvs,py36-mcpclient)
+
+__TOXENVS_DASHBOARD = py27-dashboard
 test-dashboard: start-mysql  ## Run Dashboard tests.
 	$(call run_toxenvs,$(__TOXENVS_DASHBOARD))
+
+test-dashboard-py36: start-mysql  ## Run Dashboard tests in Python 3.6.
+	$(call run_toxenvs,py36-dashboard)
 
 __TOXENVS_STORAGE_SERVICE = storage-service
 test-storage-service: start-mysql  ## Run Storage Service tests.
@@ -238,9 +247,12 @@ test-storage-service: start-mysql  ## Run Storage Service tests.
 test-storage-service-integration:  ## Run Storage Service unit and integration tests using MySQL and MinIO.
 	$(CURDIR)/submodules/archivematica-storage-service/integration/run.sh
 
-__TOXENVS_ARCHIVEMATICA_COMMON = archivematica-common
+__TOXENVS_ARCHIVEMATICA_COMMON = py27-archivematica-common
 test-archivematica-common: start-mysql  ## Run Archivematica Common tests.
 	$(call run_toxenvs,$(__TOXENVS_ARCHIVEMATICA_COMMON))
+
+test-archivematica-common-py36: start-mysql  ## Run Archivematica Common tests in Python 3.6.
+	$(call run_toxenvs,py36-archivematica-common)
 
 __TOXENVS_CHECKFORMIGRATIONS = checkformigrations-dashboard checkformigrations-storage-service
 test-checkformigrations: start-mysql  ## Check there are no pending migrations.

--- a/src/MCPClient/lib/ensure_no_mutable_globals.py
+++ b/src/MCPClient/lib/ensure_no_mutable_globals.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 from dis import HAVE_ARGUMENT, opmap
 import importlib
 import logging
+import os
 import pprint
 import sys
 import types
@@ -174,5 +175,7 @@ def print_mutable_globals_usage(supported_modules):
 
 
 if __name__ == "__main__":
-    config_path = "src/MCPClient/lib/archivematicaClientModules"
+    config_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "archivematicaClientModules"
+    )
     sys.exit(print_mutable_globals_usage(get_supported_modules(config_path)))

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 skipsdist = True
 minversion = 2.7.0
 envlist =
-    archivematica-common
-    dashboard
-    mcpserver
-    mcpclient
+    py{27,36}-archivematica-common
+    py{27,36}-dashboard
+    py{27,36}-mcpserver
+    py{27,36}-mcpclient
     mcpclient-ensure-no-mutable-globals
     storage-service
     checkformigrations-dashboard
@@ -57,18 +57,15 @@ setenv =
     # the container, and using {temp_dir} allows caching the pre-commit and flake8
     # dependencies in the tox host
     linting: HOME = {temp_dir}/user
+changedir =
+    archivematica-common: {env:ARCHIVEMATICA_COMMON_ROOT}
+    dashboard: {env:DASHBOARD_ROOT}
+    mcpserver: {env:MCPSERVER_ROOT}
+    mcpclient: {env:MCPCLIENT_ROOT}
+    storage-service: {env:STORAGE_SERVICE_DIR}
 
-[testenv:archivematica-common]
-changedir = {env:ARCHIVEMATICA_COMMON_ROOT}
-
-[testenv:dashboard]
-changedir = {env:DASHBOARD_ROOT}
-
-[testenv:mcpserver]
-changedir = {env:MCPSERVER_ROOT}
-
-[testenv:mcpclient]
-changedir = {env:MCPCLIENT_ROOT}
+[testenv:py36-{archivematica-common,dashboard,mcpserver,mcpclient}]
+deps = -r{toxinidir}/requirements-dev-py3.txt
 
 [testenv:mcpclient-ensure-no-mutable-globals]
 commands = python {env:MCPCLIENT_DIR}/ensure_no_mutable_globals.py
@@ -77,7 +74,6 @@ commands = python {env:MCPCLIENT_DIR}/ensure_no_mutable_globals.py
 deps =
     -r{env:STORAGE_SERVICE_ROOT}/requirements/production.txt
     -r{env:STORAGE_SERVICE_ROOT}/requirements/test.txt
-changedir = {env:STORAGE_SERVICE_DIR}
 
 [testenv:checkformigrations-dashboard]
 commands = bash {env:HACK_DIR}/checkformigrations.sh


### PR DESCRIPTION
This updates the `tox` configuration and adds four new `Makefile` rules to the development environment for running the component tests in Python 3.6:

* `make test-mcp-server-py36`
* `make test-mcp-client-py36`
* `make test-dashboard-py36`
* `make test-archivematica-common-py36`

Neither of these pass yet in Python 3.6 as you can see in [this CI run](https://github.com/artefactual/archivematica/actions/runs/683667061) so they're not automatically run yet in the development environment or in CI and they shouldn't break all the previous Python 2.7 rules or the existing Docker services.

I also updated a relative path that caused trouble in this new setup in the "no mutable globals" test.

Connected to https://github.com/archivematica/Issues/issues/878