### PR TITLE
Update base64-helpers frontend dependency

### DIFF
--- a/src/dashboard/frontend/package-lock.json
+++ b/src/dashboard/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "angular-ui-bootstrap": "^0.14.3",
         "angular-ui-validate": "^1.2.2",
         "archivematica-browse-helpers": "git+https://github.com/artefactual-labs/archivematica-browse-helpers.git",
-        "base64-helpers": "github:artefactual-labs/base64-helpers#dev/update",
+        "base64-helpers": "github:artefactual-labs/base64-helpers#v0.1.1",
         "d3": "^3.5.17",
         "font-awesome": "^4.7.0",
         "lodash": "^4.17.21",
@@ -2472,8 +2472,8 @@
       "dev": true
     },
     "node_modules/base64-helpers": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/artefactual-labs/base64-helpers.git#251c596888d79084d0d803c53c792001c607d865",
+      "version": "0.1.1",
+      "resolved": "git+ssh://git@github.com/artefactual-labs/base64-helpers.git#4ed8dd44bc98109505f15acd58a157aea0ee0543",
       "license": "AGPL-3.0"
     },
     "node_modules/base64id": {

--- a/src/dashboard/frontend/package-lock.json
+++ b/src/dashboard/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "angular-ui-bootstrap": "^0.14.3",
         "angular-ui-validate": "^1.2.2",
         "archivematica-browse-helpers": "git+https://github.com/artefactual-labs/archivematica-browse-helpers.git",
-        "base64-helpers": "git+https://github.com/artefactual-labs/base64-helpers.git",
+        "base64-helpers": "github:artefactual-labs/base64-helpers#dev/update",
         "d3": "^3.5.17",
         "font-awesome": "^4.7.0",
         "lodash": "^4.17.21",
@@ -2473,7 +2473,7 @@
     },
     "node_modules/base64-helpers": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/artefactual-labs/base64-helpers.git#96233c5c84bddd37e29dcd2ccd6b7edda5de6ce1",
+      "resolved": "git+ssh://git@github.com/artefactual-labs/base64-helpers.git#251c596888d79084d0d803c53c792001c607d865",
       "license": "AGPL-3.0"
     },
     "node_modules/base64id": {

--- a/src/dashboard/frontend/package.json
+++ b/src/dashboard/frontend/package.json
@@ -50,7 +50,7 @@
     "angular-ui-bootstrap": "^0.14.3",
     "angular-ui-validate": "^1.2.2",
     "archivematica-browse-helpers": "git+https://github.com/artefactual-labs/archivematica-browse-helpers.git",
-    "base64-helpers": "git+https://github.com/artefactual-labs/base64-helpers.git",
+    "base64-helpers": "github:artefactual-labs/base64-helpers#dev/update",
     "d3": "^3.5.17",
     "font-awesome": "^4.7.0",
     "lodash": "^4.17.21",

--- a/src/dashboard/frontend/package.json
+++ b/src/dashboard/frontend/package.json
@@ -50,7 +50,7 @@
     "angular-ui-bootstrap": "^0.14.3",
     "angular-ui-validate": "^1.2.2",
     "archivematica-browse-helpers": "git+https://github.com/artefactual-labs/archivematica-browse-helpers.git",
-    "base64-helpers": "github:artefactual-labs/base64-helpers#dev/update",
+    "base64-helpers": "github:artefactual-labs/base64-helpers#v0.1.1",
     "d3": "^3.5.17",
     "font-awesome": "^4.7.0",
     "lodash": "^4.17.21",

--- a/src/dashboard/frontend/test/unit/browseSpec.js
+++ b/src/dashboard/frontend/test/unit/browseSpec.js
@@ -40,10 +40,38 @@ describe('Browse', () => {
       ]
     });
   }));
+  beforeEach(angular.mock.inject((_$httpBackend_) => {
+    _$httpBackend_.when('GET', '/filesystem/children/location/772056c6-ce0c-4ba0-a4c3-8b64791ace88?path=L2hvbWUvTW9udHLDqWFsL2FyY2hpdmVtYXRpY2Etc2FtcGxlZGF0YQ%3D%3D').respond({
+      "entries": [
+        "T1BGIGZvcm1hdC1jb3JwdXM=",
+        "UkVBRE1FLm1k"
+      ],
+      "properties": {
+        "T1BGIGZvcm1hdC1jb3JwdXM=": {
+          "size": 4096,
+          "display_string": "1499 objects",
+          "object count": 1499
+        },
+        "UkVBRE1FLm1k": {
+          "size": 201,
+          "display_string": "201 bytes"
+        }
+      },
+      "directories": [
+        "T1BGIGZvcm1hdC1jb3JwdXM="
+      ]
+    });
+  }));
 
   it('should be able to list the contents of a path inside a location', angular.mock.inject((Browse, _$httpBackend_) => {
     Browse.browse('772056c6-ce0c-4ba0-a4c3-8b64791ace88', '/home/vagrant/archivematica-sampledata').then(entries => {
       expect(entries.length).toEqual(4);
+    });
+    _$httpBackend_.flush();
+  }));
+  it('should be able to list the contents of a path with non-ascii parts', angular.mock.inject((Browse, _$httpBackend_) => {
+    Browse.browse('772056c6-ce0c-4ba0-a4c3-8b64791ace88', '/home/Montréal/archivematica-sampledata').then(entries => {
+      expect(entries.length).toEqual(2);
     });
     _$httpBackend_.flush();
   }));


### PR DESCRIPTION
This updates the frontend dependencies to set a version of the `base64-helpers` package that supports encoding `Base64` strings with `UTF-8`. It adds a test to verify the Browse service can encode paths properly.

Depends on https://github.com/artefactual-labs/base64-helpers/pull/2
Connected to https://github.com/archivematica/Issues/issues/1652