### PR TITLE
Run the Python 3 Storage Service tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
             coverage: true
           - rule: storage-service
             coverage: false
+          - rule: storage-service-py36
+            coverage: false
           - rule: checkformigrations
             coverage: false
     steps:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Travis CI](https://travis-ci.org/artefactual/archivematica.svg?branch=qa/1.x)](https://travis-ci.org/artefactual/archivematica)
+[![GitHub CI](https://github.com/artefactual/archivematica/actions/workflows/test.yml/badge.svg)](https://github.com/artefactual/archivematica/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/artefactual/archivematica/branch/qa/1.x/graph/badge.svg?token=tKlfjhmrlC)](https://codecov.io/gh/artefactual/archivematica)
 
 # [Archivematica](https://www.archivematica.org/)

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -248,7 +248,7 @@ __TOXENVS_STORAGE_SERVICE = py27-storage-service
 test-storage-service: start-mysql  ## Run Storage Service tests.
 	$(call run_toxenvs,$(__TOXENVS_STORAGE_SERVICE))
 
-test-storage-service-py3: start-mysql  ## Run Storage Service tests in Python 3.6.
+test-storage-service-py36: start-mysql  ## Run Storage Service tests in Python 3.6.
 	$(call run_toxenvs,py36-storage-service)
 
 test-storage-service-integration:  ## Run Storage Service unit and integration tests using MySQL and MinIO.


### PR DESCRIPTION
This also fixes a typo in the `test-storage-service-py36` rule.

Connected to https://github.com/archivematica/Issues/issues/878