### PR TITLE
Fix empty sip_uuid on completed transfers

### DIFF
--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
         r"transfer/status/(?P<unit_uuid>" + settings.UUID_REGEX + ")",
         views.status,
         {"unit_type": "unitTransfer"},
+        name="transfer_status",
     ),
     url(r"transfer/start_transfer/", views.start_transfer_api, name="start_transfer"),
     url(r"transfer/reingest", views.reingest, {"target": "transfer"}),
@@ -73,7 +74,15 @@ urlpatterns = [
         name="processing_configuration_list",
     ),
     url(r"v2beta/package", views.package),
-    url(r"v2beta/validate/([-\w]+)", views.validate, name="validate"),
-    url(r"v2beta/jobs/(?P<unit_uuid>" + settings.UUID_REGEX + ")", views.unit_jobs),
-    url(r"v2beta/task/(?P<task_uuid>" + settings.UUID_REGEX + ")", views.task),
+    url(r"v2beta/validate/([-\w]+)", views.validate, name="v2beta_validate"),
+    url(
+        r"v2beta/jobs/(?P<unit_uuid>" + settings.UUID_REGEX + ")",
+        views.unit_jobs,
+        name="v2beta_jobs",
+    ),
+    url(
+        r"v2beta/task/(?P<task_uuid>" + settings.UUID_REGEX + ")",
+        views.task,
+        name="v2beta_task",
+    ),
 ]

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -210,7 +210,7 @@ def get_unit_status(unit_uuid, unit_type):
         .filter(jobtype="Create SIP from transfer objects")
         .exists()
     ):
-        ret["status"] = "COMPLETE"
+        ret["status"] = "PROCESSING"
         # Get SIP UUID
         sips = (
             models.File.objects.filter(transfer_id=unit_uuid, sip__isnull=False)
@@ -218,6 +218,7 @@ def get_unit_status(unit_uuid, unit_type):
             .distinct()
         )
         if sips:
+            ret["status"] = "COMPLETE"
             ret["sip_uuid"] = sips[0]["sip"]
     elif (
         models.Job.objects.filter(sipuuid=unit_uuid)

--- a/src/dashboard/tests/test_api.py
+++ b/src/dashboard/tests/test_api.py
@@ -162,7 +162,9 @@ class TestAPI(TestCase):
     def test_get_unit_status_completed_sip(self):
         """It should return COMPLETE."""
         # Setup fixtures
-        load_fixture(["jobs-processing", "jobs-transfer-complete", "jobs-sip-complete"])
+        load_fixture(
+            ["jobs-processing", "jobs-transfer-complete", "jobs-sip-complete", "files"]
+        )
         # Test
         status = views.get_unit_status(
             "4060ee97-9c3f-4822-afaf-ebdf838284c3", "unitSIP"
@@ -188,6 +190,7 @@ class TestAPI(TestCase):
                 "jobs-processing",
                 "jobs-transfer-complete",
                 "jobs-sip-complete-clean-up-last",
+                "files",
             ]
         )
         # Test
@@ -205,7 +208,7 @@ class TestAPI(TestCase):
 
     @e2e
     def test_status(self):
-        load_fixture(["jobs-transfer-complete"])
+        load_fixture(["jobs-transfer-complete", "files"])
         resp = self.client.get(
             reverse(
                 "api:transfer_status", args=["3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"]
@@ -233,14 +236,14 @@ class TestAPI(TestCase):
             ),
         )
 
-    def test__completed_units(self):
-        load_fixture(["jobs-transfer-complete"])
+    def test_completed_units(self):
+        load_fixture(["jobs-transfer-complete", "files"])
         completed = views._completed_units()
         assert completed == ["3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"]
 
-    def test__completed_units_with_bogus_unit(self):
+    def test_completed_units_with_bogus_unit(self):
         """Bogus units should be excluded and handled gracefully."""
-        load_fixture(["jobs-transfer-complete"])
+        load_fixture(["jobs-transfer-complete", "files"])
         Transfer.objects.create(uuid="1642cbe0-b72d-432d-8fc9-94dad3a0e9dd")
         try:
             completed = views._completed_units()
@@ -250,7 +253,7 @@ class TestAPI(TestCase):
 
     @e2e
     def test_completed_transfers(self):
-        load_fixture(["jobs-transfer-complete"])
+        load_fixture(["jobs-transfer-complete", "files"])
         resp = self.client.get(reverse("api:completed_transfers"))
         assert resp.status_code == 200
         payload = json.loads(resp.content.decode("utf8"))
@@ -262,7 +265,7 @@ class TestAPI(TestCase):
     @e2e
     def test_completed_transfers_with_bogus_transfer(self):
         """Bogus transfers should be excluded and handled gracefully."""
-        load_fixture(["jobs-transfer-complete"])
+        load_fixture(["jobs-transfer-complete", "files"])
         Transfer.objects.create(uuid="1642cbe0-b72d-432d-8fc9-94dad3a0e9dd")
         resp = self.client.get(reverse("api:completed_transfers"))
         assert resp.status_code == 200

--- a/src/dashboard/tests/test_api_v2beta.py
+++ b/src/dashboard/tests/test_api_v2beta.py
@@ -140,7 +140,7 @@ objects/8e758e7545212966d0256a6ac70d81db6a6d6a6d_008.tif,policy,,,,1974-01-01,op
 
     def _post(self, validator_name, payload, content_type="text/csv; charset=utf-8"):
         return self.client.post(
-            reverse("api:validate", args=[validator_name]),
+            reverse("api:v2beta_validate", args=[validator_name]),
             payload,
             content_type=content_type,
         )


### PR DESCRIPTION
This updates the transfer API endpoints to mark a transfer as complete until its SIP can be determined through the files it contains.

This also updates the `archivematica-acceptance-tests` submodule with https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/177 which removes the empty `sip_uuid` check for the black box tests.

Connected to https://github.com/archivematica/Issues/issues/690