### PR TITLE
Share test runner memory with AMAUAT container

### DIFF
--- a/hack/docker-compose.acceptance-tests.yml
+++ b/hack/docker-compose.acceptance-tests.yml
@@ -9,6 +9,7 @@ services:
     security_opt:
       - "seccomp:./etc/docker/seccomp/chrome.json"
     volumes:
+      - "/dev/shm:/dev/shm"
       - "./submodules/archivematica-acceptance-tests:/home/archivematica/acceptance-tests:rw"
       - "./submodules/archivematica-sampledata:/home/archivematica/archivematica-sampledata:ro"
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:ro"


### PR DESCRIPTION
This fixes [tab crashes](https://stackoverflow.com/a/53970825) in Google Chrome runs of the acceptance tests by sharing the test runner shared memory with the AMAUAT container.