### PR TITLE
Fix Archival Storage date range search

### DIFF
--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -306,6 +306,11 @@ def search(request):
 
     if "query" not in request.GET:
         queries, ops, fields, types = (["*"], ["or"], [""], ["term"])
+    # Use "indexedAt" field in aipfiles index for date range queries.
+    # This works for AIPs as well because of how AIP UUIDs are collected by
+    # first searching the aipfiles index.
+    if types[0] == "range":
+        fields = ["indexedAt"]
     query = advanced_search.assemble_query(queries, ops, fields, types)
     file_mode = request.GET.get("file_mode") == "true"
 

--- a/src/dashboard/src/components/tests/test_advanced_search.py
+++ b/src/dashboard/src/components/tests/test_advanced_search.py
@@ -1,0 +1,26 @@
+import pytest
+
+from components.advanced_search import _normalize_date
+
+
+@pytest.mark.parametrize(
+    "date_input,end_date,expected_timestamp,raises_value_error",
+    [
+        # Test properly formatted input for start date.
+        ("2021-10-01", False, 1633046400, False),
+        ("2021-10-01", None, 1633046400, False),
+        # Test properly formatted input for end date. This should be the Unix
+        # timestamp for the following day.
+        ("2021-10-01", True, 1633132800, False),
+        # Test improperly formatted inputs.
+        ("Dec 1 1999", False, None, True),
+        ("2021-10-01T01:14:36Z", False, None, True),
+        ("not a date", False, None, True),
+    ],
+)
+def test_filesizeformat(date_input, end_date, expected_timestamp, raises_value_error):
+    if raises_value_error:
+        with pytest.raises(ValueError):
+            _normalize_date(date_input, end_date=end_date)
+    else:
+        assert _normalize_date(date_input, end_date=end_date) == expected_timestamp


### PR DESCRIPTION
Connected to https://github.com/archivematica/issues/issues/1302

This PR fixes an issue with the Archival Storage tab search where searches on date range were not returning any results because Elasticsearch was throwing an exception when given a range query without a field specified.

In order to fix the issue, `YYYY-MM-DD` input strings are converted into Unix timestamps and then compared against the `aipfiles` index's `indexedAt` field. This is only an approximation of the AIP creation date but close enough for searches at the level of days, and allows us to fix the defect without needing to introduce any additional fields to the `aips` index.

In order to make date range searches inclusive, a day is added to end dates before converting them to Unix timestamps, and `lt` (less than) is used for end dates in the Elasticsearch DSL query rather than `lte` (less than or equal to). In practice this means a Date range search input of "2021-10-01:2021-10:11" will be converted to the following DSL query:

```
{"range": {"indexedAt": {"gte": <Unix timestamp for 2021-10-01T00:00:00>, "lt": <Unix timestamp for 2021-10-12T00:00:00>}}}
```