### PR TITLE
Convert escape_string to text

### DIFF
--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -118,7 +118,7 @@ def addAccessionEvent(fileUUID, transferUUID, date):
     if transfer.accessionid:
         eventOutcomeDetailNote = "accession#" + MySQLdb.escape_string(
             transfer.accessionid
-        )
+        ).decode("utf-8")
         insertIntoEvents(
             fileUUID=fileUUID,
             eventType="registration",


### PR DESCRIPTION
MySQLdb.escape_string always returns a sequence of bytes. This commit
converts it to text so we can concatenate in Python 3.

Connects to https://github.com/archivematica/Issues/issues/809.