### PR TITLE
Make group fields optional in create format view

### DIFF
--- a/src/dashboard/src/fpr/views.py
+++ b/src/dashboard/src/fpr/views.py
@@ -91,8 +91,14 @@ def format_edit(request, slug=None):
         format = None
         group = None
     form = fprforms.FormatForm(request.POST or None, instance=format, prefix="f")
+    # When a format is about to be created there is no format group instance,
+    # so the required fields of the FormatGroupForm class should be optional.
+    is_group_edit_form = group is not None
     format_group_form = fprforms.FormatGroupForm(
-        request.POST or None, instance=group, prefix="fg"
+        request.POST or None,
+        instance=group,
+        prefix="fg",
+        use_required_attribute=is_group_edit_form,
     )
     if form.is_valid():
         if form.cleaned_data["group"] == "new" and format_group_form.is_valid():


### PR DESCRIPTION
When a format is about to be created with the `Create format` form of the FPR there is no format group instance, so validation currently fails because the format group fields are required but hidden so the browser console shows the error `The invalid form control with name=‘fg-description’ is not focusable.`.

This makes those fields optional in that case.

Connected to https://github.com/archivematica/Issues/issues/1643