### PR TITLE
Remove django warnings in development environment

### DIFF
--- a/src/dashboard/src/components/accounts/apps.py
+++ b/src/dashboard/src/components/accounts/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig
 
 
 class AccountsConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
     name = "components.accounts"
     verbose_name = "Dashboard Accounts"
 

--- a/src/dashboard/src/components/administration/apps.py
+++ b/src/dashboard/src/components/administration/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AdministrationAppConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
+    name = "components.administration"

--- a/src/dashboard/src/components/mcp/apps.py
+++ b/src/dashboard/src/components/mcp/apps.py
@@ -1,6 +1,0 @@
-from django.apps import AppConfig
-
-
-class McpAppConfig(AppConfig):
-    default_auto_field = "django.db.models.AutoField"
-    name = "components.mcp"

--- a/src/dashboard/src/components/mcp/apps.py
+++ b/src/dashboard/src/components/mcp/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class McpAppConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
+    name = "components.mcp"

--- a/src/dashboard/src/fpr/apps.py
+++ b/src/dashboard/src/fpr/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class FprAppConfig(AppConfig):
+class FPRAppConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
     name = "fpr"

--- a/src/dashboard/src/fpr/apps.py
+++ b/src/dashboard/src/fpr/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class FprAppConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
+    name = "fpr"

--- a/src/dashboard/src/main/apps.py
+++ b/src/dashboard/src/main/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig
 
 
 class MainAppConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
     name = "main"
 
     def ready(self):


### PR DESCRIPTION
Remove Django 3.2 warnings created during "make bootstrap" in development environment. 

**warning:**  
`fpr.fpcommand: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.`

Reference: https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-DEFAULT_AUTO_FIELD 