### PR TITLE
Use logger instead of temporary file in ingest view

### DIFF
--- a/src/dashboard/src/components/ingest/urls.py
+++ b/src/dashboard/src/components/ingest/urls.py
@@ -128,6 +128,7 @@ urlpatterns += [
     re_path(
         r"^(?P<uuid>" + settings.UUID_REGEX + ")/upload/as/match/$",
         views_as.ingest_upload_as_match,
+        name="ingest_upload_as_match",
     ),
     re_path(
         r"^(?P<uuid>" + settings.UUID_REGEX + ")/upload/as/reset/$",

--- a/src/dashboard/src/components/ingest/views_as.py
+++ b/src/dashboard/src/components/ingest/views_as.py
@@ -273,7 +273,7 @@ def ingest_upload_as_match(request, uuid):
                 "Resource",
                 resource_id,
                 "File",
-                "file_uuid",
+                file_uuid,
                 "matches",
                 rows.count(),
                 file=log,

--- a/src/dashboard/src/components/ingest/views_as.py
+++ b/src/dashboard/src/components/ingest/views_as.py
@@ -268,16 +268,12 @@ def ingest_upload_as_match(request, uuid):
         rows = models.ArchivesSpaceDIPObjectResourcePairing.objects.filter(
             dipuuid=uuid, resourceid=resource_id, fileuuid=file_uuid
         )
-        with open("/tmp/delete.log", "a") as log:
-            print(
-                "Resource",
-                resource_id,
-                "File",
-                file_uuid,
-                "matches",
-                rows.count(),
-                file=log,
-            )
+        logger.debug(
+            "Resource %s File %s matches %d",
+            resource_id,
+            file_uuid,
+            rows.count(),
+        )
         models.ArchivesSpaceDIPObjectResourcePairing.objects.filter(
             dipuuid=uuid, resourceid=resource_id, fileuuid=file_uuid
         ).delete()

--- a/src/dashboard/tests/test_ingest.py
+++ b/src/dashboard/tests/test_ingest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pickle
+import uuid
 from unittest import mock
 
 import pytest
@@ -14,6 +15,7 @@ from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 from main.models import Access
+from main.models import ArchivesSpaceDIPObjectResourcePairing
 from main.models import DashboardSetting
 
 
@@ -357,3 +359,50 @@ def test_adjust_directories_draggability():
 
     # small turtles has some draggable children so it's draggable
     assert not small_turtles["not_draggable"]
+
+
+@pytest.fixture
+def dashboard_uuid(db):
+    helpers.set_setting("dashboard_uuid", str(uuid.uuid4()))
+
+
+@mock.patch("builtins.open")
+@mock.patch("builtins.print")
+def test_ingest_upload_as_match_shows_deleted_rows(
+    print_mock, open_mock, admin_client, dashboard_uuid
+):
+    dip_uuid = uuid.uuid4()
+    file_uuid = uuid.uuid4()
+    ArchivesSpaceDIPObjectResourcePairing.objects.create(
+        dipuuid=dip_uuid,
+        fileuuid=file_uuid,
+        resourceid="/repositories/2/archival_objects/1",
+    )
+    ArchivesSpaceDIPObjectResourcePairing.objects.create(
+        dipuuid=dip_uuid,
+        fileuuid=file_uuid,
+        resourceid="/repositories/2/archival_objects/2",
+    )
+
+    response = admin_client.delete(
+        reverse("ingest:ingest_upload_as_match", kwargs={"uuid": dip_uuid}),
+        data=json.dumps(
+            {
+                "resource_id": "/repositories/2/archival_objects/1",
+                "file_uuid": str(file_uuid),
+            }
+        ),
+        content_type="application/json",
+    )
+    assert response.status_code == 204
+
+    open_mock.assert_called_once_with("/tmp/delete.log", "a")
+    print_mock.assert_called_once_with(
+        "Resource",
+        "/repositories/2/archival_objects/1",
+        "File",
+        "file_uuid",
+        "matches",
+        1,
+        file=mock.ANY,
+    )

--- a/src/dashboard/tests/test_ingest.py
+++ b/src/dashboard/tests/test_ingest.py
@@ -401,7 +401,7 @@ def test_ingest_upload_as_match_shows_deleted_rows(
         "Resource",
         "/repositories/2/archival_objects/1",
         "File",
-        "file_uuid",
+        str(file_uuid),
         "matches",
         1,
         file=mock.ANY,


### PR DESCRIPTION
This replaces a temporary file used for logging in one of the ArchivesSpace related views.

As pointed in https://github.com/artefactual/archivematica/pull/1881 the temporary file represents a security risk, and this aligns the usage of Python loggers with the rest of the dashboard views.