### PR TITLE
Add make rule for running the SS tests in Python 3

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -184,7 +184,7 @@ compile-requirements-ss:  ## Run pip-compile for Storage Service
 		--no-deps \
 		--user $(CALLER_UID):$(CALLER_GID) \
 		--entrypoint bash archivematica-storage-service \
-			-c "make clean && make all"
+			-c "make pip-compile"
 
 db:  ## Connect to the MySQL server using the CLI.
 	docker-compose exec mysql mysql -hlocalhost -uroot -p12345
@@ -240,9 +240,12 @@ test-dashboard: start-mysql  ## Run Dashboard tests.
 test-dashboard-py36: start-mysql  ## Run Dashboard tests in Python 3.6.
 	$(call run_toxenvs,py36-dashboard)
 
-__TOXENVS_STORAGE_SERVICE = storage-service
+__TOXENVS_STORAGE_SERVICE = py27-storage-service
 test-storage-service: start-mysql  ## Run Storage Service tests.
 	$(call run_toxenvs,$(__TOXENVS_STORAGE_SERVICE))
+
+test-storage-service-py3: start-mysql  ## Run Storage Service tests in Python 3.6.
+	$(call run_toxenvs,py36-storage-service)
 
 test-storage-service-integration:  ## Run Storage Service unit and integration tests using MySQL and MinIO.
 	$(CURDIR)/submodules/archivematica-storage-service/integration/run.sh

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     py{27,36}-mcpserver
     py{27,36}-mcpclient
     mcpclient-ensure-no-mutable-globals
-    storage-service
+    py{27,36}-storage-service
     checkformigrations-dashboard
     checkformigrations-storage-service
     linting
@@ -70,16 +70,21 @@ deps = -r{toxinidir}/requirements-dev-py3.txt
 [testenv:mcpclient-ensure-no-mutable-globals]
 commands = python {env:MCPCLIENT_DIR}/ensure_no_mutable_globals.py
 
-[testenv:storage-service]
+[testenv:py27-storage-service]
 deps =
     -r{env:STORAGE_SERVICE_ROOT}/requirements/production.txt
     -r{env:STORAGE_SERVICE_ROOT}/requirements/test.txt
+
+[testenv:py36-storage-service]
+deps =
+    -r{env:STORAGE_SERVICE_ROOT}/requirements/production-py3.txt
+    -r{env:STORAGE_SERVICE_ROOT}/requirements/test-py3.txt
 
 [testenv:checkformigrations-dashboard]
 commands = bash {env:HACK_DIR}/checkformigrations.sh
 
 [testenv:checkformigrations-storage-service]
-deps = {[testenv:storage-service]deps}
+deps = {[testenv:py27-storage-service]deps}
 commands = bash {env:STORAGE_SERVICE_ROOT}/scripts/checkformigrations.sh
 
 [testenv:linting]


### PR DESCRIPTION
This uses the requirement file and `tox` changes in https://github.com/artefactual/archivematica-storage-service/pull/586 and adds a new `Makefile` rule `test-storage-service-py3` to run the Storage Service tests in Python 3.6 which still need to be fixed.

Connected to https://github.com/archivematica/Issues/issues/878