### PR TITLE
Fix default duration in purge command

### DIFF
--- a/src/dashboard/src/main/management/commands/purge_transient_processing_data.py
+++ b/src/dashboard/src/main/management/commands/purge_transient_processing_data.py
@@ -19,11 +19,11 @@ An optional parameter ``--keep-searches`` may be passed to retain search
 documents.
 
 By default, this command only purges packages of a certain age. It uses
-``--age='0 00:06:00'``, meaning that no packages will be removed if they have
+``--age='0 06:00:00'``, meaning that no packages will be removed if they have
 not completed processing more than six hours ago. Optionally, users can pass
 other values.
 
-``/manage.py purge_transient_processing_data --age='0 00:12:00'`` purges
+``/manage.py purge_transient_processing_data --age='0 12:00:00'`` purges
 packages that completed processing at least twelve hours ago.
 
 ``/manage.py purge_transient_processing_data --age=0`` can be used to target
@@ -81,13 +81,13 @@ class Command(DashboardCommand):
         )
         parser.add_argument(
             "--age",
-            default="0 00:06:00",
+            default="0 06:00:00",
             help=(
                 "Only purge packages of a certain age (completion date). "
                 "Supported formats are: "
                 '"%%d %%H:%%M:%%S.%%f" or ISO 8601 durations. '
                 'E.g. express "36 hours" as "1 12:00:00" or "P1DT12H". '
-                'Default value is "0 00:06:00", i.e. "6 hours".'
+                'Default value is "0 06:00:00", i.e. "6 hours".'
             ),
         )
 

--- a/src/dashboard/src/main/tests/test_command_purge_transient_processing_data.py
+++ b/src/dashboard/src/main/tests/test_command_purge_transient_processing_data.py
@@ -21,7 +21,7 @@ def search_enabled(settings):
 
 @pytest.fixture()
 def old_transfer(transfer):
-    transfer.completed_at = timezone.now() - parse_duration("0 00:12:00")
+    transfer.completed_at = timezone.now() - parse_duration("0 12:00:00")
     transfer.save()
 
     return transfer
@@ -29,7 +29,7 @@ def old_transfer(transfer):
 
 @pytest.fixture()
 def old_sip(sip):
-    sip.completed_at = timezone.now() - parse_duration("0 00:12:00")
+    sip.completed_at = timezone.now() - parse_duration("0 12:00:00")
     sip.save()
 
     return sip
@@ -61,7 +61,7 @@ def test_purge_command_keeps_package_with_failed_status(search_disabled, old_tra
 
 @pytest.mark.django_db
 def test_purge_command_skips_recent_packages(search_disabled, transfer):
-    call_command("purge_transient_processing_data", "--age", "0 00:06:00")
+    call_command("purge_transient_processing_data", "--age", "0 06:00:00")
 
     assert models.Transfer.objects.filter(pk=transfer.pk).count() == 1
 
@@ -70,7 +70,7 @@ def test_purge_command_skips_recent_packages(search_disabled, transfer):
 def test_purge_command_removes_package_matching_age_criteria(
     search_disabled, old_transfer
 ):
-    call_command("purge_transient_processing_data", "--age", "0 00:06:00")
+    call_command("purge_transient_processing_data", "--age", "0 06:00:00")
 
     assert models.Transfer.objects.filter(pk=old_transfer.pk).count() == 0
 


### PR DESCRIPTION
This fixes the default duration of the purge command and set it to 6 hours.

Connected to https://github.com/archivematica/Issues/issues/1239