### PR TITLE
Copy DIPs from uploadDIP to uploadedDIPs

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -3630,8 +3630,8 @@
       "config": {
         "@manager": "linkTaskManagerDirectories",
         "@model": "StandardTaskConfig",
-        "arguments": "\"%SIPDirectory%\" \"%watchDirectoryPath%uploadedDIPs/\"",
-        "execute": "move_v0.0",
+        "arguments": "\"%SIPDirectory%\" \"%watchDirectoryPath%uploadedDIPs/.\" -R",
+        "execute": "copy_v0.0",
         "filter_file_end": null,
         "filter_file_start": null,
         "filter_subdir": null,


### PR DESCRIPTION
Currently the MCPServer can only find processing configuration files in watched directories. https://github.com/artefactual/archivematica/commit/a6eab0642b3c7e3d4c32fde0e57758a2b32f24fa changed the workflow to move the DIP out of the `uploadDIP` watched directory breaking automated processing. This reverts that change.

A couple of options were also considered and discarded for now:

* Turning the subsequent `uploadedDIPs` directory into a watched directory so processing can continue from there. This however would change the semantics of its name because DIPs that were not uploaded to an access system would end up in this same directory. And introducing additional watched directories isn't desirable at this point.
* Introducing a unit variable to track if a DIP was uploaded and adjust the workflow accordingly. Saving state in the database seems reasonable, but it'd require considerable changes in the MCPClient scripts.

Connected to https://github.com/archivematica/Issues/issues/1551