### PR TITLE
Update filegrpuse if file already has UUID

### DIFF
--- a/src/MCPClient/lib/clientScripts/assign_file_uuids.py
+++ b/src/MCPClient/lib/clientScripts/assign_file_uuids.py
@@ -197,6 +197,17 @@ def assign_sip_file_uuid(
     file_uuid = str(uuid.uuid4())
     file_path_relative_to_sip = file_path.replace(sip_directory, "%SIPDirectory%", 1)
 
+    matching_file = File.objects.filter(
+        currentlocation=file_path_relative_to_sip,
+        sip=sip_uuid,
+    ).first()
+    if matching_file:
+        job.print_error("File already has UUID: {}".format(matching_file.uuid))
+        if update_use:
+            matching_file.filegrpuse = use
+            matching_file.save()
+        return
+
     job.print_output("Generated UUID for file {}.".format(file_uuid))
     addFileToSIP(
         file_path_relative_to_sip,


### PR DESCRIPTION
Connected to https://github.com/archivematica/issues/issues/1429

This commit fixes a defect in https://github.com/artefactual/archivematica/commit/b6183e3a7be3c893916a4bd20a8ded1e68fa561c whereby a routine in the original `assign_file_uuids` client script that checks whether a file already has a UUID and updates its `filegrpuse` if so was missed when converting the script to run per-directory rather than per-file. This resolves an issue with manual normalization and makes all of the AMAUATs pass again.