### PR TITLE
Fixes for MCPClient forking model update

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ attrs==23.2.0
     #   -r requirements.txt
     #   jsonschema
     #   referencing
-bagit==1.8.1
+bagit @ git+https://github.com/artefactual-labs/bagit-python.git@4b8fde73b4e631461bfd7add87e200500d40ca21
     # via -r requirements.txt
 brotli==1.1.0
     # via -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ Django>=4.2,<5
 agentarchives
 amclient
 ammcpc
-bagit
+git+https://github.com/artefactual-labs/bagit-python.git@4b8fde73b4e631461bfd7add87e200500d40ca21#egg=bagit
 brotli
 clamd
 django-autoslug

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
-bagit==1.8.1
+bagit @ git+https://github.com/artefactual-labs/bagit-python.git@4b8fde73b4e631461bfd7add87e200500d40ca21
     # via -r requirements.in
 brotli==1.1.0
     # via -r requirements.in

--- a/src/MCPClient/lib/client/mcp.py
+++ b/src/MCPClient/lib/client/mcp.py
@@ -2,6 +2,8 @@
 Main MCPClient entrypoint.
 """
 import logging
+import os
+import pathlib
 import signal
 
 from client import metrics
@@ -13,6 +15,11 @@ logger = logging.getLogger("archivematica.mcp.client")
 
 def main():
     metrics.start_prometheus_server()
+
+    # Use local XML schemas for validation.
+    os.environ["XML_CATALOG_FILES"] = str(
+        pathlib.Path(__file__).parent.parent / "assets" / "catalog" / "catalog.xml"
+    )
 
     pool = WorkerPool()
     pool.start()


### PR DESCRIPTION
This PR fixes a couple of problems introduced when https://github.com/artefactual/archivematica/pull/1845 was merged:

1. It restores the local XML catalog setup implemented in https://github.com/artefactual/archivematica/pull/1827 which was lost in the last `git rebase` of the forking model branch.
2. It uses [a forked version of `bagit`](https://github.com/artefactual-labs/bagit-python) that fixes the validation Pool problem explained in https://github.com/archivematica/Issues/issues/1482#issuecomment-1963128329

Connected to https://github.com/archivematica/Issues/issues/1482