### PR TITLE
Fix codecov-action configuration in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,8 @@ jobs:
           fail_ci_if_error: false
           verbose: true
           name: ${{ matrix.rule }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   frontend:
     name: "Test frontend"
     runs-on: "ubuntu-22.04"


### PR DESCRIPTION
> Tokenless uploading is unsupported.

The `v4.0.0` release of the `codecov/codecov-action` made a [breaking change](https://github.com/codecov/codecov-action/releases/tag/v4.0.0).

This PR follows their [document](https://docs.codecov.com/docs/adding-the-codecov-token#github-actions) on how to update the GitHub workflow.