### PR TITLE
Fix file name decoding in normalization report

### DIFF
--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -27,7 +27,6 @@ import elasticSearchFunctions
 import requests
 import storageService as storage_service
 from archivematicaFunctions import b64encode_string
-from archivematicaFunctions import escape
 from components import advanced_search
 from components import decorators
 from components import helpers
@@ -394,7 +393,6 @@ def ingest_normalization_report(request, uuid, current_page=None):
 
     objects = getNormalizationReportQuery(sipUUID=uuid)
     for o in objects:
-        o["location"] = escape(o["location"])
         (
             o["preservation_derivative_validation_attempted"],
             o["preservation_derivative_validation_failed"],

--- a/src/dashboard/src/components/ingest/views_NormalizationReport.py
+++ b/src/dashboard/src/components/ingest/views_NormalizationReport.py
@@ -56,8 +56,8 @@ def getNormalizationReportQuery(sipUUID, idsRestriction=""):
         select
             f.fileUUID,
             f.sipUUID,
-            f.originalLocation as location,
-            f.currentLocation,
+            CONVERT(f.originalLocation USING utf8mb4) as location,
+            CONVERT(f.currentLocation USING utf8mb4) as currentLocation,
             fid.uuid as 'fileID',
             fid.description,
             f.fileGrpUse,


### PR DESCRIPTION
The normalization report shows binary data in the `File name` column.

![imagen](https://github.com/artefactual/archivematica/assets/560781/e0cc826c-f86e-40f4-a4a1-1cf558ebd615)

This updates the SQL query used in the `getNormalizationReportQuery` helper to convert the binary data into text.