### PR TITLE
Generate SBOM in CI

### DIFF
--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -1,0 +1,59 @@
+name: Generate and upload SBOM
+
+on:
+  push:
+    branches:
+    - qa/**
+    - stable/**
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    container:
+      image: aquasec/trivy:latest
+      options: --entrypoint ""
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Set up cache
+        uses: actions/cache@v4
+        with:
+          path: .trivycache/
+          key: ${{ runner.os }}-trivy-${{ hashFiles('requirements*.txt', 'src/dashboard/frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-trivy-
+
+      - name: Generate SBOM
+        run: trivy fs --cache-dir .trivycache --format cyclonedx --file-patterns "pip:requirements.*\.txt" --include-dev-deps --output sbom.xml .
+        env:
+          TRIVY_NO_PROGRESS: "true"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.xml
+
+  upload-sbom:
+    needs: generate-sbom
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sbom
+
+      - name: Upload SBOM
+        run: |
+          curl -v -X 'POST' "${{ secrets.DEPENDENCY_TRACK_URL }}/api/v1/bom" \
+          -H "X-Api-Key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}" \
+          -H "Content-Type: multipart/form-data" \
+          -F "autoCreate=true" \
+          -F "projectName=${{ github.repository }}" \
+          -F "projectVersion=${{ github.ref_name }}" \
+          -F "parentName=Archivematica" \
+          -F "bom=@sbom.xml"
+        env:
+          DEPENDENCY_TRACK_URL: ${{ secrets.DEPENDENCY_TRACK_URL }}
+          DEPENDENCY_TRACK_API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}


### PR DESCRIPTION
Add ability to generate and upload an SBOM to Dependency Track in CI.
    
This CI workflow will autocreate a new Dependency Track project for any
qa or stable branch this workflow is picked to. The projectName
will be set to "archivematica" and the project version will be the branch
name.

Because the parentName is set to 'Archivematica', this SBOM will be grouped under
a project group of the same name which must be present in advance.
    
Dev dependencies will be included in SBOM.