### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: "Upload coverage report"
         if: matrix.rule != 'storage-service' && matrix.rule != 'migrations' && github.repository == 'artefactual/archivematica'
-        uses: "codecov/codecov-action@v3"
+        uses: "codecov/codecov-action@v4"
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
@@ -78,7 +78,7 @@ jobs:
         working-directory: "./src/dashboard/frontend/"
     steps:
       - name: "Check out repository"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
       - name: "Set up Node JS"
         uses: "actions/setup-node@v4"
         with:
@@ -97,9 +97,9 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: "Check out repository"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
       - name: "Set up Python 3.9"
-        uses: "actions/setup-python@v4"
+        uses: "actions/setup-python@v5"
         with:
           python-version: "3.9"
           cache: "pip"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,19 +25,19 @@ repos:
   - id: django-upgrade
     args: [--target-version, "4.2"]
 - repo: https://github.com/psf/black
-  rev: "23.10.1"
+  rev: "23.12.1"
   hooks:
   - id: black
     args: [--safe, --quiet]
 - repo: https://github.com/pycqa/flake8
-  rev: "6.1.0"
+  rev: "7.0.0"
   hooks:
   - id: flake8
     additional_dependencies:
     - flake8-bugbear==23.9.16
     - flake8-comprehensions==3.14.0
 - repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.37.0
+  rev: v0.39.0
   hooks:
   - id: markdownlint
     exclude: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -51,11 +51,11 @@ click==8.1.7
     #   pip-tools
 colorama==0.4.6
     # via tox
-coverage[toml]==7.4.0
+coverage[toml]==7.4.1
     # via
     #   -r requirements-dev.in
     #   pytest-cov
-cryptography==41.0.7
+cryptography==42.0.2
     # via
     #   -r requirements.txt
     #   josepy
@@ -127,7 +127,7 @@ josepy==1.14.0
     # via
     #   -r requirements.txt
     #   mozilla-django-oidc
-jsonschema==4.21.0
+jsonschema==4.21.1
     # via -r requirements.txt
 jsonschema-specifications==2023.12.1
     # via
@@ -141,7 +141,7 @@ lxml==5.1.0
     #   ammcpc
     #   metsrw
     #   python-cas
-metsrw==0.5.0
+metsrw==0.5.1
     # via -r requirements.txt
 mockldap @ git+https://github.com/artefactual-labs/mockldap@v0.3.1
     # via -r requirements-dev.in
@@ -167,11 +167,11 @@ packaging==23.2
     #   tox
 pip-tools==7.3.0
     # via -r requirements.txt
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via
     #   tox
     #   virtualenv
-pluggy==1.3.0
+pluggy==1.4.0
     # via
     #   pytest
     #   tox
@@ -192,7 +192,7 @@ pycparser==2.21
     # via
     #   -r requirements.txt
     #   cffi
-pyopenssl==23.3.0
+pyopenssl==24.0.0
     # via
     #   -r requirements.txt
     #   josepy
@@ -202,7 +202,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements.txt
     #   build
-pytest==7.4.4
+pytest==8.0.0
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -211,7 +211,7 @@ pytest==7.4.4
     #   pytest-randomly
 pytest-cov==4.1.0
     # via -r requirements-dev.in
-pytest-django==4.7.0
+pytest-django==4.8.0
     # via -r requirements-dev.in
 pytest-mock==3.12.0
     # via -r requirements-dev.in
@@ -234,7 +234,7 @@ python-mimeparse==1.6.0
     # via
     #   -r requirements.txt
     #   django-tastypie
-referencing==0.32.1
+referencing==0.33.0
     # via
     #   -r requirements.txt
     #   jsonschema
@@ -280,7 +280,7 @@ typing-extensions==4.9.0
     #   asgiref
 unidecode==1.3.8
     # via -r requirements.txt
-urllib3==2.1.0
+urllib3==2.2.0
     # via
     #   -r requirements.txt
     #   amclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ clamd==1.0.2
     # via -r requirements.in
 click==8.1.7
     # via pip-tools
-cryptography==41.0.7
+cryptography==42.0.2
     # via
     #   josepy
     #   mozilla-django-oidc
@@ -82,7 +82,7 @@ inotify-simple==1.3.5
     # via -r requirements.in
 josepy==1.14.0
     # via mozilla-django-oidc
-jsonschema==4.21.0
+jsonschema==4.21.1
     # via -r requirements.in
 jsonschema-specifications==2023.12.1
     # via jsonschema
@@ -94,7 +94,7 @@ lxml==5.1.0
     #   ammcpc
     #   metsrw
     #   python-cas
-metsrw==0.5.0
+metsrw==0.5.1
     # via -r requirements.in
 mozilla-django-oidc==4.0.0
     # via -r requirements.in
@@ -122,7 +122,7 @@ pyasn1-modules==0.3.0
     # via python-ldap
 pycparser==2.21
     # via cffi
-pyopenssl==23.3.0
+pyopenssl==24.0.0
     # via josepy
 pyproject-hooks==1.0.0
     # via build
@@ -138,7 +138,7 @@ python-ldap==3.4.4
     #   django-auth-ldap
 python-mimeparse==1.6.0
     # via django-tastypie
-referencing==0.32.1
+referencing==0.33.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -170,7 +170,7 @@ typing-extensions==4.9.0
     # via asgiref
 unidecode==1.3.8
     # via -r requirements.in
-urllib3==2.1.0
+urllib3==2.2.0
     # via
     #   amclient
     #   elasticsearch


### PR DESCRIPTION
This upgrades the Python requirements, `pre-commit` hooks and GitHub action versions.

The only exception is the `pre-commit` hook for `black` which in its latest version has introduced an incompatibility with the `reorder-python-imports` hook.