### PR TITLE
Make ES limits configurable

### DIFF
--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -143,6 +143,12 @@ variables or in the gunicorn configuration file.
     - **Type:** `float`
     - **Default:** `10`
 
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_ELASTICSEARCH_MAX_QUERY_SIZE`**:
+    - **Description:** limits the number of results per query that Elasticseach client can retrieve. Note that when using a value greater than 10000, the `total_fields.limit` and `max_result_window` must be increased in indices (For instance, when using `100000` run on ES server linux CLI: `curl -XPUT 'http://localhost:9200/aips,aipfiles,transfers,transferfiles/_settings' -H "Content-Type: application/json"  -d '{"index.mapping.total_fields.limit": 100000, "index.max_result_window": 100000}'`)
+    - **Config file example:** `Dashboard.elasticsearch_max_query_size`
+    - **Type:** `integer`
+    - **Default:** `10000`
+
 - **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED`**:
     - **Description:** controls what Elasticsearch indexes are enabled:
         - When set to `aips`, the Backlog tab, Appraisal tab, and the SIP Arrange pane in the Ingest tab will not be displayed.

--- a/src/dashboard/src/components/archival_storage/views.py
+++ b/src/dashboard/src/components/archival_storage/views.py
@@ -333,7 +333,12 @@ def search(request):
             # add size parameter in terms to override.
             # TODO: Use composite aggregation when it gets out of beta.
             query["aggs"] = {
-                "aip_uuids": {"terms": {"field": "AIPUUID", "size": "10000"}}
+                "aip_uuids": {
+                    "terms": {
+                        "field": "AIPUUID",
+                        "size": str(settings.ELASTICSEARCH_MAX_QUERY_SIZE),
+                    }
+                }
             }
             # Don't return results, just the aggregation.
             query["size"] = 0

--- a/src/dashboard/src/components/backlog/views.py
+++ b/src/dashboard/src/components/backlog/views.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 import json
 import logging
 
+from django.conf import settings
 from django.contrib import messages
 from django.urls import reverse
 from django.http import HttpResponse, Http404
@@ -179,7 +180,12 @@ def search(request):
             # add size parameter in terms to override.
             # TODO: Use composite aggregation when it gets out of beta.
             query["aggs"] = {
-                "transfer_uuid": {"terms": {"field": "sipuuid", "size": "10000"}}
+                "transfer_uuid": {
+                    "terms": {
+                        "field": "sipuuid",
+                        "size": str(settings.ELASTICSEARCH_MAX_QUERY_SIZE),
+                    }
+                }
             }
             hits = es_client.search(
                 index=es.TRANSFER_FILES_INDEX,

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -66,6 +66,11 @@ CONFIG_MAPPING = {
         "option": "elasticsearch_timeout",
         "type": "float",
     },
+    "elasticsearch_max_query_size": {
+        "section": "Dashboard",
+        "option": "elasticsearch_max_query_size",
+        "type": "int",
+    },
     "search_enabled": {
         "section": "Dashboard",
         "process_function": process_search_enabled,
@@ -180,6 +185,7 @@ shared_directory = /var/archivematica/sharedDirectory/
 watch_directory = /var/archivematica/sharedDirectory/watchedDirectories/
 elasticsearch_server = 127.0.0.1:9200
 elasticsearch_timeout = 10
+elasticsearch_max_query_size = 10000
 search_enabled = true
 gearman_server = 127.0.0.1:4730
 password_minimum_length = 8
@@ -546,6 +552,7 @@ SHARED_DIRECTORY = config.get("shared_directory")
 WATCH_DIRECTORY = config.get("watch_directory")
 ELASTICSEARCH_SERVER = config.get("elasticsearch_server")
 ELASTICSEARCH_TIMEOUT = config.get("elasticsearch_timeout")
+ELASTICSEARCH_MAX_QUERY_SIZE = config.get("elasticsearch_max_query_size")
 SEARCH_ENABLED = config.get("search_enabled")
 STORAGE_SERVICE_CLIENT_TIMEOUT = config.get("storage_service_client_timeout")
 STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT = config.get(


### PR DESCRIPTION
The total AIPs limit on the "Archival Storage" and "Appraisal" tabs were limited to 10000 items. It was hardcoded so this pull request makes this limit configurable.

Connects to https://github.com/archivematica/Issues/issues/1571