### PR TITLE
Truncates filenames if they exceed os limit

### DIFF
--- a/src/MCPClient/lib/clientScripts/change_names.py
+++ b/src/MCPClient/lib/clientScripts/change_names.py
@@ -63,8 +63,9 @@ def change_path(path):
     dirname = os.path.dirname(path)
 
     n = 1
+    max_filename = os.fpathconf(changed_name, 'PC_NAME_MAX')
     file_title, file_extension = os.path.splitext(changed_name)
-    changed_name = os.path.join(dirname, file_title + file_extension)
+    changed_name = os.path.join(dirname, file_title[:max_filename - len(file_extension)] + file_extension)
 
     while os.path.exists(changed_name):
         changed_name = os.path.join(

--- a/src/MCPClient/tests/test_filename_change.py
+++ b/src/MCPClient/tests/test_filename_change.py
@@ -308,6 +308,8 @@ class TestFilenameChange(TempDirMixin, TestCase):
         ("a\x80b", "ab"),
         ("Smörgåsbord.txt", "Smorgasbord.txt"),
         ("🚀", "_"),
+        ("thisisaverylongfilenamewhichshouldbetruncatedtoaversionwhichisnotlongerthanthefilenameallowedbytheunderlyingossowedontrunintoerrorsthisisaverylongfilenamewhichshouldbetruncatedtoaversionwhichisnotlongerthanthefilenameallowedbytheunderlyingossowedontrunintoerrors.txt",
+         "thisisaverylongfilenamewhichshouldbetruncatedtoaversionwhichisnotlongerthanthefilenameallowedbytheunderlyingossowedontrunintoerrorsthisisaverylongfilenamewhichshouldbetruncatedtoaversionwhichisnotlongerthanthefilenameallowedbytheunderlyingossowedontru.txt"),
     ],
 )
 def test_change_name(basename, expected_name):


### PR DESCRIPTION
Gets the maximum filename length and truncates the name of the renamed file if it exceeds the max allowable by the underlying OS. Is one path to addressing Archivematica/Issues#1586