### PR TITLE
Add support for Content Security Policy headers

### DIFF
--- a/requirements-dev-py3.txt
+++ b/requirements-dev-py3.txt
@@ -24,12 +24,13 @@ django-auth-ldap==1.3.0   # via -r requirements-py3.txt
 django-autoslug==1.9.3    # via -r requirements-py3.txt
 django-braces==1.0.0      # via -r requirements-py3.txt
 django-cas-ng==3.6.0      # via -r requirements-py3.txt
+django-csp==3.7.0         # via -r requirements-py3.txt
 django-extensions==1.7.9  # via -r requirements-py3.txt
 django-forms-bootstrap==3.1.0  # via -r requirements-py3.txt
 django-prometheus==1.0.15  # via -r requirements-py3.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r requirements-py3.txt
 django-tastypie==0.13.2   # via -r requirements-py3.txt
-django==1.11.29           # via -r requirements-py3.txt, django-auth-ldap, django-cas-ng, mozilla-django-oidc
+django==1.11.29           # via -r requirements-py3.txt, django-auth-ldap, django-cas-ng, django-csp, mozilla-django-oidc
 elasticsearch==6.8.2      # via -r requirements-py3.txt
 filelock==3.0.12          # via tox, virtualenv
 funcparserlib==0.3.6      # via mockldap

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,12 +28,13 @@ django-auth-ldap==1.3.0   # via -r requirements.txt
 django-autoslug==1.9.3    # via -r requirements.txt
 django-braces==1.0.0      # via -r requirements.txt
 django-cas-ng==3.6.0      # via -r requirements.txt
+django-csp==3.7.0         # via -r requirements.txt
 django-extensions==1.7.9  # via -r requirements.txt
 django-forms-bootstrap==3.1.0  # via -r requirements.txt
 django-prometheus==1.0.15  # via -r requirements.txt
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r requirements.txt
 django-tastypie==0.13.2   # via -r requirements.txt
-django==1.11.29           # via -r requirements.txt, django-auth-ldap, django-cas-ng, mozilla-django-oidc
+django==1.11.29           # via -r requirements.txt, django-auth-ldap, django-cas-ng, django-csp, mozilla-django-oidc
 elasticsearch==6.8.2      # via -r requirements.txt
 enum34==1.1.6 ; python_version < "3.4"  # via -r requirements.txt, cryptography
 filelock==3.0.12          # via tox, virtualenv

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -19,12 +19,13 @@ django-auth-ldap==1.3.0   # via -r requirements.in
 django-autoslug==1.9.3    # via -r requirements.in
 django-braces==1.0.0      # via -r requirements.in
 django-cas-ng==3.6.0      # via -r requirements.in
+django-csp==3.7.0         # via -r requirements.in
 django-extensions==1.7.9  # via -r requirements.in
 django-forms-bootstrap==3.1.0  # via -r requirements.in
 django-prometheus==1.0.15  # via -r requirements.in
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r requirements.in
 django-tastypie==0.13.2   # via -r requirements.in
-django==1.11.29           # via -r requirements.in, django-auth-ldap, django-cas-ng, mozilla-django-oidc
+django==1.11.29           # via -r requirements.in, django-auth-ldap, django-cas-ng, django-csp, mozilla-django-oidc
 elasticsearch==6.8.2      # via -r requirements.in
 future==0.18.2            # via metsrw
 gearman3==0.2.1 ; python_version >= "3"  # via -r requirements.in

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,7 @@ clamd==1.0.2
 contextdecorator==0.10.0; python_version < "3.2"
 django-autoslug==1.9.3  # used by fpr
 django-braces==1.0.0
+django-csp==3.7.0
 django-extensions==1.7.9
 django-forms-bootstrap>=3.0.0,<4.0.0
 django-prometheus==1.0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,12 +20,13 @@ django-auth-ldap==1.3.0   # via -r requirements.in
 django-autoslug==1.9.3    # via -r requirements.in
 django-braces==1.0.0      # via -r requirements.in
 django-cas-ng==3.6.0      # via -r requirements.in
+django-csp==3.7.0         # via -r requirements.in
 django-extensions==1.7.9  # via -r requirements.in
 django-forms-bootstrap==3.1.0  # via -r requirements.in
 django-prometheus==1.0.15  # via -r requirements.in
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser  # via -r requirements.in
 django-tastypie==0.13.2   # via -r requirements.in
-django==1.11.29           # via -r requirements.in, django-auth-ldap, django-cas-ng, mozilla-django-oidc
+django==1.11.29           # via -r requirements.in, django-auth-ldap, django-cas-ng, django-csp, mozilla-django-oidc
 elasticsearch==6.8.2      # via -r requirements.in
 enum34==1.1.6 ; python_version < "3.4"  # via -r requirements.in, cryptography
 functools32==3.2.3.post2  # via jsonschema

--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -12,6 +12,8 @@
     - [Gunicorn variables](#gunicorn-variables)
     - [LDAP variables](#ldap-variables)
     - [CAS variables](#cas-variables)
+    - [OIDC variables](#oidc-variables)
+    - [CSP variables](#csp-variables)
   - [Logging configuration](#logging-configuration)
 
 ## Introduction
@@ -84,10 +86,6 @@ location for this file is `/etc/nginx/sites-available/dashboard.conf`.
 - [`archivematica-dashboard.service`](./archivematica-dashboard.service) -
   systemd config sample.  The default location for this file is
   `/etc/systemd/system/archivematica-dashboard.service`.
-
-- [`archivematica-dashboard.conf`](./archivematica-dashboard.conf) - upstart
-   config sample, for use on Ubuntu 14.04 where systemd is not available. The
-   default location for this file is /etc/init/archivematica-dashboard.conf.
 
 These are fairly basic example files, that can be extended or customised to
 meet local needs.  Depending on the method used to install your Archivematica
@@ -236,6 +234,12 @@ variables or in the gunicorn configuration file.
     - **Type:** `integer`
     - **Default:** `10`
 
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_CSP_ENABLED`**:
+    - **Description:** **Experimental** support for [Control Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) headers.
+    - **Config file example:** `Dashboard.csp_enabled`
+    - **Type:** `boolean`
+    - **Default:** `False`
+
 - **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_PROMETHEUS_ENABLED`**:
     - **Description:** Determines if Prometheus metrics should be collected.
     - **Config file example:** `Dashboard.prometheus_enabled`
@@ -296,85 +300,85 @@ variables or in the gunicorn configuration file.
     - **Type:** `float`
     - **Default:** `0`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_BACKEND`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_BACKEND`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.backend`
     - **Type:** `string`
     - **Default:** `django.core.mail.backends.console.EmailBackend`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_HOST`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_HOST`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.host`
     - **Type:** `string`
     - **Default:** `smtp.gmail.com`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_HOST_USER`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_HOST_USER`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.host_user`
     - **Type:** `string`
     - **Default:** `your_email@example.com`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_HOST_PASSWORD`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_HOST_PASSWORD`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.host_password`
     - **Type:** `string`
     - **Default:** `None`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_PORT`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_PORT`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.port`
     - **Type:** `integer`
     - **Default:** `587`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_SSL_CERTFILE`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_SSL_CERTFILE`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.ssl_certfile`
     - **Type:** `string`
     - **Default:** `None`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_SSL_KEYFILE`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_SSL_KEYFILE`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.ssl_keyfile`
     - **Type:** `string`
     - **Default:** `None`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_USE_SSL`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_USE_SSL`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.use_ssl`
     - **Type:** `boolean`
     - **Default:** `False`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_USE_TLS`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_USE_TLS`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.use_tls`
     - **Type:** `boolean`
     - **Default:** `True`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_FILE_PATH`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_FILE_PATH`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.file_path`
     - **Type:** `string`
     - **Default:** `None`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_DEFAULT_FROM_EMAIL`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_DEFAULT_FROM_EMAIL`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.default_from_email`
     - **Type:** `string`
     - **Default:** `webmaster@example.com`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_SUBJECT_PREFIX`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_SUBJECT_PREFIX`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.subject_prefix`
     - **Type:** `string`
     - **Default:** `[Archivematica]`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_TIMEOUT`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_TIMEOUT`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details.
     - **Config file example:** `email.timeout`
     - **Type:** `integer`
     - **Default:** `300`
 
-- ** `ARCHIVEMATICA_DASHBOARD_EMAIL_SERVER_EMAIL`**:
+- **`ARCHIVEMATICA_DASHBOARD_EMAIL_SERVER_EMAIL`**:
     - **Description:** an email setting. See [Sending email](https://docs.djangoproject.com/en/1.8/topics/email/) for more details. When the value is `None`, Archivematica uses the value in `EMAIL_HOST_USER`.
     - **Config file example:** `email.server_email`
     - **Type:** `string`
@@ -667,6 +671,17 @@ These variables specify the behaviour of OpenID Connect (OIDC) authentication. O
     - **Description:** Algorithm used by the ID provider to sign ID tokens
     - **Type:** `string`
     - **Default:** `HS256`
+
+### CSP variables
+
+**CSP support is experimental, please share your feedback!**
+
+These variables specify the behaviour of the Content Security Policy (CSP) headers. Only applicable if `ARCHIVEMATICA_DASHBOARD_DASHBOARD_CSP_ENABLED` is set.
+
+- **`CSP_SETTINGS_FILE`**:
+    - **Description:** Path to a Python module with overrides of the [`django-csp` policy settings](https://django-csp.readthedocs.io/en/latest/configuration.html#policy-settings). An `ImproperlyConfigured` exception will be raised if the Python module cannot be imported.
+    - **Type:** `string`
+    - **Default:** ``
 
 ## Logging configuration
 

--- a/src/dashboard/src/settings/components/csp.py
+++ b/src/dashboard/src/settings/components/csp.py
@@ -1,0 +1,11 @@
+CSP_DEFAULT_SRC = ["'none'"]
+CSP_SCRIPT_SRC = ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
+CSP_STYLE_SRC = ["'self'", "'unsafe-inline'"]
+CSP_IMG_SRC = ["'self'", "data:"]
+CSP_FONT_SRC = ["'self'", "data:"]
+
+# for preview file pane in the appraisal tab
+CSP_FRAME_SRC = ["'self'"]
+
+# for /status
+CSP_CONNECT_SRC = ["'self'"]


### PR DESCRIPTION
This adds a new `ARCHIVEMATICA_DASHBOARD_DASHBOARD_CSP_ENABLED` Django
setting that enables control of content security policy headers
through the django-csp package.

A small set of header policies are loaded from the
`settings.components.csp` module, but users can provide their own
overrides though a Python module set in the `CSP_SETTINGS_FILE` Django
setting.

Connected to https://github.com/archivematica/Issues/issues/1311