### PR TITLE
Save AM docker logs on AMAUAT failures

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -60,3 +60,18 @@ jobs:
       - name: "Run AMAUAT tag"
         run: |
           make -C hack/ test-at-behave TAGS="${{ matrix.tag }}" BROWSER=${{ matrix.browser }}
+      - name: "Save docker logs on failure"
+        if: failure()
+        run: |
+          mkdir docker-logs
+          docker compose logs --no-log-prefix --no-color archivematica-mcp-server > docker-logs/mcp-server.log
+          docker compose logs --no-log-prefix --no-color archivematica-mcp-client > docker-logs/mcp-client.log
+          docker compose logs --no-log-prefix --no-color archivematica-dashboard > docker-logs/dashboard.log
+          docker compose logs --no-log-prefix --no-color archivematica-storage-service > docker-logs/storage-service.log
+        working-directory: ./hack
+      - name: "Upload docker logs on failure"
+        if: failure()
+        uses: "actions/upload-artifact@v4"
+        with:
+          name: "docker-logs-${{ matrix.tag }}-${{ matrix.browser }}"
+          path: "./hack/docker-logs"


### PR DESCRIPTION
This saves the docker logs of the AM services as downloadable artifacts when an AMAUAT tag fails.

![imagen](https://github.com/artefactual/archivematica/assets/560781/be0b312d-1558-4fe2-beec-d5773be30f56)
