### PR TITLE
Add Python 3.12 to GitHub test workflow 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           "3.9",
           "3.10",
           "3.11",
+          "3.12"
         ]
         include:
           - rule: "storage-service"

--- a/src/archivematicaCommon/lib/bindpid.py
+++ b/src/archivematicaCommon/lib/bindpid.py
@@ -528,10 +528,7 @@ def _parse_config(args):
         return {}
     config = configparser.RawConfigParser()
     with open(cf) as filei:
-        try:
-            config.read_file(filei)
-        except AttributeError:
-            config.readfp(filei)
+        config.read_file(filei)
     return {key: _get_config_val(config, key) for key in CFGABLE_PARAMS}
 
 

--- a/src/archivematicaCommon/tests/test_env_configparser.py
+++ b/src/archivematicaCommon/tests/test_env_configparser.py
@@ -21,7 +21,7 @@ class TestConfigReader(TestCase):
     def read_test_config(self, test_config, prefix=""):
         buf = StringIO(test_config)
         config = EnvConfigParser(env=self.environ, prefix=prefix)
-        config.readfp(buf)
+        config.read_file(buf)
         return config
 
     def test_env_lookup_int(self):

--- a/src/dashboard/tests/test_models.py
+++ b/src/dashboard/tests/test_models.py
@@ -99,8 +99,8 @@ def test_sip_arrange_create_many_with_integrity_error(mocker):
     arrange2_mock = mocker.Mock()
     models.SIPArrange.create_many([arrange1_mock, arrange2_mock])
     # If bulk creation fails each SIPArrange is saved individually
-    assert arrange1_mock.save.called_once()
-    assert arrange2_mock.save.called_once()
+    arrange1_mock.save.assert_called_once()
+    arrange2_mock.save.assert_called_once()
 
 
 class TestJobModel:


### PR DESCRIPTION
According to the [release schedule for Ubuntu 24.04](https://discourse.ubuntu.com/t/noble-numbat-release-schedule/35649) Python 3.12 will be the default version.

This adds Python 3.12 to the matrix configuration of the GitHub `test` workflow. I plan to reduce the number of test jobs in a following pull request.