### PR TITLE
Fix accession event helper

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -236,7 +236,7 @@ test-build:  ## Build archivematica-tests image.
 		-t archivematica-tests \
 		-f $(CURDIR)/Dockerfile \
 		--build-arg TARGET=archivematica-tests \
-		--build-arg PYTHON_VERSION=${PYTHON_VERSION} \
+		--build-arg PYTHON_VERSION \
 			../
 
 __TOXENVS_MCPSERVER := mcp-server

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -198,7 +198,7 @@ pyopenssl==23.2.0
     # via
     #   -r requirements.txt
     #   josepy
-pyproject-api==1.5.4
+pyproject-api==1.6.1
     # via tox
 pyproject-hooks==1.0.0
     # via
@@ -281,7 +281,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tox==4.10.0
+tox==4.11.0
     # via -r requirements-dev.in
 typing-extensions==4.7.1
     # via
@@ -299,7 +299,7 @@ urllib3==1.26.16
     #   vcrpy
 vcrpy==5.1.0
     # via -r requirements-dev.in
-virtualenv==20.24.3
+virtualenv==20.24.4
     # via tox
 wheel==0.41.2
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,6 @@ jsonschema
 lazy-paged-sequence
 lxml
 metsrw
-mysqlclient
 opf-fido
 pip
 pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,9 +97,7 @@ metsrw==0.4.0
 mozilla-django-oidc==3.0.0
     # via -r requirements.in
 mysqlclient==2.2.0
-    # via
-    #   -r requirements.in
-    #   agentarchives
+    # via agentarchives
 olefile==0.46
     # via opf-fido
 opf-fido==1.6.1

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -25,7 +25,6 @@ import sys
 import uuid
 from pathlib import Path
 
-import MySQLdb
 from archivematicaFunctions import get_file_checksum
 from archivematicaFunctions import get_setting
 from databaseFunctions import insertIntoEvents
@@ -120,9 +119,7 @@ def addFileToTransfer(
 def addAccessionEvent(fileUUID, transferUUID, date):
     transfer = Transfer.objects.get(uuid=transferUUID)
     if transfer.accessionid:
-        eventOutcomeDetailNote = "accession#" + MySQLdb.escape_string(
-            transfer.accessionid
-        ).decode("utf-8")
+        eventOutcomeDetailNote = f"accession#{transfer.accessionid}"
         insertIntoEvents(
             fileUUID=fileUUID,
             eventType="registration",

--- a/src/archivematicaCommon/tests/test_file_operations.py
+++ b/src/archivematicaCommon/tests/test_file_operations.py
@@ -1,5 +1,10 @@
 import pytest
+from django.db.models import Q
+from fileOperations import addAccessionEvent
 from fileOperations import get_extract_dir_name
+from main.models import Event
+from main.models import File
+from main.models import Transfer
 
 
 @pytest.mark.parametrize(
@@ -22,3 +27,21 @@ def test_get_extract_dir_name(filename, dirname):
 def test_get_extract_dir_name_raises_if_no_extension():
     with pytest.raises(ValueError):
         get_extract_dir_name("test")
+
+
+@pytest.mark.django_db
+def test_addAccessionEvent_adds_registration_event_when_accessionid_is_set():
+    f = File.objects.create()
+    t = Transfer.objects.create(accessionid="my-id")
+    date = None
+    query_filter = Q(
+        file_uuid=f,
+        event_type="registration",
+        event_outcome_detail="accession#my-id",
+    )
+
+    assert Event.objects.filter(query_filter).count() == 0
+
+    addAccessionEvent(f.uuid, t.uuid, date)
+
+    assert Event.objects.filter(query_filter).count() == 1


### PR DESCRIPTION
The `escape_string` function has been removed in recent versions of `mysqlclient` which makes the accession event helper to fail. Thanks to Jesús for reporting it!

I don't think we need to use that `mysqlclient` function anymore. It seems to come from days when we were doing raw SQL queries. And since that part seems to be the only place that used the `mysqlclient` package explicitly I have removed it from our direct dependencies.

This also fixes a build problem when the `PYTHON_VERSION` environment variable is not defined.

Connected to https://github.com/archivematica/Issues/issues/1612