### PR TITLE
Restructure DIP for CONTENTdm fix: switched file to text from binary mode

### DIFF
--- a/src/MCPClient/lib/clientScripts/restructure_dip_for_content_dm_upload.py
+++ b/src/MCPClient/lib/clientScripts/restructure_dip_for_content_dm_upload.py
@@ -163,7 +163,7 @@ def generate_project_client_package(
     job.pyprint("Path to the output tabfile", csv_path)
 
     divs_with_dmdsecs = structmap.findall(".//mets:div[@DMDID]", namespaces=ns.NSMAP)
-    with open(csv_path, "wb") as csv_file:
+    with open(csv_path, "w") as csv_file:
         writer = csv.writer(csv_file, delimiter="\t")
 
         # Iterate through every div and create a row for each

--- a/src/MCPClient/tests/test_restructure_dip_for_content_dm_upload.py
+++ b/src/MCPClient/tests/test_restructure_dip_for_content_dm_upload.py
@@ -1,0 +1,57 @@
+# -*- coding: utf8
+from __future__ import unicode_literals
+
+import os
+import shutil
+
+import pytest
+
+from job import Job
+
+import restructure_dip_for_content_dm_upload
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture
+def job():
+    return Job("stub", "stub", [])
+
+
+@pytest.fixture
+def dip_directory(tmpdir):
+    shutil.copy(
+        os.path.join(THIS_DIR, "fixtures", "mets_sip_dc.xml"),
+        str(tmpdir / "METS.a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3.xml"),
+    )
+    (tmpdir / "objects").mkdir()
+
+    return tmpdir
+
+
+def test_restructure_dip_for_content_dm_upload(job, dip_directory):
+    job.args = (
+        None,
+        "--uuid=a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3",
+        "--dipDir={}".format(dip_directory),
+    )
+    jobs = [job]
+
+    restructure_dip_for_content_dm_upload.call(jobs)
+    csv_data = (
+        (dip_directory / "objects/compound.txt")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    )
+
+    assert not job.error
+    assert job.get_exit_code() == 0
+    assert (
+        csv_data[0]
+        == "Directory name	title	creator	subject	description	publisher	contributor	date	type	format	identifier	source	relation	language	rights	isPartOf	AIP UUID	file UUID"
+    )
+    assert (
+        csv_data[1]
+        == "objects	Yamani Weapons	Keladry of Mindelan	Glaives	Glaives are cool	Tortall Press	Yuki	2014	Archival Information Package	parchement	42/1; a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3	Numair's library	None	en	Public Domain	AIC#43	a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3	"
+    )

--- a/src/MCPClient/tests/test_upload_qubit.py
+++ b/src/MCPClient/tests/test_upload_qubit.py
@@ -60,7 +60,6 @@ def test_start_synchronously(db, mocker, mcp_job, sip, job, access):
         ),
     )
 
-    mcp_job = mocker.Mock()
     opts = mocker.Mock(
         uuid=sip.uuid,
         rsync_target=False,
@@ -73,6 +72,7 @@ def test_start_synchronously(db, mocker, mcp_job, sip, job, access):
     )
 
     assert upload_qubit.start(mcp_job, opts) == 0
+    assert mcp_job.get_exit_code() == 0
 
     access = models.Access.objects.get(sipuuid=sip.uuid)
     assert access.statuscode == 14
@@ -91,7 +91,6 @@ def test_first_run(db, mocker, mcp_job, job, transfer, sip):
         ),
     )
 
-    mcp_job = mocker.Mock()
     opts = mocker.Mock(
         uuid=sip.uuid,
         rsync_target=False,
@@ -104,6 +103,7 @@ def test_first_run(db, mocker, mcp_job, job, transfer, sip):
     )
 
     assert upload_qubit.start(mcp_job, opts) == 0
+    assert mcp_job.get_exit_code() == 0
 
     access = models.Access.objects.get(sipuuid=sip.uuid)
     assert access.statuscode == 14


### PR DESCRIPTION
CONTENTdm upload stopped working in the switch to python 3, just small thing where the csv file was being written in binary mode and caused the process to fail. Fix by changing to text mode.

Connected to https://github.com/archivematica/Issues/issues/1479