### PR TITLE
Fix adding metadata in Disk Image transfers

### DIFF
--- a/src/dashboard/src/components/transfer/views.py
+++ b/src/dashboard/src/components/transfer/views.py
@@ -77,7 +77,7 @@ def component(request, uuid):
     for field in fields:
         if field.optiontaxonomy is not None:
             # check for newly added terms
-            new_term = request.POST.get("add_to_" + field.pk, "")
+            new_term = request.POST.get("add_to_" + str(field.pk), "")
             if new_term != "":
                 term = models.TaxonomyTerm()
                 term.taxonomy = field.optiontaxonomy


### PR DESCRIPTION
Regression: When SampleTransfer/ISODiskImage is processed, it raises Internal server Error when click on "Add metadata" button before Disk images transfer runs.

Connected to : https://github.com/archivematica/Issues/issues/1627