### PR TITLE
Add python3-lxml as an MCPClient OS dependency

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -190,6 +190,7 @@ RUN set -ex \
 		p7zip-full \
 		pbzip2 \
 		pst-utils \
+		python3-lxml \
 		rsync \
 		siegfried \
 		sleuthkit \


### PR DESCRIPTION
It's needed by some of the `inkscape` extensions.

Connected to https://github.com/archivematica/Issues/issues/1542