### PR TITLE
Fixed Sensitive Data Exposure

### DIFF
--- a/src/dashboard/src/components/ingest/views_as.py
+++ b/src/dashboard/src/components/ingest/views_as.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from functools import wraps
-
+from tempfile import mkstemp
 from agentarchives.archivesspace import ArchivesSpaceClient
 from agentarchives.archivesspace import ArchivesSpaceError
 from agentarchives.archivesspace import AuthenticationError
@@ -268,7 +268,8 @@ def ingest_upload_as_match(request, uuid):
         rows = models.ArchivesSpaceDIPObjectResourcePairing.objects.filter(
             dipuuid=uuid, resourceid=resource_id, fileuuid=file_uuid
         )
-        with open("/tmp/delete.log", "a") as log:
+        fd, name = mkstemp(suffix="delete", prefix=".log")
+        with open(fd, "a") as log:
             print(
                 "Resource",
                 resource_id,


### PR DESCRIPTION
### Details

In file: [views_as.py](https://github.com/artefactual/archivematica/blob/stable/1.15.x/src/dashboard/src/components/ingest/views_as.py#L271), there is a method: ingest_upload_as_match that creates a temporary file using a [hard coded path to a public writable directory](https://cwe.mitre.org/data/definitions/379.html). This exposes the temporarily created file to race condition attacks. An attacker can access, modify or even delete a file. iCR suggested that a temporary file should be created using a safe API in a secured directory instead.

### Original Code
```python
 with open("/tmp/delete.log", "a") as log:
```
But this **open** function shouldn't be used directly because it may cause sensitive data exposure as it defaults to allowing universal write access. A custom opener would be better instead to modify the permission atomically.

### Solution
```python
import os

def opener(path, flags):
    return os.open(path, flags, 0o640)

with open('/tmp/delete.log', encoding = 'utf-8', mode = 'a', opener = opener) as log:

```

### Alternative Solution
If you're unwilling to use [`opener`](https://docs.python.org/3/library/functions.html?highlight=open#open) method, you may opt-in to use the [`mkstemp`](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp) method from Python's `tempfile` library. An example is shown below - 

```python
from tempfile import mkstemp

fd, name = mkstemp(suffix="delete", prefix=".log")
with open(fd, "a") as log:
    pass
```

## Found & Fixed In
Below is a list of projects where the same bug was found and fixed.
- https://www.github.com/buffer/thug/pull/359/
- https://www.github.com/rhinstaller/anaconda/pull/5375

### CLA Requirements:
This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.

All contributed commits are already automatically signed off.

The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see https://developercertificate.org/ for more information).

[Git Commit SignOff documentation](https://developercertificate.org/)

### Sponsorship and Support:
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.