### PR TITLE
Fix the filesystem contents view in Python 3

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/urls.py
+++ b/src/dashboard/src/components/filesystem_ajax/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
     url(r"^(?P<uuid>" + settings.UUID_REGEX + ")/download/$", views.download_by_uuid),
     url(r"^(?P<uuid>" + settings.UUID_REGEX + ")/preview/$", views.preview_by_uuid),
     url(r"^contents/arrange/$", views.arrange_contents, name="contents_arrange"),
-    url(r"^contents/$", views.contents),
+    url(r"^contents/$", views.contents, name="contents"),
     url(
         r"^children/location/(?P<location_uuid>" + settings.UUID_REGEX + ")/$",
         views.directory_children_proxy_to_storage_server,

--- a/src/dashboard/tests/test_filesystem_ajax.py
+++ b/src/dashboard/tests/test_filesystem_ajax.py
@@ -606,3 +606,23 @@ def test_download_by_uuid(mocker, local_path_exists, preview):
         mock_stream_file_from_ss.assert_called_once_with(
             TEST_SS_URL, "Storage service returned {}; check logs?", preview
         )
+
+
+def test_contents_sorting(db, tmp_path, admin_client):
+    (tmp_path / "1").mkdir()
+    (tmp_path / "e").mkdir()
+    (tmp_path / "a").mkdir()
+    (tmp_path / "0").mkdir()
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    response = admin_client.get(
+        reverse("filesystem_ajax:contents"), {"path": str(tmp_path)}
+    )
+    content = json.loads(response.content.decode("utf8"))
+
+    assert [child["name"] for child in content["children"]] == [
+        b64encode_string("0"),
+        b64encode_string("1"),
+        b64encode_string("a"),
+        b64encode_string("e"),
+    ]


### PR DESCRIPTION
This makes the `keynat` helper (used to calculate natural keys for
sorting directory contents) to always return strings which avoids
comparing strings and numbers.

Connected to https://github.com/archivematica/Issues/issues/1317