### PR TITLE
Fix paths decoding of the start transfer endpoint

### DIFF
--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -32,7 +32,7 @@ urlpatterns = [
         views.status,
         {"unit_type": "unitTransfer"},
     ),
-    url(r"transfer/start_transfer/", views.start_transfer_api),
+    url(r"transfer/start_transfer/", views.start_transfer_api, name="start_transfer"),
     url(r"transfer/reingest", views.reingest, {"target": "transfer"}),
     url(
         r"ingest/status/(?P<unit_uuid>" + settings.UUID_REGEX + ")",

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -371,7 +371,7 @@ def start_transfer_api(request):
     # Note that the path may contain arbitrary, non-unicode characters,
     # and hence is POSTed to the server base64-encoded
     paths = request.POST.getlist("paths[]", [])
-    paths = [base64.b64decode(path) for path in paths]
+    paths = [base64.b64decode(path).decode("utf8") for path in paths]
     row_ids = request.POST.getlist("row_ids[]", [""])
     try:
         response = filesystem_ajax_views.start_transfer(

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -1011,7 +1011,7 @@ def _copy_from_transfer_sources(paths, relative_destination):
         # below. This allows transfers to be started on UTF-8-encoded directory
         # names.
         source = path.replace(
-            files[location]["location"]["path"].encode("utf8"), "", 1
+            six.ensure_str(files[location]["location"]["path"]), "", 1
         ).lstrip("/")
         # Use the last segment of the path for the destination - basename for a
         # file, or the last folder if not. Keep the trailing / for folders.
@@ -1021,7 +1021,7 @@ def _copy_from_transfer_sources(paths, relative_destination):
             else os.path.basename(source)
         )
         destination = os.path.join(
-            processing_location["path"].encode("utf8"),
+            six.ensure_str(processing_location["path"]),
             relative_destination,
             last_segment,
         ).replace("%sharedPath%", "")

--- a/src/dashboard/tests/test_api.py
+++ b/src/dashboard/tests/test_api.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import base64
 import datetime
 import json
 import os
@@ -603,3 +604,25 @@ def test_copy_metadata_files_api(mocker):
         "message": "Metadata files added successfully.",
         "error": None,
     }
+
+
+def test_start_transfer_api_decodes_paths(mocker, admin_client):
+    start_transfer_view = mocker.patch(
+        "components.filesystem_ajax.views.start_transfer",
+        return_value={},
+    )
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+    admin_client.post(
+        reverse("api:start_transfer"),
+        {
+            "name": "my transfer",
+            "type": "zipfile",
+            "accession": "my accession",
+            "access_system_id": "system id",
+            "paths[]": [base64.b64encode(b"/a/path")],
+            "row_ids[]": ["row1"],
+        },
+    )
+    start_transfer_view.assert_called_once_with(
+        "my transfer", "zipfile", "my accession", "system id", ["/a/path"], ["row1"]
+    )


### PR DESCRIPTION
This decodes paths as strings before they're passed to the
`filesystem_ajax.views.start_transfer` function so it doesn't fail in
Python 3.

It also decodes the paths of the transfer source and processing
locations retrieved from the storage service.

Connected to https://github.com/archivematica/Issues/issues/1317