### PR TITLE
Fix non-ascii copyright jurisdiction

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRights.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSRights.py
@@ -26,6 +26,7 @@
 import sys
 import uuid
 import lxml.etree as etree
+import six
 
 # dashboard
 from main.models import RightsStatement
@@ -69,7 +70,17 @@ def _add_start_end_date_complex_type(name, elem, start_date, end_date, end_date_
 
 
 def archivematicaGetRights(job, metadataAppliesToList, fileUUID, state):
-    """[(fileUUID, fileUUIDTYPE), (sipUUID, sipUUIDTYPE), (transferUUID, transferUUIDType)]"""
+    """Create the premis:rightsStatement elements of a file to be included
+    in its amdSec in the METS file.
+
+    :param job: MCPClient Job
+    :param metadataAppliesToList: list of tuples of (
+        UUID of File/SIP/Transfer, PK from MetadataAppliesToType,
+    )
+    :param fileUUID: string with UUID of the File
+    :param state: create_mets_v2.MetsState object
+    :return ret: list of lxml Element objects
+    """
     ret = []
     for metadataAppliesToidentifier, metadataAppliesToType in metadataAppliesToList:
         statements = RightsStatement.objects.filter(
@@ -128,7 +139,7 @@ def createRightsStatement(job, statement, fileUUID, state):
             ).text = copyright.copyrightstatus
             copyrightJurisdiction = copyright.copyrightjurisdiction
             copyrightJurisdictionCode = getCodeForCountry(
-                copyrightJurisdiction.__str__().upper()
+                six.ensure_str(copyrightJurisdiction).upper()
             )
             if copyrightJurisdictionCode is not None:
                 copyrightJurisdiction = copyrightJurisdictionCode

--- a/src/MCPClient/tests/test_archivematicaCreateMETSRights.py
+++ b/src/MCPClient/tests/test_archivematicaCreateMETSRights.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import uuid
+
+from create_mets_v2 import MetsState
+from job import Job
+from main import models
+from namespaces import NSMAP
+import pytest
+
+import archivematicaCreateMETSRights
+
+
+@pytest.fixture()
+def job():
+    return Job("stub", "stub", [])
+
+
+@pytest.fixture()
+def file_(db):
+    return models.File.objects.create(
+        uuid=uuid.uuid4(),
+    )
+
+
+@pytest.fixture()
+def rights_statement(db, file_):
+    statement = models.RightsStatement.objects.create(
+        metadataappliestotype=models.MetadataAppliesToType.objects.get(
+            id=models.MetadataAppliesToType.FILE_TYPE
+        ),
+        metadataappliestoidentifier=file_.uuid,
+        rightsbasis="Copyright",
+    )
+    models.RightsStatementCopyright.objects.create(
+        rightsstatement=statement,
+        copyrightjurisdiction="Québec",
+    )
+    return statement
+
+
+def test_archivematicaGetRights_with_non_ascii_copyright_jurisdiction(
+    db,
+    job,
+    file_,
+    rights_statement,
+):
+    metadataAppliesToList = [
+        (file_.uuid, models.MetadataAppliesToType.FILE_TYPE),
+    ]
+    result = archivematicaCreateMETSRights.archivematicaGetRights(
+        job, metadataAppliesToList, str(file_.uuid), MetsState()
+    )
+    assert len(result) == 1
+    element = result[0]
+    assert element.find("premis:rightsBasis", NSMAP).text == "Copyright"
+    assert (
+        element.find(
+            "premis:copyrightInformation/premis:copyrightJurisdiction", NSMAP
+        ).text
+        == "Québec"
+    )


### PR DESCRIPTION
This fixes METS generation when a rights statement contains a
copyright jurisdiction with non-ascii text.

Connected to https://github.com/archivematica/Issues/issues/1447