### PR TITLE
Add ability to customize LDAP Attributes

### DIFF
--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -499,6 +499,21 @@ These variables specify the behaviour of LDAP authentication. Only applicable if
     - **Type:** `string`
     - **Default:** ``
 
+- **`AUTH_LDAP_USER_FIRST_NAME_ATTR`**:
+    - **Description:** LDAP attribute for first name.
+    - **Type:** `string`
+    - **Default:** `givenName`
+
+- **`AUTH_LDAP_USER_LAST_NAME_ATTR`**:
+    - **Description:** LDAP attribute for last name.
+    - **Type:** `string`
+    - **Default:** `sn`
+
+- **`AUTH_LDAP_USER_EMAIL_ATTR`**:
+    - **Description:** LDAP attribute for email address.
+    - **Type:** `string`
+    - **Default:** `mail
+
 - **`AUTH_LDAP_GROUP_IS_ACTIVE`**:
     - **Description:** Template for LDAP group used to set the Django user `is_active` flag, e.g.
     "cn=active,ou=django,ou=groups,dc=example,dc=com".

--- a/src/dashboard/src/settings/components/ldap_auth.py
+++ b/src/dashboard/src/settings/components/ldap_auth.py
@@ -29,9 +29,9 @@ if "AUTH_LDAP_USER_SEARCH_BASE_DN" in environ:
     )
 AUTH_LDAP_USER_DN_TEMPLATE = environ.get("AUTH_LDAP_USER_DN_TEMPLATE", None)
 AUTH_LDAP_USER_ATTR_MAP = {
-    "first_name": "givenName",
-    "last_name": "sn",
-    "email": "mail",
+    "first_name": environ.get("AUTH_LDAP_USER_FIRST_NAME_ATTR", "givenName"),
+    "last_name": environ.get("AUTH_LDAP_USER_LAST_NAME_ATTR", "sn"),
+    "email": environ.get("AUTH_LDAP_USER_EMAIL_ATTR", "mail"),
 }
 
 AUTH_LDAP_USER_FLAGS_BY_GROUP = {}


### PR DESCRIPTION
This allows users to override the attributes for first name, last name, and email.

I tested this locally, and it works, and would be great to not have to overwrite core files on the system.

Thanks!

Related to https://github.com/archivematica/Issues/issues/1565