### PR TITLE
Remove old JS code in the normalization report

### DIFF
--- a/src/dashboard/src/media/js/ingest/normalization_report.js
+++ b/src/dashboard/src/media/js/ingest/normalization_report.js
@@ -18,13 +18,6 @@ along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 $(function() {
-  // add job viewer to generate dialogs with
-  var job = new Job();
-  job.set({'type': 'Approve Normalization'});
-  job.sip = new Sip();
-  job.sip.set({'directory': '{{ sipname }}'});
-  var jobView = new BaseJobView({model: job});
-
   // add popovers
   $($.find('a.file-location'))
     .popover({


### PR DESCRIPTION
This fixes a JS `Uncaught TypeError` error in the normalization report
caused by code that was used to setup dialogs for displaying job
information but which were removed a few years ago.

Connected to https://github.com/archivematica/Issues/issues/1317