### PR TITLE
Tweak purge command arguments

### DIFF
--- a/src/dashboard/src/main/tests/test_command_purge_transient_processing_data.py
+++ b/src/dashboard/src/main/tests/test_command_purge_transient_processing_data.py
@@ -1,8 +1,8 @@
-from datetime import timedelta
 import uuid
 
 from django.core.management import call_command
 from django.utils import timezone
+from django.utils.dateparse import parse_duration
 import pytest
 
 import elasticSearchFunctions as es
@@ -19,26 +19,44 @@ def search_enabled(settings):
     settings.SEARCH_ENABLED = [es.TRANSFERS_INDEX, es.AIPS_INDEX]
 
 
+@pytest.fixture()
+def old_transfer(transfer):
+    transfer.completed_at = timezone.now() - parse_duration("0 00:12:00")
+    transfer.save()
+
+    return transfer
+
+
+@pytest.fixture()
+def old_sip(sip):
+    sip.completed_at = timezone.now() - parse_duration("0 00:12:00")
+    sip.save()
+
+    return sip
+
+
 @pytest.mark.django_db
-def test_purge_command_removes_package_with_unknown_status(search_disabled, transfer):
-    models.Transfer.objects.filter(pk=transfer.pk).update(
+def test_purge_command_removes_package_with_unknown_status(
+    search_disabled, old_transfer
+):
+    models.Transfer.objects.filter(pk=old_transfer.pk).update(
         status=models.PACKAGE_STATUS_UNKNOWN
     )
 
     call_command("purge_transient_processing_data", "--purge-unknown")
 
-    assert models.Transfer.objects.filter(pk=transfer.pk).count() == 0
+    assert models.Transfer.objects.filter(pk=old_transfer.pk).count() == 0
 
 
 @pytest.mark.django_db
-def test_purge_command_keeps_package_with_failed_status(search_disabled, transfer):
-    models.Transfer.objects.filter(pk=transfer.pk).update(
+def test_purge_command_keeps_package_with_failed_status(search_disabled, old_transfer):
+    models.Transfer.objects.filter(pk=old_transfer.pk).update(
         status=models.PACKAGE_STATUS_FAILED
     )
 
     call_command("purge_transient_processing_data", "--keep-failed")
 
-    assert models.Transfer.objects.filter(pk=transfer.pk).count() == 1
+    assert models.Transfer.objects.filter(pk=old_transfer.pk).count() == 1
 
 
 @pytest.mark.django_db
@@ -49,18 +67,26 @@ def test_purge_command_skips_recent_packages(search_disabled, transfer):
 
 
 @pytest.mark.django_db
-def test_purge_command_removes_package_matching_age_criteria(search_disabled, transfer):
-    models.Transfer.objects.filter(pk=transfer.pk).update(
-        completed_at=timezone.now() - timedelta(1)
-    )
-
+def test_purge_command_removes_package_matching_age_criteria(
+    search_disabled, old_transfer
+):
     call_command("purge_transient_processing_data", "--age", "0 00:06:00")
 
-    assert models.Transfer.objects.filter(pk=transfer.pk).count() == 0
+    assert models.Transfer.objects.filter(pk=old_transfer.pk).count() == 0
 
 
 @pytest.mark.django_db
-def test_purge_command_removes_search_documents(search_enabled, transfer, mocker):
+def test_purge_command_removes_all_packages(
+    search_disabled, transfer, old_transfer, sip, old_sip
+):
+    call_command("purge_transient_processing_data", "--age", "0")
+
+    assert models.Transfer.objects.all().count() == 0
+    assert models.SIP.objects.all().count() == 0
+
+
+@pytest.mark.django_db
+def test_purge_command_removes_search_documents(search_enabled, old_transfer, mocker):
     mocker.patch(
         "main.management.commands.purge_transient_processing_data.es.create_indexes_if_needed"
     )
@@ -73,14 +99,36 @@ def test_purge_command_removes_search_documents(search_enabled, transfer, mocker
 
     call_command("purge_transient_processing_data")
 
-    mock_remove_backlog_transfer.assert_called_once_with(mocker.ANY, str(transfer.pk))
+    mock_remove_backlog_transfer.assert_called_once_with(
+        mocker.ANY, str(old_transfer.pk)
+    )
     mock_remove_backlog_transfer_files.assert_called_once_with(
-        mocker.ANY, str(transfer.pk)
+        mocker.ANY, str(old_transfer.pk)
     )
 
 
 @pytest.mark.django_db
-def test_purge_command_skips_active_packages(search_disabled, transfer, sip, capsys):
+def test_purge_command_keeps_search_documents(search_enabled, old_transfer, mocker):
+    mocker.patch(
+        "main.management.commands.purge_transient_processing_data.es.create_indexes_if_needed"
+    )
+    mock_remove_backlog_transfer = mocker.patch(
+        "main.management.commands.purge_transient_processing_data.es.remove_backlog_transfer"
+    )
+    mock_remove_backlog_transfer_files = mocker.patch(
+        "main.management.commands.purge_transient_processing_data.es.remove_backlog_transfer_files"
+    )
+
+    call_command("purge_transient_processing_data", "--keep-searches")
+
+    mock_remove_backlog_transfer.assert_not_called()
+    mock_remove_backlog_transfer_files.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_purge_command_skips_active_packages(
+    search_disabled, old_transfer, old_sip, capsys
+):
     models.Transfer.objects.create(
         uuid=uuid.uuid4(),
         currentlocation=r"%transferDirectory%",
@@ -95,9 +143,9 @@ def test_purge_command_skips_active_packages(search_disabled, transfer, sip, cap
 
 
 @pytest.mark.django_db
-def test_purge_command_output(search_disabled, transfer, sip, capsys):
+def test_purge_command_output(search_disabled, old_transfer, old_sip, capsys):
     call_command("purge_transient_processing_data")
     captured = capsys.readouterr()
 
-    assert "Transfer %s with status Done" % transfer.pk in captured.out
-    assert "SIP %s with status Done" % sip.pk in captured.out
+    assert "Transfer %s with status Done" % old_transfer.pk in captured.out
+    assert "SIP %s with status Done" % old_sip.pk in captured.out


### PR DESCRIPTION
This commit adds a new ``--keep-searches`` optional argument and a new
default for ``--age`` of six hours ("0 00:06:00"). Only when ``--age=0`` is set all
done packages will be removed.

Connects to https://github.com/archivematica/Issues/issues/1239.