### PR TITLE
Make CSRF_TRUSTED_ORIGINS and USE_X_FORWARDED_HOST configurable

### DIFF
--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -116,6 +116,20 @@ variables or in the gunicorn configuration file.
   - **Type:** `string`
   - :red_circle: **Mandatory!**
 
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_CSRF_TRUSTED_ORIGINS`**:
+  - **Description:** a comma separated list of trusted origins for unsafe
+    requests (e.g. POST). Must include the schema, e.g:
+    `"https://example.com,https://example2.com"`. <https://docs.djangoproject.com/en/dev/ref/settings/#csrf-trusted-origins>
+  - **Type:** `string`
+  - **Default:** `""`
+
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_USE_X_FORWARDED_HOST`**:
+  - **Description:** a boolean that specifies whether to use the
+    X-Forwarded-Host header in preference to the Host header. This should only
+    be enabled if a proxy which sets this header is in use. <https://docs.djangoproject.com/en/dev/ref/settings/#use-x-forwarded-host>
+  - **Type:** `boolean`
+  - **Defalt:** `false`
+
 - **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_DJANGO_SECRET_KEY`**:
   - **Description:** a secret key used for cryptographic signing. See [SECRET_KEY]
     for more details.

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -45,6 +45,16 @@ CONFIG_MAPPING = {
         "option": "shared_directory",
         "type": "string",
     },
+    "csrf_trusted_origins": {
+        "section": "Dashboard",
+        "option": "csrf_trusted_origins",
+        "type": "string",
+    },
+    "use_x_forwarded_host": {
+        "section": "Dashboard",
+        "option": "use_x_forwarded_host",
+        "type": "boolean",
+    },
     "watch_directory": {
         "section": "Dashboard",
         "option": "watch_directory",
@@ -189,6 +199,8 @@ password_disable_complexity_validation = False
 shibboleth_authentication = False
 cas_authentication = False
 ldap_authentication = False
+csrf_trusted_origins =
+use_x_forwarded_host = False
 oidc_authentication = False
 storage_service_client_timeout = 86400
 storage_service_client_quick_timeout = 5
@@ -245,6 +257,15 @@ ADMINS = (
 )
 
 MANAGERS = ADMINS
+
+# Fetch the 'csrf_trusted_origins' configuration, split by comma, or default to an empty list
+CSRF_TRUSTED_ORIGINS = (
+    config.get("csrf_trusted_origins", "").strip().split(",")
+    if config.get("csrf_trusted_origins", "").strip()
+    else []
+)
+
+USE_X_FORWARDED_HOST = config.get("use_x_forwarded_host")
 
 # Lets us know whether we're behind an HTTPS connection
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")


### PR DESCRIPTION
Make USE_X_FORWARDED_HOST and CSRF_TRUSTED_ORIGINS django settings configurable as dashboard environment variables.

Connects to https://github.com/archivematica/Issues/issues/1675