### PR TITLE
Add rights CSV validation, make act not required in CSV workflow

### DIFF
--- a/src/MCPClient/lib/clientScripts/rights_from_csv.py
+++ b/src/MCPClient/lib/clientScripts/rights_from_csv.py
@@ -45,7 +45,7 @@ class RightCsvReader(object):
     current_row = None
     rows_processed = 0
 
-    required_column_names = ["file", "grant_act"]
+    required_column_names = ["file"]
 
     optional_column_names = [
         "basis",
@@ -57,6 +57,7 @@ class RightCsvReader(object):
         "terms",
         "citation",  # mandatory for statute basis
         "note",
+        "grant_act",
         "grant_restriction",
         "grant_start_date",
         "grant_end_date",
@@ -125,10 +126,11 @@ class RightCsvReader(object):
             self.object_basis_act_usage[filepath][basis] = {}
 
         # Check that act is set and normalize value
+        self.has_act = False
         act = self.column_value("grant_act")
-        if not act:
-            raise RightsRowException("No act specified", self)
-        act = act.lower().capitalize()
+        if act:
+            act = act.lower().capitalize()
+            self.has_act = True
 
         # Process row if basis/act combination for file hasn't yet been imported
         if act not in self.object_basis_act_usage[filepath][basis]:
@@ -158,7 +160,8 @@ class RightCsvReader(object):
         elif rights_statement.rightsbasis in ["Other", "Donor", "Policy"]:
             self.store_other_info(rights_statement)
 
-        self.store_grant_info(rights_statement)
+        if self.has_act:
+            self.store_grant_info(rights_statement)
 
     def generate_rights_statement(self):
         """Generate rights statement."""

--- a/src/MCPClient/tests/fixtures/rights.csv
+++ b/src/MCPClient/tests/fixtures/rights.csv
@@ -7,3 +7,4 @@ objects/G31DS.TIF,statute,,1972-02-02,stat juris,1966-01-01,open,stat terms,stat
 objects/G31DS.TIF,other,,,,1945-01-01,1950-05-05,,,other note,other act,Allow,1920-01-01,1921-01-01,other grant note,,,
 objects/lion.svg,donor,,,,,,,,,donor act,,,,,,,
 objects/lion.svg,policy,,,,,,,,,policy act,,,,,,,
+objects/lion.svg,other,,,,,,,,,,,,,,,,

--- a/src/MCPClient/tests/test_rights_from_csv.py
+++ b/src/MCPClient/tests/test_rights_from_csv.py
@@ -50,14 +50,14 @@ class TestRightsImportFromCsv(TestRightsImportFromCsvBase):
         rows_processed = parser.parse()
 
         # Test rows processed and model intance counts
-        assert rows_processed == 8
+        assert rows_processed == 9
         assert (
-            models.RightsStatement.objects.count() == 7
+            models.RightsStatement.objects.count() == 8
         )  # One row in fixture CSV skipped due to duplicate basis/act combination
         assert models.RightsStatementLicense.objects.count() == 1
         assert models.RightsStatementCopyright.objects.count() == 2
         assert models.RightsStatementStatuteInformation.objects.count() == 1
-        assert models.RightsStatementOtherRightsInformation.objects.count() == 3
+        assert models.RightsStatementOtherRightsInformation.objects.count() == 4
         assert (
             models.RightsStatementCopyrightDocumentationIdentifier.objects.count() == 2
         )

--- a/src/dashboard/src/components/api/validators.py
+++ b/src/dashboard/src/components/api/validators.py
@@ -293,104 +293,100 @@ class RightsValidator(BaseValidator):
             )
         return True
 
-        @staticmethod
-        def _check_restriction(row, columns):
-            """If any grant fields exist, validate grant information.
+    @staticmethod
+    def _check_restriction(row, columns):
+        """If any grant fields exist, validate grant information.
 
-            :param row: list: metadata fields
-            :param columns: dict: column names and indexes
-            """
-            grant_fields = [
-                "grant_act",
-                "grant_restriction",
-                "grant_start_date",
-                "grant_end_date",
-                "grant_note",
-            ]
-            if [g for g in grant_fields if row[columns.get(g)]]:
-                if not row[columns.get("grant_act")]:
-                    raise ValidationError("No act specified.")
-                elif row[columns.get("grant_act")].lower() not in [
-                    "disallow",
-                    "conditional",
-                    "allow",
-                ]:
-                    raise ValidationError(
-                        "The value of element restriction must be: 'Allow', 'Disallow', or 'Conditional'"
-                    )
-            else:
-                return True
-
-        @staticmethod
-        def _check_basis(row, columns):
-            """Check that rights basis exists; return basis.
-
-            :param row: list: metadata fields
-            :param columns: dict: column names and indexes
-            """
-            if row[columns.get("basis")]:
-                return row[columns.get("basis")]
-            else:
-                raise ValidationError("No basis specified.")
-
-        @staticmethod
-        def _check_copyright(row, columns):
-            """Validate copyright information.
-
-            :param row: list: metadata fields
-            :param columns: dict: column names and indexes
-            """
-            if not row[columns.get("status")]:
+        :param row: list: metadata fields
+        :param columns: dict: column names and indexes
+        """
+        grant_fields = [
+            "grant_act",
+            "grant_restriction",
+            "grant_start_date",
+            "grant_end_date",
+            "grant_note",
+        ]
+        if [g for g in grant_fields if row[columns.get(g)]]:
+            if not row[columns.get("grant_act")]:
+                raise ValidationError("No act specified.")
+            elif row[columns.get("grant_act")].lower() not in [
+                "disallow",
+                "conditional",
+                "allow",
+            ]:
                 raise ValidationError(
-                    "No copyright status specified for copyright basis."
+                    "The value of element restriction must be: 'Allow', 'Disallow', or 'Conditional'"
                 )
-            elif not row[columns.get("jurisdiction")]:
-                raise ValidationError("No jurisdiction specified for copyright basis.")
-            elif [f for f in ["terms", "citation"] if row[columns.get(f)]]:
+        else:
+            return True
+
+    @staticmethod
+    def _check_basis(row, columns):
+        """Check that rights basis exists; return basis.
+
+        :param row: list: metadata fields
+        :param columns: dict: column names and indexes
+        """
+        if row[columns.get("basis")]:
+            return row[columns.get("basis")]
+        else:
+            raise ValidationError("No basis specified.")
+
+    @staticmethod
+    def _check_copyright(row, columns):
+        """Validate copyright information.
+
+        :param row: list: metadata fields
+        :param columns: dict: column names and indexes
+        """
+        if not row[columns.get("status")]:
+            raise ValidationError("No copyright status specified for copyright basis.")
+        elif not row[columns.get("jurisdiction")]:
+            raise ValidationError("No jurisdiction specified for copyright basis.")
+        elif [f for f in ["terms", "citation"] if row[columns.get(f)]]:
+            raise ValidationError(
+                "Copyright row contains fields that cannot pertain to copyright basis."
+            )
+        else:
+            return True
+
+    @staticmethod
+    def _check_statute(row, columns):
+        """Validate statute information.
+
+        :param row: list: metadata fields
+        :param columns: dict: column names and indexes
+        """
+        if not row[columns.get("citation")]:
+            raise ValidationError("No statute citation specified for statute basis.")
+        elif not row[columns.get("jurisdiction")]:
+            raise ValidationError("No jurisdiction specified for statute basis.")
+        elif [f for f in ["terms", "status"] if row[columns.get(f)]]:
+            raise ValidationError(
+                "Copyright row contains fields that cannot pertain to statute basis."
+            )
+        else:
+            return True
+
+    @staticmethod
+    def _check_documentation(row, columns):
+        """If any documentation information exist, validate documentation information.
+
+        :param row: list: metadata fields
+        :param columns: dict: column names and indexes
+        """
+        documentation_fields = ["doc_id_type", "doc_id_value", "doc_id_role"]
+        if [d for d in documentation_fields if row[columns.get(d)]]:
+            if (
+                not row[columns.get("doc_id_type")]
+                and not row[columns.get("doc_id_value")]
+            ):
                 raise ValidationError(
-                    "Copyright row contains fields that cannot pertain to copyright basis."
+                    "Documentation identifier type and value are required."
                 )
-            else:
-                return True
-
-        @staticmethod
-        def _check_statute(row, columns):
-            """Validate statute information.
-
-            :param row: list: metadata fields
-            :param columns: dict: column names and indexes
-            """
-            if not row[columns.get("citation")]:
-                raise ValidationError(
-                    "No statute citation specified for statute basis."
-                )
-            elif not row[columns.get("jurisdiction")]:
-                raise ValidationError("No jurisdiction specified for statute basis.")
-            elif [f for f in ["terms", "status"] if row[columns.get(f)]]:
-                raise ValidationError(
-                    "Copyright row contains fields that cannot pertain to statute basis."
-                )
-            else:
-                return True
-
-        @staticmethod
-        def _check_documentation(row, columns):
-            """If any documentation information exist, validate documentation information.
-
-            :param row: list: metadata fields
-            :param columns: dict: column names and indexes
-            """
-            documentation_fields = ["doc_id_type", "doc_id_value", "doc_id_role"]
-            if [d for d in documentation_fields if row[columns.get(d)]]:
-                if (
-                    not row[columns.get("doc_id_type")]
-                    and not row[columns.get("doc_id_value")]
-                ):
-                    raise ValidationError(
-                        "Documentation identifier type and value are required."
-                    )
-            else:
-                return True
+        else:
+            return True
 
     def validate(self, string):
         if PY2:

--- a/src/dashboard/src/components/api/validators.py
+++ b/src/dashboard/src/components/api/validators.py
@@ -289,7 +289,11 @@ class RightsValidator(BaseValidator):
 
         if not (all(x in row for x in req_columns)):
             raise ValidationError(
-                ("One of the required columns is missing: file, basis, grant_act.")
+                (
+                    "One of the required columns is missing: {}".format(
+                        ", ".join(req_columns)
+                    )
+                )
             )
         return True
 

--- a/src/dashboard/src/components/api/validators.py
+++ b/src/dashboard/src/components/api/validators.py
@@ -404,10 +404,8 @@ class RightsValidator(BaseValidator):
                 columns = {k: v for v, k in enumerate(row)}
             if i >= 1:
                 basis = self._check_basis(row, columns)
-                if basis.lower() == "copyright":
-                    self._check_copyright(row, columns)
-                elif basis.lower() == "statute":
-                    self._check_statute(row, columns)
+                if basis.lower() in ["copyright", "statute"]:
+                    getattr(self, "_check_{}".format(basis.lower()))(row, columns)
                 self._check_documentation
                 self._check_restriction(row, columns)
         try:

--- a/src/dashboard/src/components/api/validators.py
+++ b/src/dashboard/src/components/api/validators.py
@@ -406,7 +406,7 @@ class RightsValidator(BaseValidator):
                 basis = self._check_basis(row, columns)
                 if basis.lower() in ["copyright", "statute"]:
                     getattr(self, "_check_{}".format(basis.lower()))(row, columns)
-                self._check_documentation
+                self._check_documentation(row, columns)
                 self._check_restriction(row, columns)
         try:
             i

--- a/src/dashboard/src/components/api/validators.py
+++ b/src/dashboard/src/components/api/validators.py
@@ -244,7 +244,183 @@ class AvalonValidator(BaseValidator):
         return True
 
 
-_VALIDATORS = {"avalon": AvalonValidator}
+class RightsValidator(BaseValidator):
+    @staticmethod
+    def _check_column_data(row):
+        """Validate column data line in a PREMIS Rights CSV.
+
+        :param row: list: metadata fields
+        """
+        req_columns = ["file", "basis"]
+        optional_columns = [
+            "status",  # mandatory for copyright
+            "determination_date",
+            "start_date",
+            "end_date",
+            "jurisdiction",  # mandatory for copyright and statute basis
+            "terms",
+            "citation",  # mandatory for statute basis
+            "note",
+            "grant_act",
+            "grant_restriction",
+            "grant_start_date",
+            "grant_end_date",
+            "grant_note",
+            "doc_id_type",
+            "doc_id_value",
+            "doc_id_role",
+        ]
+        all_columns = req_columns + optional_columns
+
+        for x in row:
+            while "" in row:
+                row.remove("")
+            if x[0] == " " or x[-1] == " ":
+                raise ValidationError(
+                    "Columns cannot have leading or trailing blanks. Invalid column: "
+                    + str(x)
+                )
+
+        if not (set(row).issubset(set(all_columns))):
+            raise ValidationError(
+                "Invalid column(s) found: "
+                + ",".join(list(set(row) - set(all_columns)))
+            )
+
+        if not (all(x in row for x in req_columns)):
+            raise ValidationError(
+                ("One of the required columns is missing: file, basis, grant_act.")
+            )
+        return True
+
+        @staticmethod
+        def _check_restriction(row, columns):
+            """If any grant fields exist, validate grant information.
+
+            :param row: list: metadata fields
+            :param columns: dict: column names and indexes
+            """
+            grant_fields = [
+                "grant_act",
+                "grant_restriction",
+                "grant_start_date",
+                "grant_end_date",
+                "grant_note",
+            ]
+            if [g for g in grant_fields if row[columns.get(g)]]:
+                if not row[columns.get("grant_act")]:
+                    raise ValidationError("No act specified.")
+                elif row[columns.get("grant_act")].lower() not in [
+                    "disallow",
+                    "conditional",
+                    "allow",
+                ]:
+                    raise ValidationError(
+                        "The value of element restriction must be: 'Allow', 'Disallow', or 'Conditional'"
+                    )
+            else:
+                return True
+
+        @staticmethod
+        def _check_basis(row, columns):
+            """Check that rights basis exists; return basis.
+
+            :param row: list: metadata fields
+            :param columns: dict: column names and indexes
+            """
+            if row[columns.get("basis")]:
+                return row[columns.get("basis")]
+            else:
+                raise ValidationError("No basis specified.")
+
+        @staticmethod
+        def _check_copyright(row, columns):
+            """Validate copyright information.
+
+            :param row: list: metadata fields
+            :param columns: dict: column names and indexes
+            """
+            if not row[columns.get("status")]:
+                raise ValidationError(
+                    "No copyright status specified for copyright basis."
+                )
+            elif not row[columns.get("jurisdiction")]:
+                raise ValidationError("No jurisdiction specified for copyright basis.")
+            elif [f for f in ["terms", "citation"] if row[columns.get(f)]]:
+                raise ValidationError(
+                    "Copyright row contains fields that cannot pertain to copyright basis."
+                )
+            else:
+                return True
+
+        @staticmethod
+        def _check_statute(row, columns):
+            """Validate statute information.
+
+            :param row: list: metadata fields
+            :param columns: dict: column names and indexes
+            """
+            if not row[columns.get("citation")]:
+                raise ValidationError(
+                    "No statute citation specified for statute basis."
+                )
+            elif not row[columns.get("jurisdiction")]:
+                raise ValidationError("No jurisdiction specified for statute basis.")
+            elif [f for f in ["terms", "status"] if row[columns.get(f)]]:
+                raise ValidationError(
+                    "Copyright row contains fields that cannot pertain to statute basis."
+                )
+            else:
+                return True
+
+        @staticmethod
+        def _check_documentation(row, columns):
+            """If any documentation information exist, validate documentation information.
+
+            :param row: list: metadata fields
+            :param columns: dict: column names and indexes
+            """
+            documentation_fields = ["doc_id_type", "doc_id_value", "doc_id_role"]
+            if [d for d in documentation_fields if row[columns.get(d)]]:
+                if (
+                    not row[columns.get("doc_id_type")]
+                    and not row[columns.get("doc_id_value")]
+                ):
+                    raise ValidationError(
+                        "Documentation identifier type and value are required."
+                    )
+            else:
+                return True
+
+    def validate(self, string):
+        if PY2:
+            csvfile = BytesIO(string)
+        else:
+            csvfile = StringIO(string.decode("utf8"))
+        csvr = csv.reader(csvfile)
+        for i, row in enumerate(csvr):
+            if i == 0:
+                self._check_column_data(row)
+                columns = {k: v for v, k in enumerate(row)}
+            if i >= 1:
+                basis = self._check_basis(row, columns)
+                if basis.lower() == "copyright":
+                    self._check_copyright(row, columns)
+                elif basis.lower() == "statute":
+                    self._check_statute(row, columns)
+                self._check_documentation
+                self._check_restriction(row, columns)
+        try:
+            i
+        except NameError:
+            raise ValidationError("The document is empty.")
+        else:
+            if i < 1:
+                raise ValidationError("The document is incomplete.")
+        return True
+
+
+_VALIDATORS = {"avalon": AvalonValidator, "rights": RightsValidator}
 
 
 class ValidatorNotAvailableError(ValueError):

--- a/src/dashboard/src/components/api/validators.py
+++ b/src/dashboard/src/components/api/validators.py
@@ -320,7 +320,7 @@ class RightsValidator(BaseValidator):
                 "allow",
             ]:
                 raise ValidationError(
-                    "The value of element restriction must be: 'Allow', 'Disallow', or 'Conditional'"
+                    "The value of element restriction must be: 'allow', 'disallow', or 'conditional'"
                 )
         else:
             return True
@@ -368,7 +368,7 @@ class RightsValidator(BaseValidator):
             raise ValidationError("No jurisdiction specified for statute basis.")
         elif [f for f in ["terms", "status"] if row[columns.get(f)]]:
             raise ValidationError(
-                "Copyright row contains fields that cannot pertain to statute basis."
+                "Statute row contains fields that cannot pertain to statute basis."
             )
         else:
             return True

--- a/src/dashboard/src/components/api/validators.py
+++ b/src/dashboard/src/components/api/validators.py
@@ -308,9 +308,9 @@ class RightsValidator(BaseValidator):
             "grant_note",
         ]
         if [g for g in grant_fields if row[columns.get(g)]]:
-            if not row[columns.get("grant_act")]:
-                raise ValidationError("No act specified.")
-            elif row[columns.get("grant_act")].lower() not in [
+            if not row[columns.get("grant_restriction")]:
+                raise ValidationError("No restriction specified.")
+            elif row[columns.get("grant_restriction")].lower() not in [
                 "disallow",
                 "conditional",
                 "allow",

--- a/src/dashboard/tests/test_api_v2beta.py
+++ b/src/dashboard/tests/test_api_v2beta.py
@@ -123,6 +123,16 @@ Bibliographic ID,Bibliographic ID Lbl,Title,Creator,Contributor,Contributor,Cont
 ,,Beginning Responsibility: Lunchroom Manners,Coronet Films,,,,,,Coronet Films,,1959,"The rude, clumsy puppet Mr. Bungle shows kids how to behave in the school cafeteria - the assumption being that kids actually want to behave during lunch. This film has a cult following since it appeared on a Pee Wee Herman HBO special.",Social engineering,Puppet theater,Yes,assets/lunchroom_manners_512kb.mp4,yes,Lunchroom 1,assets/lunchroom_manners_512kb.mp4,yes,Lunchroom Again,local,This was batch ingested with skip transcoding and with structure
 """
 
+    VALID_RIGHTS_CSV = u"""file,basis,status,determination_date,jurisdiction,start_date,end_date,terms,citation,note,grant_act,grant_restriction,grant_start_date,grant_end_date,grant_note,doc_id_type,doc_id_value,doc_id_role
+objects/45212966d0256a6ac70d81db_008.tif,copyright,copyrighted,2013-08-03,us,1964-01-01,2084-01-01,,,Work for hire - copyright term 120 years from date of creation. Copyright held by the Village Green Preservation Society.,,,,,,,,
+objects/45212966d0256a6ac70d81db_008.tif,policy,,,,1974-01-01,open,,,Village Green Preservation Society records are open.,disseminate,allow,2014-01-01,open,,,,
+"""
+
+    INVALID_RIGHTS_CSV = u"""file,basis,status,determination_date,jurisdiction,start_date,end_date,terms,citation,note,grant_act,grant_restriction,grant_start_date,grant_end_date,grant_note,doc_id_type,doc_id_value,doc_id_role
+objects/8e758e7545212966d0256a6ac70d81db6a6d6a6d_008.tif,copyright,copyrighted,2013-08-03,us,1964-01-01,2084-01-01,,,Work for hire - copyright term 120 years from date of creation. Copyright held by the Village Green Preservation Society.,,,,,,,,
+objects/8e758e7545212966d0256a6ac70d81db6a6d6a6d_008.tif,policy,,,,1974-01-01,open,,,Village Green Preservation Society records are open.,disseminate,,2014-01-01,open,,,,
+"""
+
     def setUp(self):
         self.client = Client()
         self.client.login(username="test", password="test")
@@ -168,4 +178,19 @@ Bibliographic ID,Bibliographic ID Lbl,Title,Creator,Contributor,Contributor,Cont
         assert json.loads(resp.content.decode()) == {
             "valid": False,
             "reason": "Manifest includes invalid metadata field(s). Invalid field(s): Bibliographic ID Lbl",
+        }
+
+    def test_rights_pass(self):
+        resp = self._post("rights", self.VALID_RIGHTS_CSV)
+
+        assert json.loads(resp.content.decode()) == {"valid": True}
+        assert resp.status_code == 200
+
+    def test_rights_err(self):
+        resp = self._post("rights", self.INVALID_RIGHTS_CSV)
+
+        assert resp.status_code == 400
+        assert json.loads(resp.content.decode()) == {
+            "valid": False,
+            "reason": "No restriction specified.",
         }


### PR DESCRIPTION
Does the following:
* Adds a rights csv endpoint to the validation API (connected to archivematica/issues#563)
* Modifies the rights csv parser so that an act is not required (fixes archivematica/issues#1445)
* Adds or updates associated tests

For the rights csv validation, there were some decisions I made that I wanted to note:
* There were some differences in the language used (e.g., in error messages and variable names) between the Avalon validator and the rights csv parser; for the most part, I used the existing rights csv language
* Though the rights csv parser does not require "basis," I required it in the validator
* Though the rights csv parser does not check that the csv adheres to the PREMIS data dictionary (e.g,. that a copyright rights statement has a copyright status), I checked for this in the validator