### PR TITLE
Upgrade Django to 4.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
           "3.8",
           "3.9",
           "3.10",
+          "3.11",
         ]
         include:
           - rule: "storage-service"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   rev: "1.15.0"
   hooks:
   - id: django-upgrade
-    args: [--target-version, "3.2"]
+    args: [--target-version, "4.2"]
 - repo: https://github.com/psf/black
   rev: "23.10.1"
   hooks:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,42 +4,42 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements-dev.txt requirements-dev.in
 #
-agentarchives==0.8.0
+agentarchives==0.9.0
     # via -r requirements.txt
-amclient==1.2.3
+amclient==1.3.0
     # via -r requirements.txt
-ammcpc==0.1.3
+ammcpc==0.2.0
     # via -r requirements.txt
 asgiref==3.7.2
     # via
     #   -r requirements.txt
     #   django
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -r requirements.txt
     #   jsonschema
     #   referencing
 bagit==1.8.1
     # via -r requirements.txt
-brotli==1.0.9
+brotli==1.1.0
     # via -r requirements.txt
-build==0.10.0
+build==1.0.3
     # via
     #   -r requirements.txt
     #   pip-tools
-cachetools==5.3.1
+cachetools==5.3.2
     # via tox
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements.txt
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   -r requirements.txt
     #   cryptography
 chardet==5.2.0
     # via tox
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -r requirements.txt
     #   requests
@@ -51,30 +51,30 @@ click==8.1.7
     #   pip-tools
 colorama==0.4.6
     # via tox
-coverage[toml]==7.3.0
+coverage[toml]==7.4.0
     # via
     #   -r requirements-dev.in
     #   pytest-cov
-cryptography==41.0.3
+cryptography==41.0.7
     # via
     #   -r requirements.txt
     #   josepy
     #   mozilla-django-oidc
     #   pyopenssl
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
-django==4.2.5
+django==4.2.9
     # via
     #   -r requirements.txt
     #   django-auth-ldap
     #   django-cas-ng
     #   django-csp
     #   mozilla-django-oidc
-django-auth-ldap==4.5.0
+django-auth-ldap==4.6.0
     # via -r requirements.txt
 django-autoslug==1.9.9
     # via -r requirements.txt
-django-cas-ng==4.3.0
+django-cas-ng==5.0.1
     # via -r requirements.txt
 django-csp==3.7
     # via -r requirements.txt
@@ -84,38 +84,38 @@ django-prometheus==2.3.1
     # via -r requirements.txt
 django-shibboleth-remoteuser @ git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@962f6f9818683ef5f6432f091d22945e54b82592
     # via -r requirements.txt
-django-tastypie==0.14.5
+django-tastypie==0.14.6
     # via -r requirements.txt
 elasticsearch==6.8.2
     # via -r requirements.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
-filelock==3.12.3
+filelock==3.13.1
     # via
     #   tox
     #   virtualenv
-funcparserlib==1.0.1
+funcparserlib==2.0.0a0
     # via mockldap
 gearman3 @ git+https://github.com/artefactual-labs/python-gearman.git@b68efc868c7a494dd6a2d2e820fb098a6da9f797
     # via -r requirements.txt
-gevent==23.7.0
+gevent==23.9.1
     # via -r requirements.txt
-greenlet==2.0.2
+greenlet==3.0.3
     # via
     #   -r requirements.txt
     #   gevent
 gunicorn==21.2.0
     # via -r requirements.txt
-idna==3.4
+idna==3.6
     # via
     #   -r requirements.txt
     #   requests
-    #   yarl
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via
     #   -r requirements.txt
+    #   build
     #   pytest-randomly
-importlib-resources==6.0.1
+importlib-resources==6.1.1
     # via
     #   -r requirements.txt
     #   opf-fido
@@ -123,43 +123,41 @@ iniconfig==2.0.0
     # via pytest
 inotify-simple==1.3.5
     # via -r requirements.txt
-josepy==1.13.0
+josepy==1.14.0
     # via
     #   -r requirements.txt
     #   mozilla-django-oidc
-jsonschema==4.19.0
+jsonschema==4.21.0
     # via -r requirements.txt
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via
     #   -r requirements.txt
     #   jsonschema
 lazy-paged-sequence==0.3
     # via -r requirements.txt
-lxml==4.9.3
+lxml==5.1.0
     # via
     #   -r requirements.txt
     #   ammcpc
     #   metsrw
     #   python-cas
-metsrw==0.4.0
+metsrw==0.5.0
     # via -r requirements.txt
 mockldap @ git+https://github.com/artefactual-labs/mockldap@v0.3.1
     # via -r requirements-dev.in
-mozilla-django-oidc==3.0.0
+mozilla-django-oidc==4.0.0
     # via -r requirements.txt
-multidict==6.0.4
-    # via yarl
-mysqlclient==2.2.0
+mysqlclient==2.2.1
     # via
     #   -r requirements.txt
     #   agentarchives
-olefile==0.46
+olefile==0.47
     # via
     #   -r requirements.txt
     #   opf-fido
 opf-fido==1.6.1
     # via -r requirements.txt
-packaging==23.1
+packaging==23.2
     # via
     #   -r requirements.txt
     #   build
@@ -169,7 +167,7 @@ packaging==23.1
     #   tox
 pip-tools==7.3.0
     # via -r requirements.txt
-platformdirs==3.10.0
+platformdirs==4.1.0
     # via
     #   tox
     #   virtualenv
@@ -177,11 +175,11 @@ pluggy==1.3.0
     # via
     #   pytest
     #   tox
-prometheus-client==0.17.1
+prometheus-client==0.19.0
     # via
     #   -r requirements.txt
     #   django-prometheus
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via
     #   -r requirements.txt
     #   pyasn1-modules
@@ -194,7 +192,7 @@ pycparser==2.21
     # via
     #   -r requirements.txt
     #   cffi
-pyopenssl==23.2.0
+pyopenssl==23.3.0
     # via
     #   -r requirements.txt
     #   josepy
@@ -204,7 +202,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements.txt
     #   build
-pytest==7.4.0
+pytest==7.4.4
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -213,9 +211,9 @@ pytest==7.4.0
     #   pytest-randomly
 pytest-cov==4.1.0
     # via -r requirements-dev.in
-pytest-django==4.5.2
+pytest-django==4.7.0
     # via -r requirements-dev.in
-pytest-mock==3.11.1
+pytest-mock==3.12.0
     # via -r requirements-dev.in
 pytest-randomly==3.15.0
     # via -r requirements-dev.in
@@ -227,7 +225,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements.txt
     #   django-tastypie
-python-ldap==3.4.3
+python-ldap==3.4.4
     # via
     #   -r requirements.txt
     #   django-auth-ldap
@@ -236,9 +234,7 @@ python-mimeparse==1.6.0
     # via
     #   -r requirements.txt
     #   django-tastypie
-pyyaml==6.0.1
-    # via vcrpy
-referencing==0.30.2
+referencing==0.32.1
     # via
     #   -r requirements.txt
     #   jsonschema
@@ -251,7 +247,7 @@ requests==2.31.0
     #   mozilla-django-oidc
     #   opf-fido
     #   python-cas
-rpds-py==0.10.0
+rpds-py==0.17.1
     # via
     #   -r requirements.txt
     #   jsonschema
@@ -259,7 +255,6 @@ rpds-py==0.10.0
 six==1.16.0
     # via
     #   -r requirements.txt
-    #   amclient
     #   opf-fido
     #   python-cas
     #   python-dateutil
@@ -277,37 +272,29 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tox==4.11.0
+tox==4.12.1
     # via -r requirements-dev.in
-typing-extensions==4.7.1
+typing-extensions==4.9.0
     # via
     #   -r requirements.txt
     #   asgiref
-    #   filelock
-unidecode==1.3.6
+unidecode==1.3.8
     # via -r requirements.txt
-urllib3==1.26.16
+urllib3==2.1.0
     # via
     #   -r requirements.txt
     #   amclient
     #   elasticsearch
     #   requests
-    #   vcrpy
-vcrpy==5.1.0
-    # via -r requirements-dev.in
-virtualenv==20.24.4
+virtualenv==20.25.0
     # via tox
-wheel==0.41.2
+wheel==0.42.0
     # via
     #   -r requirements.txt
     #   pip-tools
-whitenoise==6.5.0
+whitenoise==6.6.0
     # via -r requirements.txt
-wrapt==1.15.0
-    # via vcrpy
-yarl==1.9.2
-    # via vcrpy
-zipp==3.16.2
+zipp==3.17.0
     # via
     #   -r requirements.txt
     #   importlib-metadata
@@ -316,20 +303,19 @@ zope-event==5.0
     # via
     #   -r requirements.txt
     #   gevent
-zope-interface==6.0
+zope-interface==6.1
     # via
     #   -r requirements.txt
     #   gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.2.1
+pip==23.3.2
     # via
     #   -r requirements.txt
     #   pip-tools
-setuptools==68.1.2
+setuptools==69.0.3
     # via
     #   -r requirements.txt
-    #   josepy
     #   pip-tools
     #   zope-event
     #   zope-interface

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements-dev.txt requirements-dev.in
 #
-agentarchives==0.9.0
+agentarchives==0.8.0
     # via -r requirements.txt
-amclient==1.3.0
+amclient==1.2.3
     # via -r requirements.txt
-ammcpc==0.2.0
+ammcpc==0.1.3
     # via -r requirements.txt
 asgiref==3.7.2
     # via
@@ -21,25 +21,25 @@ attrs==23.1.0
     #   referencing
 bagit==1.8.1
     # via -r requirements.txt
-brotli==1.1.0
+brotli==1.0.9
     # via -r requirements.txt
-build==1.0.3
+build==0.10.0
     # via
     #   -r requirements.txt
     #   pip-tools
-cachetools==5.3.2
+cachetools==5.3.1
     # via tox
-certifi==2023.11.17
+certifi==2023.7.22
     # via
     #   -r requirements.txt
     #   requests
-cffi==1.16.0
+cffi==1.15.1
     # via
     #   -r requirements.txt
     #   cryptography
 chardet==5.2.0
     # via tox
-charset-normalizer==3.3.2
+charset-normalizer==3.2.0
     # via
     #   -r requirements.txt
     #   requests
@@ -51,11 +51,11 @@ click==8.1.7
     #   pip-tools
 colorama==0.4.6
     # via tox
-coverage[toml]==7.3.2
+coverage[toml]==7.3.0
     # via
     #   -r requirements-dev.in
     #   pytest-cov
-cryptography==41.0.7
+cryptography==41.0.3
     # via
     #   -r requirements.txt
     #   josepy
@@ -63,18 +63,18 @@ cryptography==41.0.7
     #   pyopenssl
 distlib==0.3.7
     # via virtualenv
-django==3.2.23
+django==4.2.5
     # via
     #   -r requirements.txt
     #   django-auth-ldap
     #   django-cas-ng
     #   django-csp
     #   mozilla-django-oidc
-django-auth-ldap==4.6.0
+django-auth-ldap==4.5.0
     # via -r requirements.txt
 django-autoslug==1.9.9
     # via -r requirements.txt
-django-cas-ng==5.0.1
+django-cas-ng==4.3.0
     # via -r requirements.txt
 django-csp==3.7
     # via -r requirements.txt
@@ -84,38 +84,38 @@ django-prometheus==2.3.1
     # via -r requirements.txt
 django-shibboleth-remoteuser @ git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@962f6f9818683ef5f6432f091d22945e54b82592
     # via -r requirements.txt
-django-tastypie==0.14.6
+django-tastypie==0.14.5
     # via -r requirements.txt
 elasticsearch==6.8.2
     # via -r requirements.txt
-exceptiongroup==1.2.0
+exceptiongroup==1.1.3
     # via pytest
-filelock==3.13.1
+filelock==3.12.3
     # via
     #   tox
     #   virtualenv
-funcparserlib==2.0.0a0
+funcparserlib==1.0.1
     # via mockldap
 gearman3 @ git+https://github.com/artefactual-labs/python-gearman.git@b68efc868c7a494dd6a2d2e820fb098a6da9f797
     # via -r requirements.txt
-gevent==23.9.1
+gevent==23.7.0
     # via -r requirements.txt
-greenlet==3.0.1
+greenlet==2.0.2
     # via
     #   -r requirements.txt
     #   gevent
 gunicorn==21.2.0
     # via -r requirements.txt
-idna==3.6
+idna==3.4
     # via
     #   -r requirements.txt
     #   requests
+    #   yarl
 importlib-metadata==6.8.0
     # via
     #   -r requirements.txt
-    #   build
     #   pytest-randomly
-importlib-resources==6.1.1
+importlib-resources==6.0.1
     # via
     #   -r requirements.txt
     #   opf-fido
@@ -123,13 +123,13 @@ iniconfig==2.0.0
     # via pytest
 inotify-simple==1.3.5
     # via -r requirements.txt
-josepy==1.14.0
+josepy==1.13.0
     # via
     #   -r requirements.txt
     #   mozilla-django-oidc
-jsonschema==4.20.0
+jsonschema==4.19.0
     # via -r requirements.txt
-jsonschema-specifications==2023.11.1
+jsonschema-specifications==2023.7.1
     # via
     #   -r requirements.txt
     #   jsonschema
@@ -141,12 +141,14 @@ lxml==4.9.3
     #   ammcpc
     #   metsrw
     #   python-cas
-metsrw==0.5.0
+metsrw==0.4.0
     # via -r requirements.txt
 mockldap @ git+https://github.com/artefactual-labs/mockldap@v0.3.1
     # via -r requirements-dev.in
 mozilla-django-oidc==3.0.0
     # via -r requirements.txt
+multidict==6.0.4
+    # via yarl
 mysqlclient==2.2.0
     # via
     #   -r requirements.txt
@@ -157,7 +159,7 @@ olefile==0.46
     #   opf-fido
 opf-fido==1.6.1
     # via -r requirements.txt
-packaging==23.2
+packaging==23.1
     # via
     #   -r requirements.txt
     #   build
@@ -167,7 +169,7 @@ packaging==23.2
     #   tox
 pip-tools==7.3.0
     # via -r requirements.txt
-platformdirs==4.0.0
+platformdirs==3.10.0
     # via
     #   tox
     #   virtualenv
@@ -175,11 +177,11 @@ pluggy==1.3.0
     # via
     #   pytest
     #   tox
-prometheus-client==0.19.0
+prometheus-client==0.17.1
     # via
     #   -r requirements.txt
     #   django-prometheus
-pyasn1==0.5.1
+pyasn1==0.5.0
     # via
     #   -r requirements.txt
     #   pyasn1-modules
@@ -192,7 +194,7 @@ pycparser==2.21
     # via
     #   -r requirements.txt
     #   cffi
-pyopenssl==23.3.0
+pyopenssl==23.2.0
     # via
     #   -r requirements.txt
     #   josepy
@@ -202,7 +204,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements.txt
     #   build
-pytest==7.4.3
+pytest==7.4.0
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -211,9 +213,9 @@ pytest==7.4.3
     #   pytest-randomly
 pytest-cov==4.1.0
     # via -r requirements-dev.in
-pytest-django==4.7.0
+pytest-django==4.5.2
     # via -r requirements-dev.in
-pytest-mock==3.12.0
+pytest-mock==3.11.1
     # via -r requirements-dev.in
 pytest-randomly==3.15.0
     # via -r requirements-dev.in
@@ -225,7 +227,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements.txt
     #   django-tastypie
-python-ldap==3.4.4
+python-ldap==3.4.3
     # via
     #   -r requirements.txt
     #   django-auth-ldap
@@ -234,11 +236,9 @@ python-mimeparse==1.6.0
     # via
     #   -r requirements.txt
     #   django-tastypie
-pytz==2023.3.post1
-    # via
-    #   -r requirements.txt
-    #   django
-referencing==0.31.0
+pyyaml==6.0.1
+    # via vcrpy
+referencing==0.30.2
     # via
     #   -r requirements.txt
     #   jsonschema
@@ -251,7 +251,7 @@ requests==2.31.0
     #   mozilla-django-oidc
     #   opf-fido
     #   python-cas
-rpds-py==0.13.1
+rpds-py==0.10.0
     # via
     #   -r requirements.txt
     #   jsonschema
@@ -259,6 +259,7 @@ rpds-py==0.13.1
 six==1.16.0
     # via
     #   -r requirements.txt
+    #   amclient
     #   opf-fido
     #   python-cas
     #   python-dateutil
@@ -276,29 +277,37 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tox==4.11.4
+tox==4.11.0
     # via -r requirements-dev.in
-typing-extensions==4.8.0
+typing-extensions==4.7.1
     # via
     #   -r requirements.txt
     #   asgiref
-unidecode==1.3.7
+    #   filelock
+unidecode==1.3.6
     # via -r requirements.txt
-urllib3==2.1.0
+urllib3==1.26.16
     # via
     #   -r requirements.txt
     #   amclient
     #   elasticsearch
     #   requests
-virtualenv==20.24.7
+    #   vcrpy
+vcrpy==5.1.0
+    # via -r requirements-dev.in
+virtualenv==20.24.4
     # via tox
-wheel==0.42.0
+wheel==0.41.2
     # via
     #   -r requirements.txt
     #   pip-tools
-whitenoise==6.6.0
+whitenoise==6.5.0
     # via -r requirements.txt
-zipp==3.17.0
+wrapt==1.15.0
+    # via vcrpy
+yarl==1.9.2
+    # via vcrpy
+zipp==3.16.2
     # via
     #   -r requirements.txt
     #   importlib-metadata
@@ -307,19 +316,20 @@ zope-event==5.0
     # via
     #   -r requirements.txt
     #   gevent
-zope-interface==6.1
+zope-interface==6.0
     # via
     #   -r requirements.txt
     #   gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3.1
+pip==23.2.1
     # via
     #   -r requirements.txt
     #   pip-tools
-setuptools==69.0.2
+setuptools==68.1.2
     # via
     #   -r requirements.txt
+    #   josepy
     #   pip-tools
     #   zope-event
     #   zope-interface

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@962f6f9818683ef5f6432f091d22945e54b82592#egg=django-shibboleth-remoteuser
-Django>=3.2,<4
+Django>=4.2,<5
 agentarchives
 amclient
 ammcpc
@@ -9,7 +9,6 @@ clamd
 django-autoslug
 django-csp
 django-forms-bootstrap
-django-prometheus>=2.2,<2.3; python_version == "3.6"
 django-prometheus
 django-tastypie
 elasticsearch>=6.0.0,<7.0.0
@@ -27,10 +26,8 @@ pip
 pip-tools
 prometheus_client
 python-dateutil
-requests~=2.27; python_version == "3.6"
 requests
 unidecode
-whitenoise>=5.3.0,<6.0; python_version == "3.6"
 whitenoise
 
 # Required by LDAP authentication
@@ -41,5 +38,4 @@ python-ldap
 django-cas-ng
 
 # Required for OpenID Connect authentication
-mozilla-django-oidc~=2.0; python_version == "3.6"
 mozilla-django-oidc

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ cryptography==41.0.7
     #   josepy
     #   mozilla-django-oidc
     #   pyopenssl
-django==3.2.23
+django==4.2.5
     # via
     #   -r requirements.in
     #   django-auth-ldap

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ ammcpc==0.2.0
     # via -r requirements.in
 asgiref==3.7.2
     # via django
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
@@ -37,7 +37,7 @@ cryptography==41.0.7
     #   josepy
     #   mozilla-django-oidc
     #   pyopenssl
-django==4.2.5
+django==4.2.9
     # via
     #   -r requirements.in
     #   django-auth-ldap
@@ -66,13 +66,13 @@ gearman3 @ git+https://github.com/artefactual-labs/python-gearman.git@b68efc868c
     # via -r requirements.in
 gevent==23.9.1
     # via -r requirements.in
-greenlet==3.0.1
+greenlet==3.0.3
     # via gevent
 gunicorn==21.2.0
     # via -r requirements.in
 idna==3.6
     # via requests
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via
     #   -r requirements.in
     #   build
@@ -82,13 +82,13 @@ inotify-simple==1.3.5
     # via -r requirements.in
 josepy==1.14.0
     # via mozilla-django-oidc
-jsonschema==4.20.0
+jsonschema==4.21.0
     # via -r requirements.in
-jsonschema-specifications==2023.11.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
 lazy-paged-sequence==0.3
     # via -r requirements.in
-lxml==4.9.3
+lxml==5.1.0
     # via
     #   -r requirements.in
     #   ammcpc
@@ -96,11 +96,11 @@ lxml==4.9.3
     #   python-cas
 metsrw==0.5.0
     # via -r requirements.in
-mozilla-django-oidc==3.0.0
+mozilla-django-oidc==4.0.0
     # via -r requirements.in
-mysqlclient==2.2.0
+mysqlclient==2.2.1
     # via agentarchives
-olefile==0.46
+olefile==0.47
     # via opf-fido
 opf-fido==1.6.1
     # via -r requirements.in
@@ -138,9 +138,7 @@ python-ldap==3.4.4
     #   django-auth-ldap
 python-mimeparse==1.6.0
     # via django-tastypie
-pytz==2023.3.post1
-    # via django
-referencing==0.31.0
+referencing==0.32.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -152,7 +150,7 @@ requests==2.31.0
     #   mozilla-django-oidc
     #   opf-fido
     #   python-cas
-rpds-py==0.13.1
+rpds-py==0.17.1
     # via
     #   jsonschema
     #   referencing
@@ -168,9 +166,9 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via asgiref
-unidecode==1.3.7
+unidecode==1.3.8
     # via -r requirements.in
 urllib3==2.1.0
     # via
@@ -191,11 +189,11 @@ zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3.1
+pip==23.3.2
     # via
     #   -r requirements.in
     #   pip-tools
-setuptools==69.0.2
+setuptools==69.0.3
     # via
     #   pip-tools
     #   zope-event

--- a/src/MCPClient/tests/test_archivematicaClient.py
+++ b/src/MCPClient/tests/test_archivematicaClient.py
@@ -23,13 +23,13 @@ def test_handle_batch_task_replaces_non_ascii_arguments(mocker):
         },
     )
 
+    # This is the only function that uses the arguments after the replacements
+    _parse_command_line = mocker.patch("archivematicaClient._parse_command_line")
+
     # The mocked module will not have a `concurrent_instances` attribute
     mocker.patch(
         "importlib.import_module", return_value=mocker.MagicMock(spec=["call"])
     )
-
-    # This is the only function that uses the arguments after the replacements
-    _parse_command_line = mocker.patch("archivematicaClient._parse_command_line")
 
     # Mock the two parameters sent to handle_batch_task
     gearman_job_mock = mocker.Mock(task=b"task name")

--- a/src/MCPClient/tests/test_load_premis_events_from_xml.py
+++ b/src/MCPClient/tests/test_load_premis_events_from_xml.py
@@ -187,7 +187,7 @@ def test_parse_datetime_with_valid_datetime_and_timezone():
     result = load_premis_events_from_xml.parse_datetime("2019-09-24T16:54:21+04:00")
     assert (2019, 9, 24) == (result.year, result.month, result.day)
     assert (16, 54, 21) == (result.hour, result.minute, result.second)
-    assert "+0400" == result.tzname()
+    assert "UTC+04:00" == result.tzname()
 
 
 def test_parse_datetime_with_empty_string():

--- a/src/dashboard/src/components/administration/tests/test_dip_upload_configs.py
+++ b/src/dashboard/src/components/administration/tests/test_dip_upload_configs.py
@@ -60,15 +60,23 @@ class TestDipUploadAsConfig(TestCase):
         self.assertFalse(form.is_valid())
         self.assertTrue(form.errors)
 
-        self.assertFormError(response, "form", "user", "This field is required.")
-        self.assertFormError(response, "form", "xlink_show", "This field is required.")
         self.assertFormError(
-            response, "form", "xlink_actuate", "This field is required."
+            response.context["form"], "user", "This field is required."
         )
-        self.assertFormError(response, "form", "uri_prefix", "This field is required.")
-        self.assertFormError(response, "form", "repository", "This field is required.")
         self.assertFormError(
-            response, "form", "restrictions", "This field is required."
+            response.context["form"], "xlink_show", "This field is required."
+        )
+        self.assertFormError(
+            response.context["form"], "xlink_actuate", "This field is required."
+        )
+        self.assertFormError(
+            response.context["form"], "uri_prefix", "This field is required."
+        )
+        self.assertFormError(
+            response.context["form"], "repository", "This field is required."
+        )
+        self.assertFormError(
+            response.context["form"], "restrictions", "This field is required."
         )
 
         self.assertIsInstance(config, dict)
@@ -128,8 +136,14 @@ class TestDipUploadAtomConfig(TestCase):
         self.assertFalse(form.is_valid())
         self.assertTrue(form.errors)
 
-        self.assertFormError(response, "form", "email", "This field is required.")
-        self.assertFormError(response, "form", "password", "This field is required.")
-        self.assertFormError(response, "form", "version", "This field is required.")
+        self.assertFormError(
+            response.context["form"], "email", "This field is required."
+        )
+        self.assertFormError(
+            response.context["form"], "password", "This field is required."
+        )
+        self.assertFormError(
+            response.context["form"], "version", "This field is required."
+        )
 
         self.assertIsInstance(config, dict)

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -292,11 +292,9 @@ SITE_ID = 1
 
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
-USE_I18N = True
 
 # If you set this to False, Django will not format dates, numbers and
 # calendars according to the current locale
-USE_L10N = True
 
 # Enable timezone support, for more info see:
 # https://docs.djangoproject.com/en/dev/topics/i18n/timezones/
@@ -348,7 +346,14 @@ STATICFILES_FINDERS = (
     # 'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 
 TEMPLATES = [
     {

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -290,12 +290,6 @@ LOCALE_PATHS = [os.path.join(BASE_PATH, "locale")]
 
 SITE_ID = 1
 
-# If you set this to False, Django will make some optimizations so as not
-# to load the internationalization machinery.
-
-# If you set this to False, Django will not format dates, numbers and
-# calendars according to the current locale
-
 # Enable timezone support, for more info see:
 # https://docs.djangoproject.com/en/dev/topics/i18n/timezones/
 USE_TZ = True

--- a/src/dashboard/src/settings/test.py
+++ b/src/dashboard/src/settings/test.py
@@ -53,7 +53,9 @@ LOGGING = {
 }
 
 # Disable whitenoise
-STATICFILES_STORAGE = None
+STORAGES["staticfiles"][
+    "BACKEND"
+] = "django.contrib.staticfiles.storage.StaticFilesStorage"
 if MIDDLEWARE[0] == "whitenoise.middleware.WhiteNoiseMiddleware":
     del MIDDLEWARE[0]
 

--- a/src/dashboard/tests/test_api.py
+++ b/src/dashboard/tests/test_api.py
@@ -1,22 +1,26 @@
 import datetime
 import json
-import os
-import tempfile
 import uuid
 
 import archivematicaFunctions
 import pytest
+import requests
 from components import helpers
 from components.api import views
 from django.core.management import call_command
-from django.test import TestCase
-from django.test.client import Client
 from django.urls import reverse
 from django.utils.timezone import make_aware
 from lxml import etree
+from main.models import DashboardSetting
+from main.models import DublinCore
+from main.models import File
 from main.models import Job
 from main.models import LevelOfDescription
+from main.models import MetadataAppliesToType
+from main.models import PACKAGE_STATUS_COMPLETED_SUCCESSFULLY
+from main.models import RightsStatement
 from main.models import SIP
+from main.models import SIPArrange
 from main.models import Task
 from main.models import Transfer
 from processing import install_builtin_config
@@ -26,567 +30,822 @@ def load_fixture(fixtures):
     call_command("loaddata", *fixtures, **{"verbosity": 0})
 
 
-def e2e(fn):
-    """Use this decorator when your test uses the HTTP client."""
-
-    def _wrapper(self, *args):
-        load_fixture(["test_user"])
-        self.client = Client()
-        self.client.login(username="test", password="test")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
-        return fn(self, *args)
-
-    return _wrapper
+@pytest.fixture
+def dashboard_uuid(db):
+    helpers.set_setting("dashboard_uuid", str(uuid.uuid4()))
 
 
-class TestAPI(TestCase):
-    """Test API endpoints."""
+@pytest.fixture
+def transfer(db):
+    return Transfer.objects.create()
 
-    fixtures = ["transfer", "sip"]
 
-    def _test_api_error(self, response, message=None, status_code=None):
-        payload = json.loads(response.content.decode("utf8"))
-        assert payload["error"] is True
-        if message is not None:
-            assert payload["message"] == message
-        else:
-            assert "message" in payload
-        if status_code is not None:
-            assert response.status_code == status_code
+@pytest.fixture
+def sip(db):
+    return SIP.objects.create()
 
-    def test_get_unit_status_processing(self):
-        """It should return PROCESSING."""
-        # Setup fixtures
-        load_fixture(["jobs-processing"])
-        # Test
-        status = views.get_unit_status(
-            "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e", "unitTransfer"
+
+@pytest.fixture
+def files(db, transfer, sip):
+    return [File.objects.create(transfer=transfer, sip=sip)]
+
+
+@pytest.fixture
+def jobs_processing(db, transfer):
+    return [
+        Job.objects.create(
+            jobuuid="ee3b39f6-2d57-431d-bdd6-6d38f50de371",
+            microservicegroup="Examine contents",
+            sipuuid=transfer.uuid,
+            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
+            createdtime="2016-10-04T22:50:56Z",
+            unittype="unitTransfer",
+            jobtype="Examine contents?",
+        ),
+        Job.objects.create(
+            jobuuid="3ed5ec03-ee7d-4ddc-bdfc-3b1e07170c2b",
+            microservicegroup="Create SIP from Transfer",
+            sipuuid=transfer.uuid,
+            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
+            createdtime="2016-10-04T22:50:57Z",
+            unittype="unitTransfer",
+            jobtype="Load options to create SIPs",
+        ),
+        Job.objects.create(
+            jobuuid="7bd82bc3-0694-4182-8f72-48fb13f0e8e8",
+            microservicegroup="Create SIP from Transfer",
+            sipuuid=transfer.uuid,
+            currentstep=Job.STATUS_EXECUTING_COMMANDS,
+            createdtime="2016-10-04T22:50:57Z",
+            unittype="unitTransfer",
+            jobtype="Check transfer directory for objects",
+        ),
+    ]
+
+
+@pytest.fixture
+def jobs_user_input(db, transfer):
+    return [
+        Job.objects.create(
+            jobuuid="b9390fbf-8c00-434c-ab4b-eb501ed2f490",
+            microservicegroup="Create SIP from Transfer",
+            sipuuid=transfer.uuid,
+            currentstep=Job.STATUS_AWAITING_DECISION,
+            createdtime="2016-10-04T22:50:57Z",
+            unittype="unitTransfer",
+            jobtype="Create SIP(s)",
         )
-        completed = helpers.completed_units_efficient(
-            unit_type="transfer", include_failed=True
-        )
-        # Verify
-        assert len(status) == 2
-        assert "microservice" in status
-        assert status["status"] == "PROCESSING"
-        assert len(completed) == 0
+    ]
 
-    def test_get_unit_status_user_input(self):
-        """It should return USER_INPUT."""
-        # Setup fixtures
-        load_fixture(["jobs-processing", "jobs-user-input"])
-        # Test
-        status = views.get_unit_status(
-            "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e", "unitTransfer"
-        )
-        completed = helpers.completed_units_efficient(
-            unit_type="transfer", include_failed=True
-        )
-        # Verify
-        assert len(status) == 2
-        assert "microservice" in status
-        assert status["status"] == "USER_INPUT"
-        assert len(completed) == 0
 
-    def test_get_unit_status_failed(self):
-        """It should return FAILED."""
-        # Setup fixtures
-        load_fixture(["jobs-processing", "jobs-failed"])
-        # Test
-        status = views.get_unit_status(
-            "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e", "unitTransfer"
+@pytest.fixture
+def jobs_failed(db, transfer):
+    return [
+        Job.objects.create(
+            jobuuid="7d9ba893-08f1-4678-9fe9-294fdc729c55",
+            microservicegroup="Failed transfer",
+            sipuuid=transfer.uuid,
+            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
+            createdtime="2016-10-05T00:10:54Z",
+            unittype="unitTransfer",
+            jobtype="Move to the failed directory",
         )
-        completed = helpers.completed_units_efficient(
-            unit_type="transfer", include_failed=True
-        )
-        # Verify
-        assert len(status) == 2
-        assert "microservice" in status
-        assert status["status"] == "FAILED"
-        assert len(completed) == 1
+    ]
 
-    def test_get_unit_status_rejected(self):
-        """It should return REJECTED."""
-        # Setup fixtures
-        load_fixture(["jobs-processing", "jobs-rejected"])
-        # Test
-        status = views.get_unit_status(
-            "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e", "unitTransfer"
-        )
-        completed = helpers.completed_units_efficient(
-            unit_type="transfer", include_failed=True
-        )
-        # Verify
-        assert len(status) == 2
-        assert "microservice" in status
-        assert status["status"] == "REJECTED"
-        assert len(completed) == 0
 
-    def test_get_unit_status_completed_transfer(self):
-        """It should return COMPLETE and the new SIP UUID."""
-        # Setup fixtures
-        load_fixture(["jobs-processing", "jobs-transfer-complete", "files"])
-        # Test
-        status = views.get_unit_status(
-            "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e", "unitTransfer"
+@pytest.fixture
+def jobs_rejected(db, transfer):
+    return [
+        Job.objects.create(
+            jobuuid="b7902aae-ec5f-4290-a3d7-c47f844e8774",
+            microservicegroup="Reject transfer",
+            sipuuid=transfer.uuid,
+            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
+            createdtime="2016-10-04T23:48:27Z",
+            unittype="unitTransfer",
+            jobtype="Move to the rejected directory",
         )
-        completed = helpers.completed_units_efficient(
-            unit_type="transfer", include_failed=True
-        )
-        # Verify
-        assert len(status) == 3
-        assert "microservice" in status
-        assert status["status"] == "COMPLETE"
-        assert status["sip_uuid"] == "4060ee97-9c3f-4822-afaf-ebdf838284c3"
-        assert len(completed) == 1
+    ]
 
-    def test_get_unit_status_backlog(self):
-        """It should return COMPLETE and in BACKLOG."""
-        # Setup fixtures
-        load_fixture(["jobs-processing", "jobs-transfer-backlog"])
-        # Test
-        status = views.get_unit_status(
-            "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e", "unitTransfer"
-        )
-        completed = helpers.completed_units_efficient(
-            unit_type="transfer", include_failed=True
-        )
-        # Verify
-        assert len(status) == 3
-        assert "microservice" in status
-        assert status["status"] == "COMPLETE"
-        assert status["sip_uuid"] == "BACKLOG"
-        assert len(completed) == 1
 
-    def test_get_unit_status_completed_sip(self):
-        """It should return COMPLETE."""
-        # Setup fixtures
-        load_fixture(
-            ["jobs-processing", "jobs-transfer-complete", "jobs-sip-complete", "files"]
+@pytest.fixture
+def jobs_transfer_complete(db, transfer):
+    return [
+        Job.objects.create(
+            jobuuid="d51f6915-ae7f-4c23-8a02-fcec49941168",
+            microservicegroup="Create SIP from Transfer",
+            sipuuid=transfer.uuid,
+            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
+            createdtime="2016-10-04T23:05:55Z",
+            unittype="unitTransfer",
+            jobtype="Create SIP from transfer objects",
+        ),
+        Job.objects.create(
+            jobuuid="e7775bc2-613f-4fb7-abba-738dfa799c99",
+            microservicegroup="Create SIP from Transfer",
+            sipuuid=transfer.uuid,
+            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
+            createdtime="2016-10-04T23:05:56Z",
+            unittype="unitTransfer",
+            jobtype="Move to SIP creation directory for completed transfers",
+        ),
+    ]
+
+
+@pytest.fixture
+def jobs_transfer_backlog(db, transfer):
+    return [
+        Job.objects.create(
+            jobuuid="a39d74e4-c42e-404b-8c29-dde873ca48ad",
+            microservicegroup="Create SIP from Transfer",
+            sipuuid=transfer.uuid,
+            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
+            createdtime="2016-10-04T23:40:12Z",
+            unittype="unitTransfer",
+            jobtype="Move transfer to backlog",
+        ),
+        Job.objects.create(
+            jobuuid="bac0675d-44fe-4047-9713-f9ba9fe46eff",
+            microservicegroup="Create SIP from Transfer",
+            sipuuid=transfer.uuid,
+            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
+            createdtime="2016-10-04T23:40:14Z",
+            unittype="unitTransfer",
+            jobtype="Create placement in backlog PREMIS events",
+        ),
+    ]
+
+
+@pytest.fixture
+def jobs_sip_complete(db, sip):
+    return [
+        Job.objects.create(
+            jobuuid="299c727c-e72b-4070-ae0a-a78a5aa0cfd3",
+            microservicegroup="Store AIP",
+            sipuuid=sip.uuid,
+            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
+            createdtime="2016-10-04T23:18:46Z",
+            unittype="unitSIP",
+            jobtype="Remove the processing directory",
         )
-        # Test
-        status = views.get_unit_status(
-            "4060ee97-9c3f-4822-afaf-ebdf838284c3", "unitSIP"
+    ]
+
+
+@pytest.fixture
+def jobs_sip_complete_cleanup_last(db, sip):
+    return [
+        Job.objects.create(
+            jobuuid="c3e2f1de-5cd2-4543-89de-e49a75a54dc4",
+            microservicegroup="Store AIP",
+            sipuuid=sip.uuid,
+            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
+            createdtime="2016-10-04T23:18:47Z",
+            unittype="unitSIP",
+            jobtype="Clean up after storing AIP",
         )
-        completed = helpers.completed_units_efficient(
-            unit_type="transfer", include_failed=True
+    ]
+
+
+@pytest.mark.django_db
+def test_get_unit_status_processing(jobs_processing, transfer):
+    """It should return PROCESSING."""
+    status = views.get_unit_status(transfer.uuid, "unitTransfer")
+    assert len(status) == 2
+    assert "microservice" in status
+    assert status["status"] == "PROCESSING"
+
+    completed = helpers.completed_units_efficient(
+        unit_type="transfer", include_failed=True
+    )
+    assert len(completed) == 0
+
+
+@pytest.mark.django_db
+def test_get_unit_status_user_input(jobs_processing, jobs_user_input, transfer):
+    """It should return USER_INPUT."""
+    status = views.get_unit_status(transfer.uuid, "unitTransfer")
+    assert len(status) == 2
+    assert "microservice" in status
+    assert status["status"] == "USER_INPUT"
+
+    completed = helpers.completed_units_efficient(
+        unit_type="transfer", include_failed=True
+    )
+    assert len(completed) == 0
+
+
+@pytest.mark.django_db
+def test_get_unit_status_failed(jobs_processing, jobs_failed, transfer):
+    """It should return FAILED."""
+    status = views.get_unit_status(transfer.uuid, "unitTransfer")
+    assert len(status) == 2
+    assert "microservice" in status
+    assert status["status"] == "FAILED"
+
+    completed = helpers.completed_units_efficient(
+        unit_type="transfer", include_failed=True
+    )
+    assert len(completed) == 1
+
+
+@pytest.mark.django_db
+def test_get_unit_status_rejected(jobs_processing, jobs_rejected, transfer):
+    """It should return REJECTED."""
+    status = views.get_unit_status(transfer.uuid, "unitTransfer")
+    assert len(status) == 2
+    assert "microservice" in status
+    assert status["status"] == "REJECTED"
+
+    completed = helpers.completed_units_efficient(
+        unit_type="transfer", include_failed=True
+    )
+    assert len(completed) == 0
+
+
+@pytest.mark.django_db
+def test_get_unit_status_completed_transfer(
+    jobs_processing, jobs_transfer_complete, transfer, sip, files
+):
+    """It should return COMPLETE and the new SIP UUID."""
+    status = views.get_unit_status(transfer.uuid, "unitTransfer")
+    assert len(status) == 3
+    assert "microservice" in status
+    assert status["status"] == "COMPLETE"
+    assert status["sip_uuid"] == str(sip.uuid)
+
+    completed = helpers.completed_units_efficient(
+        unit_type="transfer", include_failed=True
+    )
+    assert len(completed) == 1
+
+
+@pytest.mark.django_db
+def test_get_unit_status_backlog(jobs_processing, jobs_transfer_backlog, transfer):
+    """It should return COMPLETE and in BACKLOG."""
+    status = views.get_unit_status(transfer.uuid, "unitTransfer")
+    assert len(status) == 3
+    assert "microservice" in status
+    assert status["status"] == "COMPLETE"
+    assert status["sip_uuid"] == "BACKLOG"
+
+    completed = helpers.completed_units_efficient(
+        unit_type="transfer", include_failed=True
+    )
+    assert len(completed) == 1
+
+
+@pytest.mark.django_db
+def test_get_unit_status_completed_sip(
+    transfer, sip, jobs_processing, jobs_transfer_complete, jobs_sip_complete, files
+):
+    """It should return COMPLETE."""
+    status = views.get_unit_status(sip.uuid, "unitSIP")
+    assert len(status) == 2
+    assert "microservice" in status
+    assert status["status"] == "COMPLETE"
+
+    completed = helpers.completed_units_efficient(
+        unit_type="transfer", include_failed=True
+    )
+    assert len(completed) == 1
+
+
+@pytest.mark.django_db
+def test_get_unit_status_completed_sip_issue_262_workaround(
+    transfer,
+    sip,
+    jobs_processing,
+    jobs_transfer_complete,
+    jobs_sip_complete,
+    jobs_sip_complete_cleanup_last,
+    files,
+):
+    """Test get unit status for a completed SIP when the job with the latest
+    created time is not the last in the microservice chain
+    (i.e, job with jobtype 'Remove the processing directory' is not the one with
+    latest created time)
+    It should return COMPLETE."""
+    status = views.get_unit_status(sip.uuid, "unitSIP")
+    assert len(status) == 2
+    assert "microservice" in status
+    assert status["status"] == "COMPLETE"
+
+    completed = helpers.completed_units_efficient(
+        unit_type="transfer", include_failed=True
+    )
+    assert len(completed) == 1
+
+
+@pytest.mark.django_db
+def test_status(
+    admin_client, dashboard_uuid, transfer, sip, jobs_transfer_complete, files
+):
+    resp = admin_client.get(
+        reverse("api:transfer_status", args=[transfer.uuid]),
+    )
+    assert resp.status_code == 200
+    payload = json.loads(resp.content.decode("utf8"))
+    assert payload["status"] == "COMPLETE"
+    assert payload["type"] == "transfer"
+    assert payload["uuid"] == str(transfer.uuid)
+
+
+@pytest.mark.django_db
+def test_status_transfer_not_found(admin_client, dashboard_uuid):
+    transfer_uuid = uuid.uuid4()
+    resp = admin_client.get(
+        reverse("api:transfer_status", args=[transfer_uuid]),
+    )
+
+    assert resp.status_code == 400
+    payload = json.loads(resp.content.decode("utf8"))
+    assert payload == {
+        "message": f"Cannot fetch unitTransfer with UUID {transfer_uuid}",
+        "error": True,
+        "type": "transfer",
+    }
+
+
+@pytest.mark.django_db
+def test_status_ingest_not_found(admin_client, dashboard_uuid):
+    ingest_uuid = uuid.uuid4()
+    resp = admin_client.get(
+        reverse("api:ingest_status", args=[ingest_uuid]),
+    )
+
+    assert resp.status_code == 400
+    payload = json.loads(resp.content.decode("utf8"))
+    assert payload == {
+        "message": f"Cannot fetch unitSIP with UUID {ingest_uuid}",
+        "error": True,
+        "type": "SIP",
+    }
+
+
+@pytest.mark.django_db
+def test_status_with_bogus_unit(admin_client, dashboard_uuid):
+    """It should return a 400 error as the status cannot be determined."""
+    bogus_transfer_id = "1642cbe0-b72d-432d-8fc9-94dad3a0e9dd"
+    Transfer.objects.create(uuid=bogus_transfer_id)
+    resp = admin_client.get(reverse("api:transfer_status", args=[bogus_transfer_id]))
+    assert resp.status_code == 400
+    payload = json.loads(resp.content.decode("utf8"))
+    assert payload["error"] is True
+    assert (
+        payload["message"]
+        == f"Unable to determine the status of the unit {bogus_transfer_id}"
+    )
+
+
+@pytest.mark.django_db
+def test_completed_units(transfer, sip, jobs_transfer_complete, files):
+    completed = views._completed_units()
+    assert completed == [str(transfer.uuid)]
+
+
+@pytest.mark.django_db
+def test_completed_units_with_bogus_unit(transfer, sip, jobs_transfer_complete, files):
+    """Bogus units should be excluded and handled gracefully."""
+    Transfer.objects.create(uuid="1642cbe0-b72d-432d-8fc9-94dad3a0e9dd")
+    completed = views._completed_units()
+    assert completed == [str(transfer.uuid)]
+
+
+@pytest.mark.django_db
+def test_completed_transfers(
+    admin_client, dashboard_uuid, transfer, sip, jobs_transfer_complete, files
+):
+    resp = admin_client.get(reverse("api:completed_transfers"))
+    assert resp.status_code == 200
+    payload = json.loads(resp.content.decode("utf8"))
+    assert payload == {
+        "message": "Fetched completed transfers successfully.",
+        "results": [str(transfer.uuid)],
+    }
+
+
+@pytest.mark.django_db
+def test_completed_transfers_with_bogus_transfer(
+    admin_client, dashboard_uuid, transfer, sip, jobs_transfer_complete, files
+):
+    """Bogus transfers should be excluded and handled gracefully."""
+    Transfer.objects.create(uuid="1642cbe0-b72d-432d-8fc9-94dad3a0e9dd")
+    resp = admin_client.get(reverse("api:completed_transfers"))
+    assert resp.status_code == 200
+    payload = json.loads(resp.content.decode("utf8"))
+    assert payload == {
+        "message": "Fetched completed transfers successfully.",
+        "results": [str(transfer.uuid)],
+    }
+
+
+@pytest.mark.django_db
+def test_completed_ingests(admin_client, dashboard_uuid, sip, jobs_sip_complete):
+    resp = admin_client.get(reverse("api:completed_ingests"))
+    assert resp.status_code == 200
+    payload = json.loads(resp.content.decode("utf8"))
+    assert payload == {
+        "message": "Fetched completed ingests successfully.",
+        "results": [str(sip.uuid)],
+    }
+
+
+@pytest.mark.django_db
+def test_completed_ingests_with_bogus_sip(
+    admin_client, dashboard_uuid, sip, jobs_sip_complete
+):
+    """Bogus ingests should be excluded and handled gracefully."""
+    SIP.objects.create(uuid="de702ef5-dfac-430d-93f4-f0453b18ad2f")
+    resp = admin_client.get(reverse("api:completed_ingests"))
+    assert resp.status_code == 200
+    payload = json.loads(resp.content.decode("utf8"))
+    assert payload == {
+        "message": "Fetched completed ingests successfully.",
+        "results": [str(sip.uuid)],
+    }
+
+
+@pytest.mark.django_db
+def test_unit_jobs_with_bogus_unit_uuid(admin_client, dashboard_uuid):
+    bogus_unit_uuid = "00000000-dfac-430d-93f4-f0453b18ad2f"
+    resp = admin_client.get(reverse("api:v2beta_jobs", args=[bogus_unit_uuid]))
+    assert resp.status_code == 400
+    payload = json.loads(resp.content.decode("utf8"))
+    assert payload["error"] is True
+    assert payload["message"] == f"No jobs found for unit: {bogus_unit_uuid}"
+
+
+@pytest.mark.django_db
+def test_unit_jobs(admin_client, dashboard_uuid, transfer, jobs_transfer_backlog):
+    # Add a task to an existing job
+    task_uuid = uuid.uuid4()
+    job_index = 1
+    Task.objects.create(
+        taskuuid=task_uuid,
+        job=jobs_transfer_backlog[job_index],
+        createdtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0)),
+        starttime=make_aware(datetime.datetime(2019, 6, 18, 0, 0)),
+        endtime=make_aware(datetime.datetime(2019, 6, 18, 0, 10)),
+        exitcode=0,
+    )
+    # each payload mapping has information about the job and its tasks
+    expected = []
+    for job in jobs_transfer_backlog:
+        expected.append(
+            {
+                "uuid": str(job.jobuuid),
+                "name": job.jobtype,
+                "status": "COMPLETE",
+                "microservice": job.microservicegroup,
+                "link_uuid": str(job.microservicechainlink),
+                "tasks": [
+                    {"uuid": str(task.taskuuid), "exit_code": task.exitcode}
+                    for task in job.task_set.all()
+                ],
+            }
         )
-        # Verify
-        assert len(status) == 2
-        assert "microservice" in status
-        assert status["status"] == "COMPLETE"
-        assert len(completed) == 1
 
-    def test_get_unit_status_completed_sip_issue_262_workaround(self):
-        """Test get unit status for a completed SIP when the job with the latest
-        created time is not the last in the microservice chain
-        (i.e, job with jobtype 'Remove the processing directory' is not the one with
-        latest created time)
-        It should return COMPLETE."""
-        # Setup fixtures
-        load_fixture(
-            [
-                "jobs-processing",
-                "jobs-transfer-complete",
-                "jobs-sip-complete-clean-up-last",
-                "files",
-            ]
+    resp = admin_client.get(reverse("api:v2beta_jobs", args=[transfer.uuid]))
+    assert resp.status_code == 200
+
+    # payload contains a mapping for each job
+    payload = json.loads(resp.content.decode("utf8"))
+    assert len(payload) == len(jobs_transfer_backlog)
+    assert payload == expected
+    # check the task added before is associated to the expected job
+    assert payload[job_index]["tasks"] == [{"uuid": str(task_uuid), "exit_code": 0}]
+
+
+@pytest.mark.django_db
+def test_unit_jobs_searching_for_microservice(
+    admin_client, dashboard_uuid, transfer, jobs_rejected
+):
+    resp = admin_client.get(
+        reverse("api:v2beta_jobs", args=[transfer.uuid]),
+        {"microservice": "Reject transfer"},
+    )
+    assert resp.status_code == 200
+    payload = json.loads(resp.content.decode("utf8"))
+    assert len(payload) == 1
+    job = payload[0]
+    stored_job = jobs_rejected[0]
+    assert job["uuid"] == str(stored_job.jobuuid)
+    assert job["name"] == stored_job.jobtype
+    assert job["status"] == "COMPLETE"
+    assert job["microservice"] == stored_job.microservicegroup
+    assert job["link_uuid"] == str(stored_job.microservicechainlink)
+    assert job["tasks"] == [
+        {"uuid": str(task.taskuuid), "exit_code": task.exitcode}
+        for task in stored_job.task_set.all()
+    ]
+
+
+@pytest.mark.django_db
+def test_unit_jobs_searching_for_microservice_with_prefix(
+    admin_client, dashboard_uuid, transfer, jobs_rejected
+):
+    # Test that microservice search also works with a "Microservice:" prefix
+    resp = admin_client.get(
+        reverse("api:v2beta_jobs", args=[transfer.uuid]),
+        {"microservice": "Microservice: Reject transfer"},
+    )
+    assert resp.status_code == 200
+    payload = json.loads(resp.content.decode("utf8"))
+    assert len(payload) == 1
+    job = payload[0]
+    assert job["uuid"] == jobs_rejected[0].jobuuid
+
+
+@pytest.mark.django_db
+def test_unit_jobs_searching_for_chain_link(
+    admin_client, dashboard_uuid, transfer, jobs_rejected
+):
+    stored_job = jobs_rejected[0]
+    resp = admin_client.get(
+        reverse("api:v2beta_jobs", args=[transfer.uuid]),
+        {"link_uuid": stored_job.microservicechainlink},
+    )
+    assert resp.status_code == 200
+    payload = json.loads(resp.content.decode("utf8"))
+    assert len(payload) == 1
+    job = payload[0]
+    assert job["uuid"] == str(stored_job.jobuuid)
+    assert job["name"] == stored_job.jobtype
+    assert job["status"] == "COMPLETE"
+    assert job["microservice"] == stored_job.microservicegroup
+    assert job["link_uuid"] == str(stored_job.microservicechainlink)
+    assert job["tasks"] == [
+        {"uuid": str(task.taskuuid), "exit_code": task.exitcode}
+        for task in stored_job.task_set.all()
+    ]
+
+
+@pytest.mark.django_db
+def test_unit_jobs_searching_for_name(
+    admin_client, dashboard_uuid, transfer, jobs_rejected
+):
+    resp = admin_client.get(
+        reverse("api:v2beta_jobs", args=[transfer.uuid]),
+        {"name": "Move to the rejected directory"},
+    )
+    assert resp.status_code == 200
+    payload = json.loads(resp.content.decode("utf8"))
+    assert len(payload) == 1
+    job = payload[0]
+    stored_job = jobs_rejected[0]
+    assert job["uuid"] == str(stored_job.jobuuid)
+    assert job["name"] == stored_job.jobtype
+    assert job["status"] == "COMPLETE"
+    assert job["microservice"] == stored_job.microservicegroup
+    assert job["link_uuid"] == str(stored_job.microservicechainlink)
+    assert job["tasks"] == [
+        {"uuid": str(task.taskuuid), "exit_code": task.exitcode}
+        for task in stored_job.task_set.all()
+    ]
+
+
+@pytest.mark.django_db
+def test_unit_jobs_searching_for_name_with_prefix(
+    admin_client, dashboard_uuid, transfer, jobs_rejected
+):
+    # Test that name search also works with a "Job:" prefix
+    resp = admin_client.get(
+        reverse("api:v2beta_jobs", args=[transfer.uuid]),
+        {"name": "Job: Move to the rejected directory"},
+    )
+    assert resp.status_code == 200
+    payload = json.loads(resp.content.decode("utf8"))
+    assert len(payload) == 1
+    job = payload[0]
+    assert job["uuid"] == jobs_rejected[0].jobuuid
+
+
+@pytest.mark.django_db
+def test_unit_jobs_with_detailed_task_output(
+    admin_client, dashboard_uuid, transfer, jobs_rejected
+):
+    # Add a task to an existing job
+    task_uuid = uuid.uuid4()
+    Task.objects.create(
+        taskuuid=task_uuid,
+        job=jobs_rejected[0],
+        createdtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0)),
+        starttime=make_aware(datetime.datetime(2019, 6, 18, 0, 0)),
+        endtime=make_aware(datetime.datetime(2019, 6, 18, 0, 10)),
+        exitcode=0,
+    )
+    expected = []
+    for job in jobs_rejected:
+        expected.append(
+            {
+                "uuid": str(job.jobuuid),
+                "name": job.jobtype,
+                "status": "COMPLETE",
+                "microservice": job.microservicegroup,
+                "link_uuid": str(job.microservicechainlink),
+                "tasks": [
+                    {
+                        "uuid": str(task.taskuuid),
+                        "exit_code": task.exitcode,
+                        "file_uuid": task.fileuuid,
+                        "file_name": task.filename,
+                        "time_created": task.createdtime.strftime("%Y-%m-%dT%H:%M:%S"),
+                        "time_started": task.starttime.strftime("%Y-%m-%dT%H:%M:%S"),
+                        "time_ended": task.endtime.strftime("%Y-%m-%dT%H:%M:%S"),
+                        "duration": helpers.task_duration_in_seconds(task),
+                    }
+                    for task in job.task_set.all()
+                ],
+            }
         )
-        # Test
-        status = views.get_unit_status(
-            "4060ee97-9c3f-4822-afaf-ebdf838284c3", "unitSIP"
-        )
-        completed = helpers.completed_units_efficient(
-            unit_type="transfer", include_failed=True
-        )
-        # Verify
-        assert len(status) == 2
-        assert "microservice" in status
-        assert status["status"] == "COMPLETE"
-        assert len(completed) == 1
 
-    @e2e
-    def test_status(self):
-        load_fixture(["jobs-transfer-complete", "files"])
-        resp = self.client.get(
-            reverse(
-                "api:transfer_status", args=["3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"]
-            ),
-        )
-        assert resp.status_code == 200
-        payload = json.loads(resp.content.decode("utf8"))
-        assert payload["status"] == "COMPLETE"
-        assert payload["type"] == "transfer"
-        assert payload["uuid"] == "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"
+    resp = admin_client.get(
+        reverse("api:v2beta_jobs", args=[transfer.uuid]), {"detailed": "true"}
+    )
+    assert resp.status_code == 200
 
-    @e2e
-    def test_status_with_bogus_unit(self):
-        """It should return a 400 error as the status cannot be determined."""
-        bogus_transfer_id = "1642cbe0-b72d-432d-8fc9-94dad3a0e9dd"
-        Transfer.objects.create(uuid=bogus_transfer_id)
-        resp = self.client.get(reverse("api:transfer_status", args=[bogus_transfer_id]))
-        self._test_api_error(
-            resp,
-            status_code=400,
-            message=(
-                "Unable to determine the status of the unit {}".format(
-                    bogus_transfer_id
-                )
-            ),
-        )
+    payload = json.loads(resp.content.decode("utf8"))
+    assert payload == expected
 
-    def test_completed_units(self):
-        load_fixture(["jobs-transfer-complete", "files"])
-        completed = views._completed_units()
-        assert completed == ["3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"]
 
-    def test_completed_units_with_bogus_unit(self):
-        """Bogus units should be excluded and handled gracefully."""
-        load_fixture(["jobs-transfer-complete", "files"])
-        Transfer.objects.create(uuid="1642cbe0-b72d-432d-8fc9-94dad3a0e9dd")
-        try:
-            completed = views._completed_units()
-        except Exception as err:
-            self.fail("views._completed_units raised unexpected exception", err)
-        assert completed == ["3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"]
+@pytest.mark.django_db
+def test_task_with_bogus_task_uuid(admin_client, dashboard_uuid):
+    bogus_task_uuid = "00000000-dfac-430d-93f4-f0453b18ad2f"
+    resp = admin_client.get(reverse("api:v2beta_task", args=[bogus_task_uuid]))
+    assert resp.status_code == 400
+    payload = json.loads(resp.content.decode("utf8"))
+    assert payload["error"] is True
+    assert payload["message"] == f"Task with UUID {bogus_task_uuid} does not exist"
 
-    @e2e
-    def test_completed_transfers(self):
-        load_fixture(["jobs-transfer-complete", "files"])
-        resp = self.client.get(reverse("api:completed_transfers"))
-        assert resp.status_code == 200
-        payload = json.loads(resp.content.decode("utf8"))
-        assert payload == {
-            "message": "Fetched completed transfers successfully.",
-            "results": ["3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"],
-        }
 
-    @e2e
-    def test_completed_transfers_with_bogus_transfer(self):
-        """Bogus transfers should be excluded and handled gracefully."""
-        load_fixture(["jobs-transfer-complete", "files"])
-        Transfer.objects.create(uuid="1642cbe0-b72d-432d-8fc9-94dad3a0e9dd")
-        resp = self.client.get(reverse("api:completed_transfers"))
-        assert resp.status_code == 200
-        payload = json.loads(resp.content.decode("utf8"))
-        assert payload == {
-            "message": "Fetched completed transfers successfully.",
-            "results": ["3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"],
-        }
+@pytest.mark.django_db
+def test_task(admin_client, dashboard_uuid, jobs_transfer_backlog):
+    stored_job = jobs_transfer_backlog[1]
+    # fixtures don't have any tasks
+    task_uuid = uuid.uuid4()
+    Task.objects.create(
+        taskuuid=task_uuid,
+        job=stored_job,
+        createdtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0, 0)),
+        starttime=make_aware(datetime.datetime(2019, 6, 18, 0, 0, 0)),
+        endtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0, 5)),
+        exitcode=0,
+    )
+    resp = admin_client.get(reverse("api:v2beta_task", args=[task_uuid]))
+    assert resp.status_code == 200
+    payload = json.loads(resp.content.decode("utf8"))
+    # payload is a mapping of task attributes
+    assert payload["uuid"] == str(task_uuid)
+    assert payload["exit_code"] == 0
+    assert payload["file_uuid"] is None
+    assert payload["file_name"] == ""
+    assert payload["time_created"] == "2019-06-18T00:00:00"
+    assert payload["time_started"] == "2019-06-18T00:00:00"
+    assert payload["time_ended"] == "2019-06-18T00:00:05"
+    assert payload["duration"] == 5
 
-    @e2e
-    def test_completed_ingests(self):
-        load_fixture(["jobs-sip-complete"])
-        resp = self.client.get(reverse("api:completed_ingests"))
-        assert resp.status_code == 200
-        payload = json.loads(resp.content.decode("utf8"))
-        assert payload == {
-            "message": "Fetched completed ingests successfully.",
-            "results": ["4060ee97-9c3f-4822-afaf-ebdf838284c3"],
-        }
 
-    @e2e
-    def test_completed_ingests_with_bogus_sip(self):
-        """Bogus ingests should be excluded and handled gracefully."""
-        load_fixture(["jobs-sip-complete"])
-        SIP.objects.create(uuid="de702ef5-dfac-430d-93f4-f0453b18ad2f")
-        resp = self.client.get(reverse("api:completed_ingests"))
-        assert resp.status_code == 200
-        payload = json.loads(resp.content.decode("utf8"))
-        assert payload == {
-            "message": "Fetched completed ingests successfully.",
-            "results": ["4060ee97-9c3f-4822-afaf-ebdf838284c3"],
-        }
+@pytest.mark.django_db
+def test_get_levels_of_description(admin_client, dashboard_uuid):
+    LevelOfDescription.objects.create(name="Item", sortorder=2)
+    LevelOfDescription.objects.create(name="Collection", sortorder=0)
+    LevelOfDescription.objects.create(name="Fonds", sortorder=1)
+    expected = ["Collection", "Fonds", "Item"]
 
-    @e2e
-    def test_unit_jobs_with_bogus_unit_uuid(self):
-        bogus_unit_uuid = "00000000-dfac-430d-93f4-f0453b18ad2f"
-        resp = self.client.get(reverse("api:v2beta_jobs", args=[bogus_unit_uuid]))
-        self._test_api_error(
-            resp,
-            status_code=400,
-            message=(f"No jobs found for unit: {bogus_unit_uuid}"),
-        )
+    resp = admin_client.get(reverse("api:get_levels_of_description"))
+    payload = json.loads(resp.content.decode("utf8"))
 
-    @e2e
-    def test_unit_jobs(self):
-        load_fixture(["jobs-transfer-backlog"])
-        sip_uuid = "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"
-        # fixtures don't have any tasks
-        Task.objects.create(
-            taskuuid="12345678-1234-1234-1234-123456789012",
-            job=Job.objects.get(jobuuid="d2f99030-26b9-4746-b100-856779624934"),
-            createdtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0)),
-            starttime=make_aware(datetime.datetime(2019, 6, 18, 0, 0)),
-            endtime=make_aware(datetime.datetime(2019, 6, 18, 0, 10)),
-            exitcode=0,
-        )
-        resp = self.client.get(reverse("api:v2beta_jobs", args=[sip_uuid]))
-        assert resp.status_code == 200
-        payload = json.loads(resp.content.decode("utf8"))
-        # payload contains a mapping for each job
-        assert len(payload) == 5
-        expected_job_uuids = [
-            "624581dc-ec01-4195-9da3-db0ab0ad1cc3",
-            "a39d74e4-c42e-404b-8c29-dde873ca48ad",
-            "bac0675d-44fe-4047-9713-f9ba9fe46eff",
-            "c763fa11-0e36-4b93-a8c8-6f008b74a96a",
-            "d2f99030-26b9-4746-b100-856779624934",
-        ]
-        # sort the payload results by job uuid
-        sorted_payload = sorted(payload, key=lambda job: job["uuid"])
-        assert [job["uuid"] for job in sorted_payload] == expected_job_uuids
-        # each payload mapping has information about the job and its tasks
-        job = sorted_payload[4]
-        assert job["uuid"] == "d2f99030-26b9-4746-b100-856779624934"
-        assert job["name"] == "Check transfer directory for objects"
-        assert job["status"] == "COMPLETE"
-        assert job["microservice"] == "Create SIP from Transfer"
-        assert job["link_uuid"] is None
-        assert job["tasks"] == [
-            {"uuid": "12345678-1234-1234-1234-123456789012", "exit_code": 0}
-        ]
+    result = []
+    for level_of_description in payload:
+        name = next(iter(level_of_description.values()))
+        result.append(name)
 
-    @e2e
-    def test_unit_jobs_searching_for_microservice(self):
-        load_fixture(["jobs-rejected"])
-        sip_uuid = "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"
-        resp = self.client.get(
-            reverse("api:v2beta_jobs", args=[sip_uuid]),
-            {"microservice": "Reject transfer"},
-        )
-        assert resp.status_code == 200
-        payload = json.loads(resp.content.decode("utf8"))
-        assert len(payload) == 1
-        job = payload[0]
-        assert job["uuid"] == "b7902aae-ec5f-4290-a3d7-c47f844e8774"
-        assert job["name"] == "Move to the rejected directory"
-        assert job["status"] == "COMPLETE"
-        assert job["microservice"] == "Reject transfer"
-        assert job["link_uuid"] is None
-        assert job["tasks"] == []
-        # Test that microservice search also works with a "Microservice:" prefix
-        resp = self.client.get(
-            reverse("api:v2beta_jobs", args=[sip_uuid]),
-            {"microservice": "Microservice: Reject transfer"},
-        )
-        assert resp.status_code == 200
-        payload = json.loads(resp.content.decode("utf8"))
-        assert len(payload) == 1
-        job = payload[0]
-        assert job["uuid"] == "b7902aae-ec5f-4290-a3d7-c47f844e8774"
+    assert result == expected
 
-    @e2e
-    def test_unit_jobs_searching_for_chain_link(self):
-        load_fixture(["jobs-rejected"])
-        # add chain links to the fixture jobs
-        job = Job.objects.get(jobuuid="59ace00b-4830-4314-a7d9-38fdbef64896")
-        job.microservicechainlink = "0b8f1929-5beb-4998-a2d5-40e4873fa887"
+
+@pytest.fixture
+def shared_dir(tmp_path, settings):
+    shared_dir = tmp_path / "shared_dir"
+    shared_dir.mkdir()
+
+    (shared_dir / "sharedMicroServiceTasksConfigs" / "processingMCPConfigs").mkdir(
+        parents=True
+    )
+
+    settings.SHARED_DIRECTORY = shared_dir.as_posix()
+    install_builtin_config("default")
+    install_builtin_config("automated")
+
+    return shared_dir
+
+
+def test_list_processing_configs(admin_client, dashboard_uuid, shared_dir):
+    expected_names = sorted(["default", "automated"])
+    response = admin_client.get(reverse("api:processing_configuration_list"))
+    assert response.status_code == 200
+    payload = json.loads(response.content.decode("utf8"))
+    shared_dir = payload["processing_configurations"]
+    assert len(shared_dir) == 2
+    assert all(
+        actual == expected for actual, expected in zip(shared_dir, expected_names)
+    )
+
+
+def test_get_existing_processing_config(admin_client, dashboard_uuid, shared_dir):
+    response = admin_client.get(
+        reverse("api:processing_configuration", args=["default"]),
+        HTTP_ACCEPT="xml",
+    )
+    assert response.status_code == 200
+    assert etree.fromstring(response.content).xpath(".//preconfiguredChoice")
+
+
+def test_delete_and_regenerate(admin_client, dashboard_uuid, shared_dir):
+    processing_configs = (
+        shared_dir / "sharedMicroServiceTasksConfigs" / "processingMCPConfigs"
+    )
+
+    response = admin_client.delete(
+        reverse("api:processing_configuration", args=["default"])
+    )
+    assert response.status_code == 200
+    assert not (processing_configs / "defaultProcessingMCP.xml").exists()
+
+    response = admin_client.get(
+        reverse("api:processing_configuration", args=["default"]),
+        HTTP_ACCEPT="xml",
+    )
+    assert response.status_code == 200
+    assert etree.fromstring(response.content).xpath(".//preconfiguredChoice")
+    assert (processing_configs / "defaultProcessingMCP.xml").exists()
+
+
+def test_404_for_non_existent_config(admin_client, dashboard_uuid, shared_dir):
+    response = admin_client.get(
+        reverse("api:processing_configuration", args=["nonexistent"]),
+        HTTP_ACCEPT="xml",
+    )
+    assert response.status_code == 404
+
+
+def test_404_for_delete_non_existent_config(admin_client, dashboard_uuid, shared_dir):
+    response = admin_client.delete(
+        reverse("api:processing_configuration", args=["nonexistent"])
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_get_unit_status_multiple(
+    jobs_failed,
+    jobs_transfer_complete,
+    jobs_rejected,
+    jobs_user_input,
+    jobs_transfer_backlog,
+):
+    """When the database contains 5 units of the following types:
+    1. a failed transfer
+    2. a completed transfer
+    3. a rejected transfer
+    4. a transfer awaiting user input
+    5. a transfer in backlog
+    then ``completed_units_efficient`` should return 3: the failed,
+    the completed, and the in-backlog transfer.
+    """
+    failed_transfer = Transfer.objects.create()
+    for job in jobs_failed:
+        job.sipuuid = failed_transfer.uuid
         job.save()
-        job = Job.objects.get(jobuuid="b7902aae-ec5f-4290-a3d7-c47f844e8774")
-        job.microservicechainlink = "2208efc0-ba99-4b36-bb8d-99330fcc25da"
+
+    complete_transfer = Transfer.objects.create()
+    for job in jobs_transfer_complete:
+        job.sipuuid = complete_transfer.uuid
         job.save()
-        sip_uuid = "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"
-        resp = self.client.get(
-            reverse("api:v2beta_jobs", args=[sip_uuid]),
-            {"link_uuid": "0b8f1929-5beb-4998-a2d5-40e4873fa887"},
-        )
-        assert resp.status_code == 200
-        payload = json.loads(resp.content.decode("utf8"))
-        assert len(payload) == 1
-        job = payload[0]
-        assert job["uuid"] == "59ace00b-4830-4314-a7d9-38fdbef64896"
-        assert job["name"] == "Create SIP(s)"
-        assert job["status"] == "COMPLETE"
-        assert job["microservice"] == "Create SIP from Transfer"
-        assert job["link_uuid"] == "0b8f1929-5beb-4998-a2d5-40e4873fa887"
-        assert job["tasks"] == []
 
-    @e2e
-    def test_unit_jobs_searching_for_name(self):
-        load_fixture(["jobs-rejected"])
-        sip_uuid = "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"
-        resp = self.client.get(
-            reverse("api:v2beta_jobs", args=[sip_uuid]),
-            {"name": "Move to the rejected directory"},
-        )
-        assert resp.status_code == 200
-        payload = json.loads(resp.content.decode("utf8"))
-        assert len(payload) == 1
-        job = payload[0]
-        assert job["uuid"] == "b7902aae-ec5f-4290-a3d7-c47f844e8774"
-        assert job["name"] == "Move to the rejected directory"
-        assert job["status"] == "COMPLETE"
-        assert job["microservice"] == "Reject transfer"
-        assert job["link_uuid"] is None
-        assert job["tasks"] == []
-        # Test that name search also works with a "Job:" prefix
-        resp = self.client.get(
-            reverse("api:v2beta_jobs", args=[sip_uuid]),
-            {"name": "Job: Move to the rejected directory"},
-        )
-        assert resp.status_code == 200
-        payload = json.loads(resp.content.decode("utf8"))
-        assert len(payload) == 1
-        job = payload[0]
-        assert job["uuid"] == "b7902aae-ec5f-4290-a3d7-c47f844e8774"
+    rejected_transfer = Transfer.objects.create()
+    for job in jobs_rejected:
+        job.sipuuid = rejected_transfer.uuid
+        job.save()
 
-    @e2e
-    def test_task_with_bogus_task_uuid(self):
-        bogus_task_uuid = "00000000-dfac-430d-93f4-f0453b18ad2f"
-        resp = self.client.get(reverse("api:v2beta_task", args=[bogus_task_uuid]))
-        self._test_api_error(
-            resp,
-            status_code=400,
-            message=(f"Task with UUID {bogus_task_uuid} does not exist"),
-        )
+    awaiting_transfer = Transfer.objects.create()
+    for job in jobs_user_input:
+        job.sipuuid = awaiting_transfer.uuid
+        job.save()
 
-    @e2e
-    def test_task(self):
-        load_fixture(["jobs-transfer-backlog"])
-        # fixtures don't have any tasks
-        Task.objects.create(
-            taskuuid="12345678-1234-1234-1234-123456789012",
-            job=Job.objects.get(jobuuid="d2f99030-26b9-4746-b100-856779624934"),
-            createdtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0, 0)),
-            starttime=make_aware(datetime.datetime(2019, 6, 18, 0, 0, 0)),
-            endtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0, 5)),
-            exitcode=0,
-        )
-        resp = self.client.get(
-            reverse("api:v2beta_task", args=["12345678-1234-1234-1234-123456789012"])
-        )
-        assert resp.status_code == 200
-        payload = json.loads(resp.content.decode("utf8"))
-        # payload is a mapping of task attributes
-        assert payload["uuid"] == "12345678-1234-1234-1234-123456789012"
-        assert payload["exit_code"] == 0
-        assert payload["file_uuid"] is None
-        assert payload["file_name"] == ""
-        assert payload["time_created"] == "2019-06-18T00:00:00"
-        assert payload["time_started"] == "2019-06-18T00:00:00"
-        assert payload["time_ended"] == "2019-06-18T00:00:05"
-        assert payload["duration"] == 5
+    backlog_transfer = Transfer.objects.create()
+    for job in jobs_transfer_backlog:
+        job.sipuuid = backlog_transfer.uuid
+        job.save()
 
-    @e2e
-    def test_get_levels_of_description(self):
-        LevelOfDescription.objects.create(name="Item", sortorder=2)
-        LevelOfDescription.objects.create(name="Collection", sortorder=0)
-        LevelOfDescription.objects.create(name="Fonds", sortorder=1)
-        expected = ["Collection", "Fonds", "Item"]
+    expected_uuids = [
+        str(t.uuid) for t in [failed_transfer, complete_transfer, backlog_transfer]
+    ]
 
-        resp = self.client.get(reverse("api:get_levels_of_description"))
-        payload = json.loads(resp.content.decode("utf8"))
+    completed = helpers.completed_units_efficient(
+        unit_type="transfer", include_failed=True
+    )
 
-        result = []
-        for level_of_description in payload:
-            name = next(iter(level_of_description.values()))
-            result.append(name)
-
-        assert result == expected
-
-
-class TestProcessingConfigurationAPI(TestCase):
-    fixtures = ["test_user"]
-
-    def setUp(self):
-        self.client = Client()
-        self.client.login(username="test", password="test")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
-        self.populate_shared_dir()
-
-    def populate_shared_dir(self):
-        self.shared_dir = tempfile.gettempdir()
-        self.config_path = os.path.join(
-            self.shared_dir,
-            "sharedMicroServiceTasksConfigs/processingMCPConfigs/",
-        )
-        if not os.path.exists(self.config_path):
-            os.makedirs(self.config_path)
-        with self.settings(SHARED_DIRECTORY=self.shared_dir):
-            install_builtin_config("default")
-            install_builtin_config("automated")
-
-    def test_list_processing_configs(self):
-        with self.settings(SHARED_DIRECTORY=self.shared_dir):
-            response = self.client.get(reverse("api:processing_configuration_list"))
-            assert response.status_code == 200
-            payload = json.loads(response.content.decode("utf8"))
-            processing_configs = payload["processing_configurations"]
-            assert len(processing_configs) == 2
-            expected_names = sorted(["default", "automated"])
-            assert all(
-                [
-                    actual == expected
-                    for actual, expected in zip(processing_configs, expected_names)
-                ]
-            )
-
-    def test_get_existing_processing_config(self):
-        with self.settings(SHARED_DIRECTORY=self.shared_dir):
-            response = self.client.get(
-                reverse("api:processing_configuration", args=["default"]),
-                headers={"accept": "xml"},
-            )
-            assert response.status_code == 200
-            assert etree.fromstring(response.content).xpath(".//preconfiguredChoice")
-
-    def test_delete_and_regenerate(self):
-        with self.settings(SHARED_DIRECTORY=self.shared_dir):
-            response = self.client.delete(
-                reverse("api:processing_configuration", args=["default"])
-            )
-            assert response.status_code == 200
-            assert not os.path.exists(
-                os.path.join(self.config_path, "defaultProcessingMCP.xml")
-            )
-
-            response = self.client.get(
-                reverse("api:processing_configuration", args=["default"]),
-                headers={"accept": "xml"},
-            )
-            assert response.status_code == 200
-            assert etree.fromstring(response.content).xpath(".//preconfiguredChoice")
-            assert os.path.exists(
-                os.path.join(self.config_path, "defaultProcessingMCP.xml")
-            )
-
-    def test_404_for_non_existent_config(self):
-        response = self.client.get(
-            reverse("api:processing_configuration", args=["nonexistent"]),
-            headers={"accept": "xml"},
-        )
-        assert response.status_code == 404
-
-    def test_404_for_delete_non_existent_config(self):
-        response = self.client.delete(
-            reverse("api:processing_configuration", args=["nonexistent"])
-        )
-        assert response.status_code == 404
-
-
-class TestAPI2(TestCase):
-    """Test API endpoints."""
-
-    fixtures = ["units", "jobs-various"]
-
-    def test_get_unit_status_multiple(self):
-        """When the database contains 5 units of the following types:
-        1. a failed transfer b949773d-7cf7-4c1e-aea5-ccbf65b70ccd
-        2. a completed transfer 85216028-1150-4321-abb3-31ea570a341b
-        3. a rejected transfer c9cce131-7bd9-41c8-82ab-483190961ae2
-        4. a transfer awaiting user input 37a07d96-6fc0-4002-b269-471a58783805
-        5. a transfer in backlog 5d0ab97f-a45b-4e0f-9cb6-90ee3a404549
-        then ``completed_units_efficient`` should return 3: the failed,
-        the completed, and the in-backlog transfer.
-        """
-        completed = helpers.completed_units_efficient(
-            unit_type="transfer", include_failed=True
-        )
-        assert len(completed) == 3
-        assert "85216028-1150-4321-abb3-31ea570a341b" in completed
-        assert "5d0ab97f-a45b-4e0f-9cb6-90ee3a404549" in completed
-        assert "b949773d-7cf7-4c1e-aea5-ccbf65b70ccd" in completed
+    assert set(completed) == set(expected_uuids)
 
 
 @pytest.mark.django_db
@@ -674,3 +933,530 @@ def test_reingest_approve(mocker, admin_client):
         json.loads(response.content.decode("utf8")).get("message")
         == "Approval successful."
     )
+
+
+def test_path_metadata_get(admin_client):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+    SIPArrange.objects.create(
+        arrange_path=b"/arrange/testsip/", level_of_description="Folder"
+    )
+
+    response = admin_client.get(
+        reverse("api:path_metadata"), {"path": "/arrange/testsip"}
+    )
+    assert response.status_code == 200
+
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload["level_of_description"] == "Folder"
+
+
+def test_path_metadata_raises_404_if_siparrange_does_not_exist(admin_client):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    response = admin_client.get(
+        reverse("api:path_metadata"), {"path": "/arrange/testsip"}
+    )
+    assert response.status_code == 404
+
+
+def test_path_metadata_post(admin_client):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+    SIPArrange.objects.create(
+        arrange_path=b"/arrange/testsip/", level_of_description="Folder"
+    )
+    level_of_description = LevelOfDescription.objects.create(
+        name="Collection", sortorder=0
+    )
+    expected = [
+        {"arrange_path": b"/arrange/testsip/", "level_of_description": "Collection"}
+    ]
+
+    response = admin_client.post(
+        reverse("api:path_metadata"),
+        data={
+            "path": "/arrange/testsip",
+            "level_of_description": level_of_description.pk,
+        },
+    )
+    assert response.status_code == 201
+
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload["success"]
+
+    # Verify the SIPArrange instance was updated as expected.
+    assert (
+        list(SIPArrange.objects.values("arrange_path", "level_of_description"))
+        == expected
+    )
+
+
+def test_path_metadata_post_resets_level_of_description(admin_client):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+    SIPArrange.objects.create(
+        arrange_path=b"/arrange/testsip/", level_of_description="Folder"
+    )
+    expected = [{"arrange_path": b"/arrange/testsip/", "level_of_description": ""}]
+
+    response = admin_client.post(
+        reverse("api:path_metadata"),
+        data={"path": "/arrange/testsip"},
+    )
+    assert response.status_code == 201
+
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload["success"]
+
+    # Verify the level of description was reset.
+    assert (
+        list(SIPArrange.objects.values("arrange_path", "level_of_description"))
+        == expected
+    )
+
+
+@pytest.mark.django_db
+def test_unapproved_transfers(admin_client):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    # Create a couple of jobs with one awaiting for decision, i.e. unapproved.
+    approve_transfer_uuid = uuid.uuid4()
+    Job.objects.create(
+        jobtype="Approve standard transfer",
+        currentstep=Job.STATUS_AWAITING_DECISION,
+        directory="%sharedPath%watchedDirectories/activeTransfers/standardTransfer/test-2/",
+        createdtime=make_aware(datetime.datetime(2023, 11, 14, 9, 20)),
+        unittype="unitTransfer",
+        sipuuid=approve_transfer_uuid,
+    )
+    Job.objects.create(
+        jobtype="Store AIP",
+        currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
+        directory="%sharedPath%watchedDirectories/storeAIP/test-1/",
+        createdtime=make_aware(datetime.datetime(2023, 11, 13, 0, 0)),
+        unittype="unitSIP",
+        sipuuid=uuid.UUID("520327f1-cd4e-47fe-9d8a-d9c02fded504"),
+    )
+
+    response = admin_client.get(reverse("api:unapproved_transfers"))
+    assert response.status_code == 200
+
+    # Verify the awaiting transfer is listed.
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload == {
+        "message": "Fetched unapproved transfers successfully.",
+        "results": [
+            {
+                "directory": "test-2",
+                "type": "standard",
+                "uuid": str(approve_transfer_uuid),
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "post_data,expected_error",
+    [
+        ({}, "Please specify a transfer directory."),
+        ({"directory": "mytransfer", "type": ""}, "Please specify a transfer type."),
+        ({"directory": "mytransfer", "type": "bogus"}, "Invalid transfer type."),
+        (
+            {"directory": "mytransfer", "type": "standard"},
+            "Unable to start the transfer.",
+        ),
+    ],
+    ids=[
+        "no_transfer_directory",
+        "no_transfer_type",
+        "invalid_transfer_type",
+        "mcpclient_error",
+    ],
+)
+def test_approve_transfer_failures(post_data, expected_error, admin_client, mocker):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    # Simulate an unhandled error when calling Gearman.
+    mocker.patch("contrib.mcp.client.MCPClient", side_effect=Exception())
+
+    response = admin_client.post(reverse("api:approve_transfer"), post_data)
+
+    assert response.status_code == 500
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload == {"error": True, "message": expected_error}
+
+
+def test_approve_transfer(admin_client, mocker):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    # Simulate a dashboard <-> Gearman <-> MCPServer interaction.
+    # The MCPServer approveTransferByPath RPC method returns a UUID.
+    transfer_uuid = uuid.uuid4()
+    mocker.patch("contrib.mcp.client.pickle.loads", side_effect=[transfer_uuid])
+    job_complete = mocker.patch(
+        "contrib.mcp.client.gearman.JOB_COMPLETE",
+    )
+    mocker.patch(
+        "gearman.GearmanClient",
+        return_value=mocker.Mock(
+            **{"submit_job.return_value": mocker.Mock(state=job_complete)}
+        ),
+    )
+
+    response = admin_client.post(
+        reverse("api:approve_transfer"), {"directory": "mytransfer", "type": "standard"}
+    )
+    assert response.status_code == 200
+
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload == {"message": "Approval successful.", "uuid": str(transfer_uuid)}
+
+
+@pytest.mark.django_db
+def test_waiting_for_user_input(admin_client):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    # Create a couple of jobs with one awaiting for decision.
+    approve_transfer_uuid = uuid.uuid4()
+    Job.objects.create(
+        jobtype="Approve standard transfer",
+        currentstep=Job.STATUS_AWAITING_DECISION,
+        directory="%sharedPath%watchedDirectories/activeTransfers/standardTransfer/test-2/",
+        createdtime=make_aware(datetime.datetime(2023, 11, 14, 9, 20)),
+        unittype="unitTransfer",
+        sipuuid=approve_transfer_uuid,
+    )
+    Job.objects.create(
+        jobtype="Store AIP",
+        currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
+        directory="%sharedPath%watchedDirectories/storeAIP/test-1/",
+        createdtime=make_aware(datetime.datetime(2023, 11, 13, 0, 0)),
+        unittype="unitSIP",
+        sipuuid=uuid.uuid4(),
+    )
+
+    response = admin_client.get(reverse("api:waiting_for_user_input"))
+    assert response.status_code == 200
+
+    # Verify the awaiting transfer is listed.
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload == {
+        "message": "Fetched units successfully.",
+        "results": [
+            {
+                "microservice": "Approve standard transfer",
+                "sip_directory": "test-2",
+                "sip_name": "test-2",
+                "sip_uuid": str(approve_transfer_uuid),
+            }
+        ],
+    }
+
+
+def test_reingest_fails_with_missing_parameters(admin_client):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    response = admin_client.post(
+        reverse("api:transfer_reingest", kwargs={"target": "transfer"}), {}
+    )
+
+    assert response.status_code == 400
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload == {"error": True, "message": '"name" and "uuid" are required.'}
+
+
+@pytest.fixture
+def sip_path(tmp_path):
+    shared_dir = tmp_path / "dir"
+    shared_dir.mkdir()
+
+    (shared_dir / "watchedDirectories" / "activeTransfers" / "standardTransfer").mkdir(
+        parents=True
+    )
+    (shared_dir / "watchedDirectories" / "system" / "reingestAIP").mkdir(parents=True)
+
+    tmp_dir = shared_dir / "tmp"
+    tmp_dir.mkdir()
+
+    sip_dir = tmp_dir / f"mytransfer-{uuid.uuid4()}"
+    sip_dir.mkdir()
+    (sip_dir / "myfile.txt").write_text("my file")
+
+    return sip_dir
+
+
+@pytest.mark.django_db
+def test_reingest_deletes_existing_models_related_to_sip(
+    sip_path, settings, admin_client
+):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    # Set the SHARED_DIRECTORY setting based on the sip_path fixture.
+    shared_directory = sip_path.parent.parent
+    transfer_uuid = sip_path.name[-36:]
+    settings.SHARED_DIRECTORY = shared_directory.as_posix()
+
+    # Create a Transfer and related models.
+    transfer = Transfer.objects.create(uuid=transfer_uuid)
+    job = Job.objects.create(
+        sipuuid=transfer.uuid,
+        createdtime=make_aware(datetime.datetime(2023, 11, 15, 8, 30)),
+    )
+    Task.objects.create(
+        job=job,
+        createdtime=make_aware(datetime.datetime(2023, 11, 15, 8, 30)),
+    )
+    SIP.objects.create(uuid=transfer.uuid)
+    metadata_applies_to_type = MetadataAppliesToType.objects.create()
+    RightsStatement.objects.create(
+        metadataappliestoidentifier=transfer.uuid,
+        metadataappliestotype=metadata_applies_to_type,
+    )
+    DublinCore.objects.create(
+        metadataappliestoidentifier=transfer.uuid,
+        metadataappliestotype=metadata_applies_to_type,
+    )
+
+    response = admin_client.post(
+        reverse("api:transfer_reingest", kwargs={"target": "transfer"}),
+        {"name": f"mytransfer-{transfer_uuid}", "uuid": str(transfer_uuid)},
+    )
+    assert response.status_code == 200
+
+    # Verify the related models were deleted.
+    assert Job.objects.count() == 0
+    assert Task.objects.count() == 0
+    assert SIP.objects.count() == 0
+    assert RightsStatement.objects.count() == 0
+    assert DublinCore.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_reingest_full(sip_path, settings, admin_client, mocker):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    # Fake UUID generation from the endpoint for a new Transfer.
+    transfer_uuid = uuid.uuid4()
+    mocker.patch("uuid.uuid4", return_value=transfer_uuid)
+
+    # Set the SHARED_DIRECTORY setting based on the sip_path fixture.
+    shared_directory = sip_path.parent.parent
+    settings.SHARED_DIRECTORY = shared_directory.as_posix()
+
+    # There are no existing Transfers initially.
+    assert Transfer.objects.count() == 0
+
+    response = admin_client.post(
+        reverse("api:transfer_reingest", kwargs={"target": "transfer"}),
+        {"name": sip_path.name, "uuid": sip_path.name[-36:]},
+    )
+    assert response.status_code == 200
+
+    # Verify the Transfer in the payload contains the fake UUID.
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload == {
+        "message": "Approval successful.",
+        "reingest_uuid": str(transfer_uuid),
+    }
+
+    # Verify a Transfer model was created.
+    assert (
+        Transfer.objects.filter(
+            currentlocation=f"%sharedPath%/watchedDirectories/activeTransfers/standardTransfer/mytransfer-{transfer_uuid}/",
+            type=Transfer.ARCHIVEMATICA_AIP,
+        ).count()
+        == 1
+    )
+
+    # Verify the original content was moved to the active transfers directory.
+    active_transfers_path = (
+        shared_directory / "watchedDirectories" / "activeTransfers" / "standardTransfer"
+    )
+    assert [e.name for e in active_transfers_path.iterdir()] == [
+        f"mytransfer-{transfer_uuid}"
+    ]
+    assert (
+        active_transfers_path / f"mytransfer-{transfer_uuid}" / "myfile.txt"
+    ).read_text() == "my file"
+
+
+@pytest.mark.django_db
+def test_reingest_full_fails_if_target_directory_already_exists(
+    sip_path, settings, admin_client, mocker
+):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    # Fake UUID generation from the endpoint for a new Transfer.
+    transfer_uuid = uuid.uuid4()
+    mocker.patch("uuid.uuid4", return_value=transfer_uuid)
+
+    # Set the SHARED_DIRECTORY setting based on the sip_path fixture.
+    shared_directory = sip_path.parent.parent
+    settings.SHARED_DIRECTORY = shared_directory.as_posix()
+
+    # Create a directory with the same transfer name under active transfers.
+    active_transfers_path = (
+        shared_directory / "watchedDirectories" / "activeTransfers" / "standardTransfer"
+    )
+    (active_transfers_path / f"mytransfer-{transfer_uuid}").mkdir()
+
+    response = admin_client.post(
+        reverse("api:transfer_reingest", kwargs={"target": "transfer"}),
+        {"name": sip_path.name, "uuid": sip_path.name[-36:]},
+    )
+
+    assert response.status_code == 400
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload == {
+        "error": True,
+        "message": "There is already a transfer in standardTransfer with the same name.",
+    }
+
+
+@pytest.mark.django_db
+def test_reingest_partial(sip_path, settings, admin_client):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    # Set the SHARED_DIRECTORY setting based on the sip_path fixture.
+    shared_directory = sip_path.parent.parent
+    settings.SHARED_DIRECTORY = shared_directory.as_posix()
+
+    # A partial reingest reuses the SIP UUID in the response.
+    reingest_uuid = sip_path.name[-36:]
+
+    response = admin_client.post(
+        reverse("api:ingest_reingest", kwargs={"target": "ingest"}),
+        {"name": sip_path.name, "uuid": reingest_uuid},
+    )
+    assert response.status_code == 200
+
+    # Verify the payload contains the reingest UUID.
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload == {
+        "message": "Approval successful.",
+        "reingest_uuid": reingest_uuid,
+    }
+
+    # Verify the original content was moved to the reingest directory.
+    reingests_path = shared_directory / "watchedDirectories" / "system" / "reingestAIP"
+    assert [e.name for e in reingests_path.iterdir()] == [sip_path.name]
+    assert (reingests_path / sip_path.name / "myfile.txt").read_text() == "my file"
+
+
+@pytest.mark.django_db
+def test_fetch_levels_of_description_from_atom(admin_client, mocker):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    # Set up the AtoM settings used on the Administration tab.
+    DashboardSetting.objects.create(
+        name="upload-qubit_v0.0",
+        value=str(
+            {
+                "url": "http://example.com",
+                "email": "demo@example.com",
+                "password": "password",
+            }
+        ),
+    )
+
+    # Simulate interaction with AtoM.
+    lods = ["Series", "Subseries", "File"]
+    mocker.patch(
+        "requests.get",
+        side_effect=[
+            mocker.Mock(
+                **{
+                    "status_code": 200,
+                    "json.return_value": [{"name": lod} for lod in lods],
+                },
+                spec=requests.Response,
+            )
+        ],
+    )
+
+    # Add existing LODs before calling the endpoint.
+    LevelOfDescription.objects.create(name="One existing", sortorder=1)
+    LevelOfDescription.objects.create(name="Another existing", sortorder=1)
+
+    response = admin_client.get(reverse("api:fetch_atom_lods"))
+    assert response.status_code == 200
+
+    # Verify the initial LODS were deleted and we only have the retrieved ones.
+    result = []
+    for lod in json.loads(response.content.decode("utf8")):
+        # LODs are represented as [{"8263fd14-2488-49f7-ac9d-fcfd02b524f0": "Series"}, ...]
+        name = list(lod.values())[0]
+        result.append(name)
+    assert result == lods
+    assert set(LevelOfDescription.objects.values_list("name")) == {
+        (lod,) for lod in lods
+    }
+
+
+@pytest.mark.django_db
+def test_fetch_levels_of_description_from_atom_communication_failure(
+    admin_client, mocker
+):
+    helpers.set_setting("dashboard_uuid", "test-uuid")
+
+    # Set up the AtoM settings used on the Administration tab.
+    DashboardSetting.objects.create(
+        name="upload-qubit_v0.0",
+        value=str(
+            {
+                "url": "http://example.com",
+                "email": "demo@example.com",
+                "password": "password",
+            }
+        ),
+    )
+
+    # Simulate failing interaction with AtoM.
+    mocker.patch(
+        "requests.get",
+        side_effect=[mocker.Mock(status_code=503, spec=requests.Response)],
+    )
+
+    response = admin_client.get(reverse("api:fetch_atom_lods"))
+
+    assert response.status_code == 500
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload == {
+        "success": False,
+        "error": "Unable to fetch levels of description from AtoM!",
+    }
+
+
+@pytest.mark.django_db
+def test_mark_hidden(admin_client, dashboard_uuid, transfer):
+    # This endpoint considers the status attribute instead of jobs.
+    transfer.status = PACKAGE_STATUS_COMPLETED_SUCCESSFULLY
+    transfer.save()
+
+    assert not transfer.hidden
+
+    response = admin_client.delete(
+        reverse(
+            "api:mark_hidden",
+            kwargs={"unit_type": "transfer", "unit_uuid": transfer.uuid},
+        )
+    )
+    assert response.status_code == 200
+
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload == {"removed": True}
+    assert Transfer.objects.get(pk=transfer.uuid).hidden
+
+
+@pytest.mark.django_db
+def test_mark_completed_hidden(
+    admin_client, dashboard_uuid, transfer, jobs_transfer_complete
+):
+    assert not transfer.hidden
+
+    response = admin_client.delete(
+        reverse("api:mark_completed_hidden", kwargs={"unit_type": "transfer"})
+    )
+    assert response.status_code == 200
+
+    payload = json.loads(response.content.decode("utf8"))
+    assert payload == {"removed": [str(transfer.uuid)]}
+    assert Transfer.objects.get(pk=transfer.uuid).hidden

--- a/src/dashboard/tests/test_api.py
+++ b/src/dashboard/tests/test_api.py
@@ -1,26 +1,22 @@
 import datetime
 import json
+import os
+import tempfile
 import uuid
 
 import archivematicaFunctions
 import pytest
-import requests
 from components import helpers
 from components.api import views
 from django.core.management import call_command
+from django.test import TestCase
+from django.test.client import Client
 from django.urls import reverse
 from django.utils.timezone import make_aware
 from lxml import etree
-from main.models import DashboardSetting
-from main.models import DublinCore
-from main.models import File
 from main.models import Job
 from main.models import LevelOfDescription
-from main.models import MetadataAppliesToType
-from main.models import PACKAGE_STATUS_COMPLETED_SUCCESSFULLY
-from main.models import RightsStatement
 from main.models import SIP
-from main.models import SIPArrange
 from main.models import Task
 from main.models import Transfer
 from processing import install_builtin_config
@@ -30,822 +26,567 @@ def load_fixture(fixtures):
     call_command("loaddata", *fixtures, **{"verbosity": 0})
 
 
-@pytest.fixture
-def dashboard_uuid(db):
-    helpers.set_setting("dashboard_uuid", str(uuid.uuid4()))
+def e2e(fn):
+    """Use this decorator when your test uses the HTTP client."""
+
+    def _wrapper(self, *args):
+        load_fixture(["test_user"])
+        self.client = Client()
+        self.client.login(username="test", password="test")
+        helpers.set_setting("dashboard_uuid", "test-uuid")
+        return fn(self, *args)
+
+    return _wrapper
 
 
-@pytest.fixture
-def transfer(db):
-    return Transfer.objects.create()
+class TestAPI(TestCase):
+    """Test API endpoints."""
 
+    fixtures = ["transfer", "sip"]
 
-@pytest.fixture
-def sip(db):
-    return SIP.objects.create()
+    def _test_api_error(self, response, message=None, status_code=None):
+        payload = json.loads(response.content.decode("utf8"))
+        assert payload["error"] is True
+        if message is not None:
+            assert payload["message"] == message
+        else:
+            assert "message" in payload
+        if status_code is not None:
+            assert response.status_code == status_code
 
-
-@pytest.fixture
-def files(db, transfer, sip):
-    return [File.objects.create(transfer=transfer, sip=sip)]
-
-
-@pytest.fixture
-def jobs_processing(db, transfer):
-    return [
-        Job.objects.create(
-            jobuuid="ee3b39f6-2d57-431d-bdd6-6d38f50de371",
-            microservicegroup="Examine contents",
-            sipuuid=transfer.uuid,
-            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
-            createdtime="2016-10-04T22:50:56Z",
-            unittype="unitTransfer",
-            jobtype="Examine contents?",
-        ),
-        Job.objects.create(
-            jobuuid="3ed5ec03-ee7d-4ddc-bdfc-3b1e07170c2b",
-            microservicegroup="Create SIP from Transfer",
-            sipuuid=transfer.uuid,
-            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
-            createdtime="2016-10-04T22:50:57Z",
-            unittype="unitTransfer",
-            jobtype="Load options to create SIPs",
-        ),
-        Job.objects.create(
-            jobuuid="7bd82bc3-0694-4182-8f72-48fb13f0e8e8",
-            microservicegroup="Create SIP from Transfer",
-            sipuuid=transfer.uuid,
-            currentstep=Job.STATUS_EXECUTING_COMMANDS,
-            createdtime="2016-10-04T22:50:57Z",
-            unittype="unitTransfer",
-            jobtype="Check transfer directory for objects",
-        ),
-    ]
-
-
-@pytest.fixture
-def jobs_user_input(db, transfer):
-    return [
-        Job.objects.create(
-            jobuuid="b9390fbf-8c00-434c-ab4b-eb501ed2f490",
-            microservicegroup="Create SIP from Transfer",
-            sipuuid=transfer.uuid,
-            currentstep=Job.STATUS_AWAITING_DECISION,
-            createdtime="2016-10-04T22:50:57Z",
-            unittype="unitTransfer",
-            jobtype="Create SIP(s)",
+    def test_get_unit_status_processing(self):
+        """It should return PROCESSING."""
+        # Setup fixtures
+        load_fixture(["jobs-processing"])
+        # Test
+        status = views.get_unit_status(
+            "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e", "unitTransfer"
         )
-    ]
-
-
-@pytest.fixture
-def jobs_failed(db, transfer):
-    return [
-        Job.objects.create(
-            jobuuid="7d9ba893-08f1-4678-9fe9-294fdc729c55",
-            microservicegroup="Failed transfer",
-            sipuuid=transfer.uuid,
-            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
-            createdtime="2016-10-05T00:10:54Z",
-            unittype="unitTransfer",
-            jobtype="Move to the failed directory",
+        completed = helpers.completed_units_efficient(
+            unit_type="transfer", include_failed=True
         )
-    ]
+        # Verify
+        assert len(status) == 2
+        assert "microservice" in status
+        assert status["status"] == "PROCESSING"
+        assert len(completed) == 0
 
-
-@pytest.fixture
-def jobs_rejected(db, transfer):
-    return [
-        Job.objects.create(
-            jobuuid="b7902aae-ec5f-4290-a3d7-c47f844e8774",
-            microservicegroup="Reject transfer",
-            sipuuid=transfer.uuid,
-            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
-            createdtime="2016-10-04T23:48:27Z",
-            unittype="unitTransfer",
-            jobtype="Move to the rejected directory",
+    def test_get_unit_status_user_input(self):
+        """It should return USER_INPUT."""
+        # Setup fixtures
+        load_fixture(["jobs-processing", "jobs-user-input"])
+        # Test
+        status = views.get_unit_status(
+            "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e", "unitTransfer"
         )
-    ]
-
-
-@pytest.fixture
-def jobs_transfer_complete(db, transfer):
-    return [
-        Job.objects.create(
-            jobuuid="d51f6915-ae7f-4c23-8a02-fcec49941168",
-            microservicegroup="Create SIP from Transfer",
-            sipuuid=transfer.uuid,
-            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
-            createdtime="2016-10-04T23:05:55Z",
-            unittype="unitTransfer",
-            jobtype="Create SIP from transfer objects",
-        ),
-        Job.objects.create(
-            jobuuid="e7775bc2-613f-4fb7-abba-738dfa799c99",
-            microservicegroup="Create SIP from Transfer",
-            sipuuid=transfer.uuid,
-            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
-            createdtime="2016-10-04T23:05:56Z",
-            unittype="unitTransfer",
-            jobtype="Move to SIP creation directory for completed transfers",
-        ),
-    ]
-
-
-@pytest.fixture
-def jobs_transfer_backlog(db, transfer):
-    return [
-        Job.objects.create(
-            jobuuid="a39d74e4-c42e-404b-8c29-dde873ca48ad",
-            microservicegroup="Create SIP from Transfer",
-            sipuuid=transfer.uuid,
-            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
-            createdtime="2016-10-04T23:40:12Z",
-            unittype="unitTransfer",
-            jobtype="Move transfer to backlog",
-        ),
-        Job.objects.create(
-            jobuuid="bac0675d-44fe-4047-9713-f9ba9fe46eff",
-            microservicegroup="Create SIP from Transfer",
-            sipuuid=transfer.uuid,
-            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
-            createdtime="2016-10-04T23:40:14Z",
-            unittype="unitTransfer",
-            jobtype="Create placement in backlog PREMIS events",
-        ),
-    ]
-
-
-@pytest.fixture
-def jobs_sip_complete(db, sip):
-    return [
-        Job.objects.create(
-            jobuuid="299c727c-e72b-4070-ae0a-a78a5aa0cfd3",
-            microservicegroup="Store AIP",
-            sipuuid=sip.uuid,
-            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
-            createdtime="2016-10-04T23:18:46Z",
-            unittype="unitSIP",
-            jobtype="Remove the processing directory",
+        completed = helpers.completed_units_efficient(
+            unit_type="transfer", include_failed=True
         )
-    ]
+        # Verify
+        assert len(status) == 2
+        assert "microservice" in status
+        assert status["status"] == "USER_INPUT"
+        assert len(completed) == 0
 
-
-@pytest.fixture
-def jobs_sip_complete_cleanup_last(db, sip):
-    return [
-        Job.objects.create(
-            jobuuid="c3e2f1de-5cd2-4543-89de-e49a75a54dc4",
-            microservicegroup="Store AIP",
-            sipuuid=sip.uuid,
-            currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
-            createdtime="2016-10-04T23:18:47Z",
-            unittype="unitSIP",
-            jobtype="Clean up after storing AIP",
+    def test_get_unit_status_failed(self):
+        """It should return FAILED."""
+        # Setup fixtures
+        load_fixture(["jobs-processing", "jobs-failed"])
+        # Test
+        status = views.get_unit_status(
+            "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e", "unitTransfer"
         )
-    ]
+        completed = helpers.completed_units_efficient(
+            unit_type="transfer", include_failed=True
+        )
+        # Verify
+        assert len(status) == 2
+        assert "microservice" in status
+        assert status["status"] == "FAILED"
+        assert len(completed) == 1
 
+    def test_get_unit_status_rejected(self):
+        """It should return REJECTED."""
+        # Setup fixtures
+        load_fixture(["jobs-processing", "jobs-rejected"])
+        # Test
+        status = views.get_unit_status(
+            "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e", "unitTransfer"
+        )
+        completed = helpers.completed_units_efficient(
+            unit_type="transfer", include_failed=True
+        )
+        # Verify
+        assert len(status) == 2
+        assert "microservice" in status
+        assert status["status"] == "REJECTED"
+        assert len(completed) == 0
 
-@pytest.mark.django_db
-def test_get_unit_status_processing(jobs_processing, transfer):
-    """It should return PROCESSING."""
-    status = views.get_unit_status(transfer.uuid, "unitTransfer")
-    assert len(status) == 2
-    assert "microservice" in status
-    assert status["status"] == "PROCESSING"
+    def test_get_unit_status_completed_transfer(self):
+        """It should return COMPLETE and the new SIP UUID."""
+        # Setup fixtures
+        load_fixture(["jobs-processing", "jobs-transfer-complete", "files"])
+        # Test
+        status = views.get_unit_status(
+            "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e", "unitTransfer"
+        )
+        completed = helpers.completed_units_efficient(
+            unit_type="transfer", include_failed=True
+        )
+        # Verify
+        assert len(status) == 3
+        assert "microservice" in status
+        assert status["status"] == "COMPLETE"
+        assert status["sip_uuid"] == "4060ee97-9c3f-4822-afaf-ebdf838284c3"
+        assert len(completed) == 1
 
-    completed = helpers.completed_units_efficient(
-        unit_type="transfer", include_failed=True
-    )
-    assert len(completed) == 0
+    def test_get_unit_status_backlog(self):
+        """It should return COMPLETE and in BACKLOG."""
+        # Setup fixtures
+        load_fixture(["jobs-processing", "jobs-transfer-backlog"])
+        # Test
+        status = views.get_unit_status(
+            "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e", "unitTransfer"
+        )
+        completed = helpers.completed_units_efficient(
+            unit_type="transfer", include_failed=True
+        )
+        # Verify
+        assert len(status) == 3
+        assert "microservice" in status
+        assert status["status"] == "COMPLETE"
+        assert status["sip_uuid"] == "BACKLOG"
+        assert len(completed) == 1
 
+    def test_get_unit_status_completed_sip(self):
+        """It should return COMPLETE."""
+        # Setup fixtures
+        load_fixture(
+            ["jobs-processing", "jobs-transfer-complete", "jobs-sip-complete", "files"]
+        )
+        # Test
+        status = views.get_unit_status(
+            "4060ee97-9c3f-4822-afaf-ebdf838284c3", "unitSIP"
+        )
+        completed = helpers.completed_units_efficient(
+            unit_type="transfer", include_failed=True
+        )
+        # Verify
+        assert len(status) == 2
+        assert "microservice" in status
+        assert status["status"] == "COMPLETE"
+        assert len(completed) == 1
 
-@pytest.mark.django_db
-def test_get_unit_status_user_input(jobs_processing, jobs_user_input, transfer):
-    """It should return USER_INPUT."""
-    status = views.get_unit_status(transfer.uuid, "unitTransfer")
-    assert len(status) == 2
-    assert "microservice" in status
-    assert status["status"] == "USER_INPUT"
+    def test_get_unit_status_completed_sip_issue_262_workaround(self):
+        """Test get unit status for a completed SIP when the job with the latest
+        created time is not the last in the microservice chain
+        (i.e, job with jobtype 'Remove the processing directory' is not the one with
+        latest created time)
+        It should return COMPLETE."""
+        # Setup fixtures
+        load_fixture(
+            [
+                "jobs-processing",
+                "jobs-transfer-complete",
+                "jobs-sip-complete-clean-up-last",
+                "files",
+            ]
+        )
+        # Test
+        status = views.get_unit_status(
+            "4060ee97-9c3f-4822-afaf-ebdf838284c3", "unitSIP"
+        )
+        completed = helpers.completed_units_efficient(
+            unit_type="transfer", include_failed=True
+        )
+        # Verify
+        assert len(status) == 2
+        assert "microservice" in status
+        assert status["status"] == "COMPLETE"
+        assert len(completed) == 1
 
-    completed = helpers.completed_units_efficient(
-        unit_type="transfer", include_failed=True
-    )
-    assert len(completed) == 0
+    @e2e
+    def test_status(self):
+        load_fixture(["jobs-transfer-complete", "files"])
+        resp = self.client.get(
+            reverse(
+                "api:transfer_status", args=["3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"]
+            ),
+        )
+        assert resp.status_code == 200
+        payload = json.loads(resp.content.decode("utf8"))
+        assert payload["status"] == "COMPLETE"
+        assert payload["type"] == "transfer"
+        assert payload["uuid"] == "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"
 
-
-@pytest.mark.django_db
-def test_get_unit_status_failed(jobs_processing, jobs_failed, transfer):
-    """It should return FAILED."""
-    status = views.get_unit_status(transfer.uuid, "unitTransfer")
-    assert len(status) == 2
-    assert "microservice" in status
-    assert status["status"] == "FAILED"
-
-    completed = helpers.completed_units_efficient(
-        unit_type="transfer", include_failed=True
-    )
-    assert len(completed) == 1
-
-
-@pytest.mark.django_db
-def test_get_unit_status_rejected(jobs_processing, jobs_rejected, transfer):
-    """It should return REJECTED."""
-    status = views.get_unit_status(transfer.uuid, "unitTransfer")
-    assert len(status) == 2
-    assert "microservice" in status
-    assert status["status"] == "REJECTED"
-
-    completed = helpers.completed_units_efficient(
-        unit_type="transfer", include_failed=True
-    )
-    assert len(completed) == 0
-
-
-@pytest.mark.django_db
-def test_get_unit_status_completed_transfer(
-    jobs_processing, jobs_transfer_complete, transfer, sip, files
-):
-    """It should return COMPLETE and the new SIP UUID."""
-    status = views.get_unit_status(transfer.uuid, "unitTransfer")
-    assert len(status) == 3
-    assert "microservice" in status
-    assert status["status"] == "COMPLETE"
-    assert status["sip_uuid"] == str(sip.uuid)
-
-    completed = helpers.completed_units_efficient(
-        unit_type="transfer", include_failed=True
-    )
-    assert len(completed) == 1
-
-
-@pytest.mark.django_db
-def test_get_unit_status_backlog(jobs_processing, jobs_transfer_backlog, transfer):
-    """It should return COMPLETE and in BACKLOG."""
-    status = views.get_unit_status(transfer.uuid, "unitTransfer")
-    assert len(status) == 3
-    assert "microservice" in status
-    assert status["status"] == "COMPLETE"
-    assert status["sip_uuid"] == "BACKLOG"
-
-    completed = helpers.completed_units_efficient(
-        unit_type="transfer", include_failed=True
-    )
-    assert len(completed) == 1
-
-
-@pytest.mark.django_db
-def test_get_unit_status_completed_sip(
-    transfer, sip, jobs_processing, jobs_transfer_complete, jobs_sip_complete, files
-):
-    """It should return COMPLETE."""
-    status = views.get_unit_status(sip.uuid, "unitSIP")
-    assert len(status) == 2
-    assert "microservice" in status
-    assert status["status"] == "COMPLETE"
-
-    completed = helpers.completed_units_efficient(
-        unit_type="transfer", include_failed=True
-    )
-    assert len(completed) == 1
-
-
-@pytest.mark.django_db
-def test_get_unit_status_completed_sip_issue_262_workaround(
-    transfer,
-    sip,
-    jobs_processing,
-    jobs_transfer_complete,
-    jobs_sip_complete,
-    jobs_sip_complete_cleanup_last,
-    files,
-):
-    """Test get unit status for a completed SIP when the job with the latest
-    created time is not the last in the microservice chain
-    (i.e, job with jobtype 'Remove the processing directory' is not the one with
-    latest created time)
-    It should return COMPLETE."""
-    status = views.get_unit_status(sip.uuid, "unitSIP")
-    assert len(status) == 2
-    assert "microservice" in status
-    assert status["status"] == "COMPLETE"
-
-    completed = helpers.completed_units_efficient(
-        unit_type="transfer", include_failed=True
-    )
-    assert len(completed) == 1
-
-
-@pytest.mark.django_db
-def test_status(
-    admin_client, dashboard_uuid, transfer, sip, jobs_transfer_complete, files
-):
-    resp = admin_client.get(
-        reverse("api:transfer_status", args=[transfer.uuid]),
-    )
-    assert resp.status_code == 200
-    payload = json.loads(resp.content.decode("utf8"))
-    assert payload["status"] == "COMPLETE"
-    assert payload["type"] == "transfer"
-    assert payload["uuid"] == str(transfer.uuid)
-
-
-@pytest.mark.django_db
-def test_status_transfer_not_found(admin_client, dashboard_uuid):
-    transfer_uuid = uuid.uuid4()
-    resp = admin_client.get(
-        reverse("api:transfer_status", args=[transfer_uuid]),
-    )
-
-    assert resp.status_code == 400
-    payload = json.loads(resp.content.decode("utf8"))
-    assert payload == {
-        "message": f"Cannot fetch unitTransfer with UUID {transfer_uuid}",
-        "error": True,
-        "type": "transfer",
-    }
-
-
-@pytest.mark.django_db
-def test_status_ingest_not_found(admin_client, dashboard_uuid):
-    ingest_uuid = uuid.uuid4()
-    resp = admin_client.get(
-        reverse("api:ingest_status", args=[ingest_uuid]),
-    )
-
-    assert resp.status_code == 400
-    payload = json.loads(resp.content.decode("utf8"))
-    assert payload == {
-        "message": f"Cannot fetch unitSIP with UUID {ingest_uuid}",
-        "error": True,
-        "type": "SIP",
-    }
-
-
-@pytest.mark.django_db
-def test_status_with_bogus_unit(admin_client, dashboard_uuid):
-    """It should return a 400 error as the status cannot be determined."""
-    bogus_transfer_id = "1642cbe0-b72d-432d-8fc9-94dad3a0e9dd"
-    Transfer.objects.create(uuid=bogus_transfer_id)
-    resp = admin_client.get(reverse("api:transfer_status", args=[bogus_transfer_id]))
-    assert resp.status_code == 400
-    payload = json.loads(resp.content.decode("utf8"))
-    assert payload["error"] is True
-    assert (
-        payload["message"]
-        == f"Unable to determine the status of the unit {bogus_transfer_id}"
-    )
-
-
-@pytest.mark.django_db
-def test_completed_units(transfer, sip, jobs_transfer_complete, files):
-    completed = views._completed_units()
-    assert completed == [str(transfer.uuid)]
-
-
-@pytest.mark.django_db
-def test_completed_units_with_bogus_unit(transfer, sip, jobs_transfer_complete, files):
-    """Bogus units should be excluded and handled gracefully."""
-    Transfer.objects.create(uuid="1642cbe0-b72d-432d-8fc9-94dad3a0e9dd")
-    completed = views._completed_units()
-    assert completed == [str(transfer.uuid)]
-
-
-@pytest.mark.django_db
-def test_completed_transfers(
-    admin_client, dashboard_uuid, transfer, sip, jobs_transfer_complete, files
-):
-    resp = admin_client.get(reverse("api:completed_transfers"))
-    assert resp.status_code == 200
-    payload = json.loads(resp.content.decode("utf8"))
-    assert payload == {
-        "message": "Fetched completed transfers successfully.",
-        "results": [str(transfer.uuid)],
-    }
-
-
-@pytest.mark.django_db
-def test_completed_transfers_with_bogus_transfer(
-    admin_client, dashboard_uuid, transfer, sip, jobs_transfer_complete, files
-):
-    """Bogus transfers should be excluded and handled gracefully."""
-    Transfer.objects.create(uuid="1642cbe0-b72d-432d-8fc9-94dad3a0e9dd")
-    resp = admin_client.get(reverse("api:completed_transfers"))
-    assert resp.status_code == 200
-    payload = json.loads(resp.content.decode("utf8"))
-    assert payload == {
-        "message": "Fetched completed transfers successfully.",
-        "results": [str(transfer.uuid)],
-    }
-
-
-@pytest.mark.django_db
-def test_completed_ingests(admin_client, dashboard_uuid, sip, jobs_sip_complete):
-    resp = admin_client.get(reverse("api:completed_ingests"))
-    assert resp.status_code == 200
-    payload = json.loads(resp.content.decode("utf8"))
-    assert payload == {
-        "message": "Fetched completed ingests successfully.",
-        "results": [str(sip.uuid)],
-    }
-
-
-@pytest.mark.django_db
-def test_completed_ingests_with_bogus_sip(
-    admin_client, dashboard_uuid, sip, jobs_sip_complete
-):
-    """Bogus ingests should be excluded and handled gracefully."""
-    SIP.objects.create(uuid="de702ef5-dfac-430d-93f4-f0453b18ad2f")
-    resp = admin_client.get(reverse("api:completed_ingests"))
-    assert resp.status_code == 200
-    payload = json.loads(resp.content.decode("utf8"))
-    assert payload == {
-        "message": "Fetched completed ingests successfully.",
-        "results": [str(sip.uuid)],
-    }
-
-
-@pytest.mark.django_db
-def test_unit_jobs_with_bogus_unit_uuid(admin_client, dashboard_uuid):
-    bogus_unit_uuid = "00000000-dfac-430d-93f4-f0453b18ad2f"
-    resp = admin_client.get(reverse("api:v2beta_jobs", args=[bogus_unit_uuid]))
-    assert resp.status_code == 400
-    payload = json.loads(resp.content.decode("utf8"))
-    assert payload["error"] is True
-    assert payload["message"] == f"No jobs found for unit: {bogus_unit_uuid}"
-
-
-@pytest.mark.django_db
-def test_unit_jobs(admin_client, dashboard_uuid, transfer, jobs_transfer_backlog):
-    # Add a task to an existing job
-    task_uuid = uuid.uuid4()
-    job_index = 1
-    Task.objects.create(
-        taskuuid=task_uuid,
-        job=jobs_transfer_backlog[job_index],
-        createdtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0)),
-        starttime=make_aware(datetime.datetime(2019, 6, 18, 0, 0)),
-        endtime=make_aware(datetime.datetime(2019, 6, 18, 0, 10)),
-        exitcode=0,
-    )
-    # each payload mapping has information about the job and its tasks
-    expected = []
-    for job in jobs_transfer_backlog:
-        expected.append(
-            {
-                "uuid": str(job.jobuuid),
-                "name": job.jobtype,
-                "status": "COMPLETE",
-                "microservice": job.microservicegroup,
-                "link_uuid": str(job.microservicechainlink),
-                "tasks": [
-                    {"uuid": str(task.taskuuid), "exit_code": task.exitcode}
-                    for task in job.task_set.all()
-                ],
-            }
+    @e2e
+    def test_status_with_bogus_unit(self):
+        """It should return a 400 error as the status cannot be determined."""
+        bogus_transfer_id = "1642cbe0-b72d-432d-8fc9-94dad3a0e9dd"
+        Transfer.objects.create(uuid=bogus_transfer_id)
+        resp = self.client.get(reverse("api:transfer_status", args=[bogus_transfer_id]))
+        self._test_api_error(
+            resp,
+            status_code=400,
+            message=(
+                "Unable to determine the status of the unit {}".format(
+                    bogus_transfer_id
+                )
+            ),
         )
 
-    resp = admin_client.get(reverse("api:v2beta_jobs", args=[transfer.uuid]))
-    assert resp.status_code == 200
+    def test_completed_units(self):
+        load_fixture(["jobs-transfer-complete", "files"])
+        completed = views._completed_units()
+        assert completed == ["3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"]
 
-    # payload contains a mapping for each job
-    payload = json.loads(resp.content.decode("utf8"))
-    assert len(payload) == len(jobs_transfer_backlog)
-    assert payload == expected
-    # check the task added before is associated to the expected job
-    assert payload[job_index]["tasks"] == [{"uuid": str(task_uuid), "exit_code": 0}]
+    def test_completed_units_with_bogus_unit(self):
+        """Bogus units should be excluded and handled gracefully."""
+        load_fixture(["jobs-transfer-complete", "files"])
+        Transfer.objects.create(uuid="1642cbe0-b72d-432d-8fc9-94dad3a0e9dd")
+        try:
+            completed = views._completed_units()
+        except Exception as err:
+            self.fail("views._completed_units raised unexpected exception", err)
+        assert completed == ["3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"]
 
+    @e2e
+    def test_completed_transfers(self):
+        load_fixture(["jobs-transfer-complete", "files"])
+        resp = self.client.get(reverse("api:completed_transfers"))
+        assert resp.status_code == 200
+        payload = json.loads(resp.content.decode("utf8"))
+        assert payload == {
+            "message": "Fetched completed transfers successfully.",
+            "results": ["3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"],
+        }
 
-@pytest.mark.django_db
-def test_unit_jobs_searching_for_microservice(
-    admin_client, dashboard_uuid, transfer, jobs_rejected
-):
-    resp = admin_client.get(
-        reverse("api:v2beta_jobs", args=[transfer.uuid]),
-        {"microservice": "Reject transfer"},
-    )
-    assert resp.status_code == 200
-    payload = json.loads(resp.content.decode("utf8"))
-    assert len(payload) == 1
-    job = payload[0]
-    stored_job = jobs_rejected[0]
-    assert job["uuid"] == str(stored_job.jobuuid)
-    assert job["name"] == stored_job.jobtype
-    assert job["status"] == "COMPLETE"
-    assert job["microservice"] == stored_job.microservicegroup
-    assert job["link_uuid"] == str(stored_job.microservicechainlink)
-    assert job["tasks"] == [
-        {"uuid": str(task.taskuuid), "exit_code": task.exitcode}
-        for task in stored_job.task_set.all()
-    ]
+    @e2e
+    def test_completed_transfers_with_bogus_transfer(self):
+        """Bogus transfers should be excluded and handled gracefully."""
+        load_fixture(["jobs-transfer-complete", "files"])
+        Transfer.objects.create(uuid="1642cbe0-b72d-432d-8fc9-94dad3a0e9dd")
+        resp = self.client.get(reverse("api:completed_transfers"))
+        assert resp.status_code == 200
+        payload = json.loads(resp.content.decode("utf8"))
+        assert payload == {
+            "message": "Fetched completed transfers successfully.",
+            "results": ["3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"],
+        }
 
+    @e2e
+    def test_completed_ingests(self):
+        load_fixture(["jobs-sip-complete"])
+        resp = self.client.get(reverse("api:completed_ingests"))
+        assert resp.status_code == 200
+        payload = json.loads(resp.content.decode("utf8"))
+        assert payload == {
+            "message": "Fetched completed ingests successfully.",
+            "results": ["4060ee97-9c3f-4822-afaf-ebdf838284c3"],
+        }
 
-@pytest.mark.django_db
-def test_unit_jobs_searching_for_microservice_with_prefix(
-    admin_client, dashboard_uuid, transfer, jobs_rejected
-):
-    # Test that microservice search also works with a "Microservice:" prefix
-    resp = admin_client.get(
-        reverse("api:v2beta_jobs", args=[transfer.uuid]),
-        {"microservice": "Microservice: Reject transfer"},
-    )
-    assert resp.status_code == 200
-    payload = json.loads(resp.content.decode("utf8"))
-    assert len(payload) == 1
-    job = payload[0]
-    assert job["uuid"] == jobs_rejected[0].jobuuid
+    @e2e
+    def test_completed_ingests_with_bogus_sip(self):
+        """Bogus ingests should be excluded and handled gracefully."""
+        load_fixture(["jobs-sip-complete"])
+        SIP.objects.create(uuid="de702ef5-dfac-430d-93f4-f0453b18ad2f")
+        resp = self.client.get(reverse("api:completed_ingests"))
+        assert resp.status_code == 200
+        payload = json.loads(resp.content.decode("utf8"))
+        assert payload == {
+            "message": "Fetched completed ingests successfully.",
+            "results": ["4060ee97-9c3f-4822-afaf-ebdf838284c3"],
+        }
 
-
-@pytest.mark.django_db
-def test_unit_jobs_searching_for_chain_link(
-    admin_client, dashboard_uuid, transfer, jobs_rejected
-):
-    stored_job = jobs_rejected[0]
-    resp = admin_client.get(
-        reverse("api:v2beta_jobs", args=[transfer.uuid]),
-        {"link_uuid": stored_job.microservicechainlink},
-    )
-    assert resp.status_code == 200
-    payload = json.loads(resp.content.decode("utf8"))
-    assert len(payload) == 1
-    job = payload[0]
-    assert job["uuid"] == str(stored_job.jobuuid)
-    assert job["name"] == stored_job.jobtype
-    assert job["status"] == "COMPLETE"
-    assert job["microservice"] == stored_job.microservicegroup
-    assert job["link_uuid"] == str(stored_job.microservicechainlink)
-    assert job["tasks"] == [
-        {"uuid": str(task.taskuuid), "exit_code": task.exitcode}
-        for task in stored_job.task_set.all()
-    ]
-
-
-@pytest.mark.django_db
-def test_unit_jobs_searching_for_name(
-    admin_client, dashboard_uuid, transfer, jobs_rejected
-):
-    resp = admin_client.get(
-        reverse("api:v2beta_jobs", args=[transfer.uuid]),
-        {"name": "Move to the rejected directory"},
-    )
-    assert resp.status_code == 200
-    payload = json.loads(resp.content.decode("utf8"))
-    assert len(payload) == 1
-    job = payload[0]
-    stored_job = jobs_rejected[0]
-    assert job["uuid"] == str(stored_job.jobuuid)
-    assert job["name"] == stored_job.jobtype
-    assert job["status"] == "COMPLETE"
-    assert job["microservice"] == stored_job.microservicegroup
-    assert job["link_uuid"] == str(stored_job.microservicechainlink)
-    assert job["tasks"] == [
-        {"uuid": str(task.taskuuid), "exit_code": task.exitcode}
-        for task in stored_job.task_set.all()
-    ]
-
-
-@pytest.mark.django_db
-def test_unit_jobs_searching_for_name_with_prefix(
-    admin_client, dashboard_uuid, transfer, jobs_rejected
-):
-    # Test that name search also works with a "Job:" prefix
-    resp = admin_client.get(
-        reverse("api:v2beta_jobs", args=[transfer.uuid]),
-        {"name": "Job: Move to the rejected directory"},
-    )
-    assert resp.status_code == 200
-    payload = json.loads(resp.content.decode("utf8"))
-    assert len(payload) == 1
-    job = payload[0]
-    assert job["uuid"] == jobs_rejected[0].jobuuid
-
-
-@pytest.mark.django_db
-def test_unit_jobs_with_detailed_task_output(
-    admin_client, dashboard_uuid, transfer, jobs_rejected
-):
-    # Add a task to an existing job
-    task_uuid = uuid.uuid4()
-    Task.objects.create(
-        taskuuid=task_uuid,
-        job=jobs_rejected[0],
-        createdtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0)),
-        starttime=make_aware(datetime.datetime(2019, 6, 18, 0, 0)),
-        endtime=make_aware(datetime.datetime(2019, 6, 18, 0, 10)),
-        exitcode=0,
-    )
-    expected = []
-    for job in jobs_rejected:
-        expected.append(
-            {
-                "uuid": str(job.jobuuid),
-                "name": job.jobtype,
-                "status": "COMPLETE",
-                "microservice": job.microservicegroup,
-                "link_uuid": str(job.microservicechainlink),
-                "tasks": [
-                    {
-                        "uuid": str(task.taskuuid),
-                        "exit_code": task.exitcode,
-                        "file_uuid": task.fileuuid,
-                        "file_name": task.filename,
-                        "time_created": task.createdtime.strftime("%Y-%m-%dT%H:%M:%S"),
-                        "time_started": task.starttime.strftime("%Y-%m-%dT%H:%M:%S"),
-                        "time_ended": task.endtime.strftime("%Y-%m-%dT%H:%M:%S"),
-                        "duration": helpers.task_duration_in_seconds(task),
-                    }
-                    for task in job.task_set.all()
-                ],
-            }
+    @e2e
+    def test_unit_jobs_with_bogus_unit_uuid(self):
+        bogus_unit_uuid = "00000000-dfac-430d-93f4-f0453b18ad2f"
+        resp = self.client.get(reverse("api:v2beta_jobs", args=[bogus_unit_uuid]))
+        self._test_api_error(
+            resp,
+            status_code=400,
+            message=(f"No jobs found for unit: {bogus_unit_uuid}"),
         )
 
-    resp = admin_client.get(
-        reverse("api:v2beta_jobs", args=[transfer.uuid]), {"detailed": "true"}
-    )
-    assert resp.status_code == 200
+    @e2e
+    def test_unit_jobs(self):
+        load_fixture(["jobs-transfer-backlog"])
+        sip_uuid = "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"
+        # fixtures don't have any tasks
+        Task.objects.create(
+            taskuuid="12345678-1234-1234-1234-123456789012",
+            job=Job.objects.get(jobuuid="d2f99030-26b9-4746-b100-856779624934"),
+            createdtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0)),
+            starttime=make_aware(datetime.datetime(2019, 6, 18, 0, 0)),
+            endtime=make_aware(datetime.datetime(2019, 6, 18, 0, 10)),
+            exitcode=0,
+        )
+        resp = self.client.get(reverse("api:v2beta_jobs", args=[sip_uuid]))
+        assert resp.status_code == 200
+        payload = json.loads(resp.content.decode("utf8"))
+        # payload contains a mapping for each job
+        assert len(payload) == 5
+        expected_job_uuids = [
+            "624581dc-ec01-4195-9da3-db0ab0ad1cc3",
+            "a39d74e4-c42e-404b-8c29-dde873ca48ad",
+            "bac0675d-44fe-4047-9713-f9ba9fe46eff",
+            "c763fa11-0e36-4b93-a8c8-6f008b74a96a",
+            "d2f99030-26b9-4746-b100-856779624934",
+        ]
+        # sort the payload results by job uuid
+        sorted_payload = sorted(payload, key=lambda job: job["uuid"])
+        assert [job["uuid"] for job in sorted_payload] == expected_job_uuids
+        # each payload mapping has information about the job and its tasks
+        job = sorted_payload[4]
+        assert job["uuid"] == "d2f99030-26b9-4746-b100-856779624934"
+        assert job["name"] == "Check transfer directory for objects"
+        assert job["status"] == "COMPLETE"
+        assert job["microservice"] == "Create SIP from Transfer"
+        assert job["link_uuid"] is None
+        assert job["tasks"] == [
+            {"uuid": "12345678-1234-1234-1234-123456789012", "exit_code": 0}
+        ]
 
-    payload = json.loads(resp.content.decode("utf8"))
-    assert payload == expected
+    @e2e
+    def test_unit_jobs_searching_for_microservice(self):
+        load_fixture(["jobs-rejected"])
+        sip_uuid = "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"
+        resp = self.client.get(
+            reverse("api:v2beta_jobs", args=[sip_uuid]),
+            {"microservice": "Reject transfer"},
+        )
+        assert resp.status_code == 200
+        payload = json.loads(resp.content.decode("utf8"))
+        assert len(payload) == 1
+        job = payload[0]
+        assert job["uuid"] == "b7902aae-ec5f-4290-a3d7-c47f844e8774"
+        assert job["name"] == "Move to the rejected directory"
+        assert job["status"] == "COMPLETE"
+        assert job["microservice"] == "Reject transfer"
+        assert job["link_uuid"] is None
+        assert job["tasks"] == []
+        # Test that microservice search also works with a "Microservice:" prefix
+        resp = self.client.get(
+            reverse("api:v2beta_jobs", args=[sip_uuid]),
+            {"microservice": "Microservice: Reject transfer"},
+        )
+        assert resp.status_code == 200
+        payload = json.loads(resp.content.decode("utf8"))
+        assert len(payload) == 1
+        job = payload[0]
+        assert job["uuid"] == "b7902aae-ec5f-4290-a3d7-c47f844e8774"
 
-
-@pytest.mark.django_db
-def test_task_with_bogus_task_uuid(admin_client, dashboard_uuid):
-    bogus_task_uuid = "00000000-dfac-430d-93f4-f0453b18ad2f"
-    resp = admin_client.get(reverse("api:v2beta_task", args=[bogus_task_uuid]))
-    assert resp.status_code == 400
-    payload = json.loads(resp.content.decode("utf8"))
-    assert payload["error"] is True
-    assert payload["message"] == f"Task with UUID {bogus_task_uuid} does not exist"
-
-
-@pytest.mark.django_db
-def test_task(admin_client, dashboard_uuid, jobs_transfer_backlog):
-    stored_job = jobs_transfer_backlog[1]
-    # fixtures don't have any tasks
-    task_uuid = uuid.uuid4()
-    Task.objects.create(
-        taskuuid=task_uuid,
-        job=stored_job,
-        createdtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0, 0)),
-        starttime=make_aware(datetime.datetime(2019, 6, 18, 0, 0, 0)),
-        endtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0, 5)),
-        exitcode=0,
-    )
-    resp = admin_client.get(reverse("api:v2beta_task", args=[task_uuid]))
-    assert resp.status_code == 200
-    payload = json.loads(resp.content.decode("utf8"))
-    # payload is a mapping of task attributes
-    assert payload["uuid"] == str(task_uuid)
-    assert payload["exit_code"] == 0
-    assert payload["file_uuid"] is None
-    assert payload["file_name"] == ""
-    assert payload["time_created"] == "2019-06-18T00:00:00"
-    assert payload["time_started"] == "2019-06-18T00:00:00"
-    assert payload["time_ended"] == "2019-06-18T00:00:05"
-    assert payload["duration"] == 5
-
-
-@pytest.mark.django_db
-def test_get_levels_of_description(admin_client, dashboard_uuid):
-    LevelOfDescription.objects.create(name="Item", sortorder=2)
-    LevelOfDescription.objects.create(name="Collection", sortorder=0)
-    LevelOfDescription.objects.create(name="Fonds", sortorder=1)
-    expected = ["Collection", "Fonds", "Item"]
-
-    resp = admin_client.get(reverse("api:get_levels_of_description"))
-    payload = json.loads(resp.content.decode("utf8"))
-
-    result = []
-    for level_of_description in payload:
-        name = next(iter(level_of_description.values()))
-        result.append(name)
-
-    assert result == expected
-
-
-@pytest.fixture
-def shared_dir(tmp_path, settings):
-    shared_dir = tmp_path / "shared_dir"
-    shared_dir.mkdir()
-
-    (shared_dir / "sharedMicroServiceTasksConfigs" / "processingMCPConfigs").mkdir(
-        parents=True
-    )
-
-    settings.SHARED_DIRECTORY = shared_dir.as_posix()
-    install_builtin_config("default")
-    install_builtin_config("automated")
-
-    return shared_dir
-
-
-def test_list_processing_configs(admin_client, dashboard_uuid, shared_dir):
-    expected_names = sorted(["default", "automated"])
-    response = admin_client.get(reverse("api:processing_configuration_list"))
-    assert response.status_code == 200
-    payload = json.loads(response.content.decode("utf8"))
-    shared_dir = payload["processing_configurations"]
-    assert len(shared_dir) == 2
-    assert all(
-        actual == expected for actual, expected in zip(shared_dir, expected_names)
-    )
-
-
-def test_get_existing_processing_config(admin_client, dashboard_uuid, shared_dir):
-    response = admin_client.get(
-        reverse("api:processing_configuration", args=["default"]),
-        HTTP_ACCEPT="xml",
-    )
-    assert response.status_code == 200
-    assert etree.fromstring(response.content).xpath(".//preconfiguredChoice")
-
-
-def test_delete_and_regenerate(admin_client, dashboard_uuid, shared_dir):
-    processing_configs = (
-        shared_dir / "sharedMicroServiceTasksConfigs" / "processingMCPConfigs"
-    )
-
-    response = admin_client.delete(
-        reverse("api:processing_configuration", args=["default"])
-    )
-    assert response.status_code == 200
-    assert not (processing_configs / "defaultProcessingMCP.xml").exists()
-
-    response = admin_client.get(
-        reverse("api:processing_configuration", args=["default"]),
-        HTTP_ACCEPT="xml",
-    )
-    assert response.status_code == 200
-    assert etree.fromstring(response.content).xpath(".//preconfiguredChoice")
-    assert (processing_configs / "defaultProcessingMCP.xml").exists()
-
-
-def test_404_for_non_existent_config(admin_client, dashboard_uuid, shared_dir):
-    response = admin_client.get(
-        reverse("api:processing_configuration", args=["nonexistent"]),
-        HTTP_ACCEPT="xml",
-    )
-    assert response.status_code == 404
-
-
-def test_404_for_delete_non_existent_config(admin_client, dashboard_uuid, shared_dir):
-    response = admin_client.delete(
-        reverse("api:processing_configuration", args=["nonexistent"])
-    )
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
-def test_get_unit_status_multiple(
-    jobs_failed,
-    jobs_transfer_complete,
-    jobs_rejected,
-    jobs_user_input,
-    jobs_transfer_backlog,
-):
-    """When the database contains 5 units of the following types:
-    1. a failed transfer
-    2. a completed transfer
-    3. a rejected transfer
-    4. a transfer awaiting user input
-    5. a transfer in backlog
-    then ``completed_units_efficient`` should return 3: the failed,
-    the completed, and the in-backlog transfer.
-    """
-    failed_transfer = Transfer.objects.create()
-    for job in jobs_failed:
-        job.sipuuid = failed_transfer.uuid
+    @e2e
+    def test_unit_jobs_searching_for_chain_link(self):
+        load_fixture(["jobs-rejected"])
+        # add chain links to the fixture jobs
+        job = Job.objects.get(jobuuid="59ace00b-4830-4314-a7d9-38fdbef64896")
+        job.microservicechainlink = "0b8f1929-5beb-4998-a2d5-40e4873fa887"
         job.save()
-
-    complete_transfer = Transfer.objects.create()
-    for job in jobs_transfer_complete:
-        job.sipuuid = complete_transfer.uuid
+        job = Job.objects.get(jobuuid="b7902aae-ec5f-4290-a3d7-c47f844e8774")
+        job.microservicechainlink = "2208efc0-ba99-4b36-bb8d-99330fcc25da"
         job.save()
+        sip_uuid = "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"
+        resp = self.client.get(
+            reverse("api:v2beta_jobs", args=[sip_uuid]),
+            {"link_uuid": "0b8f1929-5beb-4998-a2d5-40e4873fa887"},
+        )
+        assert resp.status_code == 200
+        payload = json.loads(resp.content.decode("utf8"))
+        assert len(payload) == 1
+        job = payload[0]
+        assert job["uuid"] == "59ace00b-4830-4314-a7d9-38fdbef64896"
+        assert job["name"] == "Create SIP(s)"
+        assert job["status"] == "COMPLETE"
+        assert job["microservice"] == "Create SIP from Transfer"
+        assert job["link_uuid"] == "0b8f1929-5beb-4998-a2d5-40e4873fa887"
+        assert job["tasks"] == []
 
-    rejected_transfer = Transfer.objects.create()
-    for job in jobs_rejected:
-        job.sipuuid = rejected_transfer.uuid
-        job.save()
+    @e2e
+    def test_unit_jobs_searching_for_name(self):
+        load_fixture(["jobs-rejected"])
+        sip_uuid = "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"
+        resp = self.client.get(
+            reverse("api:v2beta_jobs", args=[sip_uuid]),
+            {"name": "Move to the rejected directory"},
+        )
+        assert resp.status_code == 200
+        payload = json.loads(resp.content.decode("utf8"))
+        assert len(payload) == 1
+        job = payload[0]
+        assert job["uuid"] == "b7902aae-ec5f-4290-a3d7-c47f844e8774"
+        assert job["name"] == "Move to the rejected directory"
+        assert job["status"] == "COMPLETE"
+        assert job["microservice"] == "Reject transfer"
+        assert job["link_uuid"] is None
+        assert job["tasks"] == []
+        # Test that name search also works with a "Job:" prefix
+        resp = self.client.get(
+            reverse("api:v2beta_jobs", args=[sip_uuid]),
+            {"name": "Job: Move to the rejected directory"},
+        )
+        assert resp.status_code == 200
+        payload = json.loads(resp.content.decode("utf8"))
+        assert len(payload) == 1
+        job = payload[0]
+        assert job["uuid"] == "b7902aae-ec5f-4290-a3d7-c47f844e8774"
 
-    awaiting_transfer = Transfer.objects.create()
-    for job in jobs_user_input:
-        job.sipuuid = awaiting_transfer.uuid
-        job.save()
+    @e2e
+    def test_task_with_bogus_task_uuid(self):
+        bogus_task_uuid = "00000000-dfac-430d-93f4-f0453b18ad2f"
+        resp = self.client.get(reverse("api:v2beta_task", args=[bogus_task_uuid]))
+        self._test_api_error(
+            resp,
+            status_code=400,
+            message=(f"Task with UUID {bogus_task_uuid} does not exist"),
+        )
 
-    backlog_transfer = Transfer.objects.create()
-    for job in jobs_transfer_backlog:
-        job.sipuuid = backlog_transfer.uuid
-        job.save()
+    @e2e
+    def test_task(self):
+        load_fixture(["jobs-transfer-backlog"])
+        # fixtures don't have any tasks
+        Task.objects.create(
+            taskuuid="12345678-1234-1234-1234-123456789012",
+            job=Job.objects.get(jobuuid="d2f99030-26b9-4746-b100-856779624934"),
+            createdtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0, 0)),
+            starttime=make_aware(datetime.datetime(2019, 6, 18, 0, 0, 0)),
+            endtime=make_aware(datetime.datetime(2019, 6, 18, 0, 0, 5)),
+            exitcode=0,
+        )
+        resp = self.client.get(
+            reverse("api:v2beta_task", args=["12345678-1234-1234-1234-123456789012"])
+        )
+        assert resp.status_code == 200
+        payload = json.loads(resp.content.decode("utf8"))
+        # payload is a mapping of task attributes
+        assert payload["uuid"] == "12345678-1234-1234-1234-123456789012"
+        assert payload["exit_code"] == 0
+        assert payload["file_uuid"] is None
+        assert payload["file_name"] == ""
+        assert payload["time_created"] == "2019-06-18T00:00:00"
+        assert payload["time_started"] == "2019-06-18T00:00:00"
+        assert payload["time_ended"] == "2019-06-18T00:00:05"
+        assert payload["duration"] == 5
 
-    expected_uuids = [
-        str(t.uuid) for t in [failed_transfer, complete_transfer, backlog_transfer]
-    ]
+    @e2e
+    def test_get_levels_of_description(self):
+        LevelOfDescription.objects.create(name="Item", sortorder=2)
+        LevelOfDescription.objects.create(name="Collection", sortorder=0)
+        LevelOfDescription.objects.create(name="Fonds", sortorder=1)
+        expected = ["Collection", "Fonds", "Item"]
 
-    completed = helpers.completed_units_efficient(
-        unit_type="transfer", include_failed=True
-    )
+        resp = self.client.get(reverse("api:get_levels_of_description"))
+        payload = json.loads(resp.content.decode("utf8"))
 
-    assert set(completed) == set(expected_uuids)
+        result = []
+        for level_of_description in payload:
+            name = next(iter(level_of_description.values()))
+            result.append(name)
+
+        assert result == expected
+
+
+class TestProcessingConfigurationAPI(TestCase):
+    fixtures = ["test_user"]
+
+    def setUp(self):
+        self.client = Client()
+        self.client.login(username="test", password="test")
+        helpers.set_setting("dashboard_uuid", "test-uuid")
+        self.populate_shared_dir()
+
+    def populate_shared_dir(self):
+        self.shared_dir = tempfile.gettempdir()
+        self.config_path = os.path.join(
+            self.shared_dir,
+            "sharedMicroServiceTasksConfigs/processingMCPConfigs/",
+        )
+        if not os.path.exists(self.config_path):
+            os.makedirs(self.config_path)
+        with self.settings(SHARED_DIRECTORY=self.shared_dir):
+            install_builtin_config("default")
+            install_builtin_config("automated")
+
+    def test_list_processing_configs(self):
+        with self.settings(SHARED_DIRECTORY=self.shared_dir):
+            response = self.client.get(reverse("api:processing_configuration_list"))
+            assert response.status_code == 200
+            payload = json.loads(response.content.decode("utf8"))
+            processing_configs = payload["processing_configurations"]
+            assert len(processing_configs) == 2
+            expected_names = sorted(["default", "automated"])
+            assert all(
+                [
+                    actual == expected
+                    for actual, expected in zip(processing_configs, expected_names)
+                ]
+            )
+
+    def test_get_existing_processing_config(self):
+        with self.settings(SHARED_DIRECTORY=self.shared_dir):
+            response = self.client.get(
+                reverse("api:processing_configuration", args=["default"]),
+                headers={"accept": "xml"},
+            )
+            assert response.status_code == 200
+            assert etree.fromstring(response.content).xpath(".//preconfiguredChoice")
+
+    def test_delete_and_regenerate(self):
+        with self.settings(SHARED_DIRECTORY=self.shared_dir):
+            response = self.client.delete(
+                reverse("api:processing_configuration", args=["default"])
+            )
+            assert response.status_code == 200
+            assert not os.path.exists(
+                os.path.join(self.config_path, "defaultProcessingMCP.xml")
+            )
+
+            response = self.client.get(
+                reverse("api:processing_configuration", args=["default"]),
+                headers={"accept": "xml"},
+            )
+            assert response.status_code == 200
+            assert etree.fromstring(response.content).xpath(".//preconfiguredChoice")
+            assert os.path.exists(
+                os.path.join(self.config_path, "defaultProcessingMCP.xml")
+            )
+
+    def test_404_for_non_existent_config(self):
+        response = self.client.get(
+            reverse("api:processing_configuration", args=["nonexistent"]),
+            headers={"accept": "xml"},
+        )
+        assert response.status_code == 404
+
+    def test_404_for_delete_non_existent_config(self):
+        response = self.client.delete(
+            reverse("api:processing_configuration", args=["nonexistent"])
+        )
+        assert response.status_code == 404
+
+
+class TestAPI2(TestCase):
+    """Test API endpoints."""
+
+    fixtures = ["units", "jobs-various"]
+
+    def test_get_unit_status_multiple(self):
+        """When the database contains 5 units of the following types:
+        1. a failed transfer b949773d-7cf7-4c1e-aea5-ccbf65b70ccd
+        2. a completed transfer 85216028-1150-4321-abb3-31ea570a341b
+        3. a rejected transfer c9cce131-7bd9-41c8-82ab-483190961ae2
+        4. a transfer awaiting user input 37a07d96-6fc0-4002-b269-471a58783805
+        5. a transfer in backlog 5d0ab97f-a45b-4e0f-9cb6-90ee3a404549
+        then ``completed_units_efficient`` should return 3: the failed,
+        the completed, and the in-backlog transfer.
+        """
+        completed = helpers.completed_units_efficient(
+            unit_type="transfer", include_failed=True
+        )
+        assert len(completed) == 3
+        assert "85216028-1150-4321-abb3-31ea570a341b" in completed
+        assert "5d0ab97f-a45b-4e0f-9cb6-90ee3a404549" in completed
+        assert "b949773d-7cf7-4c1e-aea5-ccbf65b70ccd" in completed
 
 
 @pytest.mark.django_db
@@ -933,530 +674,3 @@ def test_reingest_approve(mocker, admin_client):
         json.loads(response.content.decode("utf8")).get("message")
         == "Approval successful."
     )
-
-
-def test_path_metadata_get(admin_client):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-    SIPArrange.objects.create(
-        arrange_path=b"/arrange/testsip/", level_of_description="Folder"
-    )
-
-    response = admin_client.get(
-        reverse("api:path_metadata"), {"path": "/arrange/testsip"}
-    )
-    assert response.status_code == 200
-
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload["level_of_description"] == "Folder"
-
-
-def test_path_metadata_raises_404_if_siparrange_does_not_exist(admin_client):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
-    response = admin_client.get(
-        reverse("api:path_metadata"), {"path": "/arrange/testsip"}
-    )
-    assert response.status_code == 404
-
-
-def test_path_metadata_post(admin_client):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-    SIPArrange.objects.create(
-        arrange_path=b"/arrange/testsip/", level_of_description="Folder"
-    )
-    level_of_description = LevelOfDescription.objects.create(
-        name="Collection", sortorder=0
-    )
-    expected = [
-        {"arrange_path": b"/arrange/testsip/", "level_of_description": "Collection"}
-    ]
-
-    response = admin_client.post(
-        reverse("api:path_metadata"),
-        data={
-            "path": "/arrange/testsip",
-            "level_of_description": level_of_description.pk,
-        },
-    )
-    assert response.status_code == 201
-
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload["success"]
-
-    # Verify the SIPArrange instance was updated as expected.
-    assert (
-        list(SIPArrange.objects.values("arrange_path", "level_of_description"))
-        == expected
-    )
-
-
-def test_path_metadata_post_resets_level_of_description(admin_client):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-    SIPArrange.objects.create(
-        arrange_path=b"/arrange/testsip/", level_of_description="Folder"
-    )
-    expected = [{"arrange_path": b"/arrange/testsip/", "level_of_description": ""}]
-
-    response = admin_client.post(
-        reverse("api:path_metadata"),
-        data={"path": "/arrange/testsip"},
-    )
-    assert response.status_code == 201
-
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload["success"]
-
-    # Verify the level of description was reset.
-    assert (
-        list(SIPArrange.objects.values("arrange_path", "level_of_description"))
-        == expected
-    )
-
-
-@pytest.mark.django_db
-def test_unapproved_transfers(admin_client):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
-    # Create a couple of jobs with one awaiting for decision, i.e. unapproved.
-    approve_transfer_uuid = uuid.uuid4()
-    Job.objects.create(
-        jobtype="Approve standard transfer",
-        currentstep=Job.STATUS_AWAITING_DECISION,
-        directory="%sharedPath%watchedDirectories/activeTransfers/standardTransfer/test-2/",
-        createdtime=make_aware(datetime.datetime(2023, 11, 14, 9, 20)),
-        unittype="unitTransfer",
-        sipuuid=approve_transfer_uuid,
-    )
-    Job.objects.create(
-        jobtype="Store AIP",
-        currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
-        directory="%sharedPath%watchedDirectories/storeAIP/test-1/",
-        createdtime=make_aware(datetime.datetime(2023, 11, 13, 0, 0)),
-        unittype="unitSIP",
-        sipuuid=uuid.UUID("520327f1-cd4e-47fe-9d8a-d9c02fded504"),
-    )
-
-    response = admin_client.get(reverse("api:unapproved_transfers"))
-    assert response.status_code == 200
-
-    # Verify the awaiting transfer is listed.
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload == {
-        "message": "Fetched unapproved transfers successfully.",
-        "results": [
-            {
-                "directory": "test-2",
-                "type": "standard",
-                "uuid": str(approve_transfer_uuid),
-            }
-        ],
-    }
-
-
-@pytest.mark.parametrize(
-    "post_data,expected_error",
-    [
-        ({}, "Please specify a transfer directory."),
-        ({"directory": "mytransfer", "type": ""}, "Please specify a transfer type."),
-        ({"directory": "mytransfer", "type": "bogus"}, "Invalid transfer type."),
-        (
-            {"directory": "mytransfer", "type": "standard"},
-            "Unable to start the transfer.",
-        ),
-    ],
-    ids=[
-        "no_transfer_directory",
-        "no_transfer_type",
-        "invalid_transfer_type",
-        "mcpclient_error",
-    ],
-)
-def test_approve_transfer_failures(post_data, expected_error, admin_client, mocker):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
-    # Simulate an unhandled error when calling Gearman.
-    mocker.patch("contrib.mcp.client.MCPClient", side_effect=Exception())
-
-    response = admin_client.post(reverse("api:approve_transfer"), post_data)
-
-    assert response.status_code == 500
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload == {"error": True, "message": expected_error}
-
-
-def test_approve_transfer(admin_client, mocker):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
-    # Simulate a dashboard <-> Gearman <-> MCPServer interaction.
-    # The MCPServer approveTransferByPath RPC method returns a UUID.
-    transfer_uuid = uuid.uuid4()
-    mocker.patch("contrib.mcp.client.pickle.loads", side_effect=[transfer_uuid])
-    job_complete = mocker.patch(
-        "contrib.mcp.client.gearman.JOB_COMPLETE",
-    )
-    mocker.patch(
-        "gearman.GearmanClient",
-        return_value=mocker.Mock(
-            **{"submit_job.return_value": mocker.Mock(state=job_complete)}
-        ),
-    )
-
-    response = admin_client.post(
-        reverse("api:approve_transfer"), {"directory": "mytransfer", "type": "standard"}
-    )
-    assert response.status_code == 200
-
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload == {"message": "Approval successful.", "uuid": str(transfer_uuid)}
-
-
-@pytest.mark.django_db
-def test_waiting_for_user_input(admin_client):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
-    # Create a couple of jobs with one awaiting for decision.
-    approve_transfer_uuid = uuid.uuid4()
-    Job.objects.create(
-        jobtype="Approve standard transfer",
-        currentstep=Job.STATUS_AWAITING_DECISION,
-        directory="%sharedPath%watchedDirectories/activeTransfers/standardTransfer/test-2/",
-        createdtime=make_aware(datetime.datetime(2023, 11, 14, 9, 20)),
-        unittype="unitTransfer",
-        sipuuid=approve_transfer_uuid,
-    )
-    Job.objects.create(
-        jobtype="Store AIP",
-        currentstep=Job.STATUS_COMPLETED_SUCCESSFULLY,
-        directory="%sharedPath%watchedDirectories/storeAIP/test-1/",
-        createdtime=make_aware(datetime.datetime(2023, 11, 13, 0, 0)),
-        unittype="unitSIP",
-        sipuuid=uuid.uuid4(),
-    )
-
-    response = admin_client.get(reverse("api:waiting_for_user_input"))
-    assert response.status_code == 200
-
-    # Verify the awaiting transfer is listed.
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload == {
-        "message": "Fetched units successfully.",
-        "results": [
-            {
-                "microservice": "Approve standard transfer",
-                "sip_directory": "test-2",
-                "sip_name": "test-2",
-                "sip_uuid": str(approve_transfer_uuid),
-            }
-        ],
-    }
-
-
-def test_reingest_fails_with_missing_parameters(admin_client):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
-    response = admin_client.post(
-        reverse("api:transfer_reingest", kwargs={"target": "transfer"}), {}
-    )
-
-    assert response.status_code == 400
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload == {"error": True, "message": '"name" and "uuid" are required.'}
-
-
-@pytest.fixture
-def sip_path(tmp_path):
-    shared_dir = tmp_path / "dir"
-    shared_dir.mkdir()
-
-    (shared_dir / "watchedDirectories" / "activeTransfers" / "standardTransfer").mkdir(
-        parents=True
-    )
-    (shared_dir / "watchedDirectories" / "system" / "reingestAIP").mkdir(parents=True)
-
-    tmp_dir = shared_dir / "tmp"
-    tmp_dir.mkdir()
-
-    sip_dir = tmp_dir / f"mytransfer-{uuid.uuid4()}"
-    sip_dir.mkdir()
-    (sip_dir / "myfile.txt").write_text("my file")
-
-    return sip_dir
-
-
-@pytest.mark.django_db
-def test_reingest_deletes_existing_models_related_to_sip(
-    sip_path, settings, admin_client
-):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
-    # Set the SHARED_DIRECTORY setting based on the sip_path fixture.
-    shared_directory = sip_path.parent.parent
-    transfer_uuid = sip_path.name[-36:]
-    settings.SHARED_DIRECTORY = shared_directory.as_posix()
-
-    # Create a Transfer and related models.
-    transfer = Transfer.objects.create(uuid=transfer_uuid)
-    job = Job.objects.create(
-        sipuuid=transfer.uuid,
-        createdtime=make_aware(datetime.datetime(2023, 11, 15, 8, 30)),
-    )
-    Task.objects.create(
-        job=job,
-        createdtime=make_aware(datetime.datetime(2023, 11, 15, 8, 30)),
-    )
-    SIP.objects.create(uuid=transfer.uuid)
-    metadata_applies_to_type = MetadataAppliesToType.objects.create()
-    RightsStatement.objects.create(
-        metadataappliestoidentifier=transfer.uuid,
-        metadataappliestotype=metadata_applies_to_type,
-    )
-    DublinCore.objects.create(
-        metadataappliestoidentifier=transfer.uuid,
-        metadataappliestotype=metadata_applies_to_type,
-    )
-
-    response = admin_client.post(
-        reverse("api:transfer_reingest", kwargs={"target": "transfer"}),
-        {"name": f"mytransfer-{transfer_uuid}", "uuid": str(transfer_uuid)},
-    )
-    assert response.status_code == 200
-
-    # Verify the related models were deleted.
-    assert Job.objects.count() == 0
-    assert Task.objects.count() == 0
-    assert SIP.objects.count() == 0
-    assert RightsStatement.objects.count() == 0
-    assert DublinCore.objects.count() == 0
-
-
-@pytest.mark.django_db
-def test_reingest_full(sip_path, settings, admin_client, mocker):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
-    # Fake UUID generation from the endpoint for a new Transfer.
-    transfer_uuid = uuid.uuid4()
-    mocker.patch("uuid.uuid4", return_value=transfer_uuid)
-
-    # Set the SHARED_DIRECTORY setting based on the sip_path fixture.
-    shared_directory = sip_path.parent.parent
-    settings.SHARED_DIRECTORY = shared_directory.as_posix()
-
-    # There are no existing Transfers initially.
-    assert Transfer.objects.count() == 0
-
-    response = admin_client.post(
-        reverse("api:transfer_reingest", kwargs={"target": "transfer"}),
-        {"name": sip_path.name, "uuid": sip_path.name[-36:]},
-    )
-    assert response.status_code == 200
-
-    # Verify the Transfer in the payload contains the fake UUID.
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload == {
-        "message": "Approval successful.",
-        "reingest_uuid": str(transfer_uuid),
-    }
-
-    # Verify a Transfer model was created.
-    assert (
-        Transfer.objects.filter(
-            currentlocation=f"%sharedPath%/watchedDirectories/activeTransfers/standardTransfer/mytransfer-{transfer_uuid}/",
-            type=Transfer.ARCHIVEMATICA_AIP,
-        ).count()
-        == 1
-    )
-
-    # Verify the original content was moved to the active transfers directory.
-    active_transfers_path = (
-        shared_directory / "watchedDirectories" / "activeTransfers" / "standardTransfer"
-    )
-    assert [e.name for e in active_transfers_path.iterdir()] == [
-        f"mytransfer-{transfer_uuid}"
-    ]
-    assert (
-        active_transfers_path / f"mytransfer-{transfer_uuid}" / "myfile.txt"
-    ).read_text() == "my file"
-
-
-@pytest.mark.django_db
-def test_reingest_full_fails_if_target_directory_already_exists(
-    sip_path, settings, admin_client, mocker
-):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
-    # Fake UUID generation from the endpoint for a new Transfer.
-    transfer_uuid = uuid.uuid4()
-    mocker.patch("uuid.uuid4", return_value=transfer_uuid)
-
-    # Set the SHARED_DIRECTORY setting based on the sip_path fixture.
-    shared_directory = sip_path.parent.parent
-    settings.SHARED_DIRECTORY = shared_directory.as_posix()
-
-    # Create a directory with the same transfer name under active transfers.
-    active_transfers_path = (
-        shared_directory / "watchedDirectories" / "activeTransfers" / "standardTransfer"
-    )
-    (active_transfers_path / f"mytransfer-{transfer_uuid}").mkdir()
-
-    response = admin_client.post(
-        reverse("api:transfer_reingest", kwargs={"target": "transfer"}),
-        {"name": sip_path.name, "uuid": sip_path.name[-36:]},
-    )
-
-    assert response.status_code == 400
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload == {
-        "error": True,
-        "message": "There is already a transfer in standardTransfer with the same name.",
-    }
-
-
-@pytest.mark.django_db
-def test_reingest_partial(sip_path, settings, admin_client):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
-    # Set the SHARED_DIRECTORY setting based on the sip_path fixture.
-    shared_directory = sip_path.parent.parent
-    settings.SHARED_DIRECTORY = shared_directory.as_posix()
-
-    # A partial reingest reuses the SIP UUID in the response.
-    reingest_uuid = sip_path.name[-36:]
-
-    response = admin_client.post(
-        reverse("api:ingest_reingest", kwargs={"target": "ingest"}),
-        {"name": sip_path.name, "uuid": reingest_uuid},
-    )
-    assert response.status_code == 200
-
-    # Verify the payload contains the reingest UUID.
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload == {
-        "message": "Approval successful.",
-        "reingest_uuid": reingest_uuid,
-    }
-
-    # Verify the original content was moved to the reingest directory.
-    reingests_path = shared_directory / "watchedDirectories" / "system" / "reingestAIP"
-    assert [e.name for e in reingests_path.iterdir()] == [sip_path.name]
-    assert (reingests_path / sip_path.name / "myfile.txt").read_text() == "my file"
-
-
-@pytest.mark.django_db
-def test_fetch_levels_of_description_from_atom(admin_client, mocker):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
-    # Set up the AtoM settings used on the Administration tab.
-    DashboardSetting.objects.create(
-        name="upload-qubit_v0.0",
-        value=str(
-            {
-                "url": "http://example.com",
-                "email": "demo@example.com",
-                "password": "password",
-            }
-        ),
-    )
-
-    # Simulate interaction with AtoM.
-    lods = ["Series", "Subseries", "File"]
-    mocker.patch(
-        "requests.get",
-        side_effect=[
-            mocker.Mock(
-                **{
-                    "status_code": 200,
-                    "json.return_value": [{"name": lod} for lod in lods],
-                },
-                spec=requests.Response,
-            )
-        ],
-    )
-
-    # Add existing LODs before calling the endpoint.
-    LevelOfDescription.objects.create(name="One existing", sortorder=1)
-    LevelOfDescription.objects.create(name="Another existing", sortorder=1)
-
-    response = admin_client.get(reverse("api:fetch_atom_lods"))
-    assert response.status_code == 200
-
-    # Verify the initial LODS were deleted and we only have the retrieved ones.
-    result = []
-    for lod in json.loads(response.content.decode("utf8")):
-        # LODs are represented as [{"8263fd14-2488-49f7-ac9d-fcfd02b524f0": "Series"}, ...]
-        name = list(lod.values())[0]
-        result.append(name)
-    assert result == lods
-    assert set(LevelOfDescription.objects.values_list("name")) == {
-        (lod,) for lod in lods
-    }
-
-
-@pytest.mark.django_db
-def test_fetch_levels_of_description_from_atom_communication_failure(
-    admin_client, mocker
-):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
-    # Set up the AtoM settings used on the Administration tab.
-    DashboardSetting.objects.create(
-        name="upload-qubit_v0.0",
-        value=str(
-            {
-                "url": "http://example.com",
-                "email": "demo@example.com",
-                "password": "password",
-            }
-        ),
-    )
-
-    # Simulate failing interaction with AtoM.
-    mocker.patch(
-        "requests.get",
-        side_effect=[mocker.Mock(status_code=503, spec=requests.Response)],
-    )
-
-    response = admin_client.get(reverse("api:fetch_atom_lods"))
-
-    assert response.status_code == 500
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload == {
-        "success": False,
-        "error": "Unable to fetch levels of description from AtoM!",
-    }
-
-
-@pytest.mark.django_db
-def test_mark_hidden(admin_client, dashboard_uuid, transfer):
-    # This endpoint considers the status attribute instead of jobs.
-    transfer.status = PACKAGE_STATUS_COMPLETED_SUCCESSFULLY
-    transfer.save()
-
-    assert not transfer.hidden
-
-    response = admin_client.delete(
-        reverse(
-            "api:mark_hidden",
-            kwargs={"unit_type": "transfer", "unit_uuid": transfer.uuid},
-        )
-    )
-    assert response.status_code == 200
-
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload == {"removed": True}
-    assert Transfer.objects.get(pk=transfer.uuid).hidden
-
-
-@pytest.mark.django_db
-def test_mark_completed_hidden(
-    admin_client, dashboard_uuid, transfer, jobs_transfer_complete
-):
-    assert not transfer.hidden
-
-    response = admin_client.delete(
-        reverse("api:mark_completed_hidden", kwargs={"unit_type": "transfer"})
-    )
-    assert response.status_code == 200
-
-    payload = json.loads(response.content.decode("utf8"))
-    assert payload == {"removed": [str(transfer.uuid)]}
-    assert Transfer.objects.get(pk=transfer.uuid).hidden

--- a/src/dashboard/tests/test_auth.py
+++ b/src/dashboard/tests/test_auth.py
@@ -74,7 +74,7 @@ class TestAuth(TestCase):
 
         for url in self.API_URLS:
             response = self.client.get(
-                url, HTTP_AUTHORIZATION=f"ApiKey test:{key}", follow=False
+                url, headers={"authorization": f"ApiKey test:{key}"}, follow=False
             )
 
             self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This sets django-upgrade in pre-commit to upgrade Django to 4.2.

One significant change is: 
The Django 4.2 version uses a datetime method called fromisoformat() to get well-formed values for timezone in parse_datetime() of dateparse module.
Ref: https://github.com/django/django/blob/main/django/utils/dateparse.py#L104

Connected to https://github.com/archivematica/Issues/issues/1624