### PR TITLE
Fix UUID serialization in AIP endpoints

### DIFF
--- a/src/dashboard/src/components/api/urls.py
+++ b/src/dashboard/src/components/api/urls.py
@@ -21,8 +21,10 @@ from django.urls import re_path
 
 app_name = "api"
 urlpatterns = [
-    re_path(r"transfer/approve", views.approve_transfer),
-    re_path(r"transfer/unapproved", views.unapproved_transfers),
+    re_path(r"transfer/approve", views.approve_transfer, name="approve_transfer"),
+    re_path(
+        r"transfer/unapproved", views.unapproved_transfers, name="unapproved_transfers"
+    ),
     re_path(
         r"transfer/completed", views.completed_transfers, name="completed_transfers"
     ),
@@ -35,13 +37,20 @@ urlpatterns = [
     re_path(
         r"transfer/start_transfer/", views.start_transfer_api, name="start_transfer"
     ),
-    re_path(r"transfer/reingest", views.reingest, {"target": "transfer"}),
+    re_path(
+        r"transfer/reingest",
+        views.reingest,
+        {"target": "transfer"},
+        name="transfer_reingest",
+    ),
     re_path(
         r"ingest/status/(?P<unit_uuid>" + settings.UUID_REGEX + ")",
         views.status,
         {"unit_type": "unitSIP"},
     ),
-    re_path(r"ingest/waiting", views.waiting_for_user_input),
+    re_path(
+        r"ingest/waiting", views.waiting_for_user_input, name="waiting_for_user_input"
+    ),
     re_path(
         r"^(?P<unit_type>transfer|ingest)/(?P<unit_uuid>"
         + settings.UUID_REGEX
@@ -52,7 +61,12 @@ urlpatterns = [
     re_path(
         r"^ingest/reingest/approve", views.reingest_approve, name="reingest_approve"
     ),
-    re_path(r"^ingest/reingest", views.reingest, {"target": "ingest"}),
+    re_path(
+        r"^ingest/reingest",
+        views.reingest,
+        {"target": "ingest"},
+        name="ingest_reingest",
+    ),
     re_path(r"^ingest/completed", views.completed_ingests, name="completed_ingests"),
     path("ingest/copy_metadata_files/", views.copy_metadata_files_api),
     path(

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -302,7 +302,7 @@ def waiting_for_user_input(request):
     # TODO should this filter based on unit type into transfer vs SIP?
     jobs = models.Job.objects.filter(currentstep=models.Job.STATUS_AWAITING_DECISION)
     for job in jobs:
-        unit_uuid = job.sipuuid
+        unit_uuid = str(job.sipuuid)
         directory = os.path.basename(os.path.normpath(job.directory))
         unit_name = directory.replace("-" + unit_uuid, "", 1)
 
@@ -468,7 +468,11 @@ def unapproved_transfers(request):
         )
 
         unapproved.append(
-            {"type": transfer_type, "directory": job_directory, "uuid": job.sipuuid}
+            {
+                "type": transfer_type,
+                "directory": job_directory,
+                "uuid": str(job.sipuuid),
+            }
         )
 
     # get list of unapproved transfers


### PR DESCRIPTION
This fixes the `List Unapproved Transfers` and `List SIPS Waiting for User Input` API endpoints that were left behind after introducing the Django 3.2 `UUIDField`. It also extends test coverage for other API endpoints.

Connected to https://github.com/archivematica/Issues/issues/1635