### PR TITLE
Disallow hiding active packages

### DIFF
--- a/src/MCPServer/lib/server/rpc_server.py
+++ b/src/MCPServer/lib/server/rpc_server.py
@@ -367,14 +367,16 @@ class RPCServer(GearmanWorker):
         jobs_awaiting_for_approval = self.package_queue.jobs_awaiting_decisions()
         objects = []
         for unit_id, timestamp in sipuuids_and_timestamps:
+            unit = model.objects.get(pk=unit_id)
+            if unit.hidden:
+                continue
             item = {
                 "id": unit_id,
                 "uuid": unit_id,
                 "timestamp": float(timestamp),
+                "active": unit.active,
                 "jobs": [],
             }
-            if model.objects.is_hidden(unit_id):
-                continue
             jobs = Job.objects.filter(sipuuid=unit_id).order_by("-createdtime")
             if jobs:
                 item["directory"] = jobs[0].get_directory_name()

--- a/src/dashboard/src/components/unit/tests/test_views.py
+++ b/src/dashboard/src/components/unit/tests/test_views.py
@@ -1,0 +1,150 @@
+from __future__ import unicode_literals
+
+import uuid
+
+from django.urls import reverse
+from django.utils import timezone
+import pytest
+
+from components import helpers
+from main import models
+
+
+@pytest.fixture()
+def install(db):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+
+@pytest.fixture()
+def transfer(db):
+    return models.Transfer.objects.create(
+        uuid=uuid.uuid4(),
+        currentlocation=r"%transferDirectory%",
+        status=models.PACKAGE_STATUS_DONE,
+    )
+
+
+@pytest.mark.django_db()
+class TestMarkHiddenView(object):
+    def test_it_rejects_non_admins(self, install, client, transfer):
+        url = reverse(
+            "unit:mark_hidden",
+            kwargs={"unit_type": "transfer", "unit_uuid": transfer.pk},
+        )
+        resp = client.delete(url)
+
+        assert resp.status_code == 302
+
+    def test_it_rejects_non_delete_verbs(self, install, admin_client, transfer):
+        url = reverse(
+            "unit:mark_hidden",
+            kwargs={"unit_type": "transfer", "unit_uuid": transfer.pk},
+        )
+        resp = admin_client.post(url)
+
+        assert resp.status_code == 405
+
+    def test_it_rejects_unknown_package_types(self, install, admin_client, transfer):
+        url = "/tranfser/{}/delete/".format(transfer.pk)
+        resp = admin_client.delete(url)
+
+        assert resp.status_code == 404
+
+    def test_it_conflicts_on_active_packages(self, install, admin_client, transfer):
+        transfer.status = models.PACKAGE_STATUS_PROCESSING
+        transfer.save()
+        url = reverse(
+            "unit:mark_hidden",
+            kwargs={"unit_type": "transfer", "unit_uuid": transfer.pk},
+        )
+        resp = admin_client.delete(url)
+
+        assert resp.status_code == 409
+        assert resp.json() == {"removed": False}
+
+    def test_it_handles_unknown_errors(self, install, admin_client, transfer, mocker):
+        mocker.patch("main.models.Transfer.objects.done", side_effect=Exception())
+        url = reverse(
+            "unit:mark_hidden",
+            kwargs={"unit_type": "transfer", "unit_uuid": transfer.pk},
+        )
+        resp = admin_client.delete(url)
+
+        assert resp.status_code == 500
+        assert resp.json() == {"removed": False}
+
+    def test_it_hides_done_packages(self, install, admin_client, transfer):
+        url = reverse(
+            "unit:mark_hidden",
+            kwargs={"unit_type": "transfer", "unit_uuid": transfer.pk},
+        )
+        resp = admin_client.delete(url)
+
+        assert resp.status_code == 200
+        assert resp.json() == {"removed": True}
+
+
+@pytest.mark.django_db()
+class TestMarkCompletedHiddenView(object):
+    def test_it_rejects_non_admins(self, install, client, transfer):
+        url = reverse("unit:mark_all_hidden", kwargs={"unit_type": "transfer"})
+        resp = client.delete(url)
+
+        assert resp.status_code == 302
+
+    def test_it_rejects_non_delete_verbs(self, install, admin_client, transfer):
+        url = reverse("unit:mark_all_hidden", kwargs={"unit_type": "transfer"})
+        resp = admin_client.post(url)
+
+        assert resp.status_code == 405
+
+    def test_it_handles_unknown_errors(self, install, admin_client, transfer, mocker):
+        mocker.patch(
+            "components.helpers.completed_units_efficient", side_effect=Exception()
+        )
+        url = reverse("unit:mark_all_hidden", kwargs={"unit_type": "transfer"})
+        resp = admin_client.delete(url)
+
+        assert resp.status_code == 500
+        assert resp.json() == {"removed": False}
+
+    def test_it_ignores_active_packages(self, install, admin_client, transfer):
+        transfer.status = models.PACKAGE_STATUS_PROCESSING
+        transfer.save()
+        url = reverse("unit:mark_all_hidden", kwargs={"unit_type": "transfer"})
+        resp = admin_client.delete(url)
+
+        assert resp.status_code == 200
+        assert resp.json() == {"removed": []}
+
+    def test_it_hides_done_packages(self, install, admin_client, transfer):
+        # mark_completed_hidden still relies on job objects.
+        models.Job.objects.create(
+            sipuuid=transfer.pk,
+            unittype="unitTransfer",
+            createdtime=timezone.now(),
+            currentstep=models.Job.STATUS_COMPLETED_SUCCESSFULLY,
+            jobtype="Move transfer to backlog",
+        )
+
+        url = reverse("unit:mark_all_hidden", kwargs={"unit_type": "transfer"})
+        resp = admin_client.delete(url)
+
+        assert resp.status_code == 200
+        assert resp.json() == {"removed": [str(transfer.pk)]}
+
+    def test_it_hides_failed_packages(self, install, admin_client, transfer):
+        # mark_completed_hidden still relies on job objects.
+        models.Job.objects.create(
+            sipuuid=transfer.pk,
+            unittype="unitTransfer",
+            createdtime=timezone.now(),
+            currentstep=models.Job.STATUS_COMPLETED_SUCCESSFULLY,
+            jobtype="Remove the processing directory",
+        )
+
+        url = reverse("unit:mark_all_hidden", kwargs={"unit_type": "transfer"})
+        resp = admin_client.delete(url)
+
+        assert resp.status_code == 200
+        assert resp.json() == {"removed": [str(transfer.pk)]}

--- a/src/dashboard/src/components/unit/urls.py
+++ b/src/dashboard/src/components/unit/urls.py
@@ -32,6 +32,10 @@ urlpatterns = [
         views.microservices,
         name="microservices",
     ),
-    url(r"^(?P<unit_uuid>" + settings.UUID_REGEX + ")/delete/$", views.mark_hidden),
-    url(r"^delete/$", views.mark_completed_hidden),
+    url(
+        r"^(?P<unit_uuid>" + settings.UUID_REGEX + ")/delete/$",
+        views.mark_hidden,
+        name="mark_hidden",
+    ),
+    url(r"^delete/$", views.mark_completed_hidden, name="mark_all_hidden"),
 ]

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -402,13 +402,6 @@ class Derivation(models.Model):
 
 
 class PackageManager(models.Manager):
-    def is_hidden(self, uuid):
-        """ Return True if the unit (SIP, Transfer) with uuid is hidden. """
-        try:
-            return self.get_queryset().get(uuid=uuid).hidden
-        except:
-            return False
-
     def done(self, completed_before=None, include_failed=True, include_unknown=False):
         statuses = [PACKAGE_STATUS_DONE, PACKAGE_STATUS_COMPLETED_SUCCESSFULLY]
         if include_failed:
@@ -507,13 +500,9 @@ class SIP(models.Model):
         except (TypeError, IndexError):
             return None
 
-
-class TransferManager(models.Manager):
-    def is_hidden(self, uuid):
-        try:
-            return Transfer.objects.get(uuid__exact=uuid).hidden is True
-        except:
-            return False
+    @property
+    def active(self):
+        return self.status == PACKAGE_STATUS_PROCESSING
 
 
 class Transfer(models.Model):
@@ -595,6 +584,10 @@ class Transfer(models.Model):
             return PACKAGE_STATUS_CHOICES[self.status][1]
         except (TypeError, IndexError):
             return None
+
+    @property
+    def active(self):
+        return self.status == PACKAGE_STATUS_PROCESSING
 
 
 @python_2_unicode_compatible

--- a/src/dashboard/src/media/js/ingest.js
+++ b/src/dashboard/src/media/js/ingest.js
@@ -66,6 +66,13 @@ $(function()
           event.preventDefault();
           event.stopPropagation();
 
+          if (this.model.attributes.active)
+          {
+            window.alert(gettext('It is not possible to remove active SIPs.'));
+
+            return;
+          }
+
           $(this.el).addClass('sip-removing');
 
           var self = this;

--- a/src/dashboard/src/media/js/transfer.js
+++ b/src/dashboard/src/media/js/transfer.js
@@ -66,6 +66,13 @@ $(function()
           event.preventDefault();
           event.stopPropagation();
 
+          if (this.model.attributes.active)
+          {
+            window.alert(gettext('It is not possible to remove active transfers.'));
+
+            return;
+          }
+
           $(this.el).addClass('sip-removing');
 
           var self = this;


### PR DESCRIPTION
This commit makes the "active" attribute of a package available to the
front-end so it is posible to reject user requests attempting to hide
them.

A window.alert dialog is used to reject the user action, but this can
be later improved, e.g. hiding the button which needs some refactoring
in the rendering layer.

A similar check is added to the back-end endpoint. The `mark_hidden`
view now rejects hiding active packages returning a 409 conflict code.

It fixes https://github.com/archivematica/Issues/issues/1446.