### PR TITLE
Remove pandas and numpy

### DIFF
--- a/requirements-dev-py3.txt
+++ b/requirements-dev-py3.txt
@@ -26,7 +26,6 @@ django-braces==1.0.0      # via -r requirements-py3.txt
 django-cas-ng==3.6.0      # via -r requirements-py3.txt
 django-extensions==1.7.9  # via -r requirements-py3.txt
 django-forms-bootstrap==3.1.0  # via -r requirements-py3.txt
-django-model-utils==1.3.1  # via -r requirements-py3.txt
 django-prometheus==1.0.15  # via -r requirements-py3.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r requirements-py3.txt
 django-tastypie==0.13.2   # via -r requirements-py3.txt

--- a/requirements-dev-py3.txt
+++ b/requirements-dev-py3.txt
@@ -56,11 +56,9 @@ mozilla-django-oidc==1.2.4  # via -r requirements-py3.txt
 multidict==5.1.0          # via yarl
 mysqlclient==1.4.6        # via -r requirements-py3.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r requirements-py3.txt
-numpy==1.19.5             # via -r requirements-py3.txt, pandas
 olefile==0.46             # via -r requirements-py3.txt, opf-fido
 opf-fido==1.4.1           # via -r requirements-py3.txt
 packaging==20.9           # via pytest, tox
-pandas==0.24.2            # via -r requirements-py3.txt
 pip-tools==5.4.0          # via -r requirements-py3.txt
 pluggy==0.13.1            # via pytest, tox
 prometheus-client==0.7.1  # via -r requirements-py3.txt, django-prometheus
@@ -78,10 +76,10 @@ pytest-pythonpath==0.7.3  # via -r requirements-dev-py3.in
 pytest-randomly==1.2.3    # via -r requirements-dev-py3.in
 pytest==4.6.11            # via -r requirements-dev-py3.in, pytest-cov, pytest-django, pytest-mock, pytest-pythonpath, pytest-randomly
 python-cas==1.5.0         # via -r requirements-py3.txt, django-cas-ng
-python-dateutil==2.6.0    # via -r requirements-py3.txt, django-tastypie, pandas
+python-dateutil==2.6.0    # via -r requirements-py3.txt, django-tastypie
 python-ldap==3.2.0        # via -r requirements-py3.txt, pyldap
 python-mimeparse==1.6.0   # via -r requirements-py3.txt, django-tastypie
-pytz==2021.1              # via -r requirements-py3.txt, django, pandas
+pytz==2021.1              # via -r requirements-py3.txt, django
 pyyaml==5.4.1             # via vcrpy
 requests==2.21.0          # via -r requirements-py3.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r requirements-py3.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -64,11 +64,9 @@ more-itertools==5.0.0     # via pytest
 mozilla-django-oidc==1.2.4  # via -r requirements.txt
 mysqlclient==1.4.6        # via -r requirements.txt, agentarchives
 ndg-httpsclient==0.5.1    # via -r requirements.txt
-numpy==1.16.6             # via -r requirements.txt, pandas
 olefile==0.46             # via -r requirements.txt, opf-fido
 opf-fido==1.4.1           # via -r requirements.txt
 packaging==20.9           # via pytest, tox
-pandas==0.24.2            # via -r requirements.txt
 pathlib2==2.3.4 ; python_version < "3"  # via -r requirements.txt, importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
 pip-tools==5.4.0          # via -r requirements.txt
 pluggy==0.13.1            # via pytest, tox
@@ -86,10 +84,10 @@ pytest-pythonpath==0.7.3  # via -r requirements-dev.in
 pytest-randomly==1.2.3    # via -r requirements-dev.in
 pytest==4.6.11            # via -r requirements-dev.in, pytest-cov, pytest-django, pytest-mock, pytest-pythonpath, pytest-randomly
 python-cas==1.5.0         # via -r requirements.txt, django-cas-ng
-python-dateutil==2.6.0    # via -r requirements.txt, django-tastypie, pandas
+python-dateutil==2.6.0    # via -r requirements.txt, django-tastypie
 python-ldap==3.2.0        # via -r requirements.txt, django-auth-ldap, mockldap
 python-mimeparse==1.6.0   # via -r requirements.txt, django-tastypie
-pytz==2021.1              # via -r requirements.txt, django, pandas
+pytz==2021.1              # via -r requirements.txt, django
 pyyaml==5.4.1             # via vcrpy
 requests==2.21.0          # via -r requirements.txt, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r requirements.txt, pathlib2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,7 +30,6 @@ django-braces==1.0.0      # via -r requirements.txt
 django-cas-ng==3.6.0      # via -r requirements.txt
 django-extensions==1.7.9  # via -r requirements.txt
 django-forms-bootstrap==3.1.0  # via -r requirements.txt
-django-model-utils==1.3.1  # via -r requirements.txt
 django-prometheus==1.0.15  # via -r requirements.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r requirements.txt
 django-tastypie==0.13.2   # via -r requirements.txt

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -43,10 +43,8 @@ metsrw==0.3.20            # via -r requirements.in
 mozilla-django-oidc==1.2.4  # via -r requirements.in
 mysqlclient==1.4.6        # via -r requirements.in, agentarchives
 ndg-httpsclient==0.5.1    # via -r requirements.in
-numpy==1.19.5             # via pandas
 olefile==0.46             # via opf-fido
 opf-fido==1.4.1           # via -r requirements.in
-pandas==0.24.2            # via -r requirements.in
 pip-tools==5.4.0          # via -r requirements.in
 prometheus-client==0.7.1  # via -r requirements.in, django-prometheus
 pyasn1-modules==0.2.8     # via python-ldap
@@ -55,10 +53,10 @@ pycparser==2.20           # via cffi
 pyldap==3.0.0.post1       # via django-auth-ldap
 pyopenssl==20.0.1         # via -r requirements.in, josepy, ndg-httpsclient
 python-cas==1.5.0         # via django-cas-ng
-python-dateutil==2.6.0    # via -r requirements.in, django-tastypie, pandas
+python-dateutil==2.6.0    # via -r requirements.in, django-tastypie
 python-ldap==3.2.0        # via -r requirements.in, pyldap
 python-mimeparse==1.6.0   # via django-tastypie
-pytz==2021.1              # via -r requirements.in, django, pandas
+pytz==2021.1              # via -r requirements.in, django
 requests==2.21.0          # via -r requirements.in, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r requirements.in
 six==1.14.0               # via -r requirements.in, amclient, django-extensions, metsrw, mozilla-django-oidc, opf-fido, pip-tools, pyopenssl, python-cas, python-dateutil

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -21,7 +21,6 @@ django-braces==1.0.0      # via -r requirements.in
 django-cas-ng==3.6.0      # via -r requirements.in
 django-extensions==1.7.9  # via -r requirements.in
 django-forms-bootstrap==3.1.0  # via -r requirements.in
-django-model-utils==1.3.1  # via -r requirements.in
 django-prometheus==1.0.15  # via -r requirements.in
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r requirements.in
 django-tastypie==0.13.2   # via -r requirements.in

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,6 @@ django-autoslug==1.9.3  # used by fpr
 django-braces==1.0.0
 django-extensions==1.7.9
 django-forms-bootstrap>=3.0.0,<4.0.0
-django-model-utils==1.3.1
 django-prometheus==1.0.15
 django-tastypie==0.13.2
 elasticsearch>=6.0.0,<7.0.0

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,6 @@ metsrw==0.3.20
 mysqlclient==1.4.6
 ndg-httpsclient
 opf-fido==1.4.1
-pandas==0.24.2
 pathlib2==2.3.4 ; python_version < '3'
 pip==20.3
 pip-tools==5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,10 +48,8 @@ metsrw==0.3.20            # via -r requirements.in
 mozilla-django-oidc==1.2.4  # via -r requirements.in
 mysqlclient==1.4.6        # via -r requirements.in, agentarchives
 ndg-httpsclient==0.5.1    # via -r requirements.in
-numpy==1.16.6             # via pandas
 olefile==0.46             # via opf-fido
 opf-fido==1.4.1           # via -r requirements.in
-pandas==0.24.2            # via -r requirements.in
 pathlib2==2.3.4 ; python_version < "3"  # via -r requirements.in
 pip-tools==5.4.0          # via -r requirements.in
 prometheus-client==0.7.1  # via -r requirements.in, django-prometheus
@@ -60,10 +58,10 @@ pyasn1==0.4.8             # via -r requirements.in, ndg-httpsclient, pyasn1-modu
 pycparser==2.20           # via cffi
 pyopenssl==20.0.1         # via -r requirements.in, josepy, ndg-httpsclient
 python-cas==1.5.0         # via django-cas-ng
-python-dateutil==2.6.0    # via -r requirements.in, django-tastypie, pandas
+python-dateutil==2.6.0    # via -r requirements.in, django-tastypie
 python-ldap==3.2.0        # via -r requirements.in, django-auth-ldap
 python-mimeparse==1.6.0   # via django-tastypie
-pytz==2021.1              # via -r requirements.in, django, pandas
+pytz==2021.1              # via -r requirements.in, django
 requests==2.21.0          # via -r requirements.in, agentarchives, amclient, mozilla-django-oidc, python-cas
 scandir==1.10.0           # via -r requirements.in, pathlib2
 six==1.14.0               # via -r requirements.in, amclient, cryptography, django-extensions, josepy, metsrw, mozilla-django-oidc, opf-fido, pathlib2, pip-tools, pyopenssl, python-cas, python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ django-braces==1.0.0      # via -r requirements.in
 django-cas-ng==3.6.0      # via -r requirements.in
 django-extensions==1.7.9  # via -r requirements.in
 django-forms-bootstrap==3.1.0  # via -r requirements.in
-django-model-utils==1.3.1  # via -r requirements.in
 django-prometheus==1.0.15  # via -r requirements.in
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r requirements.in
 django-tastypie==0.13.2   # via -r requirements.in

--- a/src/dashboard/src/components/archival_storage/tests/test_archival_storage.py
+++ b/src/dashboard/src/components/archival_storage/tests/test_archival_storage.py
@@ -267,7 +267,7 @@ def test_search_as_csv(mocker, amsetup, admin_client, tmp_path):
     )
 
     # Check that our response headers are going to be useful to the caller.
-    assert response.get(CONTENT_TYPE) == "text/csv"
+    assert response.get(CONTENT_TYPE) == "text/csv; charset=utf-8"
     assert (
         response.get(CONTENT_DISPOSITION) == 'attachment; filename="test-filename.csv"'
     )

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -268,7 +268,7 @@ def search_as_csv(es_results, file_name):
         content_type=CSV_MIMETYPE,
     )
     response["Content-Disposition"] = 'attachment; filename="{}"'.format(file_name)
-    response["mimetype"] = "{}; charset={}".format(CSV_MIMETYPE, "utf-8")
+    response["Content-Type"] = "{}; charset={}".format(CSV_MIMETYPE, "utf-8")
 
     return response
 


### PR DESCRIPTION
This pull request removes a few dependencies that are unused or
underused: pandas, numpy and django-model-utils.

pandas is great but it's definitely underused in Archivematica while
taking near [half of the space] used by our virtual environments plus
adding some complexity to our builds that we don't have capacity to
tackle right now.

Connects to archivematica/Issues#392.

[half of the space]: https://gist.github.com/sevein/43bb237f7139e22c9f16e5bfddb69295