### PR TITLE
Fix the copy_metadata_files view for partial reingests

### DIFF
--- a/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
+++ b/src/MCPClient/lib/clientScripts/parse_mets_to_db.py
@@ -551,6 +551,9 @@ def main(job, sip_uuid, sip_path):
 
     parse_rights(job, sip_uuid, root)
 
+    if sip.count():
+        sip.first().unset_partial_reingest()
+
 
 def call(jobs):
     parser = argparse.ArgumentParser()

--- a/src/MCPServer/lib/server/mcp.py
+++ b/src/MCPServer/lib/server/mcp.py
@@ -56,16 +56,17 @@ def watched_dir_handler(package_queue, path, watched_dir):
 
     package = None
     package_type = watched_dir["unit_type"]
+    watched_dir_path = watched_dir["path"]
     is_dir = os.path.isdir(path)
 
     if package_type == "SIP" and is_dir:
-        package = SIP.get_or_create_from_db_by_path(path)
+        package = SIP.get_or_create_from_db_by_path(path, watched_dir_path)
     elif package_type == "DIP" and is_dir:
-        package = DIP.get_or_create_from_db_by_path(path)
+        package = DIP.get_or_create_from_db_by_path(path, watched_dir_path)
     elif package_type == "Transfer" and is_dir:
-        package = Transfer.get_or_create_from_db_by_path(path)
+        package = Transfer.get_or_create_from_db_by_path(path, watched_dir_path)
     elif package_type == "Transfer" and not is_dir:
-        package = Transfer.get_or_create_from_db_by_path(path)
+        package = Transfer.get_or_create_from_db_by_path(path, watched_dir_path)
     else:
         raise ValueError("Unexpected unit type given for file {}".format(path))
 

--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -744,7 +744,7 @@ class SIPDIP(Package):
 
     @classmethod
     @auto_close_old_connections()
-    def get_or_create_from_db_by_path(cls, path):
+    def get_or_create_from_db_by_path(cls, path, watched_dir_path=None):
         """Matches a directory to a database SIP by its appended UUID, or path."""
         path = path.replace(_get_setting("SHARED_DIRECTORY"), r"%sharedPath%", 1)
         package_type = cls.UNIT_VARIABLE_TYPE
@@ -775,6 +775,10 @@ class SIPDIP(Package):
                     sip_type=package_type,
                     diruuids=False,
                 )
+        if package_type == "SIP" and watched_dir_path == "/system/reingestAIP/":
+            # SIP package is a partial (objects or metadata-only) reingest.
+            # Full reingests use a different workflow chain.
+            sip_obj.set_partial_reingest()
         logger.info(
             "%s %s %s (%s)",
             package_type,
@@ -819,7 +823,7 @@ class Transfer(Package):
 
     @classmethod
     @auto_close_old_connections()
-    def get_or_create_from_db_by_path(cls, path):
+    def get_or_create_from_db_by_path(cls, path, watched_dir_path=None):
         """Matches a directory to a database Transfer by its appended UUID, or path."""
         path = path.replace(_get_setting("SHARED_DIRECTORY"), r"%sharedPath%", 1)
 

--- a/src/dashboard/src/components/filesystem_ajax/urls.py
+++ b/src/dashboard/src/components/filesystem_ajax/urls.py
@@ -45,5 +45,7 @@ urlpatterns = [
         views.copy_from_arrange_to_completed,
         name="copy_from_arrange",
     ),
-    url(r"^copy_metadata_files/$", views.copy_metadata_files),
+    url(
+        r"^copy_metadata_files/$", views.copy_metadata_files, name="copy_metadata_files"
+    ),
 ]

--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -960,10 +960,10 @@ def copy_metadata_files(request):
 
     paths = [b64decode_string(p) for p in paths]
     sip = models.SIP.objects.get(uuid=sip_uuid)
-    relative_path = sip.currentpath.replace("%sharedPath%", "", 1)
-    relative_path = os.path.join(relative_path, "metadata")
+    sip_path = sip.currentpath.replace("%sharedPath%", "", 1)
+    metadata_directory_path = os.path.join(sip_path, sip.get_metadata_directory_path())
 
-    error, message = _copy_from_transfer_sources(paths, relative_path)
+    error, message = _copy_from_transfer_sources(paths, metadata_directory_path)
 
     if not error:
         message = _("Metadata files added successfully.")

--- a/src/dashboard/tests/test_filesystem_ajax.py
+++ b/src/dashboard/tests/test_filesystem_ajax.py
@@ -511,7 +511,7 @@ class TestSIPArrange(TestCase):
 
 
 @pytest.mark.django_db
-def test_copy_metadata_files(mocker):
+def test_copy_metadata_files(mocker, rf):
     # Mock helper that actually copies files from the transfer source locations
     _copy_from_transfer_sources_mock = mocker.patch(
         "components.filesystem_ajax.views._copy_from_transfer_sources",
@@ -526,11 +526,12 @@ def test_copy_metadata_files(mocker):
     )
 
     # Call the view with a mocked request
-    request = mocker.Mock(
-        **{
-            "POST.get.return_value": sip_uuid,
-            "POST.getlist.return_value": [b64encode_string("locationuuid:/some/path")],
-        }
+    request = rf.post(
+        reverse("filesystem_ajax:copy_metadata_files"),
+        {
+            "sip_uuid": sip_uuid,
+            "source_paths[]": [b64encode_string("locationuuid:/some/path")],
+        },
     )
     result = views.copy_metadata_files(request)
 


### PR DESCRIPTION
When the `copy_metadata_files` view is called on a partial (objects or metadata-only) reingest which is waiting for approval (i.e. before the `Restructure from bag AIP to SIP directory format` job is executed) the SIP structure still looks like a bag causing the view to create an extra `metadata` directory in the wrong location. This affects the associated API endpoint and the `Add metadata files` view of the dashboard UI.

This fixes it by adding a `isPartialReingest` unit variable that is set when the MCPServer creates the SIP package and checking it when the `copy_metadata_files` view is called. The unit variable is later removed once the reingest structucture has been normalized and the reingested METS has been parsed to repopulate the database.

Connected to https://github.com/archivematica/Issues/issues/959