### PR TITLE
Add bytes column to Archival Storage CSV

### DIFF
--- a/src/dashboard/src/components/archival_storage/tests/test_archival_storage.py
+++ b/src/dashboard/src/components/archival_storage/tests/test_archival_storage.py
@@ -228,6 +228,7 @@ def test_search_as_csv(mocker, amsetup, admin_client, tmp_path):
             "file_count": 2,
             "location": "/var/archivematica/AIPStore",
             "isPartOf": None,
+            "bytes": 200100,
             "size": "200.1\xa0KB",
             "type": "AIC",
         },
@@ -243,6 +244,7 @@ def test_search_as_csv(mocker, amsetup, admin_client, tmp_path):
             "file_count": 2,
             "location": "thé cloud",
             "isPartOf": None,
+            "bytes": 152100,
             "size": "152.1\xa0KB",
             "type": "AIP",
         },
@@ -276,9 +278,9 @@ def test_search_as_csv(mocker, amsetup, admin_client, tmp_path):
     csv_file = StringIO(streamed_content.decode("utf8"))
 
     assert csv_file.read() == (
-        '"Name","UUID","AICID","Count AIPs in AIC","Size","File count","Accession IDs","Created date (UTC)","Status","Type","Encrypted","Location"\n'
-        '"tz","a341dbc0-9715-4806-8477-fb407b105a5e","AIC#2040","2","200.1 KB","2","","2020-07-16 22:21:40+00:00","Stored","AIC","False","/var/archivematica/AIPStore"\n'
-        '"tz","22423d5c-f992-4979-9390-1cb61c87da14","","","152.1 KB","2","Àà; Éé; Îî; Ôô; Ùù","2020-07-16 22:23:20+00:00","Stored","AIP","True","thé cloud"\n'
+        '"Name","UUID","AICID","Count AIPs in AIC","Bytes","Size","File count","Accession IDs","Created date (UTC)","Status","Type","Encrypted","Location"\n'
+        '"tz","a341dbc0-9715-4806-8477-fb407b105a5e","AIC#2040","2","200100","200.1 KB","2","","2020-07-16 22:21:40+00:00","Stored","AIC","False","/var/archivematica/AIPStore"\n'
+        '"tz","22423d5c-f992-4979-9390-1cb61c87da14","","","152100","152.1 KB","2","Àà; Éé; Îî; Ôô; Ùù","2020-07-16 22:23:20+00:00","Stored","AIP","True","thé cloud"\n'
     )
 
 

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -202,6 +202,7 @@ _ORDERED_DICT_ES_FIELDS = OrderedDict(
         (es.ES_FIELD_UUID, _("UUID")),
         (es.ES_FIELD_AICID, _("AICID")),
         (es.ES_FIELD_AICCOUNT, _("Count AIPs in AIC")),
+        ("bytes", _("Bytes")),
         (es.ES_FIELD_SIZE, _("Size")),
         (es.ES_FIELD_FILECOUNT, _("File count")),
         (es.ES_FIELD_ACCESSION_IDS, _("Accession IDs")),
@@ -414,6 +415,7 @@ def search_augment_aip_results(raw_results, counts):
         size = fields.get("size")
         if size is not None:
             bytecount = size * (1024 * 1024)
+            new_item["bytes"] = bytecount
             new_item["size"] = filesizeformat(bytecount)
 
         aic_id = fields.get("AICID")


### PR DESCRIPTION
Connected to https://github.com/archivematica/Issues/issues/1450

This is one potential solution to the linked issue. Another might be to use a consistent unit of measure in the Archival Storage web UI and CSV, e.g. to always use MB.