### PR TITLE
Remove message attribute from exceptions

### DIFF
--- a/src/MCPClient/lib/fork_runner.py
+++ b/src/MCPClient/lib/fork_runner.py
@@ -151,7 +151,7 @@ if __name__ == "__main__":
             six.moves.cPickle.dump(
                 {
                     "uncaught_exception": {
-                        "message": e.message,
+                        "message": str(e),
                         "type": type(e).__name__,
                         "traceback": traceback.format_exc(),
                     }

--- a/src/dashboard/src/components/archival_storage/forms.py
+++ b/src/dashboard/src/components/archival_storage/forms.py
@@ -50,14 +50,15 @@ class UploadMetadataOnlyAtomForm(forms.Form):
                 _("Connection establishment failed: AtoM server cannot be reached.")
             )
         except CommunicationError as e:
-            if "404" in e.message:
+            message = str(e)
+            if "404" in message:
                 raise forms.ValidationError(
                     _("Description with slug %(slug)s not found!"),
                     code="notfound",
                     params={"slug": slug},
                 )
             raise forms.ValidationError(
-                _("Unknown error: %(error)s"), code="error", params={"error": e.message}
+                _("Unknown error: %(error)s"), code="error", params={"error": message}
             )
         return slug
 


### PR DESCRIPTION
The `message` attribute was [deprecated in Python 2.6 and dropped in Python 3](https://www.python.org/dev/peps/pep-0352/).

Connects to https://github.com/archivematica/Issues/issues/1500.