### PR TITLE
Move DIP from uploadDIP to uploadedDIPs

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -3630,8 +3630,8 @@
       "config": {
         "@manager": "linkTaskManagerDirectories",
         "@model": "StandardTaskConfig",
-        "arguments": "\"%SIPDirectory%\" \"%watchDirectoryPath%uploadedDIPs/.\" -R",
-        "execute": "copy_v0.0",
+        "arguments": "\"%SIPDirectory%\" \"%watchDirectoryPath%uploadedDIPs/\"",
+        "execute": "move_v0.0",
         "filter_file_end": null,
         "filter_file_start": null,
         "filter_subdir": null,


### PR DESCRIPTION
Connected to https://github.com/archivematica/Issues/issues/1488

This commit modifies the workflow to move DIPs from the `uploadDIP` to `uploadedDIPs` watched directories instead of copying. This change fixes an issue where an MCPServer restart was causing Archivematica to attempt a duplicate DIP upload.