### PR TITLE
Consider directory actions in file explorer

### DIFF
--- a/src/dashboard/src/media/css/directory_picker.css
+++ b/src/dashboard/src/media/css/directory_picker.css
@@ -54,15 +54,19 @@
   background-image: none;
 }
 
-/* Layout of directory items using CSS Grid */
+/* Entry layout using CSS Grid */
 
-.backbone-file-explorer-directory {
+.backbone-file-explorer-entry {
   display: -ms-grid;
   display: grid;
-  -ms-grid-columns: 30px 1fr;
-  grid-template-columns: 30px 1fr;
+  -ms-grid-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr auto;
 }
 
-.backbone-file-explorer-directory > span {
+.backbone-file-explorer-entry > span {
   height: 100%;
+}
+
+.backbone-file-explorer-directory_entry_actions {
+  padding-left: 5px;
 }


### PR DESCRIPTION
Use grid layout for all entries in the file explorer and give auto space
to the directory icon and the directory actions. Add left padding to the
actions to match icon padding.

![Screenshot from 2022-01-11 14-05-29](https://user-images.githubusercontent.com/637040/148947812-0449244a-0968-43ca-9eb5-5706cb8c62ca.png)

Still considering long directory names and now also file names:

![Screenshot from 2022-01-11 14-00-47](https://user-images.githubusercontent.com/637040/148947934-2f92074d-e81e-4ea1-9e51-8d1cc124ebee.png)

Refs https://github.com/archivematica/Issues/issues/1518