### PR TITLE
Update Storage Service test hooks

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -299,7 +299,7 @@ test-storage-service: start-mysql  ## Run Storage Service tests.
 	$(call run_toxenvs,$(__TOXENVS_STORAGE_SERVICE))
 
 test-storage-service-integration:  ## Run Storage Service unit and integration tests using MySQL and MinIO.
-	$(CURDIR)/submodules/archivematica-storage-service/integration/run.sh
+	$(CURDIR)/submodules/archivematica-storage-service/tests/integration/run.sh
 
 __TOXENVS_ARCHIVEMATICA_COMMON = archivematica-common
 test-archivematica-common: start-mysql  ## Run Archivematica Common tests.

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ changedir =
     dashboard: {toxinidir}/tests/dashboard
     mcp-server: {toxinidir}/tests/MCPServer
     mcp-client: {toxinidir}/tests/MCPClient
-    storage-service: {env:STORAGE_SERVICE_DIR}
+    storage-service: {env:STORAGE_SERVICE_ROOT}
 
 [testenv:mcp-client-ensure-no-mutable-globals]
 commands = python {env:MCPCLIENT_DIR}/ensure_no_mutable_globals.py


### PR DESCRIPTION
These are updates needed in the development environment because of https://github.com/artefactual/archivematica-storage-service/pull/691.