### PR TITLE
Pass USER_ID and GROUP_ID to AMAUATs build

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -333,7 +333,7 @@ test-all: start-mysql  ## Run all tests.
 
 test-at-build:  ## AMAUAT: build image.
 	$(call compose_amauat, \
-		build archivematica-acceptance-tests)
+		build --build-arg USER_ID=$(CALLER_UID) --build-arg GROUP_ID=$(CALLER_GID) archivematica-acceptance-tests)
 
 test-at-check: test-at-build  ## AMAUAT: test browsers.
 	$(call compose_amauat, \


### PR DESCRIPTION
This is a follow up to https://github.com/artefactual/archivematica/pull/1909 to give the AMAUATs runs the ability to browse the watched directories which is needed in a few tests like the [`aip-encryption` tag](https://github.com/artefactual-labs/archivematica-acceptance-tests/blob/85260b4fcae3cdfe6be0176e99a03fef8b02e31a/features/core/aip-encryption.feature#L53).