### PR TITLE
Fix Shibboleth URL patterns

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -78,7 +78,7 @@ django-forms-bootstrap==3.1.0
     # via -r requirements.txt
 django-prometheus==2.3.1
     # via -r requirements.txt
-django-shibboleth-remoteuser @ git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@962f6f9818683ef5f6432f091d22945e54b82592
+django-shibboleth-remoteuser @ git+https://github.com/artefactual-labs/django-shibboleth-remoteuser.git@f08a7864d6130416c352981ccf318fff0fd5be58
     # via -r requirements.txt
 django-tastypie==0.14.6
     # via -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@962f6f9818683ef5f6432f091d22945e54b82592#egg=django-shibboleth-remoteuser
+git+https://github.com/artefactual-labs/django-shibboleth-remoteuser.git@f08a7864d6130416c352981ccf318fff0fd5be58#egg=django-shibboleth-remoteuser
 Django>=4.2,<5
 agentarchives
 amclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ django-forms-bootstrap==3.1.0
     # via -r requirements.in
 django-prometheus==2.3.1
     # via -r requirements.in
-django-shibboleth-remoteuser @ git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@962f6f9818683ef5f6432f091d22945e54b82592
+django-shibboleth-remoteuser @ git+https://github.com/artefactual-labs/django-shibboleth-remoteuser.git@f08a7864d6130416c352981ccf318fff0fd5be58
     # via -r requirements.in
 django-tastypie==0.14.6
     # via -r requirements.in

--- a/src/dashboard/src/main/urls.py
+++ b/src/dashboard/src/main/urls.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 from django.conf import settings
-from django.urls import include
 from django.urls import path
 from django.urls import re_path
 from main import views
@@ -48,14 +47,3 @@ urlpatterns = [
     ),
     re_path(r"formdata/(?P<type>\w+)/(?P<parent_id>\d+)/$", views.formdata),
 ]
-
-if "shibboleth" in settings.INSTALLED_APPS:
-    # Simulate a shibboleth urls module (so our custom Shibboleth logout view
-    # matches the same namespaced URL name as the standard logout view from
-    # the shibboleth lib)
-    class shibboleth_urls:
-        urlpatterns = [
-            path("logout/", views.CustomShibbolethLogoutView.as_view(), name="logout")
-        ]
-
-    urlpatterns += [path("shib/", include(shibboleth_urls, namespace="shibboleth"))]

--- a/src/dashboard/src/main/views.py
+++ b/src/dashboard/src/main/views.py
@@ -30,7 +30,6 @@ from django.views.decorators.http import last_modified
 from django.views.i18n import JavaScriptCatalog
 from lxml import etree
 from main import models
-from shibboleth.views import ShibbolethLogoutView
 
 
 @cache_page(86400, key_prefix="js18n-%s" % get_language())
@@ -318,7 +317,3 @@ def formdata(request, type, parent_id, delete_id=None):
         response["message"] = _("Incorrect type.")
 
     return helpers.json_response(response)
-
-
-class CustomShibbolethLogoutView(ShibbolethLogoutView):
-    pass

--- a/src/dashboard/src/middleware/common.py
+++ b/src/dashboard/src/middleware/common.py
@@ -32,7 +32,10 @@ logger = logging.getLogger("archivematica.dashboard")
 
 class AJAXSimpleExceptionResponseMiddleware(MiddlewareMixin):
     def process_exception(self, request, exception):
-        if not settings.DEBUG or not request.is_ajax():
+        if (
+            not settings.DEBUG
+            or not request.headers.get("x-requested-with") == "XMLHttpRequest"
+        ):
             return
         (exc_type, exc_info, tb) = sys.exc_info()
         tracebacks = traceback.format_tb(tb)

--- a/src/dashboard/src/urls.py
+++ b/src/dashboard/src/urls.py
@@ -51,7 +51,10 @@ urlpatterns = [
 
 if settings.PROMETHEUS_ENABLED:
     # Include prometheus metrics at /metrics
-    urlpatterns.append(path("", include("django_prometheus.urls")))
+    urlpatterns += [path("", include("django_prometheus.urls"))]
 
 if settings.OIDC_AUTHENTICATION:
-    urlpatterns.append(path("oidc/", include("mozilla_django_oidc.urls")))
+    urlpatterns += [path("oidc/", include("mozilla_django_oidc.urls"))]
+
+if "shibboleth" in settings.INSTALLED_APPS:
+    urlpatterns += [path("shib/", include("shibboleth.urls"))]


### PR DESCRIPTION
This sets a forked version of the `django-shibboleth-remoteuser` library compatible with Django 3.2 and above and removes the custom Shibboleth logout view which is not necessary after the middleware removed the `LOGOUT_SESSION_KEY`.

It also replaces the `request.is_ajax()` call that was [deprecated in Django 3.1](https://docs.djangoproject.com/en/dev/releases/3.1/#id2) and [removed in 4.0](https://docs.djangoproject.com/en/dev/releases/4.0/#features-removed-in-4-0).

Connected to https://github.com/archivematica/Issues/issues/1667