### PR TITLE
Fix codecov path fixing configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,4 +18,4 @@ coverage:
         if_not_found: success
 
 fixes:
-  - "/src/::"
+  - "/src/src/::src/"


### PR DESCRIPTION
This fixes a `404 NOT FOUND` issue when you navigate to a Python module in codecov.io.

![Screenshot_2021-04-06 Code coverage done right ](https://user-images.githubusercontent.com/560781/113751237-f56b2f00-96c8-11eb-9cad-88054380462a.png)

Connected to https://github.com/archivematica/Issues/issues/1434