### PR TITLE
Fix typos

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,4 +1,4 @@
-# Archivematica develoment on Docker Compose
+# Archivematica development on Docker Compose
 
 - [Audience](#audience)
 - [Requirements](#requirements)
@@ -334,7 +334,7 @@ database. If this is case, run the following command:
 
     $ docker-compose up -d --force-recreate --build
 
-Additionally you may want to delete all the deta including the stuff in the
+Additionally you may want to delete all the data including the stuff in the
 external volumes:
 
     $ make flush
@@ -463,7 +463,7 @@ e.g.:
 
 1. Edit `MCPClient-base.Dockerfile`.
 2. Build image with new tag.
-3. Update the `FROM` instruciton in `MCPClient.Dockerfile` to use it.
+3. Update the `FROM` instruction in `MCPClient.Dockerfile` to use it.
 4. Build the image of the `archivematica-mcp-client` service.
 5. Test it.
 6. Publish image.
@@ -506,7 +506,7 @@ The defaults are defined in the `Makefile`:
 
 In the event that `make bootstrap` fails to run while installing, the Bootstrap
 components may need to be installed individually inside the application. This
-error message is more likely if you are attemping to install Archivematica on a
+error message is more likely if you are attempting to install Archivematica on a
 Mac.
 
 First, go into the Makefile and comment out everything in the

--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -13,20 +13,20 @@
 
 ## Introduction
 
-Archivematica components can be configured using multiple methods.  All
+Archivematica components can be configured using multiple methods. All
 components follow the same pattern:
 
 1. **Environment variables** - setting a configuration parameter with an
    environment variable will override all other methods.
 1. **Configuration file** - if the parameter is not set by an environment
    variable, the component will look for a setting in its default configuration file.
-1. **Application defaults**  - if the parameter is not set in an environment
+1. **Application defaults** - if the parameter is not set in an environment
    variable or the config file, the application default is used.
 
 Logging behaviour is configured differently, and provides two methods:
 
 1. **`logging.json` file** - if a JSON file is present in the default location,
-    the contents of the JSON file will control the components logging behaviour.
+   the contents of the JSON file will control the components logging behaviour.
 1. **Application default** - if no JSON file is present, the default logging
    behaviour is to write to standard streams (standard out and standard error).
 

--- a/src/MCPServer/install/README.md
+++ b/src/MCPServer/install/README.md
@@ -10,20 +10,20 @@
 
 ## Introduction
 
-Archivematica components can be configured using multipe methods.  All
+Archivematica components can be configured using multiple methods. All
 components follow the same pattern:
 
 1. **Environment variables** - setting a configuration parameter with an
    environment variable will override all other methods.
 1. **Configuration file** - if the parameter is not set by an environment
    variable, the component will look for a setting in its default configuration file.
-1. **Application defaults**  - if the parameter is not set in an environment
+1. **Application defaults** - if the parameter is not set in an environment
    variable or the config file, the application default is used.
 
 Logging behaviour is configured differently, and provides two methods:
 
 1. **`logging.json` file** - if a JSON file is present in the default location,
-    the contents of the JSON file will control the components logging behaviour.
+   the contents of the JSON file will control the components logging behaviour.
 1. **Application default** - if no JSON file is present, the default logging
    behaviour is to write to standard streams (standard out and standard error).
 

--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -18,20 +18,20 @@
 
 ## Introduction
 
-Archivematica components can be configured using multipe methods.  All
+Archivematica components can be configured using multiple methods. All
 components follow the same pattern:
 
 1. **Environment variables** - setting a configuration parameter with an
    environment variable will override all other methods.
 1. **Configuration file** - if the parameter is not set by an environment
    variable, the component will look for a setting in its default configuration file.
-1. **Application defaults**  - if the parameter is not set in an environment
+1. **Application defaults** - if the parameter is not set in an environment
    variable or the config file, the application default is used.
 
 Logging behaviour is configured differently, and provides two methods:
 
 1. **`logging.json` file** - if a JSON file is present in the default location,
-    the contents of the JSON file will control the components logging behaviour.
+   the contents of the JSON file will control the components logging behaviour.
 1. **Application default** - if no JSON file is present, the default logging
    behaviour is to write to standard streams (standard out and standard error).
 
@@ -65,7 +65,7 @@ The Dashboard will look for a configuration file in one location:
 
 Traditionally, the dbsettings file was used to hold mysql login credentials,
 which are then shared with other Archivematica components like MCPClient.
-Non-database parameters can be set in the dbsets,tings file, to override the
+Non-database parameters can be set in the dbsettings file to override the
 application defaults.
 
 The dashboard is a [WSGI](https://wsgi.readthedocs.io/) application. The
@@ -582,7 +582,7 @@ These variables specify the behaviour of LDAP authentication. Only applicable if
     - **Default:** ``
 
 - **`AUTH_LDAP_TLS_REQUIRE_CERT`**:
-    - **Description:** How strict to be regarding TLS cerfiticate verification. Allowed values are "never",
+    - **Description:** How strict to be regarding TLS certificate verification. Allowed values are "never",
     "allow", "try", "demand", or "hard". Corresponds to the TLSVerifyClient OpenLDAP setting.
     - **Type:** `string`
     - **Default:** ``


### PR DESCRIPTION
PR addresses various typos in README files.

I noticed a typo in one of the headings, so I figured I'd run a spell check extension to see if there were any others. I also noticed a couple whitespace inconsistencies while I was reviewing.

One of the typos was covered in https://github.com/artefactual/archivematica/pull/1792, which still needs to be merged. I'm fine with rebasing and resolving the conflict after https://github.com/artefactual/archivematica/pull/1792 gets merged if it's preferred to do the two in sequence. I'll do it such that this PR remains a single commit.