### PR TITLE
Convert script to capture mutable globals into test

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -288,7 +288,7 @@ test-mcp-server: start-mysql  ## Run MCPServer tests.
 	$(call grant_all_on_dbs,$(__TEST_DBS_MCPSERVER))
 	$(call run_toxenvs,$(__TOXENVS_MCPSERVER))
 
-__TOXENVS_MCPCLIENT = mcp-client mcp-client-ensure-no-mutable-globals
+__TOXENVS_MCPCLIENT = mcp-client
 test-mcp-client: start-mysql  ## Run MCPClient tests.
 	$(call grant_all_on_dbs,$(__TEST_DBS_MCPCLIENT))
 	$(call run_toxenvs,$(__TOXENVS_MCPCLIENT))

--- a/tests/MCPClient/test_ensure_no_mutable_globals.py
+++ b/tests/MCPClient/test_ensure_no_mutable_globals.py
@@ -13,9 +13,8 @@ returned. Otherwise a happy message is printed and 0 is returned.
 """
 import importlib
 import logging
-import os
+import pathlib
 import pprint
-import sys
 import types
 from dis import get_instructions
 from dis import opmap
@@ -149,8 +148,15 @@ def print_mutable_globals_usage(supported_modules):
     return 0
 
 
-if __name__ == "__main__":
-    config_path = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "archivematicaClientModules"
+def test_ensure_no_mutable_globals():
+    config_path = (
+        pathlib.Path(__file__).parent.parent.parent
+        / "src"
+        / "MCPClient"
+        / "lib"
+        / "archivematicaClientModules"
     )
-    sys.exit(print_mutable_globals_usage(get_supported_modules(config_path)))
+
+    result = print_mutable_globals_usage(get_supported_modules(config_path))
+
+    assert result == 0

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist =
     dashboard
     mcp-server
     mcp-client
-    mcp-client-ensure-no-mutable-globals
     storage-service
     migrations-dashboard
     migrations-storage-service
@@ -62,9 +61,6 @@ changedir =
     mcp-server: {toxinidir}/tests/MCPServer
     mcp-client: {toxinidir}/tests/MCPClient
     storage-service: {env:STORAGE_SERVICE_ROOT}
-
-[testenv:mcp-client-ensure-no-mutable-globals]
-commands = python {env:MCPCLIENT_DIR}/ensure_no_mutable_globals.py
 
 [testenv:storage-service]
 deps =


### PR DESCRIPTION
This converts the script into an MCPClient test so its separate `tox` environment and `make` rule can be removed.