### PR TITLE
Use TMPDIR environment variable for temporary file path in createAndRunScript

### DIFF
--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -147,11 +147,11 @@ def createAndRunScript(
         env_updates = {}
     # Output the text to a temporary file
     tmpdir_path = os.environ.get('TMPDIR', '/tmp')
-    scriptPath =  tmpdir_path + '/' + uuid.uuid4().__str__()()
-    FILE = os.open(scriptPath, os.O_WRONLY | os.O_CREAT, 0o770)
+    script_path =  tmpdir_path + '/' + uuid.uuid4().__str__()()
+    FILE = os.open(script_path, os.O_WRONLY | os.O_CREAT, 0o770)
     os.write(FILE, text.encode("utf8"))
     os.close(FILE)
-    cmd = [scriptPath]
+    cmd = [script_path]
     cmd.extend(arguments)
 
     # Run it
@@ -164,7 +164,7 @@ def createAndRunScript(
     )
 
     # Remove the temp file
-    os.remove(scriptPath)
+    os.remove(script_path)
 
     return ret
 

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -147,7 +147,7 @@ def createAndRunScript(
         env_updates = {}
     # Output the text to a temporary file
     tmpdir_path = os.environ.get('TMPDIR', '/tmp')
-    script_path =  tmpdir_path + '/' + uuid.uuid4().__str__()
+    script_path = tmpdir_path + '/' + uuid.uuid4().__str__()
     FILE = os.open(script_path, os.O_WRONLY | os.O_CREAT, 0o770)
     os.write(FILE, text.encode("utf8"))
     os.close(FILE)

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -145,8 +145,9 @@ def createAndRunScript(
         arguments = []
     if env_updates is None:
         env_updates = {}
-    # Output the text to a /tmp/ file
-    scriptPath = "/tmp/" + uuid.uuid4().__str__()
+    # Output the text to a temporary file
+    tmpdir_path = os.environ.get('TMPDIR', '/tmp')
+    scriptPath =  tmpdir_path + '/' + uuid.uuid4().__str__()()
     FILE = os.open(scriptPath, os.O_WRONLY | os.O_CREAT, 0o770)
     os.write(FILE, text.encode("utf8"))
     os.close(FILE)

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -147,7 +147,7 @@ def createAndRunScript(
         env_updates = {}
     # Output the text to a temporary file
     tmpdir_path = os.environ.get('TMPDIR', '/tmp')
-    script_path =  tmpdir_path + '/' + uuid.uuid4().__str__()()
+    script_path =  tmpdir_path + '/' + uuid.uuid4().__str__()
     FILE = os.open(script_path, os.O_WRONLY | os.O_CREAT, 0o770)
     os.write(FILE, text.encode("utf8"))
     os.close(FILE)

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -146,8 +146,8 @@ def createAndRunScript(
     if env_updates is None:
         env_updates = {}
     # Output the text to a temporary file
-    tmpdir_path = os.environ.get('TMPDIR', '/tmp')
-    script_path = tmpdir_path + '/' + uuid.uuid4().__str__()
+    tmpdir_path = os.environ.get("TMPDIR", "/tmp")
+    script_path = tmpdir_path + "/" + uuid.uuid4().__str__()
     FILE = os.open(script_path, os.O_WRONLY | os.O_CREAT, 0o770)
     os.write(FILE, text.encode("utf8"))
     os.close(FILE)

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -26,8 +26,8 @@ def launchSubProcess(
     command,
     stdIn="",
     printing=True,
-    arguments=None,
-    env_updates=None,
+    arguments=[],
+    env_updates={},
     capture_output=False,
 ):
     """
@@ -59,10 +59,6 @@ def launchSubProcess(
                     returned IF the subprocess has failed, i.e., returned a
                     non-zero exit code.
     """
-    if arguments is None:
-        arguments = []
-    if env_updates is None:
-        env_updates = {}
     stdError = ""
     stdOut = ""
 
@@ -138,12 +134,8 @@ def launchSubProcess(
 
 
 def createAndRunScript(
-    text, stdIn="", printing=True, arguments=None, env_updates=None, capture_output=True
+    text, stdIn="", printing=True, arguments=[], env_updates={}, capture_output=True
 ):
-    if arguments is None:
-        arguments = []
-    if env_updates is None:
-        env_updates = {}
     # Output the text to a temporary file
     with tempfile.NamedTemporaryFile(
         encoding="utf-8", mode="wt", delete=False
@@ -171,8 +163,8 @@ def executeOrRun(
     text,
     stdIn="",
     printing=True,
-    arguments=None,
-    env_updates=None,
+    arguments=[],
+    env_updates={},
     capture_output=True,
 ):
     """
@@ -205,10 +197,6 @@ def executeOrRun(
     capture_output: Whether or not to capture output for the executed process.
                 Default is `True`.
     """
-    if arguments is None:
-        arguments = []
-    if env_updates is None:
-        env_updates = {}
     if type == "command":
         return launchSubProcess(
             text,

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -145,7 +145,7 @@ def createAndRunScript(
         arguments = []
     if env_updates is None:
         env_updates = {}
-    # Output the text to a temporary file
+    # Write script to temporary file and execute it
     with tempfile.NamedTemporaryFile(
         encoding="utf-8", mode="wt", delete=False
     ) as tmpfile:

--- a/src/archivematicaCommon/lib/executeOrRunSubProcess.py
+++ b/src/archivematicaCommon/lib/executeOrRunSubProcess.py
@@ -22,12 +22,13 @@ import subprocess
 import sys
 import tempfile
 
+
 def launchSubProcess(
     command,
     stdIn="",
     printing=True,
-    arguments=[],
-    env_updates={},
+    arguments=None,
+    env_updates=None,
     capture_output=False,
 ):
     """
@@ -59,6 +60,10 @@ def launchSubProcess(
                     returned IF the subprocess has failed, i.e., returned a
                     non-zero exit code.
     """
+    if arguments is None:
+        arguments = []
+    if env_updates is None:
+        env_updates = {}
     stdError = ""
     stdOut = ""
 
@@ -134,8 +139,12 @@ def launchSubProcess(
 
 
 def createAndRunScript(
-    text, stdIn="", printing=True, arguments=[], env_updates={}, capture_output=True
+    text, stdIn="", printing=True, arguments=None, env_updates=None, capture_output=True
 ):
+    if arguments is None:
+        arguments = []
+    if env_updates is None:
+        env_updates = {}
     # Output the text to a temporary file
     with tempfile.NamedTemporaryFile(
         encoding="utf-8", mode="wt", delete=False
@@ -163,8 +172,8 @@ def executeOrRun(
     text,
     stdIn="",
     printing=True,
-    arguments=[],
-    env_updates={},
+    arguments=None,
+    env_updates=None,
     capture_output=True,
 ):
     """
@@ -197,6 +206,10 @@ def executeOrRun(
     capture_output: Whether or not to capture output for the executed process.
                 Default is `True`.
     """
+    if arguments is None:
+        arguments = []
+    if env_updates is None:
+        env_updates = {}
     if type == "command":
         return launchSubProcess(
             text,

--- a/src/archivematicaCommon/tests/test_execute_functions.py
+++ b/src/archivematicaCommon/tests/test_execute_functions.py
@@ -1,4 +1,6 @@
+import os
 import shlex
+import tempfile
 
 import executeOrRunSubProcess as execsub
 
@@ -54,3 +56,33 @@ def test_capture_output():
     )
     assert std_out.strip() == "out"
     assert std_err.strip() == "error"
+
+
+def test_tmpfile_execution():
+    """Tests behaviour of createAndRunScript funciton."""
+    script_content = """
+    #!/bin/bash
+    echo "Script output"
+    exit 0
+    """
+
+    with tempfile.NamedTemporaryFile(
+        encoding="utf-8", mode="wt", delete=False
+    ) as tmpfile:
+        tmpfile.write(script_content)
+        tmpfile.close()
+
+        try:
+            # Run the script and capture output
+            ret, std_out, std_err = execsub.createAndRunScript(
+                script_content,
+                stdIn="",
+                printing=False,
+                capture_output=True,
+            )
+            assert std_out.strip() == "Script output"
+            assert std_err == ""
+
+        finally:
+            # Clean up temporary file
+            os.unlink(tmpfile.name)


### PR DESCRIPTION
Fixes use of hardcoded temp directory.
This fixes issue [archivematica/Issues#1425](https://github.com/archivematica/Issues/issues/1425)

Reviewed in AM1.14
- Transfer with compression
- Reingest
- Fixity run

Users facing the issue 7z when mounting /tmp directory with noexec can set the environment variable `TMPDIR=/path/to/dir` in /etc/default/archivematica-mcp-client