### PR TITLE
Add new config attribute "workflow_file"

### DIFF
--- a/src/MCPServer/install/README.md
+++ b/src/MCPServer/install/README.md
@@ -191,6 +191,12 @@ This is the full list of variables supported by MCPServer:
     - **Type:** `int`
     - **Default:** 4
 
+- **`ARCHIVEMATICA_MCPSERVER_WORKFLOW_FILE`**:
+    - **Description:** the path to the user-customised workflow file. If this is empty, Archivematica will load the default workflow. This configuration attribute is not recommended for general use, but only for users with development skills, an understanding for the Archivematica workflow engine, and are willing to maintain their own workflow file.
+    - **Config file example:** `MCPServer.workflow_file`
+    - **Type:** `string`
+    - **Default:** `""`
+
 - **`ARCHIVEMATICA_MCPSERVER_MCPSERVER_WORKER_THREADS`**:
     - **Description:** the number of threads used to handle MCPServer jobs.
     - **Config file example:** `MCPServer.worker_threads`

--- a/src/MCPServer/lib/server/mcp.py
+++ b/src/MCPServer/lib/server/mcp.py
@@ -43,7 +43,7 @@ from server.packages import DIP, Transfer, SIP
 from server.queues import PackageQueue
 from server.tasks import Task
 from server.watch_dirs import watch_directories
-from server.workflow import load_default_workflow
+from server.workflow import load_workflow
 
 
 logger = logging.getLogger("archivematica.mcp.server")
@@ -97,7 +97,7 @@ def main(shutdown_event=None):
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 
-    workflow = load_default_workflow()
+    workflow = load_workflow()
     logger.debug("Loaded default workflow.")
 
     shared_dirs.create()

--- a/src/MCPServer/lib/server/workflow.py
+++ b/src/MCPServer/lib/server/workflow.py
@@ -27,6 +27,7 @@ from jsonschema.exceptions import ValidationError
 
 from server.jobs import Job
 from server.translation import FALLBACK_LANG, TranslationLabel
+from django.conf import settings as django_settings
 
 
 _LATEST_SCHEMA = "workflow-schema-v1.json"
@@ -243,9 +244,12 @@ def load(fp):
     return parsed
 
 
-def load_default_workflow():
-    with open(DEFAULT_WORKFLOW) as default_workflow:
-        return load(default_workflow)
+def load_workflow():
+    workflow_path = DEFAULT_WORKFLOW
+    if django_settings.WORKFLOW_FILE != "":
+        workflow_path = django_settings.WORKFLOW_FILE
+    with open(workflow_path) as workflow_file:
+        return load(workflow_file)
 
 
 class SchemaValidationError(ValidationError):

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -115,6 +115,11 @@ CONFIG_MAPPING = {
         "option": "prometheus_bind_port",
         "type": "string",
     },
+    "workflow_file": {
+        "section": "MCPServer",
+        "option": "workflow_file",
+        "type": "string",
+    },
     "time_zone": {"section": "MCPServer", "option": "time_zone", "type": "string"},
     # [client]
     "db_engine": {"section": "client", "option": "engine", "type": "string"},
@@ -145,6 +150,7 @@ storage_service_client_timeout = 86400
 storage_service_client_quick_timeout = 5
 prometheus_bind_address =
 prometheus_bind_port =
+workflow_file =
 time_zone = UTC
 
 [client]
@@ -281,6 +287,8 @@ except ValueError:
     PROMETHEUS_ENABLED = False
 else:
     PROMETHEUS_ENABLED = True
+
+WORKFLOW_FILE = config.get("workflow_file")
 
 # Apply email settings
 globals().update(email_settings.get_settings(config))

--- a/src/MCPServer/tests/test_mcp.py
+++ b/src/MCPServer/tests/test_mcp.py
@@ -96,7 +96,7 @@ def test_mcp_main(mocker, settings):
     settings.WORKER_THREADS = 1
     settings.PROMETHEUS_ENABLED = True
 
-    mock_load_default_workflow = mocker.patch("server.mcp.load_default_workflow")
+    mock_load_workflow = mocker.patch("server.mcp.load_workflow")
     mock_shared_dirs = mocker.patch("server.mcp.shared_dirs")
     mock_job = mocker.patch("server.mcp.Job")
     mock_task = mocker.patch("server.mcp.Task")
@@ -107,7 +107,7 @@ def test_mcp_main(mocker, settings):
 
     main(shutdown_event=shutdown_event)
 
-    mock_load_default_workflow.assert_called_once()
+    mock_load_workflow.assert_called_once()
     mock_shared_dirs.create.assert_called_once()
     mock_job.cleanup_old_db_entries.assert_called_once()
     mock_task.cleanup_old_db_entries.assert_called_once()


### PR DESCRIPTION
This PR will introduce the new
attribute workflow_file, which will allow users
to specify their own customized workflow file as
ARCHIVEMATICA_MCPSERVER_WORKFLOW_FILE in the
docker-compose.yml.
Default behavior stays the same if given an
empty String.
This will fix the issue [1441](https://github.com/archivematica/Issues/issues/1441).