### PR TITLE
Do not resolve external xml entities

### DIFF
--- a/src/MCPClient/lib/clientScripts/characterize_file.py
+++ b/src/MCPClient/lib/clientScripts/characterize_file.py
@@ -97,7 +97,10 @@ def main(job, file_path, file_uuid, sip_uuid):
             and rule.command.output_format.pronom_id == "fmt/101"
         ):
             try:
-                etree.fromstring(stdout.encode("utf8"))
+                etree.fromstring(
+                    stdout.encode("utf8"),
+                    etree.XMLParser(resolve_entities=False, no_network=True),
+                )
                 insertIntoFPCommandOutput(file_uuid, stdout, rule.uuid)
                 job.write_output(
                     'Saved XML output for command "{}" ({})'.format(

--- a/src/MCPClient/lib/clientScripts/create_mets_v2.py
+++ b/src/MCPClient/lib/clientScripts/create_mets_v2.py
@@ -405,8 +405,10 @@ def createDublincoreDMDSecFromDBData(
             dcXMLFile = os.path.join(transfers, transfer, "dublincore.xml")
             if os.path.isfile(dcXMLFile):
                 try:
-                    parser = etree.XMLParser(remove_blank_text=True)
-                    dtree = etree.parse(dcXMLFile, parser)
+                    parser = etree.XMLParser(
+                        remove_blank_text=True, resolve_entities=False, no_network=True
+                    )
+                    dtree = etree.parse(dcXMLFile, parser)  # nosec B320
                     dc = dtree.getroot()
                     break
                 except Exception as inst:
@@ -446,7 +448,10 @@ def createDSpaceDMDSec(job, label, dspace_mets_path, directoryPathSTR, state):
     :return: dict of {<dmdSec ID>: <dmdSec Element>}
     """
     dmdsecs = collections.OrderedDict()
-    root = etree.parse(dspace_mets_path)
+    parser = etree.XMLParser(
+        remove_blank_text=True, resolve_entities=False, no_network=True
+    )
+    root = etree.parse(dspace_mets_path, parser)
 
     # Create mdRef to DSpace METS file
     state.globalDmdSecCounter += 1
@@ -937,7 +942,10 @@ def include_custom_structmap(
         if not os.path.isdir(dirPath):
             continue
         if os.path.isfile(structMapXmlPath):
-            tree = etree.parse(structMapXmlPath)
+            tree = etree.parse(  # nosec B320
+                structMapXmlPath,
+                etree.XMLParser(resolve_entities=False, no_network=True),
+            )
             root = tree.getroot()
             structMap = root.find(ns.metsBNS + "structMap")
             id_ = structMap.get("ID")
@@ -1452,7 +1460,9 @@ def create_object_metadata(job, struct_map, baseDirectoryPath, state):
         xmldata = etree.SubElement(mdwrap, ns.metsBNS + "xmlData")
         source_md_counter += 1
         parser = etree.XMLParser(remove_blank_text=True)
-        md = etree.parse(filename, parser)
+        md = etree.parse(  # nosec B320
+            filename, parser, etree.XMLParser(resolve_entities=False, no_network=True)
+        )
         xmldata.append(md.getroot())
 
     for filename in source:

--- a/src/MCPClient/lib/clientScripts/create_transfer_mets.py
+++ b/src/MCPClient/lib/clientScripts/create_transfer_mets.py
@@ -387,7 +387,10 @@ def get_premis_object_characteristics_extension(documents):
         # is UTF-8 encoded.
         # See https://lxml.de/parsing.html#python-unicode-strings
         # This only covers the UTF-8 and ASCII cases.
-        xml_element = etree.fromstring(document.content.encode("utf-8"))
+        xml_element = etree.fromstring(  # nosec B320
+            document.content.encode("utf-8"),
+            etree.XMLParser(resolve_entities=False, no_network=True),
+        )
 
         extensions += (("object_characteristics_extension", xml_element),)
 

--- a/src/MCPClient/lib/clientScripts/load_premis_events_from_xml.py
+++ b/src/MCPClient/lib/clientScripts/load_premis_events_from_xml.py
@@ -262,7 +262,12 @@ def get_premis_schema(premis_xsd_path, printfn=print):
         log_missing_xsd(premis_xsd_path, printfn)
         return
     try:
-        return etree.XMLSchema(etree.parse(premis_xsd_path))
+        return etree.XMLSchema(
+            etree.parse(  # nosec B320
+                premis_xsd_path,
+                etree.XMLParser(resolve_entities=False, no_network=True),
+            )
+        )
     except (etree.XMLSyntaxError, etree.XMLSchemaParseError) as exception:
         log_invalid_xsd(premis_xsd_path, exception, printfn)
         return
@@ -274,7 +279,10 @@ def get_validated_etree(premis_events_xml_path, premis_schema, printfn=print):
         log_missing_events_xml(premis_events_xml_path, printfn)
         return
     try:
-        result = etree.parse(premis_events_xml_path)
+        result = etree.parse(  # nosec B320
+            premis_events_xml_path,
+            etree.XMLParser(resolve_entities=False, no_network=True),
+        )
         premis_schema.assertValid(result)
         return result
     except (etree.XMLSyntaxError, etree.DocumentInvalid) as exception:

--- a/src/MCPClient/lib/clientScripts/verify_mets.py
+++ b/src/MCPClient/lib/clientScripts/verify_mets.py
@@ -31,8 +31,17 @@ def call(jobs):
                 return
             if not os.path.isfile(mets_xsd):
                 raise VerifyMETSException
-            xmlschema = etree.XMLSchema(etree.parse(mets_xsd))
+            xmlschema = etree.XMLSchema(
+                etree.parse(  # nosec B320
+                    mets_xsd, etree.XMLParser(resolve_entities=False, no_network=True)
+                )
+            )
             # Raise an exception if not valid, e.g. etree.DocumentInvalid
             # otherwise, the document validates correctly and returns.
-            xmlschema.assertValid(etree.parse(mets_structmap))
+            xmlschema.assertValid(
+                etree.parse(  # nosec B320
+                    mets_structmap,
+                    etree.XMLParser(resolve_entities=False, no_network=True),
+                )
+            )
             job.pyprint("Custom structmap validated correctly")


### PR DESCRIPTION
Use a custom parser with lxml that disables external entity resolution
and disables network access.

'no_network' is true by default.