### PR TITLE
Fix rebuild_transfer_backlog for non-bags transfers

### DIFF
--- a/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
+++ b/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
@@ -405,6 +405,15 @@ def _convert_checksum_algo(algo):
     return algo.replace("-", "").lower()
 
 
+def _get_transfer_mets_path(transfer_dir):
+    mets_relative_path = "metadata/submissionDocumentation/METS.xml"
+    try:
+        bagit.Bag(str(transfer_dir))
+        return str(transfer_dir / "data" / mets_relative_path)
+    except bagit.BagError:
+        return str(transfer_dir / mets_relative_path)
+
+
 def _import_self_describing_transfer(
     cmd, es_client, stdout, transfer_dir, transfer_uuid, size
 ):
@@ -436,9 +445,7 @@ def _import_self_describing_transfer(
 
     # The transfer did not exist, we need to populate everything else.
     if created:
-        mets = metsrw.METSDocument.fromfile(
-            str(transfer_dir / "data/metadata/submissionDocumentation/METS.xml")
-        )
+        mets = metsrw.METSDocument.fromfile(_get_transfer_mets_path(transfer_dir))
 
         try:
             alt_id = mets.alternate_ids[0]


### PR DESCRIPTION
This fixes METS parsing in the `rebuild_transfer_backlog` management
command when the backlog transfers retrieved from the Storage Service
don't have a bag structure.

Reproducing the problem in the docker development environment was the hardest part, so I'm going to document what I did for future reference:

I tested this using the `am.git` repo and setting the AM branch to `stable/1.9.x` and the SS branch to `stable/0.14.x` to be able to create backlog transfers with no bag structure which is what makes the management command to fail. I had to install the `md5deep` and `bagit` packages manually in the `archivematica-mcp-client` container.

After restarting all the services I created a couple of transfers, sent them to the backlog and finally dumped the `SS` database into a local file with:

```
docker-compose exec mysql mysqldump -hlocalhost -uroot -p12345 SS > /tmp/sql
```

I then stopped  the `am.git` environment and set up a separate `qa/1.x` environment. I dropped the `SS` db in the new environment, copied the dumped sql file to the `mysql` container, restored it, migrated the `SS` database and restarted all the services.

I was able to reproduce the problem calling the command and passing the `pipeline` UUID from the `am.git` environment:

```
$ make manage-dashboard ARG="rebuild_transfer_backlog --from-storage-service --pipeline=97ee2354-27ec-4980-a64a-1778c97becb8"
docker-compose run \
	--user 1000:1000 \
	--rm \
	--entrypoint /src/src/dashboard/src/manage.py \
		archivematica-dashboard \
			rebuild_transfer_backlog --from-storage-service --pipeline=97ee2354-27ec-4980-a64a-1778c97becb8
Building with native build. Learn about native build in Compose here: https://docs.docker.com/go/compose-native-build/
Creating hack_archivematica-dashboard_run ... done
WARNING: This script will delete your current Elasticsearch transfer data, rebuilding it using files.
Are you sure you want to continue?

Type "yes" to continue, or "no" to cancel:  yes
Rebuilding "transfers" index from packages in Storage Service.
Connected to Elasticsearch node am-node (v6.5.4).
Deleting all transfers and transfer files in the "transfers" and "transferfiles" indexes...
Creating indexes...
Importing transfer 01909b72-9bd5-40c8-a979-04675472d6db from temporarily downloaded copy.
Traceback (most recent call last):
  File "/src/src/dashboard/src/manage.py", line 13, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.6/dist-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/src/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py", line 141, in handle
    self.populate_data_from_storage_service(es_client, pipeline_uuid)
  File "/src/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py", line 267, in populate_data_from_storage_service
    transfer["size"],
  File "/src/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py", line 440, in _import_self_describing_transfer
    str(transfer_dir / "data/metadata/submissionDocumentation/METS.xml")
  File "/usr/local/lib/python3.6/dist-packages/metsrw/mets.py", line 596, in fromfile
    return cls.fromtree(etree.parse(path, parser=parser))
  File "src/lxml/etree.pyx", line 3521, in lxml.etree.parse
  File "src/lxml/parser.pxi", line 1859, in lxml.etree._parseDocument
  File "src/lxml/parser.pxi", line 1885, in lxml.etree._parseDocumentFromURL
  File "src/lxml/parser.pxi", line 1789, in lxml.etree._parseDocFromFile
  File "src/lxml/parser.pxi", line 1177, in lxml.etree._BaseParser._parseDocFromFile
  File "src/lxml/parser.pxi", line 615, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 725, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 652, in lxml.etree._raiseParseError
OSError: Error reading file '/tmp/tmpmvvko6ah/demo-01909b72-9bd5-40c8-a979-04675472d6db/data/metadata/submissionDocumentation/METS.xml': failed to load external entity "/tmp/tmpmvvko6ah/demo-01909b72-9bd5-40c8-a979-04675472d6db/data/metadata/submissionDocumentation/METS.xml"
ERROR: 1
Makefile:118: fallo en las instrucciones para el objetivo 'manage-dashboard'
make: *** [manage-dashboard] Error 1
```

And after setting this branch my two backlog transfers were successfully imported:

```
$ make manage-dashboard ARG="rebuild_transfer_backlog --from-storage-service --pipeline=97ee2354-27ec-4980-a64a-1778c97becb8"
docker-compose run \
	--user 1000:1000 \
	--rm \
	--entrypoint /src/src/dashboard/src/manage.py \
		archivematica-dashboard \
			rebuild_transfer_backlog --from-storage-service --pipeline=97ee2354-27ec-4980-a64a-1778c97becb8
Building with native build. Learn about native build in Compose here: https://docs.docker.com/go/compose-native-build/
Creating hack_archivematica-dashboard_run ... done
WARNING: This script will delete your current Elasticsearch transfer data, rebuilding it using files.
Are you sure you want to continue?

Type "yes" to continue, or "no" to cancel:  yes
Rebuilding "transfers" index from packages in Storage Service.
Connected to Elasticsearch node am-node (v6.5.4).
Deleting all transfers and transfer files in the "transfers" and "transferfiles" indexes...
Creating indexes...
Importing transfer 01909b72-9bd5-40c8-a979-04675472d6db from temporarily downloaded copy.
Importing transfer 333ae592-24e7-496d-91f8-7339d6658af4 from temporarily downloaded copy.
2 transfers indexed!
```


Connected to https://github.com/archivematica/Issues/issues/1455