### PR TITLE
Upload AMAUAT logs based on outcome of the tag run

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -58,10 +58,11 @@ jobs:
         run: |
           make -C hack/ restart-am-services
       - name: "Run AMAUAT tag"
+        id: "amauat-run"
         run: |
           make -C hack/ test-at-behave TAGS="${{ matrix.tag }}" BROWSER=${{ matrix.browser }}
       - name: "Save docker logs on failure"
-        if: failure()
+        if: "${{ (failure() && steps.amauat-run.outcome == 'failure') || (cancelled() && steps.amauat-run.outcome == 'cancelled') }}"
         run: |
           mkdir docker-logs
           docker compose logs --no-log-prefix --no-color archivematica-mcp-server > docker-logs/mcp-server.log
@@ -70,7 +71,7 @@ jobs:
           docker compose logs --no-log-prefix --no-color archivematica-storage-service > docker-logs/storage-service.log
         working-directory: ./hack
       - name: "Upload docker logs on failure"
-        if: failure()
+        if: "${{ (failure() && steps.amauat-run.outcome == 'failure') || (cancelled() && steps.amauat-run.outcome == 'cancelled') }}"
         uses: "actions/upload-artifact@v4"
         with:
           name: "docker-logs-${{ matrix.tag }}-${{ matrix.browser }}"


### PR DESCRIPTION
This generates and uploads the Docker logs of the AMAUAT workflow only if the `Run AMAUAT tag` step either fails or gets cancelled.

This gets us the logs even if GitHub times out the workflow run when the tag execution hangs or if the developer cancels it manually, and avoids getting empty logs on Docker build failures.