### PR TITLE
Truncates filenames if they exceed OS limit

### DIFF
--- a/src/MCPClient/lib/clientScripts/change_names.py
+++ b/src/MCPClient/lib/clientScripts/change_names.py
@@ -70,7 +70,7 @@ def change_path(path, max_filename):
     while os.path.exists(changed_name):
         changed_name = os.path.join(
             dirname,
-            file_title[:max_file_title - (len(REPLACEMENT_CHAR) + len(str(n)))]
+            file_title[: max_file_title - (len(REPLACEMENT_CHAR) + len(str(n)))]
             + REPLACEMENT_CHAR
             + str(n)
             + file_extension,

--- a/src/MCPClient/lib/clientScripts/change_names.py
+++ b/src/MCPClient/lib/clientScripts/change_names.py
@@ -69,7 +69,11 @@ def change_path(path, max_filename):
 
     while os.path.exists(changed_name):
         changed_name = os.path.join(
-            dirname, file_title[:max_file_title - (len(REPLACEMENT_CHAR) + len(str(n)))] + REPLACEMENT_CHAR + str(n) + file_extension
+            dirname,
+            file_title[:max_file_title - (len(REPLACEMENT_CHAR) + len(str(n)))]
+            + REPLACEMENT_CHAR
+            + str(n)
+            + file_extension,
         )
         n += 1
     shutil.move(path, changed_name)
@@ -87,7 +91,7 @@ def change_tree(start_path, old_start_path):
     dir.
     """
     start_path = os.path.abspath(start_path)
-    max_filename = os.pathconf(start_path, 'PC_NAME_MAX')
+    max_filename = os.pathconf(start_path, "PC_NAME_MAX")
 
     for dir_entry in scandir(start_path):
         is_dir = dir_entry.is_dir()  # cache is_dir before rename

--- a/src/MCPClient/lib/clientScripts/change_names.py
+++ b/src/MCPClient/lib/clientScripts/change_names.py
@@ -53,7 +53,7 @@ def change_name(basename):
     return ALLOWED_CHARS.sub(REPLACEMENT_CHAR, unicode_name)
 
 
-def change_path(path):
+def change_path(path, max_filename):
     basename = os.path.basename(path)
     changed_name = change_name(basename)
 
@@ -64,7 +64,7 @@ def change_path(path):
 
     n = 1
     file_title, file_extension = os.path.splitext(changed_name)
-    changed_name = os.path.join(dirname, file_title + file_extension)
+    changed_name = os.path.join(dirname, file_title[:max_filename - len(file_extension)] + file_extension)
 
     while os.path.exists(changed_name):
         changed_name = os.path.join(
@@ -86,11 +86,12 @@ def change_tree(start_path, old_start_path):
     dir.
     """
     start_path = os.path.abspath(start_path)
+    max_filename = os.pathconf(start_path, 'PC_NAME_MAX')
 
     for dir_entry in scandir(start_path):
         is_dir = dir_entry.is_dir()  # cache is_dir before rename
 
-        changed_name = change_path(dir_entry.path)
+        changed_name = change_path(dir_entry.path, max_filename)
         changed_path = os.path.join(start_path, changed_name)
         old_path = os.path.join(old_start_path, dir_entry.name)
 

--- a/src/MCPClient/lib/clientScripts/change_names.py
+++ b/src/MCPClient/lib/clientScripts/change_names.py
@@ -64,11 +64,12 @@ def change_path(path, max_filename):
 
     n = 1
     file_title, file_extension = os.path.splitext(changed_name)
-    changed_name = os.path.join(dirname, file_title[:max_filename - len(file_extension)] + file_extension)
+    max_file_title = max_filename - len(file_extension)
+    changed_name = os.path.join(dirname, file_title[:max_file_title] + file_extension)
 
     while os.path.exists(changed_name):
         changed_name = os.path.join(
-            dirname, file_title + REPLACEMENT_CHAR + str(n) + file_extension
+            dirname, file_title[:max_file_title - (len(REPLACEMENT_CHAR) + len(str(n)))] + REPLACEMENT_CHAR + str(n) + file_extension
         )
         n += 1
     shutil.move(path, changed_name)

--- a/src/MCPClient/lib/clientScripts/change_names.py
+++ b/src/MCPClient/lib/clientScripts/change_names.py
@@ -65,6 +65,7 @@ def change_path(path, max_filename):
     n = 1
     file_title, file_extension = os.path.splitext(changed_name)
     max_file_title = max_filename - len(file_extension)
+    print(max_file_title)
     changed_name = os.path.join(dirname, file_title[:max_file_title] + file_extension)
 
     while os.path.exists(changed_name):

--- a/src/MCPClient/lib/clientScripts/change_names.py
+++ b/src/MCPClient/lib/clientScripts/change_names.py
@@ -65,7 +65,6 @@ def change_path(path, max_filename):
     n = 1
     file_title, file_extension = os.path.splitext(changed_name)
     max_file_title = max_filename - len(file_extension)
-    print(max_file_title)
     changed_name = os.path.join(dirname, file_title[:max_file_title] + file_extension)
 
     while os.path.exists(changed_name):

--- a/src/MCPClient/lib/clientScripts/change_sip_name.py
+++ b/src/MCPClient/lib/clientScripts/change_sip_name.py
@@ -21,6 +21,7 @@
 # @subpackage archivematicaClientScript
 # @author Joseph Perry <joseph@artefactual.com>
 
+import os
 import sys
 
 import django
@@ -58,7 +59,8 @@ def call(jobs):
                     job.pyprint("invalid unit type: ", unitType, file=sys.stderr)
                     job.set_status(1)
                     continue
-                dst = change_path(SIPDirectory)
+                max_filename = os.pathconf(SIPDirectory, "PC_NAME_MAX")
+                dst = change_path(SIPDirectory, max_filename)
                 if SIPDirectory != dst:
                     dst = dst.replace(sharedDirectoryPath, "%sharedPath%", 1) + "/"
                     job.pyprint(

--- a/src/MCPClient/tests/test_filename_change.py
+++ b/src/MCPClient/tests/test_filename_change.py
@@ -308,6 +308,8 @@ class TestFilenameChange(TempDirMixin, TestCase):
         ("a\x80b", "ab"),
         ("Smörgåsbord.txt", "Smorgasbord.txt"),
         ("🚀", "_"),
+        ("thisisaverylongfilenamewhichshouldbetruncatedtoaversionwhichisnotlongerthanthefilenameallowedbytheunderlyingossowedontrunintoerrorsthisisaverylongfilenamewhichshouldbetruncatedtoaversionwhichisnotlongerthanthefilenameallowedbytheunderlyingossowedontrunintoerrors.txt",
+         "thisisaverylongfilenamewhichshouldbetruncatedtoaversionwhichisnotlongerthanthefilenameallowedbytheunderlyingossowedontrunintoerrorsthisisaverylongfilenamewhichshouldbetruncatedtoaversionwhichisnotlongerthanthefilenameallowedbytheunderlyingossowedontru.txt"),
     ],
 )
 def test_change_name(basename, expected_name):

--- a/src/MCPClient/tests/test_filename_change.py
+++ b/src/MCPClient/tests/test_filename_change.py
@@ -313,6 +313,7 @@ class TestFilenameChange(TempDirMixin, TestCase):
     ],
 )
 def test_change_name(basename, expected_name):
+    print(os.pathconf(basename, "PC_NAME_MAX"))
     assert change_names.change_name(basename) == expected_name
 
 

--- a/src/MCPClient/tests/test_filename_change.py
+++ b/src/MCPClient/tests/test_filename_change.py
@@ -308,12 +308,9 @@ class TestFilenameChange(TempDirMixin, TestCase):
         ("a\x80b", "ab"),
         ("Smörgåsbord.txt", "Smorgasbord.txt"),
         ("🚀", "_"),
-        ("thisisaverylongfilenamewhichshouldbetruncatedtoaversionwhichisnotlongerthanthefilenameallowedbytheunderlyingossowedontrunintoerrorsthisisaverylongfilenamewhichshouldbetruncatedtoaversionwhichisnotlongerthanthefilenameallowedbytheunderlyingossowedontrunintoerrors.txt",
-         "thisisaverylongfilenamewhichshouldbetruncatedtoaversionwhichisnotlongerthanthefilenameallowedbytheunderlyingossowedontrunintoerrorsthisisaverylongfilenamewhichshouldbetruncatedtoaversionwhichisnotlongerthanthefilenameallowedbytheunderlyingossowedontru.txt"),
     ],
 )
 def test_change_name(basename, expected_name):
-    print(os.pathconf(basename, "PC_NAME_MAX"))
     assert change_names.change_name(basename) == expected_name
 
 


### PR DESCRIPTION
Gets the maximum filename length and truncates the name of the renamed file if it exceeds the max allowable by the underlying OS. Addresses https://github.com/archivematica/Issues/issues/1586

There is not a test which covers this new functionality because I couldn't find a logical place to test - the more atomic `change_names` function (which I attempted to test first) just replaces Unicode, it doesn't examine filename length. The `change_paths` function (which is what I want to test) isn't really tested anywhere, except maybe implicitly via `change_objects` but I was having a hard time untangling all of that. One thought I had was to pull lines 63-74 out into a new function called `construct_file_title` or something that would be more easily testable (and wouldn't require writing files to disk). Would welcome thoughts on the best approach.