### PR TITLE
Allow more than 10 AIPs in AICs

### DIFF
--- a/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
+++ b/src/dashboard/src/media/js/archival_storage/archival_storage_search.js
@@ -408,20 +408,10 @@ $(document).ready(function() {
     }
   });
 
+  // hide create_aic button by default
+  $("#create-aic-btn").hide();
   $("#create-aic-btn").click(function() {
-    var aip_uuids = []
-    // Get object containing UUIDs from the DataTable.
-    var table_uuids = $('#id_show_files').prop('checked')
-      ? []
-      : $('#archival-storage-entries').DataTable().column(1).data();
-    // Add each UUID in the returned object to our clean aip_uuids array.
-    for (i = 0; i < table_uuids.length; i++) {
-      aip_uuids.push(table_uuids[i]);
-    }
-    // Redirect window URL to Django create_aic view, including the AIP UUIDs
-    // as a comma-separated string in the URL parameters.
-    var uuids_string = aip_uuids.join(",");
-    window.location = "/archival-storage/search/create_aic/?uuids=" + uuids_string;
+    window.location = "/archival-storage/search/create_aic/?" + search.toUrlParams()
   });
 
   // Vars and functions to Enable the download of the Archival Storage table


### PR DESCRIPTION
This modifies the Create AIC view to search for the AIP UUIDs to include in the AIC instead of receiving them from the frontend which was constrained by the DataTable pagination logic.

Connected to https://github.com/archivematica/Issues/issues/1593