### PR TITLE
Simplify dict normalization for ES indexing

### DIFF
--- a/src/archivematicaCommon/tests/test_elasticsearch_functions.py
+++ b/src/archivematicaCommon/tests/test_elasticsearch_functions.py
@@ -104,8 +104,8 @@ class TestElasticSearchFunctions(unittest.TestCase):
             for item in actions:
                 try:
                     dmd_section = item["_source"]["METS"]["dmdSec"]
-                    metadata_container = dmd_section["mets:xmlData_dict_list"][0]
-                    dc = metadata_container["dcterms:dublincore_dict_list"][0]
+                    metadata_container = dmd_section["mets:xmlData_dict"]
+                    dc = metadata_container["dcterms:dublincore_dict"]
                 except (KeyError, IndexError):
                     dc = None
                 indexed_data[item["_source"]["filePath"]] = dc
@@ -390,8 +390,8 @@ def test_index_aipfile_dmdsec(
         for item in actions:
             try:
                 dmd_section = item["_source"]["METS"]["dmdSec"]
-                metadata_container = dmd_section["mets:xmlData_dict_list"][0]
-                dc = metadata_container["dcterms:dublincore_dict_list"][0]
+                metadata_container = dmd_section["mets:xmlData_dict"]
+                dc = metadata_container["dcterms:dublincore_dict"]
             except (KeyError, IndexError):
                 dc = None
             indexed_data[item["_source"]["filePath"]] = dc


### PR DESCRIPTION
Elasticsearch fields accept a single value or a list of values so there
is no need to make a distinction in that case, only between strings and
dictionaries. The previous normalization named dict fields always as
"tag_dict_list" even if there was only one value and it named string
fields as "tag" (for a single value) or "tag_str_list" (for multiple
values). The new normalization only differentiates between dicts
("tag_dict") and strings ("tag").

Refs https://github.com/archivematica/Issues/issues/1524.