### PR TITLE
models: fix Access.get_title() exception handling

### DIFF
--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -896,7 +896,7 @@ class JobQuerySet(models.QuerySet):
         TODO(sevein): why is the name not a property of the unit?
         """
         try:
-            job = self.first()
+            job = self[0]
         # No jobs yet, e.g. not started; there will be no directory name yet.
         except IndexError:
             return _("(Unnamed)")


### PR DESCRIPTION
Fix JobQuerySet.get_directory_name() exception handling, which is invoked by Access.get_title()

Replace first() with [0] in order to trigger IndexError when required, and correctly handle the exception. Using first() may return a None potentially causing an unhandled exception dowstream (cf. https://docs.djangoproject.com/en/1.11/ref/models/querysets/#first)

Fixes https://github.com/archivematica/Issues/issues/1572