### PR TITLE
Fix Drag and drop in Appraisal tab

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -915,8 +915,8 @@ def copy_to_arrange(request, sources=None, destinations=None, fetch_children=Fal
                 for entry in entries:
                     entries_to_copy.append(
                         models.SIPArrange(
-                            original_path=entry["original_path"],
-                            arrange_path=entry["arrange_path"],
+                            original_path=entry["original_path"].encode(),
+                            arrange_path=entry["arrange_path"].encode(),
                             file_uuid=entry["file_uuid"],
                             transfer_uuid=entry["transfer_uuid"],
                         )

--- a/src/dashboard/src/main/models.py
+++ b/src/dashboard/src/main/models.py
@@ -635,7 +635,10 @@ class SIPArrange(models.Model):
     def __str__(self):
         return str(
             _("%(original)s -> %(arrange)s")
-            % {"original": self.original_path, "arrange": self.arrange_path}
+            % {
+                "original": self.original_path.decode(),
+                "arrange": self.arrange_path.decode(),
+            }
         )
 
     @classmethod


### PR DESCRIPTION
In Appraisal tab for drag and drop of files was not working.

Ref: https://www.archivematica.org/en/docs/archivematica-1.14/user-manual/appraisal/appraisal/#arrangement