### PR TITLE
Add rebuild_transfer_backlog and related fixes

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -821,6 +821,8 @@ def _index_transfer_files(
                 bulk_extractor_reports = _list_bulk_extractor_reports(path, file_uuid)
                 if f.modificationtime is not None:
                     modification_date = f.modificationtime.strftime("%Y-%m-%d")
+                else:
+                    modification_date = ""
             except File.DoesNotExist:
                 file_uuid, modification_date = "", ""
                 formats = []

--- a/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
+++ b/src/dashboard/src/main/management/commands/rebuild_transfer_backlog.py
@@ -132,7 +132,7 @@ class Command(DashboardCommand):
             "-d",
             "--delete",
             action="store_true",
-            help="Delete AIP-related Elasticsearch data before" " indexing AIP data",
+            help="Delete AIP-related Elasticsearch data before indexing AIP data",
         )
 
     def handle(self, *args, **options):
@@ -162,7 +162,9 @@ class Command(DashboardCommand):
             self.info('Rebuilding "transfers" index from packages in Storage Service.')
         else:
             if not os.path.exists(transfer_backlog_dir):
-                raise CommandError("Directory does not exist: %s", transfer_backlog_dir)
+                raise CommandError(
+                    "Directory does not exist: %s" % transfer_backlog_dir
+                )
             self.info(
                 'Rebuilding "transfers" index from {}.'.format(transfer_backlog_dir)
             )


### PR DESCRIPTION
- Add the following options to rebuild_transfer_backlog:
    --delete-all: to delete entire index (do not delete it by default)
    --uuid: to only index a specific transfer
    --skip-to: start indexing from a specific transfer
    ---delete: before re-reindexing a transfer, will delete any data found in Elasticsearch with a matching UUID

-   Add missing  modification_date assignment in elasticSearchFunctions._index_transfer_files() to prevent "local variable referenced before assignment" exception

Connected to https://github.com/archivematica/Issues/issues/1457 and https://github.com/archivematica/Issues/issues/1458