### PR TITLE
Add purge_transient_processing_data command

### DIFF
--- a/src/dashboard/src/main/management/commands/purge_transient_processing_data.py
+++ b/src/dashboard/src/main/management/commands/purge_transient_processing_data.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+"""Purge transient processing data.
+
+This command purges package-related data that is generated during processing
+from the Archivematica database. In some user workflows, this type of data is
+considered discardable as long as the AIPs are successfully stored by the
+Archivematica Storage Service.
+
+It can be safely executed on active Archivematica instances since it only
+targets packages that have completed processing.
+
+An optional parameter ``--purge-unknown`` may be passed to also purge packages
+in unknown state.
+
+An optional parameter ``--keep-failed`` may be passed to prevent failed packages
+from being purged.
+
+An optional parameter ``--age`` may be passed to exclude recent packages, i.e.
+it indicates how old a package must be in order to be purged.
+
+Execution example used to purge packages that completed more than six hours ago.
+./manage.py purge_transient_processing_data --age='0 00:06:00'
+"""
+from __future__ import unicode_literals
+
+import logging
+import traceback
+
+from elasticsearch import ElasticsearchException
+from django.conf import settings as django_settings
+from django.core.management.base import CommandError
+from django.utils import timezone
+from django.utils.dateparse import parse_duration
+import six
+
+import elasticSearchFunctions as es
+from main.management.commands import DashboardCommand
+from main import models
+
+
+class Command(DashboardCommand):
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print packages but do not purge.",
+        )
+        parser.add_argument(
+            "--purge-unknown",
+            action="store_true",
+            help=("Purge packages in unknown state.",),
+        )
+        parser.add_argument(
+            "--keep-failed",
+            action="store_true",
+            help="Do not purge failed packages.",
+        )
+        parser.add_argument(
+            "-q",
+            "--quiet",
+            action="store_true",
+            help="Reduce verbosity.",
+        )
+        parser.add_argument(
+            "--age",
+            help=(
+                "Only purge packages of a certain age (completion date). "
+                "Supported formats are: "
+                '"%%d %%H:%%M:%%S.%%f" or ISO 8601 durations. '
+                'E.g. express "36 hours" as "1 12:00:00" or "P1DT12H".'
+            ),
+        )
+
+    def handle(self, *args, **options):
+        if django_settings.SEARCH_ENABLED:
+            # Ignore elasticsearch-py logging events unless they're errors.
+            logging.getLogger("elasticsearch").setLevel(logging.ERROR)
+            logging.getLogger("archivematica.common").setLevel(logging.ERROR)
+            try:
+                es.setup_reading_from_conf(django_settings)
+                es_client = es.get_client()
+            except ElasticsearchException as err:
+                raise CommandError("Unable to connect to Elasticsearch: {}".format(err))
+
+        # Build look-up options.
+        kwargs = {
+            "include_unknown": options["purge_unknown"],
+            "include_failed": not options["keep_failed"],
+        }
+        if options["age"]:
+            duration = parse_duration(options["age"])
+            if duration is None:
+                raise CommandError("Age could not be parsed.")
+            kwargs["completed_before"] = timezone.now() - duration
+
+        self.info("Purging SIPs...")
+        sips = models.SIP.objects.done(**kwargs)
+        for sip in sips:
+            package_id = sip.pk
+            if not options["quiet"]:
+                self.warning(
+                    "» SIP {} with status {}".format(package_id, sip.status_str)
+                )
+            if options["dry_run"]:
+                continue
+            try:
+                self.delete_queryset(
+                    models.Access.objects.filter(sipuuid=package_id),
+                    options["quiet"],
+                )
+                self.delete_queryset(
+                    models.UnitVariable.objects.filter(
+                        unittype="SIP", unituuid=package_id
+                    ),
+                    options["quiet"],
+                )
+                self.delete_queryset(
+                    models.Job.objects.filter(sipuuid=package_id, unittype="unitSIP"),
+                    options["quiet"],
+                )
+                self.delete_queryset(
+                    models.SIP.objects.filter(pk=package_id),
+                    options["quiet"],
+                )
+                if es.AIPS_INDEX in django_settings.SEARCH_ENABLED:
+                    if not options["quiet"]:
+                        self.info("  Purging search documents...")
+                    es.delete_aip(es_client, package_id)
+                    es.delete_aip_files(es_client, package_id)
+            except Exception as err:
+                self.error("  Error: {}".format(err))
+                self.stdout.write(traceback.print_exc())
+
+        self.info("Purging transfers...")
+        transfers = models.Transfer.objects.done(**kwargs)
+        for transfer in transfers:
+            package_id = transfer.pk
+            if not options["quiet"]:
+                self.warning(
+                    "» Transfer {} with status {}".format(
+                        package_id, transfer.status_str
+                    )
+                )
+            if options["dry_run"]:
+                continue
+            try:
+                self.delete_queryset(
+                    models.UnitVariable.objects.filter(
+                        unittype="Transfer", unituuid=package_id
+                    ),
+                    options["quiet"],
+                )
+                self.delete_queryset(
+                    models.Job.objects.filter(
+                        sipuuid=package_id, unittype="unitTransfer"
+                    ),
+                    options["quiet"],
+                )
+                self.delete_queryset(
+                    models.Transfer.objects.filter(pk=package_id),
+                    options["quiet"],
+                )
+                if es.TRANSFERS_INDEX in django_settings.SEARCH_ENABLED:
+                    if not options["quiet"]:
+                        self.info("  Purging search documents...")
+                    es.remove_backlog_transfer(es_client, package_id)
+                    es.remove_backlog_transfer_files(es_client, package_id)
+            except Exception as err:
+                self.error("  Error: {}".format(err))
+                self.stdout.write(traceback.format_exc())
+
+    def delete_queryset(self, queryset, quiet):
+        result = queryset.delete()
+        if not quiet and result and len(result) == 2:
+            matches = result[1]
+            for model, count in six.iteritems(matches):
+                self.info("  Purging {} objects: {} rows deleted.".format(model, count))

--- a/src/dashboard/src/main/migrations/0081_package_status.py
+++ b/src/dashboard/src/main/migrations/0081_package_status.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
                 choices=[
                     (0, "Unknown"),
                     (1, "Processing"),
-                    (1, "Done"),
+                    (2, "Done"),
                     (3, "Completed successfully"),
                     (4, "Failed"),
                 ],
@@ -44,7 +44,7 @@ class Migration(migrations.Migration):
                 choices=[
                     (0, "Unknown"),
                     (1, "Processing"),
-                    (1, "Done"),
+                    (2, "Done"),
                     (3, "Completed successfully"),
                     (4, "Failed"),
                 ],

--- a/src/dashboard/src/main/tests/test_command_purge_transient_processing_data.py
+++ b/src/dashboard/src/main/tests/test_command_purge_transient_processing_data.py
@@ -1,0 +1,137 @@
+from datetime import timedelta
+import uuid
+
+from django.core.management import call_command
+from django.utils import timezone
+import pytest
+
+import elasticSearchFunctions as es
+from main import models
+
+
+@pytest.fixture
+def search_disabled(settings):
+    settings.SEARCH_ENABLED = []
+
+
+@pytest.fixture
+def search_enabled(settings):
+    settings.SEARCH_ENABLED = [es.TRANSFERS_INDEX, es.AIPS_INDEX]
+
+
+@pytest.fixture
+def transfer(db):
+    transfer = models.Transfer.objects.create(
+        uuid=uuid.uuid4(),
+        currentlocation=r"%transferDirectory%",
+        status=models.PACKAGE_STATUS_DONE,
+        completed_at=timezone.now(),
+    )
+
+    models.Job.objects.create(
+        sipuuid=transfer.pk, unittype="unitTransfer", createdtime=timezone.now()
+    )
+    models.File.objects.create(uuid=uuid.uuid4(), transfer=transfer)
+
+    return transfer
+
+
+@pytest.fixture
+def sip(db):
+    sip = models.SIP.objects.create(
+        uuid=uuid.uuid4(),
+        status=models.PACKAGE_STATUS_DONE,
+        completed_at=timezone.now(),
+    )
+
+    models.Job.objects.create(
+        sipuuid=sip.pk, unittype="unitSIP", createdtime=timezone.now()
+    )
+    models.File.objects.create(uuid=uuid.uuid4(), sip=sip)
+    models.Access.objects.create(sipuuid=sip.pk)
+
+    return sip
+
+
+@pytest.mark.django_db
+def test_purge_command_removes_package_with_unknown_status(search_disabled, transfer):
+    models.Transfer.objects.filter(pk=transfer.pk).update(
+        status=models.PACKAGE_STATUS_UNKNOWN
+    )
+
+    call_command("purge_transient_processing_data", "--purge-unknown")
+
+    assert models.Transfer.objects.filter(pk=transfer.pk).count() == 0
+
+
+@pytest.mark.django_db
+def test_purge_command_keeps_package_with_failed_status(search_disabled, transfer):
+    models.Transfer.objects.filter(pk=transfer.pk).update(
+        status=models.PACKAGE_STATUS_FAILED
+    )
+
+    call_command("purge_transient_processing_data", "--keep-failed")
+
+    assert models.Transfer.objects.filter(pk=transfer.pk).count() == 1
+
+
+@pytest.mark.django_db
+def test_purge_command_skips_recent_packages(search_disabled, transfer):
+    call_command("purge_transient_processing_data", "--age", "0 00:06:00")
+
+    assert models.Transfer.objects.filter(pk=transfer.pk).count() == 1
+
+
+@pytest.mark.django_db
+def test_purge_command_removes_package_matching_age_criteria(search_disabled, transfer):
+    models.Transfer.objects.filter(pk=transfer.pk).update(
+        completed_at=timezone.now() - timedelta(1)
+    )
+
+    call_command("purge_transient_processing_data", "--age", "0 00:06:00")
+
+    assert models.Transfer.objects.filter(pk=transfer.pk).count() == 0
+
+
+@pytest.mark.django_db
+def test_purge_command_removes_search_documents(search_enabled, transfer, mocker):
+    mocker.patch(
+        "main.management.commands.purge_transient_processing_data.es.create_indexes_if_needed"
+    )
+    mock_remove_backlog_transfer = mocker.patch(
+        "main.management.commands.purge_transient_processing_data.es.remove_backlog_transfer"
+    )
+    mock_remove_backlog_transfer_files = mocker.patch(
+        "main.management.commands.purge_transient_processing_data.es.remove_backlog_transfer_files"
+    )
+
+    call_command("purge_transient_processing_data")
+
+    mock_remove_backlog_transfer.assert_called_once_with(mocker.ANY, str(transfer.pk))
+    mock_remove_backlog_transfer_files.assert_called_once_with(
+        mocker.ANY, str(transfer.pk)
+    )
+
+
+@pytest.mark.django_db
+def test_purge_command_skips_active_packages(search_disabled, transfer, sip, capsys):
+    models.Transfer.objects.create(
+        uuid=uuid.uuid4(),
+        currentlocation=r"%transferDirectory%",
+        status=models.PACKAGE_STATUS_PROCESSING,
+    )
+
+    call_command("purge_transient_processing_data")
+
+    # We've created three packages, but only 1 is in active state.
+    assert models.Transfer.objects.all().count() == 1
+    assert models.SIP.objects.all().count() == 0
+
+
+@pytest.mark.django_db
+def test_purge_command_output(search_disabled, transfer, sip, capsys):
+    call_command("purge_transient_processing_data")
+    captured = capsys.readouterr()
+
+    assert "Transfer %s with status Done" % transfer.pk in captured.out
+    assert "SIP %s with status Done" % sip.pk in captured.out


### PR DESCRIPTION
This pull request introduces `purge_transient_processing_data`, a new command that is able to identify packages and remove them from the database. It provides a safer way to remove processing data taking into consideration currently processing packages. Related data isn't removed from Elasticsearch, we may want to tackle that in the future.

Usage:

    $ manage.py purge_transient_processing_data --help

Connects to https://github.com/archivematica/Issues/issues/1239.