### PR TITLE
Fix archivematicaCommon tests in Python 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,18 +15,28 @@ jobs:
         include:
           - rule: mcp-server
             coverage: true
+            python_version: py27
           - rule: mcp-client
             coverage: true
+            python_version: py27
           - rule: dashboard
             coverage: true
+            python_version: py27
           - rule: archivematica-common
             coverage: true
+            python_version: py27
+          - rule: archivematica-common-py36
+            coverage: true
+            python_version: py36
           - rule: storage-service
             coverage: false
+            python_version: py27
           - rule: storage-service-py36
             coverage: false
+            python_version: py36
           - rule: checkformigrations
             coverage: false
+            python_version: py27
     steps:
       - name: "Check out repository"
         uses: "actions/checkout@v2"
@@ -94,6 +104,7 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           name: ${{ matrix.rule }}
+          flags: ${{ matrix.python_version }}
       - name: "Set newest docker cache"
         run: |
           rm -rf /tmp/.docker-cache-old

--- a/requirements-dev-py3.txt
+++ b/requirements-dev-py3.txt
@@ -40,6 +40,8 @@ gevent==1.3.6             # via -r requirements-py3.txt
 greenlet==1.0.0           # via -r requirements-py3.txt, gevent
 gunicorn==19.9.0          # via -r requirements-py3.txt
 idna==2.8                 # via -r requirements-py3.txt, requests, yarl
+importlib-metadata==3.10.0  # via pluggy, pytest, tox, virtualenv
+importlib-resources==5.1.2  # via virtualenv
 inotify_simple==1.1.8     # via -r requirements-py3.txt
 josepy==1.8.0             # via -r requirements-py3.txt, mozilla-django-oidc
 jsonschema==2.6.0         # via -r requirements-py3.txt
@@ -54,7 +56,7 @@ mozilla-django-oidc==1.2.4  # via -r requirements-py3.txt
 multidict==5.1.0          # via yarl
 mysqlclient==1.4.6        # via -r requirements-py3.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r requirements-py3.txt
-numpy==1.20.2             # via -r requirements-py3.txt, pandas
+numpy==1.19.5             # via -r requirements-py3.txt, pandas
 olefile==0.46             # via -r requirements-py3.txt, opf-fido
 opf-fido==1.4.1           # via -r requirements-py3.txt
 packaging==20.9           # via pytest, tox
@@ -86,6 +88,7 @@ scandir==1.10.0           # via -r requirements-py3.txt
 six==1.14.0               # via -r requirements-py3.txt, amclient, django-extensions, metsrw, mozilla-django-oidc, opf-fido, pip-tools, pyopenssl, pytest, python-cas, python-dateutil, tox, vcrpy, virtualenv
 toml==0.10.2              # via tox
 tox==3.23.0               # via -r requirements-dev-py3.in
+typing-extensions==3.7.4.3  # via importlib-metadata, yarl
 unidecode==0.04.19        # via -r requirements-py3.txt
 urllib3==1.24.3           # via -r requirements-py3.txt, amclient, elasticsearch, requests
 vcrpy==1.13.0             # via -r requirements-dev-py3.in
@@ -94,6 +97,7 @@ wcwidth==0.2.5            # via pytest
 whitenoise==3.3.0         # via -r requirements-py3.txt
 wrapt==1.12.1             # via vcrpy
 yarl==1.6.3               # via vcrpy
+zipp==3.4.1               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==20.3                 # via -r requirements-py3.txt, pip-tools

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -43,7 +43,7 @@ metsrw==0.3.15            # via -r requirements.in
 mozilla-django-oidc==1.2.4  # via -r requirements.in
 mysqlclient==1.4.6        # via -r requirements.in, agentarchives
 ndg-httpsclient==0.5.1    # via -r requirements.in
-numpy==1.20.2             # via pandas
+numpy==1.19.5             # via pandas
 olefile==0.46             # via opf-fido
 opf-fido==1.4.1           # via -r requirements.in
 pandas==0.24.2            # via -r requirements.in

--- a/src/archivematicaCommon/lib/dicts.py
+++ b/src/archivematicaCommon/lib/dicts.py
@@ -149,10 +149,8 @@ class ReplacementDict(dict):
 
             if expand_path and sipdir is not None:
                 base_location = base_location.replace("%sharedPath%", shared_path)
-                # If the original location contains non-unicode characters,
-                # using base_location as retrieved from the DB will raise.
                 origin = file_.originallocation.replace(
-                    "%transferDirectory%", base_location.encode("utf-8")
+                    "%transferDirectory%", base_location
                 )
                 current_location = file_.currentlocation.replace(
                     "%transferDirectory%", base_location

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -134,7 +134,7 @@ def launchSubProcess(
         print(type(inst), file=sys.stderr)  # the exception instance
         print(inst.args, file=sys.stderr)
         return -1, "Execution failed:", command
-    return retcode, stdOut, stdError
+    return retcode, six.ensure_text(stdOut), six.ensure_text(stdError)
 
 
 def createAndRunScript(
@@ -222,7 +222,7 @@ def executeOrRun(
             capture_output=capture_output,
         )
     if type == "pythonScript":
-        text = "#!/usr/bin/env python2\n" + text
+        text = "#!/usr/bin/env python\n" + text
         return createAndRunScript(
             text,
             stdIn=stdIn,

--- a/src/archivematicaCommon/lib/identifier_functions.py
+++ b/src/archivematicaCommon/lib/identifier_functions.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 """
 Functions to fetch identifiers for indexing in ElasticSearch.
 

--- a/src/archivematicaCommon/lib/storageService.py
+++ b/src/archivematicaCommon/lib/storageService.py
@@ -227,7 +227,7 @@ def location_description_from_slug(aip_location_slug):
        * /api/v2/location/3e796bef-0d56-4471-8700-eeb256859811/
        * /api/v2/location/default/AS/"
 
-    :param string aip_location: storage location URI slug
+    :param string aip_location_slug: storage location URI slug
     :return: storage service location description
     :rtype: dict
     """
@@ -669,7 +669,7 @@ def retrieve_storage_location_description(aip_location_slug, logger=None):
        * /api/v2/location/3e796bef-0d56-4471-8700-eeb256859811/
        * /api/v2/location/default/AS/"
 
-    :param string aip_location: storage location URI slug
+    :param string aip_location_slug: storage location URI slug
     :return: storage service location description or an empty string
     if a description cannot be retrieved.
     :rtype: str

--- a/src/archivematicaCommon/tests/test_database_functions.py
+++ b/src/archivematicaCommon/tests/test_database_functions.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 import os

--- a/src/archivematicaCommon/tests/test_dicts.py
+++ b/src/archivematicaCommon/tests/test_dicts.py
@@ -1,10 +1,8 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 import os
 import pytest
-
-import six
 
 from dicts import ReplacementDict, ChoicesDict
 from dicts import setup as setup_dicts
@@ -122,14 +120,3 @@ def test_replacementdict_model_constructor_file_only():
 def test_replacementdict_options():
     d = ReplacementDict({"%relativeLocation%": "bar"})
     assert d.to_gnu_options() == ["--relative-location=bar"]
-
-
-def test_replacementdict_replace_returns_bytestring():
-    in_str = u"%originalLocation%/location/การแปล"
-    assert isinstance(in_str, six.text_type)
-
-    d = ReplacementDict(
-        {"%originalLocation%": "\x82\xdb\x82\xc1\x82\xd5\x82\xe9\x83\x81\x83C\x83\x8b"}
-    )
-    out_str = d.replace(in_str)[0]
-    assert isinstance(out_str, six.binary_type)

--- a/src/archivematicaCommon/tests/test_elasticsearch_functions.py
+++ b/src/archivematicaCommon/tests/test_elasticsearch_functions.py
@@ -11,6 +11,7 @@ import vcr
 import elasticSearchFunctions
 
 from lxml import etree
+import six
 
 try:
     from unittest.mock import ANY, patch
@@ -405,7 +406,7 @@ def test_index_aipfile_dmdsec(
         identifiers=[],
     )
 
-    for key, value in dmdsec_dict["dublincore_dict"].iteritems():
+    for key, value in six.iteritems(dmdsec_dict["dublincore_dict"]):
         assert indexed_data[dmdsec_dict["filePath"]][key] == value
 
 

--- a/src/archivematicaCommon/tests/test_execute_functions.py
+++ b/src/archivematicaCommon/tests/test_execute_functions.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 import shlex

--- a/src/archivematicaCommon/tests/test_identifier_functions.py
+++ b/src/archivematicaCommon/tests/test_identifier_functions.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 import os

--- a/src/archivematicaCommon/tests/test_storage_service.py
+++ b/src/archivematicaCommon/tests/test_storage_service.py
@@ -21,7 +21,7 @@ def mock_response(status_code, content_type, content):
     response.status_code = status_code
     response.headers["content-type"] = content_type
     response.status = "Mocked status value"
-    response._content = json.dumps(content)
+    response._content = json.dumps(content).encode("utf8")
     return response
 
 
@@ -34,7 +34,7 @@ def mock_response(status_code, content_type, content):
         (204, "x-application/mocked", {}),
         (400, "x-application/mocked", {}),
         (500, "x-application/mocked", {}),
-        (None, "", {}),
+        (0, "", {}),
     ],
 )
 def test_location_desc_from_slug(status_code, content_type, expected_result, mocker):

--- a/src/dashboard/src/main/migrations/0077_uuid_fields.py
+++ b/src/dashboard/src/main/migrations/0077_uuid_fields.py
@@ -15,14 +15,14 @@ class Migration(migrations.Migration):
             model_name="event",
             name="event_id",
             field=django_extensions.db.fields.UUIDField(
-                auto=False, db_column=b"eventIdentifierUUID", null=True, unique=True
+                auto=False, db_column="eventIdentifierUUID", null=True, unique=True
             ),
         ),
         migrations.AlterField(
             model_name="job",
             name="microservicechainlink",
             field=django_extensions.db.fields.UUIDField(
-                auto=False, blank=True, db_column=b"MicroServiceChainLinksPK", null=True
+                auto=False, blank=True, db_column="MicroServiceChainLinksPK", null=True
             ),
         ),
         migrations.AlterField(
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
             model_name="unitvariable",
             name="microservicechainlink",
             field=django_extensions.db.fields.UUIDField(
-                auto=False, blank=True, db_column=b"microServiceChainLink", null=True
+                auto=False, blank=True, db_column="microServiceChainLink", null=True
             ),
         ),
     ]

--- a/src/dashboard/src/main/migrations/0078_username_check.py
+++ b/src/dashboard/src/main/migrations/0078_username_check.py
@@ -37,7 +37,7 @@ def data_migration_up(apps, schema_editor):
     )
     maxlen = result["username_len__max"]
     interactive = "--no-input" not in sys.argv
-    if interactive and maxlen > _DJANGO_USERNAME_MAX_LENGTH:
+    if interactive and maxlen is not None and maxlen > _DJANGO_USERNAME_MAX_LENGTH:
         raise Exception(
             "At least one user in the system exceeds the maximum number of"
             " characters expected in the username field."


### PR DESCRIPTION
This also adds the `archivematicaCommon` Python 3 tests to the `test` CI workflow and updates the `Upload coverage report` step to include the Python version as a flag for codecov.io.

Connected to https://github.com/archivematica/Issues/issues/809