### PR TITLE
Prefer QuerySet.exists() to QuerySet.count() > 0

### DIFF
--- a/src/MCPClient/lib/clientScripts/archivematica_clamscan.py
+++ b/src/MCPClient/lib/clientScripts/archivematica_clamscan.py
@@ -222,10 +222,7 @@ class ClamScanner(ScannerBase):
 
 
 def file_already_scanned(file_uuid):
-    return (
-        0
-        < Event.objects.filter(file_uuid_id=file_uuid, event_type="virus check").count()
-    )
+    return Event.objects.filter(file_uuid_id=file_uuid, event_type="virus check").exists()
 
 
 def queue_event(file_uuid, date, scanner, passed, queue):

--- a/src/MCPClient/lib/clientScripts/characterize_file.py
+++ b/src/MCPClient/lib/clientScripts/characterize_file.py
@@ -39,7 +39,7 @@ def main(job, file_path, file_uuid, sip_uuid):
 
     # Check to see whether the file has already been characterized; don't try
     # to characterize it a second time if so.
-    if FPCommandOutput.objects.filter(file_id=file_uuid).count() > 0:
+    if FPCommandOutput.objects.filter(file_id=file_uuid).exists():
         return 0
 
     try:

--- a/src/dashboard/src/components/ingest/views_as.py
+++ b/src/dashboard/src/components/ingest/views_as.py
@@ -56,8 +56,7 @@ def _get_reset_view(uuid):
     if (
         models.ArchivesSpaceDIPObjectResourcePairing.objects.filter(
             dipuuid=uuid
-        ).count()
-        > 0
+        ).exists()
     ):
         return "ingest:ingest_upload_as_reset"
 
@@ -270,7 +269,7 @@ def ingest_upload_as_match(request, uuid):
         records = models.ArchivesSpaceDIPObjectResourcePairing.objects.filter(
             **criteria
         )
-        if records.count() < 1:
+        if not records.exists():
             models.ArchivesSpaceDIPObjectResourcePairing.objects.create(
                 dipuuid=uuid, resourceid=resource_id, fileuuid=file_uuid
             )

--- a/src/dashboard/src/components/unit/views.py
+++ b/src/dashboard/src/components/unit/views.py
@@ -39,7 +39,7 @@ def detail(request, unit_type, unit_uuid):
     jobs = models.Job.objects.filter(sipuuid=unit_uuid)
     name = jobs.get_directory_name()
     is_waiting = (
-        jobs.filter(currentstep=models.Job.STATUS_AWAITING_DECISION).count() > 0
+        jobs.filter(currentstep=models.Job.STATUS_AWAITING_DECISION).exists()
     )
     context = {
         "name": name,


### PR DESCRIPTION
This is a micro-optimisation I found while looking at some database issues in the clamscan script; the Django documentation suggests using this instead of `count() > 0`.

See https://docs.djangoproject.com/en/4.1/ref/models/querysets/#django.db.models.query.QuerySet.exists

This is for https://github.com/archivematica/Issues/issues/1578 and https://github.com/wellcomecollection/archivematica-infrastructure/issues/101