### PR TITLE
Development environment fixes

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -33,13 +33,6 @@ jobs:
         uses: "actions/checkout@v3"
         with:
           submodules: true
-      - name: Downgrade docker compose plugin
-        run: |
-          rm  ~/.docker/config.json
-          mkdir -p ~/.docker/cli-plugins
-          curl -o ~/.docker/cli-plugins/docker-compose -sL https://github.com/docker/compose/releases/download/v2.18.1/docker-compose-linux-x86_64
-          chmod +x ~/.docker/cli-plugins/docker-compose
-          docker compose version
       - name: "Create external volumes"
         run: |
           make -C hack/ create-volumes

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -68,16 +68,17 @@ RUN set -ex \
 		yarn nodejs \
 	&& rm -rf /var/lib/apt/lists/*
 
+ENV PYENV_ROOT="/pyenv/data"
+ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+
 RUN set -ex \
 	&& groupadd --gid ${GROUP_ID} --system archivematica \
-	&& useradd -m --uid ${USER_ID} --gid ${GROUP_ID} --create-home --home-dir /home/archivematica --system archivematica \
+	&& useradd --uid ${USER_ID} --gid ${GROUP_ID} --home-dir /var/archivematica --system archivematica \
 	&& mkdir -p /var/archivematica/sharedDirectory \
-	&& chown -R archivematica:archivematica /var/archivematica
+	&& mkdir -p /pyenv \
+	&& chown -R archivematica:archivematica /var/archivematica /pyenv
 
 USER archivematica
-
-ENV PYENV_ROOT="/home/archivematica/.pyenv"
-ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 
 RUN set -ex \
 	&& curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -50,7 +50,12 @@ start-mysql: test-build
 define create_db
 	docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e '\
 		DROP DATABASE IF EXISTS `$(1)`; \
-		CREATE DATABASE `$(1)`; \
+		CREATE DATABASE `$(1)`;'
+	$(call grant_all_on_db,$(1))
+endef
+
+define grant_all_on_db
+	docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e '\
 		GRANT ALL ON `$(1)`.* TO "archivematica"@"%" IDENTIFIED BY "demo";'
 endef
 
@@ -60,6 +65,10 @@ endef
 
 define create_dbs
 	$(foreach test_db,$(1),$(call create_db,$(test_db));)
+endef
+
+define grant_all_on_dbs
+	$(foreach test_db,$(1),$(call grant_all_on_db,$(test_db));)
 endef
 
 create-volumes:  ## Create external data volumes.
@@ -82,10 +91,7 @@ build:  # Build Compose services.
 bootstrap: bootstrap-storage-service bootstrap-dashboard-db bootstrap-dashboard-frontend  ## Full bootstrap.
 
 bootstrap-storage-service:  ## Boostrap Storage Service (new database).
-	docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e "\
-		DROP DATABASE IF EXISTS SS; \
-		CREATE DATABASE SS; \
-		GRANT ALL ON SS.* TO 'archivematica'@'%' IDENTIFIED BY 'demo';"
+	$(call create_db,SS)
 	docker compose run \
 		--rm \
 		--no-deps \
@@ -135,10 +141,7 @@ manage-ss:  ## Run Django /manage.py on Storage Service, suppling <command> [opt
 				$(ARG)
 
 bootstrap-dashboard-db:  ## Bootstrap Dashboard (new database).
-	docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e "\
-		DROP DATABASE IF EXISTS MCP; \
-		CREATE DATABASE MCP; \
-		GRANT ALL ON MCP.* TO 'archivematica'@'%' IDENTIFIED BY 'demo';"
+	$(call create_db,MCP)
 	docker compose run \
 		--rm \
 		--no-deps \
@@ -236,22 +239,22 @@ test-build:  ## Build archivematica-tests image.
 
 __TOXENVS_MCPSERVER := mcp-server
 test-mcp-server: start-mysql  ## Run MCPServer tests.
-	$(call create_dbs,$(__TEST_DBS_MCPSERVER))
+	$(call grant_all_on_dbs,$(__TEST_DBS_MCPSERVER))
 	$(call run_toxenvs,$(__TOXENVS_MCPSERVER))
 
 __TOXENVS_MCPCLIENT = mcp-client mcp-client-ensure-no-mutable-globals
 test-mcp-client: start-mysql  ## Run MCPClient tests.
-	$(call create_dbs,$(__TEST_DBS_MCPCLIENT))
+	$(call grant_all_on_dbs,$(__TEST_DBS_MCPCLIENT))
 	$(call run_toxenvs,$(__TOXENVS_MCPCLIENT))
 
 __TOXENVS_DASHBOARD = dashboard
 test-dashboard: start-mysql  ## Run Dashboard tests.
-	$(call create_dbs,$(__TEST_DBS_DASHBOARD))
+	$(call grant_all_on_dbs,$(__TEST_DBS_DASHBOARD))
 	$(call run_toxenvs,$(__TOXENVS_DASHBOARD))
 
 __TOXENVS_STORAGE_SERVICE = storage-service
 test-storage-service: start-mysql  ## Run Storage Service tests.
-	$(call create_dbs,$(__TEST_DBS_STORAGE_SERVICE))
+	$(call grant_all_on_dbs,$(__TEST_DBS_STORAGE_SERVICE))
 	$(call run_toxenvs,$(__TOXENVS_STORAGE_SERVICE))
 
 test-storage-service-integration:  ## Run Storage Service unit and integration tests using MySQL and MinIO.
@@ -259,7 +262,7 @@ test-storage-service-integration:  ## Run Storage Service unit and integration t
 
 __TOXENVS_ARCHIVEMATICA_COMMON = archivematica-common
 test-archivematica-common: start-mysql  ## Run Archivematica Common tests.
-	$(call create_dbs,$(__TEST_DBS_DASHBOARD))
+	$(call grant_all_on_dbs,$(__TEST_DBS_DASHBOARD))
 	$(call run_toxenvs,$(__TOXENVS_ARCHIVEMATICA_COMMON))
 
 __TOXENVS_MIGRATIONS = migrations-dashboard migrations-storage-service
@@ -273,7 +276,7 @@ test-linting:  ## Check linting.
 
 __TOXENVS_ALL := $(__TOXENVS_MCPSERVER) $(__TOXENVS_MCPCLIENT) $(__TOXENVS_DASHBOARD) $(__TOXENVS_STORAGE_SERVICE) $(__TOXENVS_ARCHIVEMATICA_COMMON)
 test-all: start-mysql  ## Run all tests.
-	$(call create_dbs,$(__TEST_DBS_MCPSERVER) $(__TEST_DBS_MCPCLIENT) $(__TEST_DBS_DASHBOARD) $(__TEST_DBS_STORAGE_SERVICE) $(__TEST_DBS_ARCHIVEMATICA_COMMON))
+	$(call grant_all_on_dbs,$(__TEST_DBS_MCPSERVER) $(__TEST_DBS_MCPCLIENT) $(__TEST_DBS_DASHBOARD) $(__TEST_DBS_STORAGE_SERVICE) $(__TEST_DBS_ARCHIVEMATICA_COMMON))
 	$(call run_toxenvs,$(__TOXENVS_ALL))
 
 test-at-build:  ## AMAUAT: build image.

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -105,7 +105,7 @@ bootstrap-storage-service:  ## Boostrap Storage Service (new database).
 					--superuser
 	# SS needs to be restarted so the local space is created.
 	# See #303 (https://git.io/vNKlM) for more details.
-	docker compose restart archivematica-storage-service
+	docker compose restart --no-deps archivematica-storage-service
 
 makemigrations-ss:
 	docker compose run \
@@ -173,10 +173,10 @@ bootstrap-dashboard-frontend:  ## Build front-end assets.
 				--cwd=/src/src/dashboard/frontend install --frozen-lockfile
 
 restart-am-services:  ## Restart Archivematica services: MCPServer, MCPClient, Dashboard and Storage Service.
-	docker compose restart archivematica-mcp-server
-	docker compose restart archivematica-mcp-client
-	docker compose restart archivematica-dashboard
-	docker compose restart archivematica-storage-service
+	docker compose restart --no-deps archivematica-mcp-server
+	docker compose restart --no-deps archivematica-mcp-client
+	docker compose restart --no-deps archivematica-dashboard
+	docker compose restart --no-deps archivematica-storage-service
 
 compile-requirements-am:  ## Run pip-compile for Archivematica
 	docker compose run --workdir /src \
@@ -204,7 +204,7 @@ flush: flush-shared-dir flush-search bootstrap restart-am-services  ## Delete AL
 flush-shared-dir-mcp-configs:  ## Delete processing configurations - it restarts MCPServer.
 	rm -f ${AM_PIPELINE_DATA}/sharedMicroServiceTasksConfigs/processingMCPConfigs/defaultProcessingMCP.xml
 	rm -f ${AM_PIPELINE_DATA}/sharedMicroServiceTasksConfigs/processingMCPConfigs/automatedProcessingMCP.xml
-	docker compose restart archivematica-mcp-server
+	docker compose restart --no-deps archivematica-mcp-server
 
 flush-shared-dir:  ## Delete contents of the shared directory data volume.
 	rm -rf ${AM_PIPELINE_DATA}/*


### PR DESCRIPTION
This fixes a few problems identified after the `1.14` release:

* Removes a workaround in the AMAUATs CI workflow caused by Compose 2.19.0 that prevented services to be restarted
* Sets the home directory of the `archivematica` user and the `pyenv` root directory outside of the `/home` directory to avoid exposing files to the external volumes
* Sets permissions on test databases only instead of creating them on each test run which integrates better with `pytest-django`

Connected to https://github.com/archivematica/Issues/issues/1613