### PR TITLE
Fix dockerignore whitelist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,14 +2,14 @@
 **
 
 # Include
-!/hack/osdeps.py
-!/src/**
-!/pytest.ini
-!/requirements*
-!/tox.ini
-!/LICENSE
-!/COPYRIGHT
-!/TRADEMARK
+!hack/osdeps.py
+!src/**
+!pytest.ini
+!requirements*
+!tox.ini
+!LICENSE
+!COPYRIGHT
+!TRADEMARK
 
 # Exclude
 src/dashboard/frontend/node_modules


### PR DESCRIPTION
PR addresses failures in COPY steps when running `make build` such as the following:

```
Step 10/60 : COPY hack/osdeps.py /src/hack/osdeps.py
ERROR: Service 'archivematica-mcp-server' failed to build: COPY failed: file not found in build context or excluded by .dockerignore: stat hack/osdeps.py: file does not exist
Makefile:81: recipe for target 'build' failed
make: *** [build] Error 1
```

This issue was caused by syntax errors in the .dockerignore whitelist. Removing the initial forward slash for each entry results in the build successfully completing.

Since this is my first PR for this project, I'll get the contributor agreement sent off in the next couple days. [Done]