### PR TITLE
Support XML metadata files and modify DMD sections

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -9,6 +9,7 @@ jobs:
     name: "Test ${{ matrix.tag }} on ${{ matrix.browser }}"
     runs-on: "ubuntu-18.04"
     strategy:
+      fail-fast: false
       matrix:
         tag:
           - "aip-encrypt"
@@ -17,6 +18,7 @@ jobs:
           - "icc"
           - "ipc preservation"
           - "ipc access"
+          - "metadata-xml"
           - "mo-aip-reingest"
           - "tcc"
           - "tpc"
@@ -26,10 +28,6 @@ jobs:
           - "Chrome"
         exclude:
           - tag: "black-box"
-            browser: Firefox
-          - tag: "ipc preservation"
-            browser: Firefox
-          - tag: "ipc access"
             browser: Firefox
     steps:
       - name: "Check out repository"

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -141,6 +141,8 @@ services:
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_BACKEND: "clamdscanner" # Option: clamdscanner or clamscan;
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_PROMETHEUS_BIND_PORT: "7999"
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_PROMETHEUS_BIND_ADDRESS: "0.0.0.0"
+      ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_METADATA_XML_VALIDATION_ENABLED: "true"
+      METADATA_XML_VALIDATION_SETTINGS_FILE: "/src/hack/submodules/archivematica-sampledata/xml-validation/xml_validation.py"
     volumes:
       - "../:/src"
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -104,7 +104,7 @@ idna==3.2
     #   -r requirements.txt
     #   requests
     #   yarl
-importlib-metadata==4.6.1
+importlib-metadata==4.8.3
     # via
     #   -r requirements.txt
     #   backports.entry-points-selectable
@@ -134,7 +134,7 @@ lxml==4.6.3
     #   ammcpc
     #   metsrw
     #   python-cas
-metsrw==0.3.20
+metsrw==0.3.21
     # via -r requirements.txt
 mock==4.0.3
     # via -r requirements-dev.in

--- a/requirements.in
+++ b/requirements.in
@@ -17,12 +17,13 @@ elasticsearch>=6.0.0,<7.0.0
 gearman3==0.2.1
 gevent==1.3.6  # used by gunicorn's async workers
 gunicorn==19.9.0
+importlib-metadata==4.8.3
 inotify_simple==1.1.8
 jsonschema==2.6.0
 lazy-paged-sequence
 logutils==0.3.3
 lxml~=4.6
-metsrw==0.3.20
+metsrw==0.3.21
 mysqlclient==1.4.6
 ndg-httpsclient
 opf-fido==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,8 +70,9 @@ gunicorn==19.9.0
     # via -r requirements.in
 idna==3.2
     # via requests
-importlib-metadata==4.6.1
+importlib-metadata==4.8.3
     # via
+    #   -r requirements.in
     #   click
     #   pep517
 inotify_simple==1.1.8
@@ -90,7 +91,7 @@ lxml==4.6.3
     #   ammcpc
     #   metsrw
     #   python-cas
-metsrw==0.3.20
+metsrw==0.3.21
     # via -r requirements.in
 mozilla-django-oidc==1.2.4
     # via -r requirements.in

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSMetadataXML.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSMetadataXML.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+#
+# This file is part of Archivematica.
+#
+# Copyright 2010-2021 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica. If not, see <http://www.gnu.org/licenses/>.
+
+"""Management of XML metadata files."""
+
+import csv
+from lxml import etree
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import urlopen
+import requests
+
+from importlib_metadata import version
+import create_mets_v2 as createmets2
+
+from databaseFunctions import insertIntoEvents
+import namespaces as ns
+
+from main import models
+
+
+def process_xml_metadata(mets, sip_dir, sip_uuid, sip_type, xml_validation):
+    if not xml_validation:
+        return mets, []
+    xml_metadata_mapping, xml_metadata_errors = _get_xml_metadata_mapping(
+        sip_dir, reingest="REIN" in sip_type
+    )
+    if not xml_metadata_mapping:
+        return mets, xml_metadata_errors
+    for fsentry in mets.all_files():
+        if fsentry.use != "original" and fsentry.type != "Directory":
+            continue
+        path = fsentry.get_path()
+        if path not in xml_metadata_mapping:
+            continue
+        for xml_type, xml_path in xml_metadata_mapping[path].items():
+            if not xml_path:
+                fsentry.delete_dmdsec("OTHER", xml_type)
+                continue
+            tree = etree.parse(str(xml_path))
+            try:
+                schema_uri = _get_schema_uri(tree, xml_validation)
+            except ValueError as err:
+                xml_metadata_errors.append(err)
+                continue
+            if schema_uri:
+                xml_rel_path = xml_path.relative_to(sip_dir)
+                try:
+                    metadata_file = models.File.objects.get(
+                        sip_id=sip_uuid,
+                        currentlocation="%SIPDirectory%{}".format(xml_rel_path),
+                    )
+                except models.File.DoesNotExist:
+                    xml_metadata_errors.append(
+                        "No uuid for file: {}".format(xml_rel_path)
+                    )
+                    continue
+                valid, errors = _validate_xml(tree, schema_uri)
+                _add_validation_event(
+                    mets, metadata_file.uuid, schema_uri, valid, errors
+                )
+                if not valid:
+                    xml_metadata_errors += errors
+                    continue
+            fsentry.add_dmdsec(
+                tree.getroot(),
+                "OTHER",
+                othermdtype=xml_type,
+                status="update" if "REIN" in sip_type else "original",
+            )
+    return mets, xml_metadata_errors
+
+
+def _get_xml_metadata_mapping(sip_path, reingest=False):
+    """Get a mapping of files/dirs in the SIP and their related XML files.
+
+    On initial ingests, it looks for such mapping in source-metadata.csv
+    files located on each transfer metadata folder. On reingest it only
+    considers the source-metadata.csv file in the main metadata folder.
+
+    Example source-metadata.csv:
+
+    filename,metadata,type
+    objects,objects_metadata.xml,metadata_type
+    objects/dir,dir_metadata.xml,metadata_type
+    objects/dir/file.pdf,file_metadata_a.xml,metadata_type_a
+    objects/dir/file.pdf,file_metadata_b.xml,metadata_type_b
+
+    Example dict returned:
+
+    {
+        "objects": {"metadata_type": Path("/path/to/objects_metadata.xml")},
+        "objects/dir": {"metadata_type": Path("/path/to/dir_metadata.xml")},
+        "objects/dir/file.pdf": {
+            "metadata_type_a": Path("/path/to/file_metadata_a.xml"),
+            "metadata_type_b": Path("/path/to/file_metadata_b.xml"),
+        },
+    }
+
+    :param str sip_path: Absolute path to the SIP.
+    :param bool reingest: Boolean to indicate if it's a reingest.
+    :return dict, list: Dictionary with File/dir path -> dict of type -> metadata
+    file pathlib Path, and list with errors (if a CSV row is missing the filename
+    or type, or if there is more than one entry for the same filename and type).
+    """
+    mapping = {}
+    errors = []
+    source_metadata_paths = []
+    metadata_path = Path(sip_path) / "objects" / "metadata"
+    transfers_metadata_path = metadata_path / "transfers"
+    if reingest:
+        source_metadata_paths.append(metadata_path / "source-metadata.csv")
+    elif transfers_metadata_path.is_dir():
+        for dir_ in transfers_metadata_path.iterdir():
+            source_metadata_paths.append(dir_ / "source-metadata.csv")
+    for source_metadata_path in source_metadata_paths:
+        if not source_metadata_path.is_file():
+            continue
+        with source_metadata_path.open() as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                if not all(k in row and row[k] for k in ["filename", "type"]):
+                    errors.append(
+                        "A row in {} is missing the filename and/or type".format(
+                            source_metadata_path
+                        )
+                    )
+                    continue
+                if row["type"] == "CUSTOM":
+                    errors.append(
+                        "A row in {} is using CUSTOM, a reserved type".format(
+                            source_metadata_path
+                        )
+                    )
+                    continue
+                if row["filename"] not in mapping:
+                    mapping[row["filename"]] = {}
+                elif row["type"] in mapping[row["filename"]]:
+                    errors.append(
+                        "More than one entry in {} for path {} and type {}".format(
+                            source_metadata_path, row["filename"], row["type"]
+                        )
+                    )
+                    continue
+                if row["metadata"]:
+                    row["metadata"] = source_metadata_path.parent / row["metadata"]
+                mapping[row["filename"]][row["type"]] = row["metadata"]
+    return mapping, errors
+
+
+def _get_schema_uri(tree, xml_validation):
+    key = None
+    checked_keys = []
+    schema_location = tree.xpath(
+        "/*/@xsi:noNamespaceSchemaLocation", namespaces={"xsi": ns.xsiNS}
+    )
+    if schema_location:
+        key = schema_location[0].strip()
+        checked_keys.append(key)
+    if not key or key not in xml_validation:
+        schema_location = tree.xpath(
+            "/*/@xsi:schemaLocation", namespaces={"xsi": ns.xsiNS}
+        )
+        if schema_location:
+            key = schema_location[0].strip().split()[-1]
+            checked_keys.append(key)
+    if not key or key not in xml_validation:
+        key = tree.xpath("namespace-uri(.)")
+        checked_keys.append(key)
+    if not key or key not in xml_validation:
+        key = tree.xpath("local-name(.)")
+        checked_keys.append(key)
+    if not key or key not in xml_validation:
+        raise ValueError(
+            "XML validation schema not found for keys: {}".format(checked_keys)
+        )
+    return xml_validation[key]
+
+
+class Resolver(etree.Resolver):
+    def resolve(self, url, id, context):
+        url_scheme = urlparse(url).scheme
+        if url_scheme in ("http", "https"):
+            try:
+                response = requests.get(url)
+            except requests.RequestException:
+                return super().resolve(url, id, context)
+            else:
+                return self.resolve_string(response.text, context)
+        else:
+            return super().resolve(url, id, context)
+
+
+def _validate_xml(tree, schema_uri):
+    schema_type = schema_uri.split(".")[-1]
+    parse_result = urlparse(schema_uri)
+    if not parse_result.scheme and schema_uri == parse_result.path:
+        # URI is a local file
+        try:
+            schema_uri = Path(schema_uri).as_uri()
+        except ValueError:
+            return False, [
+                "XML schema local path {} must be absolute".format(schema_uri)
+            ]
+    try:
+        with urlopen(schema_uri) as f:
+            if schema_type == "dtd":
+                schema = etree.DTD(f)
+            elif schema_type == "xsd":
+                schema_contents = etree.parse(f)
+                try:
+                    schema = etree.XMLSchema(schema_contents)
+                except etree.XMLSchemaParseError:
+                    # Try parsing the schema again with a custom resolver
+                    parser = etree.XMLParser()
+                    resolver = Resolver()
+                    parser.resolvers.add(resolver)
+                    with urlopen(schema_uri) as f2:
+                        schema_contents = etree.parse(f2, parser)
+                    schema = etree.XMLSchema(schema_contents)
+            elif schema_type == "rng":
+                schema_contents = etree.parse(f)
+                schema = etree.RelaxNG(schema_contents)
+            else:
+                return False, [
+                    "Unknown XML validation schema type: {}".format(schema_type)
+                ]
+    except etree.LxmlError as err:
+        return False, ["Could not parse schema file: {}".format(schema_uri), err]
+    if not schema.validate(tree):
+        return False, schema.error_log
+    return True, []
+
+
+def _add_validation_event(mets, file_uuid, schema_uri, valid, errors):
+    event_detail = {
+        "type": "metadata",
+        "validation-source-type": schema_uri.split(".")[-1],
+        "validation-source": schema_uri,
+        "program": "lxml",
+        "version": version("lxml"),
+    }
+    event_data = {
+        "eventType": "validation",
+        "eventDetail": "; ".join([f'{k}="{v}"' for k, v in event_detail.items()]),
+        "eventOutcome": "pass" if valid else "fail",
+        "eventOutcomeDetailNote": "\n".join([str(err) for err in errors]),
+    }
+    event_object = insertIntoEvents(file_uuid, **event_data)
+    metadata_fsentry = mets.get_file(file_uuid=file_uuid)
+    metadata_fsentry.add_premis_event(createmets2.createEvent(event_object))

--- a/src/MCPClient/lib/clientScripts/archivematicaCreateMETSTrim.py
+++ b/src/MCPClient/lib/clientScripts/archivematicaCreateMETSTrim.py
@@ -22,6 +22,7 @@
 # @author Joseph Perry <joseph@artefactual.com>
 # @version svn: $Id$
 
+from datetime import datetime
 import os
 import sys
 import lxml.etree as etree
@@ -34,7 +35,11 @@ import namespaces as ns
 
 def getTrimDmdSec(job, baseDirectoryPath, sipUUID):
     # containerMetadata
-    ret = etree.Element(ns.metsBNS + "dmdSec")
+    ret = etree.Element(
+        ns.metsBNS + "dmdSec",
+        STATUS="original",
+        CREATED=datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+    )
     mdWrap = etree.SubElement(ret, ns.metsBNS + "mdWrap")
     mdWrap.set("MDTYPE", "DC")
     xmlData = etree.SubElement(mdWrap, ns.metsBNS + "xmlData")
@@ -106,7 +111,11 @@ def getTrimDmdSec(job, baseDirectoryPath, sipUUID):
 
 
 def getTrimFileDmdSec(job, baseDirectoryPath, sipUUID, fileUUID):
-    ret = etree.Element(ns.metsBNS + "dmdSec")
+    ret = etree.Element(
+        ns.metsBNS + "dmdSec",
+        STATUS="original",
+        CREATED=datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+    )
     mdWrap = etree.SubElement(ret, ns.metsBNS + "mdWrap")
     mdWrap.set("MDTYPE", "DC")
     xmlData = etree.SubElement(mdWrap, ns.metsBNS + "xmlData")

--- a/src/MCPClient/lib/clientScripts/create_aic_mets.py
+++ b/src/MCPClient/lib/clientScripts/create_aic_mets.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+from datetime import datetime
 from lxml import etree
 from lxml.builder import ElementMaker
 import os
@@ -25,7 +26,7 @@ import storageService as storage_service
 
 
 def get_aip_info(aic_dir, job):
-    """ Get AIP UUID, name and labels from objects directory and METS file. """
+    """Get AIP UUID, name and labels from objects directory and METS file."""
     aips = []
     aic_dir = os.path.join(aic_dir, "objects")
     # Parse out AIP names and UUIDs
@@ -75,7 +76,7 @@ def get_aip_info(aic_dir, job):
 
 
 def create_mets_file(aic, aips, job):
-    """ Create AIC METS file with AIP information. """
+    """Create AIC METS file with AIP information."""
 
     # Prepare constants
     nsmap = {"mets": ns.metsNS, "xlink": ns.xlinkNS, "xsi": ns.xsiNS}
@@ -85,7 +86,12 @@ def create_mets_file(aic, aips, job):
     E = ElementMaker(namespace=ns.metsNS, nsmap=nsmap)
     mets = E.mets(
         E.metsHdr(CREATEDATE=now),
-        E.dmdSec(E.mdWrap(E.xmlData(), MDTYPE="DC"), ID="dmdSec_1"),  # mdWrap  # dmdSec
+        E.dmdSec(
+            E.mdWrap(E.xmlData(), MDTYPE="DC"),
+            ID="dmdSec_1",
+            STATUS="original",
+            CREATED=datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+        ),  # mdWrap  # dmdSec
         E.fileSec(E.fileGrp()),
         E.structMap(
             E.div(TYPE="Archival Information Collection", DMDID="dmdSec_1"),

--- a/src/MCPClient/lib/clientScripts/restructure_dip_for_content_dm_upload.py
+++ b/src/MCPClient/lib/clientScripts/restructure_dip_for_content_dm_upload.py
@@ -114,7 +114,7 @@ def splitDmdSecs(job, dmdSecs):
         return dmdSecPair
     for dmdSec in dmdSecs:
         mdWrap = dmdSec.find("mets:mdWrap", namespaces=ns.NSMAP)
-        if mdWrap.get("MDTYPE") == "OTHER":
+        if mdWrap.get("MDTYPE") == "OTHER" and mdWrap.get("OTHERMDTYPE") == "CUSTOM":
             dmdSecPair["nonDc"] = parseDmdSec(dmdSec)
         if mdWrap.get("MDTYPE") == "DC":
             dmdSecPair["dc"] = parseDmdSec(dmdSec)

--- a/src/MCPClient/tests/fixtures/mets_file_dc_updated.xml
+++ b/src/MCPClient/tests/fixtures/mets_file_dc_updated.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="windows-1252"?>
 <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version18/mets.xsd">
   <mets:metsHdr CREATEDATE="2015-06-24T00:27:29"/>
-  <mets:dmdSec ID="dmdSec_1" STATUS="original">
+  <mets:dmdSec ID="dmdSec_1" STATUS="original-superseded">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
         <dcterms:dublincore xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd">
@@ -11,7 +11,7 @@
       </mets:xmlData>
     </mets:mdWrap>
   </mets:dmdSec>
-  <mets:dmdSec ID="dmdSec_2" STATUS="updated" CREATED="2015-01-01T01:01:01">
+  <mets:dmdSec ID="dmdSec_2" STATUS="update" CREATED="2015-01-01T01:01:01">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
         <dcterms:dublincore xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd">

--- a/src/MCPClient/tests/fixtures/mets_multiple_sip_dc.xml
+++ b/src/MCPClient/tests/fixtures/mets_multiple_sip_dc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="windows-1252"?>
 <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version18/mets.xsd">
   <mets:metsHdr CREATEDATE="2015-06-15T20:10:16"/>
-  <mets:dmdSec ID="dmdSec_1" STATUS="original">
+  <mets:dmdSec ID="dmdSec_1" STATUS="original-superseded">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
         <dcterms:dublincore xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd">
@@ -24,7 +24,7 @@
       </mets:xmlData>
     </mets:mdWrap>
   </mets:dmdSec>
-  <mets:dmdSec ID="dmdSec_2" STATUS="updated" CREATED="2015-06-15T21:12:28">
+  <mets:dmdSec ID="dmdSec_2" STATUS="update" CREATED="2015-06-15T21:12:28">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
         <dcterms:dublincore xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd">

--- a/src/MCPClient/tests/test_archivematicaCreateMETSMetadataXML.py
+++ b/src/MCPClient/tests/test_archivematicaCreateMETSMetadataXML.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python
+"""
+Tests for XML metadata management on the METS creation process:
+
+archivematicaCreateMETSMetadataXML.process_xml_metadata()
+"""
+
+from pathlib import Path
+from uuid import uuid4
+
+from importlib_metadata import version
+from lxml.etree import parse
+import metsrw
+import pytest
+import requests
+
+from main.models import File, SIP
+
+from archivematicaCreateMETSMetadataXML import process_xml_metadata
+
+
+METADATA_DIR = Path("objects") / "metadata"
+TRANSFER_METADATA_DIR = METADATA_DIR / "transfers" / "transfer_a"
+TRANSFER_SOURCE_METADATA_CSV = TRANSFER_METADATA_DIR / "source-metadata.csv"
+VALID_XML = '<?xml version="1.0" encoding="UTF-8"?><foo><bar/></foo>'
+INVALID_XML = '<?xml version="1.0" encoding="UTF-8"?><foo/>'
+SCHEMAS = {
+    "xsd": """<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="bar" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+""",
+    "dtd": """<!ELEMENT foo (bar)>
+<!ELEMENT bar (#PCDATA)>
+""",
+    "rng": """<element name="foo" xmlns="http://relaxng.org/ns/structure/1.0">
+  <oneOrMore>
+    <element name="bar">
+      <text/>
+    </element>
+  </oneOrMore>
+</element>
+""",
+}
+IMPORTED_SCHEMA = """<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://foo.com/1.0" targetNamespace="http://foo.com/1.0">
+</xs:schema>"""
+
+
+@pytest.fixture
+def make_schema_file(tmp_path):
+    def _make_schema_file(schema_type):
+        schema_path = tmp_path / (schema_type + "." + schema_type)
+        schema_path.write_text(SCHEMAS[schema_type])
+        return schema_path
+
+    return _make_schema_file
+
+
+@pytest.fixture
+def sip(db, tmp_path):
+    sip_dir = tmp_path / "sip_dir"
+    transfer_metadata_dir = sip_dir / TRANSFER_METADATA_DIR
+    transfer_metadata_dir.mkdir(parents=True)
+    (transfer_metadata_dir / "valid.xml").write_text(VALID_XML)
+    (transfer_metadata_dir / "invalid.xml").write_text(INVALID_XML)
+    return SIP.objects.create(
+        uuid=uuid4(),
+        sip_type="SIP",
+        currentpath=str(sip_dir),
+    )
+
+
+@pytest.fixture
+def make_metadata_file(db, sip):
+    def _make_metadata_file(rel_path):
+        return File.objects.create(
+            uuid=uuid4(),
+            sip_id=sip.uuid,
+            currentlocation="%SIPDirectory%{}".format(rel_path),
+        )
+
+    return _make_metadata_file
+
+
+@pytest.fixture
+def make_mock_fsentry(mocker):
+    def _make_mock_fsentry(**kwargs):
+        mock_fsentry = metsrw.FSEntry(**kwargs)
+        mock_fsentry.add_dmdsec = mocker.Mock()
+        mock_fsentry.delete_dmdsec = mocker.Mock()
+        mock_fsentry.add_premis_event = mocker.Mock()
+        return mock_fsentry
+
+    return _make_mock_fsentry
+
+
+@pytest.fixture
+def make_mock_mets(mocker, make_mock_fsentry):
+    def _make_mock_mets(metadata_file_uuids=[]):
+        sip = make_mock_fsentry(label="sip", type="Directory")
+        objects = make_mock_fsentry(label="objects", type="Directory")
+        directory = make_mock_fsentry(label="directory", type="Directory")
+        file_txt = make_mock_fsentry(label="file.txt")
+        sip.add_child(objects).add_child(directory).add_child(file_txt)
+        files = [sip, objects, directory, file_txt]
+        for uuid in metadata_file_uuids:
+            files.append(make_mock_fsentry(file_uuid=uuid, use="metadata"))
+        mock_mets = mocker.Mock()
+        mock_mets.all_files.return_value = files
+        mock_mets.get_file.side_effect = lambda **kwargs: next(
+            (
+                f
+                for f in files
+                if all(v == getattr(f, k, None) for k, v in kwargs.items())
+            ),
+            None,
+        )
+        return mock_mets
+
+    return _make_mock_mets
+
+
+@pytest.fixture
+def insert_into_events_mock(mocker):
+    return mocker.patch(
+        "archivematicaCreateMETSMetadataXML.insertIntoEvents",
+        return_value="fake_event",
+    )
+
+
+@pytest.fixture
+def create_event_mock(mocker):
+    return mocker.patch(
+        "archivematicaCreateMETSMetadataXML.createmets2.createEvent",
+        return_value="fake_element",
+    )
+
+
+@pytest.fixture
+def requests_get(mocker):
+    # Return a mock response good enough to be parsed as an XML schema.
+    return mocker.patch(
+        "requests.get",
+        return_value=mocker.Mock(text=IMPORTED_SCHEMA),
+    )
+
+
+@pytest.fixture
+def requests_get_error(mocker):
+    # Simulate an error retrieving an imported schema.
+    return mocker.patch(
+        "requests.get",
+        side_effect=requests.RequestException("error"),
+    )
+
+
+@pytest.fixture
+def etree_parse(mocker):
+    # Mocked etree.parse used in the resolver tests that returns None before the first
+    # XMLSchema call, which triggers an etree.XMLSchemaParseError exception
+    # and forces reparsing the validation schema with a custom etree.Resolver.
+    class mock:
+        def __init__(self, *args, **kwargs):
+            self.call_count = 0
+
+        def __call__(self, *args, **kwargs):
+            self.call_count += 1
+            # Parse is called first with the metadata XML file
+            # and then with the XML validation schema.
+            if self.call_count == 2:
+                return
+            return parse(*args, **kwargs)
+
+    mocker.patch(
+        "archivematicaCreateMETSMetadataXML.etree.parse",
+        mock(),
+    )
+
+
+@pytest.fixture
+def schema_with_remote_import(tmp_path):
+    # Create a schema that imports a remote schema.
+    schema = """<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="http://foo.com/1.0" schemaLocation="http://foo.com/my.xsd" />
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="bar" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+"""
+    schema_path = tmp_path / "schema.xsd"
+    schema_path.write_text(schema)
+    return schema_path
+
+
+@pytest.fixture
+def schema_with_local_import(tmp_path):
+    # Create a schema that imports a local schema.
+    schema = """<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="http://foo.com/1.0" schemaLocation="my.xsd" />
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="bar" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+"""
+    schema_path = tmp_path / "schema.xsd"
+    schema_path.write_text(schema)
+
+    local_schema = tmp_path / "my.xsd"
+    local_schema.write_text(IMPORTED_SCHEMA)
+
+    return schema_path
+
+
+def test_disabled_settings(make_mock_mets):
+    mock_mets = make_mock_mets()
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, "sip_uuid", "sip_path", "sip_type", False
+    )
+    assert not errors
+    mock_mets.all_files.assert_not_called()
+
+
+def test_no_source_metadata_csv(settings, make_mock_mets, sip):
+    settings.METADATA_XML_VALIDATION_ENABLED = True
+    xml_validation = {"foo": None}
+    mock_mets = make_mock_mets()
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    assert not errors
+    mock_mets.all_files.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "xml_file, schema, should_pass",
+    [
+        ("valid.xml", "xsd", True),
+        ("valid.xml", "dtd", True),
+        ("valid.xml", "rng", True),
+        ("invalid.xml", "xsd", False),
+        ("invalid.xml", "dtd", False),
+        ("invalid.xml", "rng", False),
+    ],
+)
+def test_validation(
+    settings,
+    make_metadata_file,
+    make_mock_mets,
+    make_schema_file,
+    sip,
+    mocker,
+    insert_into_events_mock,
+    create_event_mock,
+    xml_file,
+    schema,
+    should_pass,
+):
+    schema_uri = str(make_schema_file(schema))
+    settings.METADATA_XML_VALIDATION_ENABLED = True
+    xml_validation = {"foo": schema_uri}
+    source_metadata_csv_contents = "filename,metadata,type\nobjects,{},mdtype".format(
+        xml_file
+    )
+    metadata_csv_path = sip.currentpath / TRANSFER_SOURCE_METADATA_CSV
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+    metadata_file_rel_path = TRANSFER_METADATA_DIR / xml_file
+    metadata_file = make_metadata_file(metadata_file_rel_path)
+    mock_mets = make_mock_mets([str(metadata_file.uuid)])
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    objects_fsentry = mock_mets.get_file(label="objects")
+    metadata_fsentry = mock_mets.get_file(file_uuid=str(metadata_file.uuid))
+    if should_pass:
+        # Use ANY to avoid comparision with etree.Element, but confirm element tag.
+        objects_fsentry.add_dmdsec.assert_called_once_with(
+            mocker.ANY, "OTHER", othermdtype="mdtype", status="original"
+        )
+        assert objects_fsentry.add_dmdsec.call_args[0][0].tag == "foo"
+    else:
+        objects_fsentry.add_dmdsec.assert_not_called()
+    event_detail = {
+        "type": "metadata",
+        "validation-source-type": schema,
+        "validation-source": schema_uri,
+        "program": "lxml",
+        "version": version("lxml"),
+    }
+    insert_into_events_mock.assert_called_with(
+        str(metadata_file.uuid),
+        **{
+            "eventType": "validation",
+            "eventDetail": "; ".join([f'{k}="{v}"' for k, v in event_detail.items()]),
+            "eventOutcome": "pass" if should_pass else "fail",
+            "eventOutcomeDetailNote": "\n".join([str(err) for err in errors]),
+        },
+    )
+    create_event_mock.assert_called_once_with("fake_event")
+    metadata_fsentry.add_premis_event.assert_called_once_with("fake_element")
+
+
+def test_skipped_validation(settings, make_metadata_file, make_mock_mets, sip, mocker):
+    settings.METADATA_XML_VALIDATION_ENABLED = True
+    xml_validation = {"foo": None}
+    source_metadata_csv_contents = "filename,metadata,type\nobjects,invalid.xml,mdtype"
+    metadata_csv_path = sip.currentpath / TRANSFER_SOURCE_METADATA_CSV
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+    metadata_file_rel_path = TRANSFER_METADATA_DIR / "invalid.xml"
+    metadata_file = make_metadata_file(metadata_file_rel_path)
+    mock_mets = make_mock_mets([str(metadata_file.uuid)])
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    objects_fsentry = mock_mets.get_file(label="objects")
+    metadata_fsentry = mock_mets.get_file(file_uuid=str(metadata_file.uuid))
+    assert not errors
+    # Use ANY to avoid comparision with etree.Element, but confirm element tag.
+    objects_fsentry.add_dmdsec.assert_called_once_with(
+        mocker.ANY, "OTHER", othermdtype="mdtype", status="original"
+    )
+    assert objects_fsentry.add_dmdsec.call_args[0][0].tag == "foo"
+    metadata_fsentry.add_premis_event.assert_not_called()
+
+
+def test_validation_schema_errors(
+    settings, make_metadata_file, make_mock_mets, make_schema_file, sip
+):
+    settings.METADATA_XML_VALIDATION_ENABLED = True
+    xml_validation = {"foo": "bad_path.xsd"}
+    source_metadata_csv_contents = "filename,metadata,type\nobjects,valid.xml,mdtype"
+    metadata_csv_path = sip.currentpath / TRANSFER_SOURCE_METADATA_CSV
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+    metadata_file_rel_path = TRANSFER_METADATA_DIR / "valid.xml"
+    metadata_file = make_metadata_file(metadata_file_rel_path)
+    mock_mets = make_mock_mets([str(metadata_file.uuid)])
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    assert "XML schema local path bad_path.xsd must be absolute" in errors[0]
+    schema_file = make_schema_file("xsd")
+    schema_file.write_text("")
+    xml_validation = {"foo": str(schema_file)}
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    assert "Could not parse schema file" in errors[0]
+    unk_schema_file = schema_file.with_suffix(".unk")
+    unk_schema_file.write_text("")
+    xml_validation = {"foo": str(unk_schema_file)}
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    assert "Unknown XML validation schema type: unk" in errors[0]
+
+
+def test_source_metadata_errors(settings, make_mock_mets, sip):
+    settings.METADATA_XML_VALIDATION_ENABLED = True
+    xml_validation = {"foo": None}
+    mock_mets = make_mock_mets()
+    metadata_csv_path = sip.currentpath / TRANSFER_SOURCE_METADATA_CSV
+    source_metadata_csv_contents = (
+        "filename,metadata,type\n"
+        + "valid.xml,none\n"
+        + ",valid.xml,none\n"
+        + "objects,valid.xml\n"
+        + "objects,valid.xml,"
+    )
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    assert len(errors) == 4
+    for error in errors:
+        assert "missing the filename and/or type" in error
+    source_metadata_csv_contents = "filename,metadata,type\nobjects,valid.xml,CUSTOM"
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    assert "is using CUSTOM, a reserved type" in errors[0]
+    source_metadata_csv_contents = (
+        "filename,metadata,type\n"
+        + "objects,valid.xml,mdtype\n"
+        + "objects,invalid.xml,mdtype"
+    )
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    assert (
+        "More than one entry in {} for path objects and type mdtype".format(
+            metadata_csv_path
+        )
+        in errors[0]
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "validation_key, should_error",
+    [
+        ("http://foo.com/foo_no_namespace_schema.xsd", False),
+        ("http://foo.com/foo_schema.xsd", False),
+        ("http://foo.com/foo_namespace.xsd", False),
+        ("foo", False),
+        ("bar", True),
+    ],
+)
+def test_schema_uri_retrieval(
+    settings,
+    make_metadata_file,
+    make_mock_mets,
+    make_schema_file,
+    sip,
+    validation_key,
+    should_error,
+):
+    schema_path = str(make_schema_file("xsd"))
+    settings.METADATA_XML_VALIDATION_ENABLED = True
+    xml_validation = {validation_key: schema_path}
+    source_metadata_csv_contents = "filename,metadata,type\nobjects,valid.xml,mdtype"
+    metadata_csv_path = sip.currentpath / TRANSFER_SOURCE_METADATA_CSV
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+    metadata_file_contents = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        + '<foo:foo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+        + 'xmlns:foo="http://foo.com/foo_namespace.xsd" '
+        + 'xsi:schemaLocation="http://foo.com/foo http://foo.com/foo_schema.xsd" '
+        + 'xsi:noNamespaceSchemaLocation="http://foo.com/foo_no_namespace_schema.xsd"/>'
+    )
+    metadata_file_rel_path = TRANSFER_METADATA_DIR / "valid.xml"
+    metadata_file = make_metadata_file(metadata_file_rel_path)
+    metadata_file_path = sip.currentpath / metadata_file_rel_path
+    metadata_file_path.write_text(metadata_file_contents)
+    mock_mets = make_mock_mets([str(metadata_file.uuid)])
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    metadata_fsentry = mock_mets.get_file(file_uuid=str(metadata_file.uuid))
+    if should_error:
+        assert "XML validation schema not found for keys:" in str(errors[0])
+        metadata_fsentry.add_premis_event.assert_not_called()
+    else:
+        metadata_fsentry.add_premis_event.assert_called()
+
+
+@pytest.mark.django_db
+def test_multiple_dmdsecs(settings, make_metadata_file, make_mock_mets, sip):
+    mdkeys = ["foo", "foo_2", "foo_3"]
+    settings.METADATA_XML_VALIDATION_ENABLED = True
+    xml_validation = {}
+    csv_contents = "filename,metadata,type\n"
+    metadata_file_uuids = []
+    for mdkey in mdkeys:
+        xml_validation[mdkey] = None
+        csv_contents += "objects,{}.xml,{}\n".format(mdkey, mdkey)
+        csv_contents += "objects/directory,{}.xml,{}\n".format(mdkey, mdkey)
+        csv_contents += "objects/directory/file.txt,{}.xml,{}\n".format(mdkey, mdkey)
+        metadata_file_rel_path = TRANSFER_METADATA_DIR / "{}.xml".format(mdkey)
+        metadata_file = make_metadata_file(metadata_file_rel_path)
+        metadata_file_path = sip.currentpath / metadata_file_rel_path
+        metadata_file_path.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?><{}/>'.format(mdkey)
+        )
+        metadata_file_uuids.append(str(metadata_file.uuid))
+    metadata_csv_path = sip.currentpath / TRANSFER_SOURCE_METADATA_CSV
+    metadata_csv_path.write_text(csv_contents)
+    mock_mets = make_mock_mets(metadata_file_uuids)
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    assert not errors
+    for label in ["objects", "directory", "file.txt"]:
+        fsentry = mock_mets.get_file(label=label)
+        assert fsentry.add_dmdsec.call_count == 3
+
+
+@pytest.mark.django_db
+def test_reingest(
+    settings, make_schema_file, make_metadata_file, make_mock_mets, sip, mocker
+):
+    settings.METADATA_XML_VALIDATION_ENABLED = True
+    xml_validation = {"foo": str(make_schema_file("xsd"))}
+    source_metadata_csv_contents = "filename,metadata,type\nobjects,valid.xml,mdtype"
+    metadata_csv_path = sip.currentpath / METADATA_DIR / "source-metadata.csv"
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+    metadata_file_rel_path = METADATA_DIR / "valid.xml"
+    metadata_file = make_metadata_file(metadata_file_rel_path)
+    (sip.currentpath / metadata_file_rel_path).write_text(VALID_XML)
+    mock_mets = make_mock_mets([str(metadata_file.uuid)])
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "REIN", xml_validation
+    )
+    objects_fsentry = mock_mets.get_file(label="objects")
+    metadata_fsentry = mock_mets.get_file(file_uuid=str(metadata_file.uuid))
+    assert not errors
+    # Use ANY to avoid comparision with etree.Element, but confirm element tag.
+    objects_fsentry.add_dmdsec.assert_called_once_with(
+        mocker.ANY, "OTHER", othermdtype="mdtype", status="update"
+    )
+    assert objects_fsentry.add_dmdsec.call_args[0][0].tag == "foo"
+    metadata_fsentry.add_premis_event.assert_called()
+    source_metadata_csv_contents = "filename,metadata,type\nobjects,,mdtype"
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "REIN", xml_validation
+    )
+    assert not errors
+    objects_fsentry.delete_dmdsec.assert_called_with("OTHER", "mdtype")
+
+
+@pytest.mark.django_db
+def test_resolver(
+    settings,
+    make_metadata_file,
+    make_mock_mets,
+    sip,
+    etree_parse,
+    requests_get,
+    schema_with_remote_import,
+):
+    settings.METADATA_XML_VALIDATION_ENABLED = True
+    xml_validation = {"foo": str(schema_with_remote_import)}
+    source_metadata_csv_contents = "filename,metadata,type\nobjects,valid.xml,mdtype"
+    metadata_csv_path = sip.currentpath / TRANSFER_SOURCE_METADATA_CSV
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+    metadata_file_rel_path = TRANSFER_METADATA_DIR / "valid.xml"
+    metadata_file = make_metadata_file(metadata_file_rel_path)
+    mock_mets = make_mock_mets([str(metadata_file.uuid)])
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    assert not errors
+    requests_get.assert_called_once_with("http://foo.com/my.xsd")
+
+
+@pytest.mark.django_db
+def test_resolver_with_requests_error(
+    settings,
+    make_metadata_file,
+    make_mock_mets,
+    sip,
+    etree_parse,
+    requests_get_error,
+    schema_with_remote_import,
+):
+    settings.METADATA_XML_VALIDATION_ENABLED = True
+    xml_validation = {"foo": str(schema_with_remote_import)}
+    source_metadata_csv_contents = "filename,metadata,type\nobjects,valid.xml,mdtype"
+    metadata_csv_path = sip.currentpath / TRANSFER_SOURCE_METADATA_CSV
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+    metadata_file_rel_path = TRANSFER_METADATA_DIR / "valid.xml"
+    metadata_file = make_metadata_file(metadata_file_rel_path)
+    mock_mets = make_mock_mets([str(metadata_file.uuid)])
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    assert not errors
+
+
+@pytest.mark.django_db
+def test_resolver_with_local_import(
+    settings,
+    make_metadata_file,
+    make_mock_mets,
+    sip,
+    etree_parse,
+    requests_get,
+    schema_with_local_import,
+):
+    settings.METADATA_XML_VALIDATION_ENABLED = True
+    xml_validation = {"foo": str(schema_with_local_import)}
+    source_metadata_csv_contents = "filename,metadata,type\nobjects,valid.xml,mdtype"
+    metadata_csv_path = sip.currentpath / TRANSFER_SOURCE_METADATA_CSV
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+    metadata_file_rel_path = TRANSFER_METADATA_DIR / "valid.xml"
+    metadata_file = make_metadata_file(metadata_file_rel_path)
+    mock_mets = make_mock_mets([str(metadata_file.uuid)])
+    mock_mets, errors = process_xml_metadata(
+        mock_mets, sip.currentpath, sip.uuid, "sip_type", xml_validation
+    )
+    assert not errors
+    requests_get.assert_not_called()

--- a/src/MCPClient/tests/test_reingest_mets.py
+++ b/src/MCPClient/tests/test_reingest_mets.py
@@ -708,17 +708,17 @@ class TestUpdateDublinCore(TestCase):
             root.find('mets:dmdSec[@ID="dmdSec_3"]', namespaces=NSMAP).get("STATUS")
             is None
         )
-        # Verify original SIP-level marked as original
+        # Verify original SIP-level marked as original-superseded
         assert (
             root.find('mets:dmdSec[@ID="dmdSec_4"]', namespaces=NSMAP).attrib["STATUS"]
-            == "original"
+            == "original-superseded"
         )
         # Verify dmdSec created
         dmdsec = root.xpath(
             'mets:dmdSec[not(@ID="dmdSec_1" or @ID="dmdSec_2" or @ID="dmdSec_3" or @ID="dmdSec_4")]',
             namespaces=NSMAP,
         )[0]
-        assert dmdsec.attrib["STATUS"] == "updated"
+        assert dmdsec.attrib["STATUS"] == "update"
         assert dmdsec.attrib["CREATED"]
         # Verify fileSec div updated
         assert (
@@ -787,20 +787,20 @@ class TestUpdateDublinCore(TestCase):
             len(root.findall('mets:dmdSec/mets:mdWrap[@MDTYPE="DC"]', namespaces=NSMAP))
             == 3
         )
-        # Verify existing DC marked as original
+        # Verify existing DC marked as original-superseded
         assert (
             root.find('mets:dmdSec[@ID="dmdSec_1"]', namespaces=NSMAP).get("STATUS")
-            == "original"
+            == "original-superseded"
         )
         assert (
             root.find('mets:dmdSec[@ID="dmdSec_2"]', namespaces=NSMAP).get("STATUS")
-            == "updated"
+            == "update-superseded"
         )
         # Verify dmdSec created
         dmdsec = root.xpath(
             'mets:dmdSec[not(@ID="dmdSec_1" or @ID="dmdSec_2")]', namespaces=NSMAP
         )[0]
-        assert dmdsec.attrib["STATUS"] == "updated"
+        assert dmdsec.attrib["STATUS"] == "update"
         assert dmdsec.attrib["CREATED"]
         # Verify fileSec div updated
         assert (
@@ -873,48 +873,17 @@ class TestUpdateDublinCore(TestCase):
 
         assert (
             len(root.findall('mets:dmdSec/mets:mdWrap[@MDTYPE="DC"]', namespaces=NSMAP))
-            == 3
+            == 2
         )
-        # Verify existing DC marked as original
+        # Verify existing DC marked as original-superseded and deleted
         assert (
             root.find('mets:dmdSec[@ID="dmdSec_1"]', namespaces=NSMAP).get("STATUS")
-            == "original"
+            == "original-superseded"
         )
         assert (
             root.find('mets:dmdSec[@ID="dmdSec_2"]', namespaces=NSMAP).get("STATUS")
-            == "updated"
+            == "deleted"
         )
-        # Verify dmdSec created
-        dmdsec = root.xpath(
-            'mets:dmdSec[not(@ID="dmdSec_1" or @ID="dmdSec_2")]', namespaces=NSMAP
-        )[0]
-        assert dmdsec.attrib["STATUS"] == "updated"
-        assert dmdsec.attrib["CREATED"]
-        # Verify fileSec div updated
-        assert (
-            dmdsec.attrib["ID"]
-            in root.find(
-                'mets:structMap/mets:div[@TYPE="Directory"]/mets:div[@TYPE="Directory"][@LABEL="objects"]',
-                namespaces=NSMAP,
-            ).attrib["DMDID"]
-        )
-        assert (
-            "dmdSec_1"
-            in root.find(
-                'mets:structMap/mets:div[@TYPE="Directory"]/mets:div[@TYPE="Directory"][@LABEL="objects"]',
-                namespaces=NSMAP,
-            ).attrib["DMDID"]
-        )
-        assert (
-            "dmdSec_2"
-            in root.find(
-                'mets:structMap/mets:div[@TYPE="Directory"]/mets:div[@TYPE="Directory"][@LABEL="objects"]',
-                namespaces=NSMAP,
-            ).attrib["DMDID"]
-        )
-        # Verify new DC
-        dc_elem = dmdsec.find(".//dcterms:dublincore", namespaces=NSMAP)
-        assert len(dc_elem) == 0
 
 
 class TestUpdateRights(TestCase):
@@ -1995,7 +1964,7 @@ class TestUpdateMetadataCSV(TestCase):
         dmdsec = root.find("mets:dmdSec", namespaces=NSMAP)
         assert dmdsec.attrib["ID"]
         assert dmdsec.attrib["CREATED"]
-        assert dmdsec.attrib["STATUS"] == "original"
+        assert dmdsec.attrib["STATUS"] == "update"
         assert dmdsec.findtext(".//dc:title", namespaces=NSMAP) == "Mountain Tents"
         assert (
             dmdsec.findtext(".//dc:description", namespaces=NSMAP)
@@ -2044,7 +2013,7 @@ class TestUpdateMetadataCSV(TestCase):
         root = mets.serialize()
         assert len(root.findall("mets:dmdSec", namespaces=NSMAP)) == 2
         orig = root.find('mets:dmdSec[@ID="dmdSec_1"]', namespaces=NSMAP)
-        assert orig.attrib["STATUS"] == "original"
+        assert orig.attrib["STATUS"] == "original-superseded"
         div = root.xpath('.//mets:div[contains(@DMDID,"dmdSec_1")]', namespaces=NSMAP)[
             0
         ]
@@ -2052,7 +2021,7 @@ class TestUpdateMetadataCSV(TestCase):
         dmdid = div.attrib["DMDID"].split()[1]
         new = root.find('mets:dmdSec[@ID="' + dmdid + '"]', namespaces=NSMAP)
         assert new.attrib["CREATED"]
-        assert new.attrib["STATUS"] == "updated"
+        assert new.attrib["STATUS"] == "update"
         assert new.findtext(".//dc:title", namespaces=NSMAP) == "Mountain Tents"
         assert (
             new.findtext(".//dc:description", namespaces=NSMAP) == "Tents on a mountain"
@@ -2079,9 +2048,9 @@ class TestUpdateMetadataCSV(TestCase):
         root = mets.serialize()
         assert len(root.findall("mets:dmdSec", namespaces=NSMAP)) == 3
         orig = root.find('mets:dmdSec[@ID="dmdSec_1"]', namespaces=NSMAP)
-        assert orig.attrib["STATUS"] == "original"
+        assert orig.attrib["STATUS"] == "original-superseded"
         updated = root.find('mets:dmdSec[@ID="dmdSec_2"]', namespaces=NSMAP)
-        assert updated.attrib["STATUS"] == "updated"
+        assert updated.attrib["STATUS"] == "update-superseded"
         div = root.xpath('.//mets:div[contains(@DMDID,"dmdSec_1")]', namespaces=NSMAP)[
             0
         ]
@@ -2089,7 +2058,7 @@ class TestUpdateMetadataCSV(TestCase):
         dmdid = div.attrib["DMDID"].split()[2]
         new = root.find('mets:dmdSec[@ID="' + dmdid + '"]', namespaces=NSMAP)
         assert new.attrib["CREATED"]
-        assert new.attrib["STATUS"] == "updated"
+        assert new.attrib["STATUS"] == "update"
         assert new.findtext(".//dc:title", namespaces=NSMAP) == "Mountain Tents"
         assert (
             new.findtext(".//dc:description", namespaces=NSMAP) == "Tents on a mountain"

--- a/src/archivematicaCommon/lib/databaseFunctions.py
+++ b/src/archivematicaCommon/lib/databaseFunctions.py
@@ -183,6 +183,7 @@ def insertIntoEvents(
         eventOutcomeDetailNote element in the AIP METS.
     :param list agents: List of Agent IDs to associate with this. If None
         provided, automatically fetches Agents representing Archivematica.
+    :returns Event: The created event object.
     """
     if eventDateTime is None:
         eventDateTime = getUTCDate()
@@ -204,6 +205,7 @@ def insertIntoEvents(
     )
     # Splat agents list into multiple arguments
     event.agents.add(*agents)
+    return event
 
 
 def insertIntoDerivations(sourceFileUUID, derivedFileUUID, relatedEventUUID=None):

--- a/src/archivematicaCommon/tests/test_elasticsearch_functions.py
+++ b/src/archivematicaCommon/tests/test_elasticsearch_functions.py
@@ -467,7 +467,20 @@ def test_get_directories_with_metadata(physical_struct_map):
 
 
 METS = """<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <mets:dmdSec ID="dmdSec_1">
+  <mets:dmdSec ID="dmdSec_1" CREATED="2022-02-18T18:44:33" STATUS="original">
+    <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+      <mets:xmlData>
+        <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:intellectualEntity" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+          <premis:objectIdentifier>
+            <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>6cebefad-2b19-4874-b014-094ec35a85aa</premis:objectIdentifierValue>
+          </premis:objectIdentifier>
+          <premis:originalName>pics_2-6cebefad-2b19-4874-b014-094ec35a85aa</premis:originalName>
+        </premis:object>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="dmdSec_2" CREATED="2022-02-18T18:44:33" STATUS="original">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
         <dcterms:dublincore xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xsi:schemaLocation="http://purl.org/dc/terms/ https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd">
@@ -480,12 +493,48 @@ METS = """<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xsi="http://www
       </mets:xmlData>
     </mets:mdWrap>
   </mets:dmdSec>
-  <mets:dmdSec ID="dmdSec_2">
+  <mets:dmdSec ID="dmdSec_3" CREATED="2022-02-18T18:44:33" STATUS="original-superseded" GROUPID="5329fa70-214e-43a8-8974-958bbfc19c4c">
     <mets:mdWrap MDTYPE="OTHER" OTHERMDTYPE="CUSTOM">
       <mets:xmlData>
         <custom_field>custom field part 1</custom_field>
         <custom_field>custom field part 2</custom_field>
         <custom_field2>custom field 2</custom_field2>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="dmdSec_4" CREATED="2022-02-18T18:44:33" STATUS="deleted">
+    <mets:mdWrap MDTYPE="OTHER" OTHERMDTYPE="">
+      <mets:xmlData>
+        <record>
+          <idfield>deleted</idfield>
+        </record>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="dmdSec_5" CREATED="2022-02-19T18:44:33" STATUS="update" GROUPID="5329fa70-214e-43a8-8974-958bbfc19c4c">
+    <mets:mdWrap MDTYPE="OTHER" OTHERMDTYPE="CUSTOM">
+      <mets:xmlData>
+        <custom_field>updated custom field part 1</custom_field>
+        <custom_field>updated custom field part 2</custom_field>
+        <custom_field2>updated custom field 2</custom_field2>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="dmdSec_6" CREATED="2022-02-19T18:44:33" STATUS="update">
+    <mets:mdWrap MDTYPE="OTHER" OTHERMDTYPE="">
+      <mets:xmlData>
+        <record>
+          <idfield>idfield</idfield>
+          <controlfield>controlfield 1</controlfield>
+          <controlfield>controlfield 2</controlfield>
+          <datafield>
+            <subfield>subfield 1</subfield>
+            <subfield>subfield 2</subfield>
+          </datafield>
+          <datafield>
+            <subfield>subfield 3</subfield>
+          </datafield>
+        </record>
       </mets:xmlData>
     </mets:mdWrap>
   </mets:dmdSec>
@@ -516,7 +565,7 @@ def mets():
 def directory():
     result = etree.Element("directory")
     result.set("LABEL", "some/path/to/directory")
-    result.set("DMDID", "dmdSec_1 dmdSec_2")
+    result.set("DMDID", "dmdSec_1 dmdSec_2 dmdSec_3 dmdSec_4 dmdSec_5 dmdSec_6")
     result.set("ADMID", "amdSec_1")
     return result
 
@@ -524,54 +573,72 @@ def directory():
 @pytest.fixture
 def directory_with_no_metadata():
     result = etree.Element("directory")
-    result.set("DMDID", "dmdSec_3")
     return result
-
-
-def test_get_directory_metadata(mets, directory, directory_with_no_metadata):
-    result = elasticSearchFunctions._get_directory_metadata(
-        directory_with_no_metadata, mets
-    )
-    assert result == {}
-    result = elasticSearchFunctions._get_directory_metadata(directory, mets)
-    # all fields are combined into a single dictionary
-    assert result == {
-        "__DIRECTORY_LABEL__": "some/path/to/directory",
-        "FIELD_CONTACT_NAME": ["A.", "R.", "Chivist"],
-        "Payload-Oxum": "63140.2",
-        "custom_field": ["custom field part 1", "custom field part 2"],
-        "custom_field2": "custom field 2",
-        "dc:creator": "AM",
-        "dc:subject": [None, None, None],
-        "dc:title": "Some title",
-    }
 
 
 @pytest.fixture
 def file_pointer():
     result = etree.Element("file")
-    result.set("DMDID", "dmdSec_1 dmdSec_2")
+    result.set("DMDID", "dmdSec_1 dmdSec_2 dmdSec_3 dmdSec_4 dmdSec_5 dmdSec_6")
     return result
 
 
 @pytest.fixture
 def file_pointer_with_no_metadata():
     result = etree.Element("file")
-    result.set("DMDID", "dmdSec_3")
     return result
 
 
-def test_get_file_metadata(mets, file_pointer, file_pointer_with_no_metadata):
-    result = elasticSearchFunctions._get_file_metadata(
-        file_pointer_with_no_metadata, mets
+expected_file_metadata = {
+    "custom_field": ["updated custom field part 1", "updated custom field part 2"],
+    "custom_field2": "updated custom field 2",
+    "dc:creator": "AM",
+    "dc:subject": [None, None, None],
+    "dc:title": "Some title",
+    "record_dict": {
+        "idfield": "idfield",
+        "controlfield": [
+            "controlfield 1",
+            "controlfield 2",
+        ],
+        "datafield_dict": [
+            {
+                "subfield": [
+                    "subfield 1",
+                    "subfield 2",
+                ]
+            },
+            {
+                "subfield": "subfield 3",
+            },
+        ],
+    },
+}
+
+
+expected_directory_metadata = {
+    "__DIRECTORY_LABEL__": "some/path/to/directory",
+    "FIELD_CONTACT_NAME": ["A.", "R.", "Chivist"],
+    "Payload-Oxum": "63140.2",
+    **expected_file_metadata,
+}
+
+
+@pytest.mark.parametrize(
+    "element_fixture_name, method_name, expected_metadata",
+    [
+        ("directory", "_get_directory_metadata", expected_directory_metadata),
+        ("directory_with_no_metadata", "_get_directory_metadata", {}),
+        ("file_pointer", "_get_file_metadata", expected_file_metadata),
+        ("file_pointer_with_no_metadata", "_get_file_metadata", {}),
+    ],
+)
+def test_get_metadata(
+    request, mets, element_fixture_name, method_name, expected_metadata
+):
+    assert (
+        getattr(elasticSearchFunctions, method_name)(
+            request.getfixturevalue(element_fixture_name), mets
+        )
+        == expected_metadata
     )
-    assert result == {}
-    result = elasticSearchFunctions._get_file_metadata(file_pointer, mets)
-    # all fields are combined into a single dictionary
-    assert result == {
-        "custom_field": ["custom field part 1", "custom field part 2"],
-        "custom_field2": "custom field 2",
-        "dc:creator": "AM",
-        "dc:subject": [None, None, None],
-        "dc:title": "Some title",
-    }


### PR DESCRIPTION
Add support for XML metadata files including configurable validation
and addition to the METS file as DMD sections on ingest and re-ingest.
Modify DMD sections management to improve versioning and indexing.

Refs https://github.com/archivematica/Issues/issues/1531 and https://github.com/archivematica/Issues/issues/1537.