### PR TITLE
Fix permission issues in the development environment

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -85,6 +85,10 @@ create-volumes:  ## Create external data volumes.
 		--opt o=bind \
 		--opt device=$(SS_LOCATION_DATA) \
 			ss-location-data
+	# This workaround prevents Docker from creating this directory structure
+	# inside the external SS_LOCATION_DATA volume directory assigning root as
+	# the owner of some parts of it.
+	mkdir -p $(SS_LOCATION_DATA)/archivematica/archivematica-sampledata
 
 build:  # Build Compose services.
 	docker compose build \

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -87,7 +87,9 @@ create-volumes:  ## Create external data volumes.
 			ss-location-data
 
 build:  # Build Compose services.
-	docker compose build
+	docker compose build \
+		--build-arg USER_ID=$(CALLER_UID) \
+		--build-arg GROUP_ID=$(CALLER_GID)
 
 bootstrap: bootstrap-storage-service bootstrap-dashboard-db bootstrap-dashboard-frontend  ## Full bootstrap.
 


### PR DESCRIPTION
This fixes two permission problems when setting up the development environment:

* The `CALLER_UID` and `CALLER_GID` variables are not propagated by the `make build` rule to the `docker compose build` command. This means the Docker images are always built with the default values of `USER_ID=1000` and `GROUP_ID=1000`. If the account of Docker host user doesn't match those values it won't have ownership nor write permissions on the content created by the Archivematica services in the external volumes.
* The `ss-location-data` external volume should give the Docker host user ability to set content in the default transfer source for Archivematica to process. However after the `create-volumes` rule has created the external volume directories owned by the Docker host user the initial `docker compose up -d` command changes the ownership of the `ss-location-data` to `root` making it read-only.