### PR TITLE
Development environment updates

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -38,14 +38,14 @@ jobs:
           make -C hack/ create-volumes
       - name: "Start MySQL"
         run: |
-          docker-compose up -d mysql
+          docker compose up -d mysql
         working-directory: ./hack
       - name: "Build images"
         run: |
           make -C hack/ build
       - name: "Start services"
         run: |
-          docker-compose up -d
+          docker compose up -d
         env:
           cluster.routing.allocation.disk.threshold_enabled: false
         working-directory: ./hack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,22 +15,16 @@ jobs:
         include:
           - rule: mcp-server
             coverage: true
-            python_version: py36
           - rule: mcp-client
             coverage: true
-            python_version: py36
           - rule: dashboard
             coverage: true
-            python_version: py36
           - rule: archivematica-common
             coverage: true
-            python_version: py36
           - rule: storage-service
             coverage: false
-            python_version: py36
           - rule: migrations
             coverage: false
-            python_version: py36
     steps:
       - name: "Check out repository"
         uses: "actions/checkout@v3"
@@ -98,7 +92,6 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           name: ${{ matrix.rule }}
-          flags: ${{ matrix.python_version }}
       - name: "Set newest docker cache"
         run: |
           rm -rf /tmp/.docker-cache-old

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -2,6 +2,10 @@ ARG TARGET=archivematica-mcp-server
 
 FROM ubuntu:18.04 AS base
 
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+ARG PYTHON_VERSION=3.6
+
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
 
@@ -9,12 +13,25 @@ RUN set -ex \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		apt-transport-https \
+		build-essential \
 		curl \
 		gettext \
 		git \
 		gpg-agent \
+		libbz2-dev \
+		libffi-dev \
+		liblzma-dev \
+		libncursesw5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		libxml2-dev \
+		libxmlsec1-dev \
 		locales \
 		software-properties-common \
+		tk-dev \
+		xz-utils \
+		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Set the locale
@@ -36,7 +53,7 @@ RUN set -ex \
 	&& add-apt-repository --no-update --yes "deb http://archive.ubuntu.com/ubuntu/ bionic-updates multiverse" \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
-		build-essential python3-dev libyaml-dev clamav \
+		libyaml-dev clamav \
 	&& /src/hack/osdeps.py Ubuntu-18 1 | grep -v -E "nginx|postfix" | xargs apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -45,8 +62,6 @@ RUN freshclam --quiet
 
 # Install pip, Node.js and Yarn
 RUN set -ex \
-	&& curl -s https://bootstrap.pypa.io/pip/3.6/get-pip.py | python3.6 \
-	&& update-alternatives --install /usr/bin/python python /usr/bin/python3 10 \
 	&& curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 	&& add-apt-repository --yes "deb https://dl.yarnpkg.com/debian/ stable main" \
 	&& apt-get install -y --no-install-recommends \
@@ -54,15 +69,27 @@ RUN set -ex \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN set -ex \
-	&& groupadd --gid 333 --system archivematica \
-	&& useradd -m --uid 333 --gid 333 --system archivematica
-
-RUN set -ex \
+	&& groupadd --gid ${GROUP_ID} --system archivematica \
+	&& useradd -m --uid ${USER_ID} --gid ${GROUP_ID} --create-home --home-dir /home/archivematica --system archivematica \
 	&& mkdir -p /var/archivematica/sharedDirectory \
 	&& chown -R archivematica:archivematica /var/archivematica
 
+USER archivematica
+
+ENV PYENV_ROOT="/home/archivematica/.pyenv"
+ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+
+RUN set -ex \
+	&& curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+	&& pyenv install ${PYTHON_VERSION} \
+	&& pyenv global ${PYTHON_VERSION}
+
 COPY requirements-dev.txt /src/requirements-dev.txt
-RUN pip3 install -r /src/requirements-dev.txt
+
+RUN set -ex \
+	&& pyenv exec python${PYTHON_VERSION} -m pip install --upgrade pip setuptools \
+	&& pyenv exec python${PYTHON_VERSION} -m pip install --requirement /src/requirements-dev.txt \
+	&& pyenv rehash
 
 COPY . /src
 
@@ -70,12 +97,12 @@ COPY . /src
 
 FROM base AS archivematica-mcp-client
 
+ARG PYTHON_VERSION=3.6
+
 # Some scripts in archivematica-fpr-admin executed by MCPClient rely on certain
 # files being available in this image (e.g. see https://git.io/vA1wF).
 COPY src/archivematicaCommon/lib/externals/fido/ /usr/lib/archivematica/archivematicaCommon/externals/fido/
 COPY src/archivematicaCommon/lib/externals/fiwalk_plugins/ /usr/lib/archivematica/archivematicaCommon/externals/fiwalk_plugins/
-
-USER archivematica
 
 ENV DJANGO_SETTINGS_MODULE settings.common
 ENV PYTHONPATH /src/src/MCPClient/lib/:/src/src/MCPClient/lib/clientScripts:/src/src/archivematicaCommon/lib/:/src/src/dashboard/src/
@@ -83,35 +110,42 @@ ENV ARCHIVEMATICA_MCPCLIENT_ARCHIVEMATICACLIENTMODULES /src/src/MCPClient/lib/ar
 ENV ARCHIVEMATICA_MCPCLIENT_CLIENTASSETSDIRECTORY /src/src/MCPClient/lib/assets/
 ENV ARCHIVEMATICA_MCPCLIENT_CLIENTSCRIPTSDIRECTORY /src/src/MCPClient/lib/clientScripts/
 
-ENTRYPOINT ["/src/src/MCPClient/lib/archivematicaClient.py"]
+ENTRYPOINT pyenv exec python${PYTHON_VERSION} /src/src/MCPClient/lib/archivematicaClient.py
 
 # -----------------------------------------------------------------------------
 
 FROM base AS archivematica-mcp-server
 
-USER archivematica
+ARG PYTHON_VERSION=3.6
 
 ENV DJANGO_SETTINGS_MODULE settings.common
 ENV PYTHONPATH /src/src/MCPServer/lib/:/src/src/archivematicaCommon/lib/:/src/src/dashboard/src/
 
-ENTRYPOINT ["/src/src/MCPServer/lib/archivematicaMCP.py"]
+ENTRYPOINT pyenv exec python${PYTHON_VERSION} /src/src/MCPServer/lib/archivematicaMCP.py
 
 # -----------------------------------------------------------------------------
 
 FROM base AS archivematica-dashboard
 
+ARG PYTHON_VERSION=3.6
+
+USER root
+
 RUN set -ex \
 	&& internalDirs=' \
+		/src/src/dashboard/frontend \
 		/src/src/dashboard/src/static \
 		/src/src/dashboard/src/media \
 	' \
 	&& mkdir -p $internalDirs \
-	&& chown -R archivematica:archivematica $internalDirs \
+	&& chown -R archivematica $internalDirs
+
+USER archivematica
+
+RUN set -ex \
 	&& yarn --cwd=/src/src/dashboard/frontend install --frozen-lockfile
 
 WORKDIR /src/src/dashboard/src
-
-USER archivematica
 
 ENV DJANGO_SETTINGS_MODULE settings.local
 ENV PYTHONPATH /src/src/dashboard/src/:/src/src/archivematicaCommon/lib/
@@ -127,7 +161,7 @@ ENV DJANGO_SETTINGS_MODULE settings.production
 
 EXPOSE 8000
 
-ENTRYPOINT ["/usr/local/bin/gunicorn", "--config=/src/src/dashboard/install/dashboard.gunicorn-config.py", "wsgi:application"]
+ENTRYPOINT pyenv exec python${PYTHON_VERSION} -m gunicorn --config=/src/src/dashboard/install/dashboard.gunicorn-config.py wsgi:application
 
 # -----------------------------------------------------------------------------
 

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -1,10 +1,5 @@
 .DEFAULT_GOAL := help
 
-# Ensure that Composes uses BuildKit.
-export COMPOSE_DOCKER_CLI_BUILD=1
-export DOCKER_BUILDKIT=1
-export BUILDKIT_PROGRESS=plain
-
 # Paths for Docker named volumes
 AM_PIPELINE_DATA ?= $(HOME)/.am/am-pipeline-data
 SS_LOCATION_DATA ?= $(HOME)/.am/ss-location-data
@@ -18,15 +13,15 @@ NULL :=
 SPACE := $(NULL) $(NULL)
 
 define compose_all
-	docker-compose -f docker-compose.yml -f docker-compose.acceptance-tests.yml -f docker-compose.pmm.yml $(1)
+	docker compose -f docker-compose.yml -f docker-compose.acceptance-tests.yml -f docker-compose.pmm.yml $(1)
 endef
 
 define compose_amauat
-	docker-compose -f docker-compose.yml -f docker-compose.acceptance-tests.yml $(1)
+	docker compose -f docker-compose.yml -f docker-compose.acceptance-tests.yml $(1)
 endef
 
 define compose_tests
-	docker-compose -f docker-compose.yml -f docker-compose.tests.yml $(1)
+	docker compose -f docker-compose.yml -f docker-compose.tests.yml $(1)
 endef
 
 define run_toxenvs
@@ -53,14 +48,14 @@ start-mysql: test-build
 					/src/hack/wait-for-it.sh mysql:3306 --timeout=30)
 
 define create_db
-	docker-compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e '\
+	docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e '\
 		DROP DATABASE IF EXISTS `$(1)`; \
 		CREATE DATABASE `$(1)`; \
 		GRANT ALL ON `$(1)`.* TO "archivematica"@"%" IDENTIFIED BY "demo";'
 endef
 
 define drop_db
-	docker-compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e 'DROP DATABASE IF EXISTS `$(1)`;'
+	docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e 'DROP DATABASE IF EXISTS `$(1)`;'
 endef
 
 create-volumes:  ## Create external data volumes.
@@ -78,21 +73,21 @@ create-volumes:  ## Create external data volumes.
 			ss-location-data
 
 build:  # Build Compose services.
-	docker-compose build
+	docker compose build
 
 bootstrap: bootstrap-storage-service bootstrap-dashboard-db bootstrap-dashboard-frontend  ## Full bootstrap.
 
 bootstrap-storage-service:  ## Boostrap Storage Service (new database).
-	docker-compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e "\
+	docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e "\
 		DROP DATABASE IF EXISTS SS; \
 		CREATE DATABASE SS; \
 		GRANT ALL ON SS.* TO 'archivematica'@'%' IDENTIFIED BY 'demo';"
-	docker-compose run \
+	docker compose run \
 		--rm \
 		--entrypoint /src/storage_service/manage.py \
 			archivematica-storage-service \
 				migrate --noinput
-	docker-compose run \
+	docker compose run \
 		--rm \
 		--entrypoint /src/storage_service/manage.py \
 			archivematica-storage-service \
@@ -104,10 +99,10 @@ bootstrap-storage-service:  ## Boostrap Storage Service (new database).
 					--superuser
 	# SS needs to be restarted so the local space is created.
 	# See #303 (https://git.io/vNKlM) for more details.
-	docker-compose restart archivematica-storage-service
+	docker compose restart archivematica-storage-service
 
 makemigrations-ss:
-	docker-compose run \
+	docker compose run \
 		--user $(CALLER_UID):$(CALLER_GID) \
 		--rm \
 		--entrypoint /src/storage_service/manage.py \
@@ -115,7 +110,7 @@ makemigrations-ss:
 				makemigrations
 
 manage-dashboard:  ## Run Django /manage.py on Dashboard, suppling <command> [options] as value to ARG, e.g., `make manage-ss ARG=shell`
-	docker-compose run \
+	docker compose run \
 		--user $(CALLER_UID):$(CALLER_GID) \
 		--rm \
 		--entrypoint /src/src/dashboard/src/manage.py \
@@ -123,7 +118,7 @@ manage-dashboard:  ## Run Django /manage.py on Dashboard, suppling <command> [op
 				$(ARG)
 
 manage-ss:  ## Run Django /manage.py on Storage Service, suppling <command> [options] as value to ARG, e.g., `make manage-ss ARG='shell --help'`
-	docker-compose run \
+	docker compose run \
 		--user $(CALLER_UID):$(CALLER_GID) \
 		--rm \
 		--entrypoint /src/storage_service/manage.py \
@@ -131,16 +126,16 @@ manage-ss:  ## Run Django /manage.py on Storage Service, suppling <command> [opt
 				$(ARG)
 
 bootstrap-dashboard-db:  ## Bootstrap Dashboard (new database).
-	docker-compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e "\
+	docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e "\
 		DROP DATABASE IF EXISTS MCP; \
 		CREATE DATABASE MCP; \
 		GRANT ALL ON MCP.* TO 'archivematica'@'%' IDENTIFIED BY 'demo';"
-	docker-compose run \
+	docker compose run \
 		--rm \
 		--entrypoint /src/src/dashboard/src/manage.py \
 			archivematica-dashboard \
 				migrate --noinput
-	docker-compose run \
+	docker compose run \
 		--rm \
 		--entrypoint /src/src/dashboard/src/manage.py \
 			archivematica-dashboard \
@@ -157,7 +152,7 @@ bootstrap-dashboard-db:  ## Bootstrap Dashboard (new database).
 					--site-url="http://archivematica-dashboard:8000"
 
 bootstrap-dashboard-frontend:  ## Build front-end assets.
-	docker-compose run \
+	docker compose run \
 		-e HOME=/tmp/yarn-config \
 		--rm \
 		--no-deps \
@@ -167,13 +162,13 @@ bootstrap-dashboard-frontend:  ## Build front-end assets.
 				--cwd=/src/src/dashboard/frontend install --frozen-lockfile
 
 restart-am-services:  ## Restart Archivematica services: MCPServer, MCPClient, Dashboard and Storage Service.
-	docker-compose restart archivematica-mcp-server
-	docker-compose restart archivematica-mcp-client
-	docker-compose restart archivematica-dashboard
-	docker-compose restart archivematica-storage-service
+	docker compose restart archivematica-mcp-server
+	docker compose restart archivematica-mcp-client
+	docker compose restart archivematica-dashboard
+	docker compose restart archivematica-storage-service
 
 compile-requirements-am:  ## Run pip-compile for Archivematica
-	docker-compose run --workdir /src \
+	docker compose run --workdir /src \
 		-e XDG_CACHE_HOME=/tmp/pip-cache \
 		--rm \
 		--no-deps \
@@ -182,7 +177,7 @@ compile-requirements-am:  ## Run pip-compile for Archivematica
 			-c "make pip-compile"
 
 compile-requirements-ss:  ## Run pip-compile for Storage Service
-	docker-compose run --workdir /src/requirements \
+	docker compose run --workdir /src/requirements \
 		-e XDG_CACHE_HOME=/tmp/pip-cache \
 		--rm \
 		--no-deps \
@@ -191,20 +186,20 @@ compile-requirements-ss:  ## Run pip-compile for Storage Service
 			-c "make pip-compile"
 
 db:  ## Connect to the MySQL server using the CLI.
-	docker-compose exec mysql mysql -hlocalhost -uroot -p12345
+	docker compose exec mysql mysql -hlocalhost -uroot -p12345
 
 flush: flush-shared-dir flush-search bootstrap restart-am-services  ## Delete ALL user data.
 
 flush-shared-dir-mcp-configs:  ## Delete processing configurations - it restarts MCPServer.
 	rm -f ${AM_PIPELINE_DATA}/sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml
 	rm -f ${AM_PIPELINE_DATA}/sharedMicroServiceTasksConfigs/processingMCPConfigs/automatedProcessingMCP.xml
-	docker-compose restart archivematica-mcp-server
+	docker compose restart archivematica-mcp-server
 
 flush-shared-dir:  ## Delete contents of the shared directory data volume.
 	rm -rf ${AM_PIPELINE_DATA}/*
 
 flush-search:  ## Delete Elasticsearch indices.
-	docker-compose exec archivematica-mcp-client curl -XDELETE "http://elasticsearch:9200/aips,aipfiles,transfers,transferfiles"
+	docker compose exec archivematica-mcp-client curl -XDELETE "http://elasticsearch:9200/aips,aipfiles,transfers,transferfiles"
 
 flush-logs:  ## Delete container logs - requires root privileges.
 	@./helpers/flush-docker-logs.sh

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -207,7 +207,7 @@ flush-logs:  ## Delete container logs - requires root privileges.
 # These include the database names used in the settings.testmysql
 # modules plus the prefixed and suffixed variations used by Django and
 # tox
-__TEST_DBS := DASHBOARDTEST MCPCLIENTTEST MCPSERVERTEST SSTEST test_DASHBOARDTEST test_DASHBOARDTEST_archivematica-common test_DASHBOARDTEST_dashboard test_MCP test_MCPCLIENTTEST test_MCPCLIENTTEST_mcpclient test_MCPSERVERTEST test_MCPSERVERTEST_mcpserver test_SS test_SSTEST test_SSTEST_storage-service
+__TEST_DBS := DASHBOARDTEST MCPCLIENTTEST MCPSERVERTEST SSTEST test_DASHBOARDTEST test_DASHBOARDTEST_archivematica-common test_DASHBOARDTEST_dashboard test_MCP test_MCPCLIENTTEST test_MCPCLIENTTEST_mcp-client test_MCPSERVERTEST test_MCPSERVERTEST_mcp-server test_SS test_SSTEST test_SSTEST_storage-service
 flush-test-dbs: start-mysql
 	$(foreach test_db,$(__TEST_DBS),$(call drop_db,$(test_db));)
 
@@ -218,30 +218,30 @@ test-build:  ## Build archivematica-tests image.
 		--build-arg TARGET=archivematica-tests \
 			../
 
-__TOXENVS_MCPSERVER := py36-mcpserver
+__TOXENVS_MCPSERVER := mcp-server
 test-mcp-server: start-mysql  ## Run MCPServer tests.
 	$(call run_toxenvs,$(__TOXENVS_MCPSERVER))
 
-__TOXENVS_MCPCLIENT = py36-mcpclient py36-mcpclient-ensure-no-mutable-globals
+__TOXENVS_MCPCLIENT = mcp-client mcp-client-ensure-no-mutable-globals
 test-mcp-client: start-mysql  ## Run MCPClient tests.
 	$(call run_toxenvs,$(__TOXENVS_MCPCLIENT))
 
-__TOXENVS_DASHBOARD = py36-dashboard
+__TOXENVS_DASHBOARD = dashboard
 test-dashboard: start-mysql  ## Run Dashboard tests.
 	$(call run_toxenvs,$(__TOXENVS_DASHBOARD))
 
-__TOXENVS_STORAGE_SERVICE = py36-storage-service
+__TOXENVS_STORAGE_SERVICE = storage-service
 test-storage-service: start-mysql  ## Run Storage Service tests.
 	$(call run_toxenvs,$(__TOXENVS_STORAGE_SERVICE))
 
 test-storage-service-integration:  ## Run Storage Service unit and integration tests using MySQL and MinIO.
 	$(CURDIR)/submodules/archivematica-storage-service/integration/run.sh
 
-__TOXENVS_ARCHIVEMATICA_COMMON = py36-archivematica-common
+__TOXENVS_ARCHIVEMATICA_COMMON = archivematica-common
 test-archivematica-common: start-mysql  ## Run Archivematica Common tests.
 	$(call run_toxenvs,$(__TOXENVS_ARCHIVEMATICA_COMMON))
 
-__TOXENVS_MIGRATIONS = py36-migrations-dashboard migrations-storage-service
+__TOXENVS_MIGRATIONS = migrations-dashboard migrations-storage-service
 test-migrations: start-mysql  ## Check there are no pending migrations.
 	$(call create_db,DASHBOARDTEST)
 	$(call create_db,SSTEST)

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -58,6 +58,10 @@ define drop_db
 	docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e 'DROP DATABASE IF EXISTS `$(1)`;'
 endef
 
+define create_dbs
+	$(foreach test_db,$(1),$(call create_db,$(test_db));)
+endef
+
 create-volumes:  ## Create external data volumes.
 	mkdir -p ${AM_PIPELINE_DATA}
 	docker volume create \
@@ -84,11 +88,13 @@ bootstrap-storage-service:  ## Boostrap Storage Service (new database).
 		GRANT ALL ON SS.* TO 'archivematica'@'%' IDENTIFIED BY 'demo';"
 	docker compose run \
 		--rm \
+		--no-deps \
 		--entrypoint /src/storage_service/manage.py \
 			archivematica-storage-service \
 				migrate --noinput
 	docker compose run \
 		--rm \
+		--no-deps \
 		--entrypoint /src/storage_service/manage.py \
 			archivematica-storage-service \
 				create_user \
@@ -105,6 +111,7 @@ makemigrations-ss:
 	docker compose run \
 		--user $(CALLER_UID):$(CALLER_GID) \
 		--rm \
+		--no-deps \
 		--entrypoint /src/storage_service/manage.py \
 			archivematica-storage-service \
 				makemigrations
@@ -113,6 +120,7 @@ manage-dashboard:  ## Run Django /manage.py on Dashboard, suppling <command> [op
 	docker compose run \
 		--user $(CALLER_UID):$(CALLER_GID) \
 		--rm \
+		--no-deps \
 		--entrypoint /src/src/dashboard/src/manage.py \
 			archivematica-dashboard \
 				$(ARG)
@@ -121,6 +129,7 @@ manage-ss:  ## Run Django /manage.py on Storage Service, suppling <command> [opt
 	docker compose run \
 		--user $(CALLER_UID):$(CALLER_GID) \
 		--rm \
+		--no-deps \
 		--entrypoint /src/storage_service/manage.py \
 			archivematica-storage-service \
 				$(ARG)
@@ -132,11 +141,13 @@ bootstrap-dashboard-db:  ## Bootstrap Dashboard (new database).
 		GRANT ALL ON MCP.* TO 'archivematica'@'%' IDENTIFIED BY 'demo';"
 	docker compose run \
 		--rm \
+		--no-deps \
 		--entrypoint /src/src/dashboard/src/manage.py \
 			archivematica-dashboard \
 				migrate --noinput
 	docker compose run \
 		--rm \
+		--no-deps \
 		--entrypoint /src/src/dashboard/src/manage.py \
 			archivematica-dashboard \
 				install \
@@ -206,8 +217,13 @@ flush-logs:  ## Delete container logs - requires root privileges.
 
 # These include the database names used in the settings.testmysql
 # modules plus the prefixed and suffixed variations used by Django and
-# tox
-__TEST_DBS := DASHBOARDTEST MCPCLIENTTEST MCPSERVERTEST SSTEST test_DASHBOARDTEST test_DASHBOARDTEST_archivematica-common test_DASHBOARDTEST_dashboard test_MCP test_MCPCLIENTTEST test_MCPCLIENTTEST_mcp-client test_MCPSERVERTEST test_MCPSERVERTEST_mcp-server test_SS test_SSTEST test_SSTEST_storage-service
+# tox when running in parallel mode
+__TEST_DBS_MCPCLIENT = MCPCLIENTTEST test_MCPCLIENTTEST test_MCPCLIENTTEST_mcp-client
+__TEST_DBS_MIGRATIONS = DASHBOARDTEST SSTEST
+__TEST_DBS_DASHBOARD = DASHBOARDTEST test_DASHBOARDTEST test_DASHBOARDTEST_dashboard test_DASHBOARDTEST_archivematica-common
+__TEST_DBS_MCPSERVER = MCPSERVERTEST test_MCPSERVERTEST test_MCPSERVERTEST_mcp-server
+__TEST_DBS_STORAGE_SERVICE = test_SSTEST test_SSTEST_storage-service
+__TEST_DBS := $(__TEST_DBS_MCPCLIENT) $(__TEST_DBS_MIGRATIONS) $(__TEST_DBS_DASHBOARD) $(__TEST_DBS_MCPSERVER) $(__TEST_DBS_STORAGE_SERVICE) test_MCP test_SS
 flush-test-dbs: start-mysql
 	$(foreach test_db,$(__TEST_DBS),$(call drop_db,$(test_db));)
 
@@ -220,18 +236,22 @@ test-build:  ## Build archivematica-tests image.
 
 __TOXENVS_MCPSERVER := mcp-server
 test-mcp-server: start-mysql  ## Run MCPServer tests.
+	$(call create_dbs,$(__TEST_DBS_MCPSERVER))
 	$(call run_toxenvs,$(__TOXENVS_MCPSERVER))
 
 __TOXENVS_MCPCLIENT = mcp-client mcp-client-ensure-no-mutable-globals
 test-mcp-client: start-mysql  ## Run MCPClient tests.
+	$(call create_dbs,$(__TEST_DBS_MCPCLIENT))
 	$(call run_toxenvs,$(__TOXENVS_MCPCLIENT))
 
 __TOXENVS_DASHBOARD = dashboard
 test-dashboard: start-mysql  ## Run Dashboard tests.
+	$(call create_dbs,$(__TEST_DBS_DASHBOARD))
 	$(call run_toxenvs,$(__TOXENVS_DASHBOARD))
 
 __TOXENVS_STORAGE_SERVICE = storage-service
 test-storage-service: start-mysql  ## Run Storage Service tests.
+	$(call create_dbs,$(__TEST_DBS_STORAGE_SERVICE))
 	$(call run_toxenvs,$(__TOXENVS_STORAGE_SERVICE))
 
 test-storage-service-integration:  ## Run Storage Service unit and integration tests using MySQL and MinIO.
@@ -239,12 +259,12 @@ test-storage-service-integration:  ## Run Storage Service unit and integration t
 
 __TOXENVS_ARCHIVEMATICA_COMMON = archivematica-common
 test-archivematica-common: start-mysql  ## Run Archivematica Common tests.
+	$(call create_dbs,$(__TEST_DBS_DASHBOARD))
 	$(call run_toxenvs,$(__TOXENVS_ARCHIVEMATICA_COMMON))
 
 __TOXENVS_MIGRATIONS = migrations-dashboard migrations-storage-service
 test-migrations: start-mysql  ## Check there are no pending migrations.
-	$(call create_db,DASHBOARDTEST)
-	$(call create_db,SSTEST)
+	$(call create_dbs,$(__TEST_DBS_MIGRATIONS))
 	$(call run_toxenvs,$(__TOXENVS_MIGRATIONS))
 
 __TOXENVS_LINTING = linting
@@ -253,6 +273,7 @@ test-linting:  ## Check linting.
 
 __TOXENVS_ALL := $(__TOXENVS_MCPSERVER) $(__TOXENVS_MCPCLIENT) $(__TOXENVS_DASHBOARD) $(__TOXENVS_STORAGE_SERVICE) $(__TOXENVS_ARCHIVEMATICA_COMMON)
 test-all: start-mysql  ## Run all tests.
+	$(call create_dbs,$(__TEST_DBS_MCPSERVER) $(__TEST_DBS_MCPCLIENT) $(__TEST_DBS_DASHBOARD) $(__TEST_DBS_STORAGE_SERVICE) $(__TEST_DBS_ARCHIVEMATICA_COMMON))
 	$(call run_toxenvs,$(__TOXENVS_ALL))
 
 test-at-build:  ## AMAUAT: build image.

--- a/hack/README.md
+++ b/hack/README.md
@@ -19,175 +19,197 @@
   - [Percona Monitoring and Management](#percona-monitoring-and-management)
 - [Troubleshooting](#troubleshooting)
   - [Nginx returns 502 Bad Gateway](#nginx-returns-502-bad-gateway)
-  - [MCPClient osdeps cannot be updated](#mcpclient-osdeps-cannot-be-updated)
-  - [Error while mounting volume](#error-while-mounting-volume)
-  - [make bootstrap fails to run](#make-bootstrap-fails-to-run)
   - [Bootstrap seems to run but the Dashboard and Elasticsearch are still down][intro-1]
-  - [My environment is still broken](#my-environment-is-still-broken)
   - [PMM client service doesn't start](#pmm-client-service-doesnt-start)
+  - [My environment is still broken](#my-environment-is-still-broken)
 
 [intro-0]: #upgrading-to-the-latest-version-of-archivematica
 [intro-1]: #Bootstrap-seems-to-run-but-the-Dashboard-and-Elasticsearch-are-still-down
 
 ## Audience
 
-This Archivematica environment is based on Docker Compose and it is
-specifically **designed for developers**. Compose can be used in a production
-environment but that is beyond the scope of this recipe.
+This Archivematica environment is based on Docker Compose [V3][audience-compose-v3]
+and it is specifically **designed for developers**. Compose can be used in a
+production environment but that is beyond the scope of this recipe. Please read
+the [documentation][audience-compose-reference].
 
-Artefactual developers use Docker Compose heavily so it's important that you're
-familiar with it. Please read the [documentation][audience-0].
+Artefactual developers use Docker Compose on Linux heavily so it's important
+that you're familiar with it, and some choices in the configuration of this
+environment break in other operative systems.
 
-[audience-0]: https://docs.docker.com/compose/reference/overview/
+[audience-compose-v3]: https://docs.docker.com/compose/compose-file/compose-file-v3/
+[audience-compose-reference]: https://docs.docker.com/compose/reference/overview/
 
 ## Requirements
 
-[System requirements][requirements-0]. Memory usage when the environment is
-initialized (obtained using `docker stats`):
+[System requirements][requirements-am-docs]. The following is a sample of
+memory usage when the environment is initialized in a virtual machine with
+8 GB of RAM:
 
+```shell
+docker stats --all --format "table {{.Name}}\t{{.MemUsage}}"
 ```
-CONTAINER NAME                  MEM USAGE (MiB)
-archivematica-mcp-server         60.6
-archivematica-mcp-client         32.5
-archivematica-dashboard          60.0
-archivematica-storage-service    74.6
-clamavd                         545.6
-gearmand                          1.6
-mysql                           530.4
-nginx                             2.5
-elasticsearch                   229.3
-fits                             70.7
+```console
+NAME                                 MEM USAGE / LIMIT
+am-archivematica-mcp-client-1        41.3MiB / 7.763GiB
+am-archivematica-dashboard-1         145.1MiB / 7.763GiB
+am-archivematica-mcp-server-1        39.43MiB / 7.763GiB
+am-archivematica-storage-service-1   83.96MiB / 7.763GiB
+am-nginx-1                           2.715MiB / 7.763GiB
+am-elasticsearch-1                   900.2MiB / 7.763GiB
+am-fits-1                            71.09MiB / 7.763GiB
+am-gearmand-1                        3.395MiB / 7.763GiB
+am-mysql-1                           551.9MiB / 7.763GiB
+am-clamavd-1                         570MiB / 7.763GiB
 ```
 
-Software dependencies: Docker, Docker Compose, git and make. Please use a
-recent version of Docker and Compose that support multi-stage builds and
-BuildKit.
+Software dependencies: Docker Engine, Docker Compose V3, git and make. Please
+use a version of Docker Engine greater than 23.0 which includes Buildkit as
+the default builder with support for multi-stage builds.
 
 It is beyond the scope of this document to explain how these dependencies are
-installed in your computer. If you're using Ubuntu 16.04 the following commands
-may work:
+installed in your computer.
 
-    $ sudo apt update
-    $ sudo apt install -y build-essential python-dev git
-    $ sudo pip install -U docker-compose
+Follow [these instructions][requirements-docker-install] to install Docker
+Engine in Ubuntu. Docker also provides instructions on how to use it as a
+[non-root user][requirements-docker-non-root] so you don't have to run the
+following `docker compose` commands with `sudo`. Make sure to read about the
+[security implications][requirements-docker-security] of this change.
 
-And install Docker CE following [these instructions][requirements-1].
-
-[requirements-0]: https://www.archivematica.org/docs/latest/getting-started/overview/system-requirements/
-[requirements-1]: https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/
-
-Install the `rng-tools` daemon if you want to set up GPG encrypted spaces. The
-Storage Service container should have access to the `/dev/random` device.
-
-### Docker and Linux
-
-Docker will provide instructions on how to use it as a non-root user. This may
-not be desirable for all.
-
-	If you would like to use Docker as a non-root user, you should now consider
-	adding your user to the "docker" group with something like:
-
-	  sudo usermod -aG docker <user>
-
-	Remember that you will have to log out and back in for this to take effect!
-
-	WARNING: Adding a user to the "docker" group will grant the ability to run
-			 containers which can be used to obtain root privileges on the
-			 docker host.
-			 Refer to https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface
-			 for more information.
-
-The impact to those following this recipe is that any of the commands below
-which call Docker will need to be run as a root user using 'sudo'.
-
-### Docker and Mac
-
-Installation of Archivematica on machines running macOS using Docker is
-possible, but still in development and may require some extra steps. If you are
-new to Archivematica and/or Docker, or have an older machine, it may be better
-to instead use a Linux machine.
+[requirements-am-docs]: https://www.archivematica.org/docs/latest/getting-started/overview/system-requirements/
+[requirements-docker-install]: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
+[requirements-docker-non-root]: https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user
+[requirements-docker-security]: https://docs.docker.com/engine/security/#docker-daemon-attack-surface
 
 ### Elasticsearch container
 
 For the Elasticsearch container to run properly, you may need to increase the
-maximum virtual memory address space `vm.max_map_count` to at least `[262144]`.
+maximum virtual memory address space `vm.max_map_count` to at least `262144`.
 This is a configuration setting on the host machine running Docker, not the
 container itself.
 
-To make this change:
+To make this change run:
 
-`sudo sysctl -w vm.max_map_count=262144`
+```shell
+sudo sysctl -w vm.max_map_count=262144
+```
 
 To persist this setting, modify `/etc/sysctl.conf` and add:
-`vm.max_map_count=262144`
+
+```text
+vm.max_map_count=262144
+```
 
 For more information, please consult the Elasticsearch `6.x`
-[documentation][documentation-0].
+[documentation][elasticsearch-docs-map-count].
 
-[documentation-0]: https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
+[elasticsearch-docs-map-count]: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/vm-max-map-count.html
 
 ## Installation
 
-If you haven't already, create a directory to store this repository using git
-clone, and pull all the submodules:
+First, clone this repository this way:
 
-    $ git clone https://github.com/artefactual/archivematica.git --branch qa/1.x --recurse-submodules
+```shell
+git clone https://github.com/artefactual/archivematica.git --branch qa/1.x --recurse-submodules
+```
 
-Run the installation (and all Docker Compose) commands from within the hack
-directory:
+This will set up the submodules defined in 
+https://github.com/artefactual/archivematica/tree/qa/1.x/hack/submodules which
+are from the `qa/1.x` branch of Archivematica and the `qa/0.x` branch of
+Archivematica Storage Service. These two branches are the focus of
+Archivematica development and pull requests are expected to target them.
 
-    $ cd ./archivematica/hack
+Next, run the installation (and all Docker Compose) commands from within the
+`hack` directory:
 
-These are the commands you need to run when starting from scratch:
+```shell
+cd ./archivematica/hack
+```
 
-    $ make create-volumes
-    $ make build
-    $ docker-compose up -d
-    $ make bootstrap
-    $ make restart-am-services
+Run the following command to create two Docker external volumes:
 
-`make create-volumes` creates two external volumes. They're heavily used in our
-containers but they are provided in the host machine:
+```shell
+make create-volumes
+```
 
-- `$HOME/.am/am-pipeline-data` - the shared directory.
+These are heavily used in our containers but they are provided in the host
+machine:
+
+- `$HOME/.am/am-pipeline-data` - Archivematica's shared directory.
 - `$HOME/.am/ss-location-data` - the transfer source location.
+
+Next, build the Docker images:
+
+```shell
+make build
+```
+
+You may want to rebuild images with this command after updating the
+`Dockerfile` or the Python requirement files, but it's not necessary to rebuild
+the images after changing Python code.
+
+Start the services with:
+
+```shell
+docker compose up -d
+```
+
+On the first run, the Archivematica services will fail because the databases
+of the Dashboard and the Storage Service have not been created. To do so, run:
+
+```shell
+make bootstrap
+```
+
+Be aware that this command drops and recreates both databases, and then runs
+Django's migrations so you will lose any existing data if you run it again.
+
+Now that the databases have been created, use the following command to restart
+only the Archivematica services:
+
+```shell
+make restart-am-services
+```
 
 ### GNU make
 
 Make commands above, and any subsequent calls to it below can be reviewed using
-the following command from the compose directory:
+the following command:
 
-    $ make help
+```shell
+make help
+```
 
 ## Upgrading to the latest version of Archivematica
-
-The installation instructions above will install the submodules defined in
-https://github.com/artefactual-labs/am/tree/master/src which are from the
-`qa/1.x` branch of Archivematica and the `qa/0.x` branch of Archivematica
-Storage Service.
 
 To upgrade your installation to include the most recent changes in the
 submodules, use the following commands:
 
-    $ git pull --rebase
-    $ git submodule update --init --recursive
-    $ docker-compose up -d --force-recreate --build
-    $ make bootstrap
-    $ make restart-am-services
+```shell
+git pull --rebase
+git submodule update --init --recursive
+docker compose up -d --force-recreate --build
+make bootstrap
+make restart-am-services
+```
 
 The submodules are not always up to date, i.e. they may not be pointing to the
 latest commits of their tracking branches. They can be updated manually using
 `git pull --rebase`:
 
-    $ cd ./submodules/archivematica-storage-service && git pull --rebase
-    $ cd ./submodules/archivematica-sampledata && git pull --rebase
-    $ cd ./submodules/archivematica-acceptance-tests && git pull --rebase
+```shell
+cd ./submodules/archivematica-storage-service && git pull --rebase
+cd ./submodules/archivematica-sampledata && git pull --rebase
+cd ./submodules/archivematica-acceptance-tests && git pull --rebase
+```
 
 Once you're done, run:
 
-    $ docker-compose up -d --force-recreate --build
-    $ make bootstrap
-    $ make restart-am-services
+```shell
+docker compose up -d --force-recreate --build
+make bootstrap
+make restart-am-services
+```
 
 Working with submodules can be a little confusing. GitHub's
 [Working with submodules][submodules-0] blog post is a good introduction.
@@ -212,13 +234,13 @@ code changes.
 Other components in the stack like the `MCPServer` don't offer this option and
 they need to be restarted manually, e.g.:
 
-    $ docker-compose up -d --force-recreate --no-deps archivematica-mcp-server
+    $ docker compose up -d --force-recreate --no-deps archivematica-mcp-server
 
 If you've added new dependencies or changes the `Dockerfile` you should also
 add the `--build` argument to the previous command in order to ensure that the
 container is using the newest image, e.g.:
 
-    $ docker-compose up -d --force-recreate --build --no-deps archivematica-mcp-server
+    $ docker compose up -d --force-recreate --build --no-deps archivematica-mcp-server
 
 ## Logs
 
@@ -230,15 +252,19 @@ replicas that we may be deploying of our services across the cluster.
 Docker Compose aggregates the logs for us so you can see everything from one
 place. Some examples:
 
-- `docker-compose logs -f`
-- `docker-compose logs -f archivematica-storage-service`
-- `docker-compose logs -f nginx archivematica-dashboard`
+- `docker compose logs --follow`
+- `docker compose logs --follow archivematica-storage-service`
+- `docker compose logs --follow nginx archivematica-dashboard`
+
+### Clearing the logs
 
 Docker keeps the logs in files using the [JSON File logging driver][logs-0].
 If you want to clear them, we provide a simple script that can do it for us
 quickly but it needs root privileges, e.g.:
 
-    $ sudo make flush-logs
+```shell
+sudo make flush-logs
+```
 
 [logs-0]: https://docs.docker.com/config/containers/logging/json-file/
 
@@ -248,15 +274,21 @@ With Docker Compose we can run as many containers as we want for a service,
 e.g. by default we only provision a single replica of the
 `archivematica-mcp-client` service but nothing stops you from running more:
 
-    $ docker-compose up -d --scale archivematica-mcp-client=3
+```shell
+docker compose up -d --scale archivematica-mcp-client=3
+```
 
 We still have one service but three containers. Let's verify that the workers
 are connected to Gearman:
 
-    $ echo workers | socat - tcp:127.0.0.1:62004,shut-none | grep "_v0.0" | awk '{print $2}' - | sort -u
-    172.19.0.15
-    172.19.0.16
-    172.19.0.17
+```shell
+echo workers | socat - tcp:127.0.0.1:62004,shut-none | grep "_v0.0" | awk '{print $2}' - | sort -u
+```
+```console
+172.19.0.15
+172.19.0.16
+172.19.0.17
+```
 
 ## Ports
 
@@ -274,11 +306,12 @@ are connected to Gearman:
 
 The `Makefile` includes many useful targets for testing. List them all with:
 
-    $ make 2>&1 | grep test-
+```shell
+make help | grep test-
+```
 
 The following targets use [`tox`](https://tox.readthedocs.io) and
-[`pytest`](https://docs.pytest.org) to run the tests using MySQL
-databases from Docker containers:
+[`pytest`](https://docs.pytest.org) to run the tests using MySQL:
 
 ```
 test-all                   Run all tests.
@@ -291,8 +324,8 @@ test-storage-service       Run Storage Service tests.
 
 `tox` sets up separate virtual environments for each target and calls
 `pytest` to run the tests. Their configurations live in the `tox.ini`
-and `pytest.ini` files but you can set the [`TOXARGS`](tox-cli) and
-[`PYTEST_ADDOPTS`](pytest-cli) environment variables to pass command
+and `pytest.ini` files but you can set the [`TOXARGS`][tox-cli] and
+[`PYTEST_ADDOPTS`][pytest-cli] environment variables to pass command
 line options to each.
 
 [tox-cli]: https://tox.readthedocs.io/en/latest/config.html#cli
@@ -302,26 +335,44 @@ For example you can run all the tests in `tox` [parallel
 mode](https://tox.readthedocs.io/en/latest/example/basic.html#parallel-mode)
 and make it extra verbose like this:
 
-    $ env TOXARGS='-vv --parallel' make test-all
+```shell
+env TOXARGS='-vv --parallel' make test-all
+```
 
-The MySQL test databases created by `pytest` are kept and reused after
-each run, but you could [force it to recreate
-them](pytest-recreate-db) like this:
+The MySQL databases created by `pytest` are kept and reused after
+each run, but you could [force it to recreate them][pytest-recreate-db] like
+this:
 
-    $ env PYTEST_ADDOPTS=--create-db make test-dashboard
+```shell
+env PYTEST_ADDOPTS='--create-db' make test-dashboard
+```
 
 [pytest-recreate-db]: https://pytest-django.readthedocs.io/en/latest/database.html#example-work-flow-with-reuse-db-and-create-db
 
 Or you could run only a specific test module using its relative path
 in the `PYTHONPATH` of the `tox` environment like this:
 
-    $ env PYTEST_ADDOPTS=tests/test_reingest_mets.py make test-mcp-client
+```shell
+env PYTEST_ADDOPTS=tests/test_reingest_mets.py make test-mcp-client
+```
 
-The sources of the [acceptance
-tests](https://github.com/artefactual-labs/archivematica-acceptance-tests)
-have been made available inside Docker using volumes so you can edit
-them and the changes will apply immediately. Their `Makefile` targets
-start with `test-at-`.
+### AMAUATs
+
+The sources of the [Archivematica Automated User Acceptance Tests
+(AMAUATs)](https://github.com/artefactual-labs/archivematica-acceptance-tests)
+are available inside Docker using volumes so you can edit
+them and the changes will apply immediately. They can be executed with the
+`test-at-behave` Makefile target.
+
+For example, once your Archivematica services start and you can reach the [Web
+UIs](#web-uis) you can execute the [`black-box`][amauats-black-box] tag of the
+AMAUATs in Firefox like this:
+
+```shell
+make test-at-behave TAGS=black-box BROWSER=Firefox
+```
+
+[amauats-black-box]: https://github.com/artefactual-labs/archivematica-acceptance-tests/tree/qa/1.x/features/black_box
 
 ## Resetting the environment
 
@@ -330,43 +381,56 @@ containers at once and make sure the latest version of the images are built.
 But also, you don't want to lose your data like the search index or the
 database. If this is case, run the following command:
 
-    $ docker-compose up -d --force-recreate --build
+```shell
+docker compose up -d --force-recreate --build
+```
 
 Additionally you may want to delete all the data including the stuff in the
 external volumes:
 
-    $ make flush
+```shell
+make flush
+```
 
 Both snippets can be combined or used separately.
 
 You may need to update the codebase, and for that you can run this command:
 
-    $ git submodule update --init --recursive
+```shell
+git submodule update --init --recursive
+```
 
 ## Cleaning up
 
 The most effective way is:
 
-    $ docker-compose down --volumes
+```shell
+docker compose down --volumes
+```
 
 It doesn't delete the external volumes described in the
 [Installation](#installation) section of this document. You have to delete the
 volumes manually with:
 
-    $ docker volume rm am-pipeline-data
-    $ docker volume rm ss-location-data
+```shell
+docker volume rm am-pipeline-data
+docker volume rm ss-location-data
+```
 
 Optionally you may also want to delete the directories:
 
-    $ rm -rf $HOME/.am/am-pipeline-data $HOME/.am/ss-location-data
+```shell
+rm -rf $HOME/.am/am-pipeline-data $HOME/.am/ss-location-data
+```
 
 ## Percona tuning
 
 To use different settings on the MySQL container, please edit the
 `etc/mysql/tunning.conf` file and rebuild the container with:
 
-    $ docker down
-    $ docker-compose up -d
+```shell
+docker compose up -d --force-recreate mysql
+```
 
 ## Instrumentation
 
@@ -377,15 +441,17 @@ to monitor Archivematica processes.
 
 To run them, reference the `docker-compose.instrumentation.yml` file:
 
-    $ docker-compose -f docker-compose.yml -f docker-compose.instrumentation.yml up -d
+```shell
+docker compose -f docker-compose.yml -f docker-compose.instrumentation.yml up -d
+```
 
-Prometheus will start on [localhost:9090][instrumentation-2]; Grafana on
-[localhost:3000][instrumentation-3].
+Prometheus will start on [127.0.0.1:9090][instrumentation-2]; Grafana on
+[127.0.0.1:3000][instrumentation-3].
 
 [instrumentation-0]: https://prometheus.io/
 [instrumentation-1]: https://grafana.com/
-[instrumentation-2]: http://localhost:9090
-[instrumentation-3]: http://localhost:3000
+[instrumentation-2]: http://127.0.0.1:9090
+[instrumentation-3]: http://127.0.0.1:3000
 
 ### Percona Monitoring and Management
 
@@ -395,12 +461,14 @@ collect metrics and query analytics data from the `mysql` service. To set up the
 PMM server and client services alongside all the others you'll need to indicate
 two Docker Compose files:
 
-    $ docker-compose -f docker-compose.yml -f docker-compose.pmm.yml up -d
+```shell
+docker compose -f docker-compose.yml -f docker-compose.pmm.yml up -d
+```
 
-To access the PMM server interface, visit http://localhost:62007:
+To access the PMM server interface, visit http://127.0.0.1:62007:
 
-* Username: ``pmm``
-* Password: ``pmm``
+* Username: ``admin``
+* Password: ``admin``
 
 [instrumentation-4]: https://www.percona.com/doc/percona-monitoring-and-management
 
@@ -409,136 +477,59 @@ To access the PMM server interface, visit http://localhost:62007:
 ##### Nginx returns 502 Bad Gateway
 
 We're using Nginx as a proxy. Likely the underlying issue is that
-either the Dashboard or the Storage Service died. Run `docker-compose
+either the Dashboard or the Storage Service died. Run `docker compose
 ps` to confirm the state of their services like this:
 
-```bash
-$ docker-compose ps archivematica-dashboard archivematica-storage-service
-                Name                              Command                State      Ports
--------------------------------------------------------------------------------------------
-hack_archivematica-dashboard_1         /usr/local/bin/gunicorn -- ...   Up         8000/tcp
-hack_archivematica-storage-service_1   /bin/sh -c /usr/local/bin/ ...   Exit 137
+```shell
+docker compose ps --all archivematica-dashboard archivematica-storage-service
+```
+```console
+NAME                                 IMAGE                              COMMAND                  SERVICE                         CREATED             STATUS                      PORTS
+am-archivematica-dashboard-1         am-archivematica-dashboard         "/usr/local/bin/guni…"   archivematica-dashboard         11 minutes ago      Up 27 seconds               8000/tcp
+am-archivematica-storage-service-1   am-archivematica-storage-service   "/usr/local/bin/guni…"   archivematica-storage-service   11 minutes ago      Exited (3) 28 seconds ago
 ```
 
-You want to see what's in the logs of the
-`archivematica-storage-service` service, e.g.:
+You want to see what's in the logs of the `archivematica-storage-service`
+service, e.g.:
 
-    $ docker-compose logs -f archivematica-storage-service
-
-    ImportError: No module named storage_service.wsgi
-    [2017-10-26 19:28:24 +0000] [11] [INFO] Worker exiting (pid: 11)
-    [2017-10-26 19:28:24 +0000] [7] [INFO] Shutting down: Master
-    [2017-10-26 19:28:24 +0000] [7] [INFO] Reason: Worker failed to boot.
+```shell
+docker compose logs --no-log-prefix --tail 5 archivematica-storage-service
+```
+```console
+  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
+ModuleNotFoundError: No module named 'storage_service.wsgi'
+[2023-06-02 03:53:00 +0000] [9] [INFO] Worker exiting (pid: 9)
+[2023-06-02 03:53:00 +0000] [1] [INFO] Shutting down: Master
+[2023-06-02 03:53:00 +0000] [1] [INFO] Reason: Worker failed to boot.
+```
 
 Now we know why -  I had deleted the `wsgi` module. The worker crashed and
 Gunicorn gave up. This could happen for example when we're rebasing a branch
 and git is not atomically moving things around. But it's fixed now and you want
-to give it another shot so we run `docker-compose up -d` to ensure that all the
-services are up again. Next run `docker-compose ps` to verify that it's all up.
-
-##### MCPClient osdeps cannot be updated
-
-The MCPClient Docker image bundles a number of tools that are used by
-Archivematica. They're listed in the [osdeps files][0] but the
-[MCPClient.Dockerfile][1] is not making use of it yet. If you need to
-introduce dependency changes in MCPClient you will need to update both.
-
-In [#931][2] we started publishing a MCPClient base Docker image to speed up
-development workflows. This means that the dependencies listed in the osdeps
-files are now included in [MCPClient-base.Dockerfile][3]. Once the file is
-updated you would publish the corresponding image as follows:
-
-```
-$ docker build -f MCPClient-base.Dockerfile -t artefactual/archivematica-mcp-client-base:20180219.01.52dc9959 .
-$ docker push artefactual/archivematica-mcp-client-base:20180219.01.52dc9959
-```
-
-Where the tag `20180219.01.52dc9959` is a combination of the date, build number
-that day and the commit that updates the Dockerfile.
-
-As a developer you may want to build the image and test it before publishing it,
-e.g.:
-
-1. Edit `MCPClient-base.Dockerfile`.
-2. Build image with new tag.
-3. Update the `FROM` instruction in `MCPClient.Dockerfile` to use it.
-4. Build the image of the `archivematica-mcp-client` service.
-5. Test it.
-6. Publish image.
-
-[0]: https://github.com/artefactual/archivematica/tree/qa/1.x/src/MCPClient/osdeps
-[1]: https://github.com/artefactual/archivematica/blob/qa/1.x/src/MCPClient.Dockerfile
-[2]: https://github.com/artefactual/archivematica/pull/931
-[3]: https://github.com/artefactual/archivematica/blob/qa/1.x/src/MCPClient-base.Dockerfile
-
-##### Error while mounting volume
-
-Our Docker named volumes are stored under `/tmp` which means that it is
-possible that they will be recycled at some point by the operative system. This
-frequently happens when you restart your machine.
-
-Under this scenario, if you try to bring up the services again you will likely
-see one or more errors like the following:
-
-    ERROR: for hack_archivematica-mcp-server_1  Cannot create container for
-    service archivematica-mcp-server: error while mounting volume with options:
-    type='none' device='/home/user/.am/am-pipeline-data' o='bind': no such file
-    or directory
-
-The solution is simple. You need to create the volumes again:
-
-    $ make create-volumes
-
-And now you're ready to continue as usual:
-
-    $ docker-compose up -d --build
-
-Optionally, you can define new persistent locations for the external volumes.
-The defaults are defined in the `Makefile`:
-
-    # Paths for Docker named volumes
-    AM_PIPELINE_DATA ?= $(HOME)/.am/am-pipeline-data
-    SS_LOCATION_DATA ?= $(HOME)/.am/ss-location-data
-
-##### make bootstrap fails to run
-
-In the event that `make bootstrap` fails to run while installing, the Bootstrap
-components may need to be installed individually inside the application. This
-error message is more likely if you are attempting to install Archivematica on a
-Mac.
-
-First, go into the Makefile and comment out everything in the
-`bootstrap-dashboard-frontend` section of the script, then run `make bootstrap`
-again and continue with the install process.
-
-To install frontend Bootstrap dependencies manually:
-
-```
-yarn --cwd src/archivematica/src/dashboard/frontend install
-```
-
-`npm` should also work fine.
+to give it another shot so we run `docker compose up -d` to ensure that all the
+services are up again. Next run `docker compose ps` to verify that it's all up.
 
 ##### Bootstrap seems to run but the Dashboard and Elasticsearch are still down
 
-If after running the bootstrap processes and `docker-compose ps` still shows
+If after running the bootstrap processes and `docker compose ps` still shows
 that the dashboard and elasticsearch are still down then check the
 elasticsearch logs using:
 
-`$ docker-compose logs -f elasticsearch`
+```shell
+docker compose logs --no-log-prefix --tail 8 elasticsearch
+```
 
 You may see entries as follows:
 
-```
-[2019-01-25T16:36:43,535][INFO ][o.e.n.Node               ] [am-node] starting ...
-[2019-01-25T16:36:43,671][INFO ][o.e.t.TransportService   ] [am-node] publish_address {172.18.0.7:9300}, bound_addresses {0.0.0.0:9300}
-[2019-01-25T16:36:43,681][INFO ][o.e.b.BootstrapChecks    ] [am-node] bound or publishing to a non-loopback address, enforcing bootstrap checks
+```console
+[2023-06-02T03:50:27,970][INFO ][o.e.b.BootstrapChecks    ] [am-node] bound or publishing to a non-loopback address, enforcing bootstrap checks
 ERROR: [1] bootstrap checks failed
 [1]: max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]
-[2019-01-25T16:36:43,688][INFO ][o.e.n.Node               ] [am-node] stopping ...
-[2019-01-25T16:36:43,720][INFO ][o.e.n.Node               ] [am-node] stopped
-[2019-01-25T16:36:43,720][INFO ][o.e.n.Node               ] [am-node] closing ...
-[2019-01-25T16:36:43,730][INFO ][o.e.n.Node
+[2023-06-02T03:50:28,006][INFO ][o.e.n.Node               ] [am-node] stopping ...
+[2023-06-02T03:50:28,077][INFO ][o.e.n.Node               ] [am-node] stopped
+[2023-06-02T03:50:28,077][INFO ][o.e.n.Node               ] [am-node] closing ...
+[2023-06-02T03:50:28,088][INFO ][o.e.n.Node               ] [am-node] closed
+[2023-06-02T03:50:28,090][INFO ][o.e.x.m.j.p.NativeController] [am-node] Native controller process has stopped - no new native processes can be started
 ```
 
 This indicates that you may need to increase the virtual memory available to
@@ -546,6 +537,22 @@ Elasticsearch, as discussed in the section [Elasticsearch container][es-0]
 above.
 
 [es-0]: #elasticsearch-container
+
+##### PMM client service doesn't start
+
+In some cases the `pmm_client` service fails to start reporting the following
+error:
+
+```console
+[main] app already is running, exiting
+```
+
+You'll need to fully recreate the container to make it work:
+
+```shell
+docker compose -f docker-compose.yml -f docker-compose.pmm.yml rm pmm_client
+docker compose -f docker-compose.yml -f docker-compose.pmm.yml up -d
+```
 
 ##### My environment is still broken
 
@@ -563,17 +570,5 @@ environment is not working? Here are some tips:
 - Look for open/closed [issues][am-issues] that may relate to your
   problem!
 - [Get support](https://www.archivematica.org/community/support/).
-
-##### PMM client service doesn't start
-
-In some cases the `pmm_client` service fails to start reporting the following
-error:
-
-    [main] app already is running, exiting
-
-You'll need to fully recreate the container to make it work:
-
-    docker-compose -f docker-compose.yml -f docker-compose.pmm.yml rm pmm_client
-    docker-compose -f docker-compose.yml -f docker-compose.pmm.yml up -d
 
 [am-issues]: https://github.com/archivematica/issues/issues

--- a/hack/docker-compose.acceptance-tests.yml
+++ b/hack/docker-compose.acceptance-tests.yml
@@ -1,5 +1,4 @@
 ---
-version: "2.1"
 
 services:
   archivematica-acceptance-tests:

--- a/hack/docker-compose.instrumentation.yml
+++ b/hack/docker-compose.instrumentation.yml
@@ -1,5 +1,4 @@
 ---
-version: "2.1"
 
 volumes:
 

--- a/hack/docker-compose.pmm.yml
+++ b/hack/docker-compose.pmm.yml
@@ -1,5 +1,4 @@
 ---
-version: "2.1"
 
 volumes:
   pmm_prometheus_data:

--- a/hack/docker-compose.tests.yml
+++ b/hack/docker-compose.tests.yml
@@ -1,5 +1,4 @@
 ---
-version: "2.1"
 
 services:
   archivematica-tests:

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -108,6 +108,9 @@ services:
       dockerfile: "hack/Dockerfile"
       args:
         TARGET: "archivematica-mcp-server"
+        USER_ID: ${USER_ID:-1000}
+        GROUP_ID: ${GROUP_ID:-1000}
+        PYTHON_VERSION: ${PYTHON_VERSION:-3.6}
     environment:
       DJANGO_SECRET_KEY: "12345"
       DJANGO_SETTINGS_MODULE: "settings.common"
@@ -132,6 +135,9 @@ services:
       dockerfile: "hack/Dockerfile"
       args:
         TARGET: "archivematica-mcp-client"
+        USER_ID: ${USER_ID:-1000}
+        GROUP_ID: ${GROUP_ID:-1000}
+        PYTHON_VERSION: ${PYTHON_VERSION:-3.6}
     environment:
       DJANGO_SECRET_KEY: "12345"
       DJANGO_SETTINGS_MODULE: "settings.common"
@@ -171,6 +177,9 @@ services:
       dockerfile: "hack/Dockerfile"
       args:
         TARGET: "archivematica-dashboard"
+        USER_ID: ${USER_ID:-1000}
+        GROUP_ID: ${GROUP_ID:-1000}
+        PYTHON_VERSION: ${PYTHON_VERSION:-3.6}
     environment:
       FORWARDED_ALLOW_IPS: "*"
       AM_GUNICORN_ACCESSLOG: "/dev/null"
@@ -203,6 +212,9 @@ services:
       context: "submodules/archivematica-storage-service"
       args:
         TARGET: "archivematica-storage-service"
+        USER_ID: ${USER_ID:-1000}
+        GROUP_ID: ${GROUP_ID:-1000}
+        PYTHON_VERSION: ${PYTHON_VERSION:-3.6}
     environment:
       FORWARDED_ALLOW_IPS: "*"
       SS_GUNICORN_ACCESSLOG: "/dev/null"

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -27,7 +27,7 @@ volumes:
 services:
 
   mysql:
-    image: "percona:5.6"
+    image: "percona:5.7"
     user: "mysql"
     command: "--character-set-server=utf8 --collation-server=utf8_general_ci"
     environment:
@@ -42,7 +42,7 @@ services:
       - "127.0.0.1:62001:3306"
 
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:6.5.4"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.23"
     environment:
       - "cluster.name=am-cluster"
       - "node.name=am-node"
@@ -54,11 +54,14 @@ services:
         soft: -1
         hard: -1
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsSL http://localhost:9200/_cat/health?h=status | grep -q -v 'red'"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
+      test: [
+        "CMD-SHELL",
+        "curl -fsSL http://localhost:9200/_cat/health?h=status | sed -r 's/^[[:space:]]+|[[:space:]]+$//g' | grep -q -E 'green|yellow'",
+      ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     volumes:
       - "elasticsearch_data:/usr/share/elasticsearch/data"
     ports:

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: "2.1"
+name: am
 
 volumes:
 
@@ -16,11 +16,13 @@ volumes:
   # host - the expectation being that these directories are actually mounted
   # filesystems from elsewhere.
   archivematica_pipeline_data:
-    external:
-      name: "am-pipeline-data"
+    name: "am-pipeline-data"
+    external: true
+
   archivematica_storage_service_location_data:
-    external:
-      name: "ss-location-data"
+    name: "ss-location-data"
+    external: true
+
 
 services:
 
@@ -51,6 +53,12 @@ services:
       memlock:
         soft: -1
         hard: -1
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsSL http://localhost:9200/_cat/health?h=status | grep -q -v 'red'"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     volumes:
       - "elasticsearch_data:/usr/share/elasticsearch/data"
     ports:
@@ -177,6 +185,10 @@ services:
     volumes:
       - "../:/src"
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+        restart: true
     links:
       - "mysql"
       - "gearmand"

--- a/hack/helpers/compile-i18n-messages.sh
+++ b/hack/helpers/compile-i18n-messages.sh
@@ -11,7 +11,7 @@ __root_dir="$(cd "$(dirname "${__compose_dir}")" && pwd)"
 cd ${__compose_dir}
 
 function dashboard::manage {
-	docker-compose run \
+	docker compose run \
 		--user=$(id -u):$(id -g) \
 		--rm --no-deps \
 		--workdir=/src/src/dashboard/src \
@@ -20,7 +20,7 @@ function dashboard::manage {
 }
 
 function storage::manage {
-	docker-compose run \
+	docker compose run \
 		--user=$(id -u):$(id -g) \
 		--rm --no-deps \
 		--workdir=/src/storage_service \

--- a/hack/helpers/extract-i18n-messages.sh
+++ b/hack/helpers/extract-i18n-messages.sh
@@ -17,7 +17,7 @@ __root_dir="$(cd "$(dirname "${__compose_dir}")" && pwd)"
 cd ${__compose_dir}
 
 function dashboard::manage {
-	docker-compose run \
+	docker compose run \
 		--user=$(id -u):$(id -g) \
 		--rm --no-deps \
 		--workdir=/src/src/dashboard/src \
@@ -26,7 +26,7 @@ function dashboard::manage {
 }
 
 function storage::manage {
-	docker-compose run \
+	docker compose run \
 		--user=$(id -u):$(id -g) \
 		--rm --no-deps \
 		--workdir=/src/storage_service \
@@ -43,7 +43,7 @@ echo "Dashboard: extracting messages..."
 dashboard::manage makemessages --all --domain django
 dashboard::manage makemessages --all --domain djangojs --ignore build/*
 
-docker-compose run \
+docker compose run \
 	--user=$(id -u):$(id -g) \
 	--rm --no-deps \
 	--workdir=/src/src/dashboard/frontend \

--- a/hack/helpers/flush-docker-logs.sh
+++ b/hack/helpers/flush-docker-logs.sh
@@ -14,7 +14,7 @@ if [[ $(/usr/bin/id -u) -ne 0 ]]; then
     exit
 fi
 
-for container_id in $(docker-compose ps --quiet); do
+for container_id in $(docker compose ps --quiet); do
     logpath=$(docker inspect --format='{{.LogPath}}' ${container_id})
     echo "Removing ${logpath}..."
     echo '' > $(docker inspect --format='{{.LogPath}}' ${container_id})

--- a/src/MCPClient/install/README.md
+++ b/src/MCPClient/install/README.md
@@ -430,7 +430,7 @@ will be handled by whichever process is managing Archivematica's services. For
 example on Ubuntu 16.04, Ubuntu 18.04 or CentOS 7, Archivematica's processes are
 managed by systemd. Logs for the MCPClient can be accessed using
 `sudo journalctl -u archivematica-mcp-client`. When running Archivematica using
-docker, `docker-compose logs` commands can be used to access the logs from
+docker, `docker compose logs` commands can be used to access the logs from
 different containers.
 
 The MCPClient will look in `/etc/archivematica` for a file called

--- a/src/MCPClient/lib/settings/testmysql.py
+++ b/src/MCPClient/lib/settings/testmysql.py
@@ -10,5 +10,6 @@ DATABASES = {
         "HOST": "mysql",
         "PORT": "3306",
         "CONN_MAX_AGE": 600,
+        "TEST": {"NAME": "test_MCPCLIENTTEST"},
     }
 }

--- a/src/MCPServer/install/README.md
+++ b/src/MCPServer/install/README.md
@@ -334,7 +334,7 @@ will be handled by whichever process is managing Archivematica's services. For
 example on Ubuntu 16.04, Ubuntu 18.04 or CentOS 7, Archivematica's processes are
 managed by systemd. Logs for the MCPServer can be accessed using
 `sudo journalctl -u archivematica-mcp-server`. When running Archivematica using
-docker, `docker-compose logs` commands can be used to access the logs from
+docker, `docker compose logs` commands can be used to access the logs from
 different containers.
 
 The MCPServer will look in `/etc/archivematica` for a file called

--- a/src/MCPServer/lib/settings/testmysql.py
+++ b/src/MCPServer/lib/settings/testmysql.py
@@ -10,5 +10,6 @@ DATABASES = {
         "HOST": "mysql",
         "PORT": "3306",
         "CONN_MAX_AGE": 600,
+        "TEST": {"NAME": "test_MCPSERVERTEST"},
     }
 }

--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -715,7 +715,7 @@ will be handled by whichever process is managing Archivematica's services. For
 example on Ubuntu 16.04, Ubuntu 18.04 or CentOS 7, Archivematica's processes are
 managed by systemd. Logs for the Dashboard can be accessed using
 `sudo journalctl -u archivematica-dashboard`. When running Archivematica using
-docker, `docker-compose logs` commands can be used to access the logs from
+docker, `docker compose logs` commands can be used to access the logs from
 different containers.
 
 The dashboard will look in `/etc/archivematica` for a file called

--- a/src/dashboard/osdeps/CentOS-7.json
+++ b/src/dashboard/osdeps/CentOS-7.json
@@ -43,10 +43,6 @@
       "state": "latest"
     },
     {
-      "name": "python3-devel",
-      "state": "latest"
-    },
-    {
       "name": "openldap-devel",
       "state": "latest"
     },

--- a/src/dashboard/osdeps/RedHat-7.json
+++ b/src/dashboard/osdeps/RedHat-7.json
@@ -43,10 +43,6 @@
       "state": "latest"
     },
     {
-      "name": "python3-devel",
-      "state": "latest"
-    },
-    {
       "name": "openldap-devel",
       "state": "latest"
     },

--- a/src/dashboard/osdeps/Ubuntu-18.json
+++ b/src/dashboard/osdeps/Ubuntu-18.json
@@ -38,10 +38,6 @@
       "state": "latest"
     },
     {
-      "name": "python3.6-dev",
-      "state": "latest"
-    },
-    {
       "name": "libsasl2-dev",
       "state": "latest"
     },

--- a/src/dashboard/src/settings/testmysql.py
+++ b/src/dashboard/src/settings/testmysql.py
@@ -10,5 +10,6 @@ DATABASES = {
         "HOST": "mysql",
         "PORT": "3306",
         "CONN_MAX_AGE": 600,
+        "TEST": {"NAME": "test_DASHBOARDTEST"},
     }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,13 @@
 skipsdist = True
 minversion = 2.7.0
 envlist =
-    py36-archivematica-common
-    py36-dashboard
-    py36-mcpserver
-    py36-mcpclient
-    py36-mcpclient-ensure-no-mutable-globals
-    py36-storage-service
-    py36-migrations-dashboard
+    archivematica-common
+    dashboard
+    mcp-server
+    mcp-client
+    mcp-client-ensure-no-mutable-globals
+    storage-service
+    migrations-dashboard
     migrations-storage-service
     linting
 
@@ -48,8 +48,8 @@ setenv =
     # TOXENV-specific
     archivematica-common: PYTHONPATH = {env:DASHBOARD_PYTHONPATH}
     dashboard: PYTHONPATH = {env:DASHBOARD_PYTHONPATH}
-    mcpserver: PYTHONPATH = {env:MCPSERVER_PYTHONPATH}
-    mcpclient: PYTHONPATH = {env:MCPCLIENT_PYTHONPATH}
+    mcp-server: PYTHONPATH = {env:MCPSERVER_PYTHONPATH}
+    mcp-client: PYTHONPATH = {env:MCPCLIENT_PYTHONPATH}
     storage-service: PYTHONPATH = {env:STORAGE_SERVICE_PYTHONPATH}
     migrations-dashboard: PYTHONPATH = {env:DASHBOARD_PYTHONPATH}
     migrations-storage-service: PYTHONPATH = {env:STORAGE_SERVICE_PYTHONPATH}
@@ -60,24 +60,24 @@ setenv =
 changedir =
     archivematica-common: {env:ARCHIVEMATICA_COMMON_ROOT}
     dashboard: {env:DASHBOARD_ROOT}
-    mcpserver: {env:MCPSERVER_ROOT}
-    mcpclient: {env:MCPCLIENT_ROOT}
+    mcp-server: {env:MCPSERVER_ROOT}
+    mcp-client: {env:MCPCLIENT_ROOT}
     storage-service: {env:STORAGE_SERVICE_DIR}
 
-[testenv:py36-mcpclient-ensure-no-mutable-globals]
+[testenv:mcp-client-ensure-no-mutable-globals]
 commands = python {env:MCPCLIENT_DIR}/ensure_no_mutable_globals.py
 
-[testenv:py36-storage-service]
+[testenv:storage-service]
 deps =
     -r{env:STORAGE_SERVICE_ROOT}/requirements/production.txt
     -r{env:STORAGE_SERVICE_ROOT}/requirements/test.txt
 
-[testenv:py36-migrations-dashboard]
+[testenv:migrations-dashboard]
 commands = django-admin makemigrations --check --dry-run
 
 [testenv:migrations-storage-service]
-deps = {[testenv:py36-storage-service]deps}
-commands = {[testenv:py36-migrations-dashboard]commands}
+deps = {[testenv:storage-service]deps}
+commands = {[testenv:migrations-dashboard]commands}
 
 [testenv:linting]
 basepython = python3


### PR DESCRIPTION
This makes the following changes to the Docker environment:

* Installs Python 3.6 using [`pyenv`](https://github.com/pyenv/pyenv).
* Migrates the old [Compose V1 configuration](https://docs.docker.com/compose/migrate/) and upgrades dependencies.
* Adds arguments for setting the `archivematica` user and group IDs so the content created in the external volumes can be owned by the Docker host user.
* Removes unnecessary prefixes from the `tox` environments.
* Updates the `hack/README.md` file to reflect these updates.

Depends on https://github.com/artefactual/archivematica-storage-service/pull/649
Connected to https://github.com/archivematica/Issues/issues/1612
Connected to https://github.com/archivematica/Issues/issues/1557