### PR TITLE
Workflow: Include policy validation events in transfer METS

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -2496,7 +2496,7 @@
       "config": {
         "@manager": "linkTaskManagerUnitVariableLinkPull",
         "@model": "TaskConfigUnitVariableLinkPull",
-        "chain_id": "675acd22-828d-4949-adc7-1888240f5e3d",
+        "chain_id": "307edcde-ad10-401c-92c4-652917c993ed",
         "variable": "postExtractSpecializedProcessing"
       },
       "description": {
@@ -2509,7 +2509,7 @@
       "exit_codes": {
         "0": {
           "job_status": "Completed successfully",
-          "link_id": "2fd123ea-196f-4c9c-95c0-117aa65ed9c6"
+          "link_id": "307edcde-ad10-401c-92c4-652917c993ed"
         }
       },
       "fallback_job_status": "Failed",
@@ -3791,7 +3791,7 @@
       "exit_codes": {
         "0": {
           "job_status": "Completed successfully",
-          "link_id": "ec3c965c-c056-47e3-a551-ad1966e00824"
+          "link_id": "675acd22-828d-4949-adc7-1888240f5e3d"
         }
       },
       "fallback_job_status": "Failed",
@@ -8208,11 +8208,11 @@
       "exit_codes": {
         "0": {
           "job_status": "Completed successfully",
-          "link_id": "675acd22-828d-4949-adc7-1888240f5e3d"
+          "link_id": "307edcde-ad10-401c-92c4-652917c993ed"
         }
       },
       "fallback_job_status": "Failed",
-      "fallback_link_id": "675acd22-828d-4949-adc7-1888240f5e3d",
+      "fallback_link_id": "307edcde-ad10-401c-92c4-652917c993ed",
       "group": {
         "en": "Identify DSpace files",
         "fr": "Identifier les fichiers DSpace",
@@ -8912,11 +8912,11 @@
       "exit_codes": {
         "0": {
           "job_status": "Completed successfully",
-          "link_id": "307edcde-ad10-401c-92c4-652917c993ed"
+          "link_id": "ec3c965c-c056-47e3-a551-ad1966e00824"
         }
       },
       "fallback_job_status": "Failed",
-      "fallback_link_id": "307edcde-ad10-401c-92c4-652917c993ed",
+      "fallback_link_id": "ec3c965c-c056-47e3-a551-ad1966e00824",
       "group": {
         "en": "Validation",
         "es": "Validación",
@@ -12028,11 +12028,11 @@
       "exit_codes": {
         "0": {
           "job_status": "Completed successfully",
-          "link_id": "db99ab43-04d7-44ab-89ec-e09d7bbdc39d"
+          "link_id": "307edcde-ad10-401c-92c4-652917c993ed"
         }
       },
       "fallback_job_status": "Completed successfully",
-      "fallback_link_id": "61c316a6-0a50-4f65-8767-1f44b1eeb6dd",
+      "fallback_link_id": "70fc7040-d4fb-4d19-a0e6-792387ca1006",
       "group": {
         "en": "Parse external files",
         "no": "Analyser eksterne filer"
@@ -12999,7 +12999,7 @@
       "exit_codes": {
         "0": {
           "job_status": "Completed successfully",
-          "link_id": "db99ab43-04d7-44ab-89ec-e09d7bbdc39d"
+          "link_id": "307edcde-ad10-401c-92c4-652917c993ed"
         }
       },
       "fallback_job_status": "Failed",


### PR DESCRIPTION
This PR moves the "Generate METS.xml document" job later in the transfer workflow, which allows `validation` events from "Policy checks for originals" to be written into the transfer METS file.

Connected to https://github.com/archivematica/issues/issues/781

 For comparison:

**current qa/1.x**

![qa-1](https://user-images.githubusercontent.com/6758804/114095661-b0432a80-988b-11eb-8d41-a191a8f38c8e.png)
![qa-2](https://user-images.githubusercontent.com/6758804/114095666-b20cee00-988b-11eb-8b9e-ff2e1704e7ed.png)

**new workflow**

![new-1](https://user-images.githubusercontent.com/6758804/114095688-ba652900-988b-11eb-945f-9c7bb77d1ab2.png)
![new-2](https://user-images.githubusercontent.com/6758804/114095693-bb965600-988b-11eb-9fb7-3ecfb64ff440.png)

I have done manual testing with a number of transfer types and it appears to be working correctly, with the exception of a few known bugs:
* https://github.com/archivematica/Issues/issues/1438 (Dataverse transfers skip "Policy checks for originals" and "Examine contents")
* https://github.com/archivematica/Issues/issues/1007#issuecomment-567553434 (DSpace transfers hang on "Policy checks for originals")

Otherwise when "Policy checks for originals" is set to Yes, there is a matching FPR rule, and a transfer is stored in the backlog, the transfer METS file downloaded from the backlog contains validation events from "Policy checks for originals". As far as I can tell, DSpace transfers are continuing to work correctly following the changes as long as "Policy checks for originals" is not attempted.