### PR TITLE
Make javascript catalog view login exempt

### DIFF
--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -466,7 +466,7 @@ CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
 # login-related settings
 LOGIN_URL = "/administration/accounts/login/"
 LOGIN_REDIRECT_URL = "/"
-LOGIN_EXEMPT_URLS = [r"^administration/accounts/login", r"^api"]
+LOGIN_EXEMPT_URLS = [r"^administration/accounts/login", r"^api", r"^jsi18n"]
 # Django debug toolbar
 try:
     import debug_toolbar  # noqa: F401


### PR DESCRIPTION
The `installer.middleware.ConfigurationCheckMiddleware` class requires
authentication for accessing the javascript catalog view at `/jsi18n`
which produces a JS `Uncaught SyntaxError` in the login form when its
`<script>` tag receives HTML instead of JS.

This fixes it by adding the javascript catalog path to the list of
login exempt URLs.

Connected to https://github.com/archivematica/Issues/issues/1317