### PR TITLE
Remove unused file filter

### DIFF
--- a/src/MCPServer/lib/assets/workflow-schema-v1.json
+++ b/src/MCPServer/lib/assets/workflow-schema-v1.json
@@ -292,9 +292,6 @@
         "filter_file_end": {
           "type": "string"
         },
-        "filter_file_start": {
-          "type": "string"
-        },
         "filter_subdir": {
           "type": "string"
         },
@@ -330,9 +327,6 @@
           "type": "string"
         },
         "filter_file_end": {
-          "type": "string"
-        },
-        "filter_file_start": {
           "type": "string"
         },
         "filter_subdir": {

--- a/src/MCPServer/lib/server/jobs/client.py
+++ b/src/MCPServer/lib/server/jobs/client.py
@@ -168,11 +168,6 @@ class FilesClientScriptJob(ClientScriptJob):
     """
 
     @property
-    def filter_file_start(self):
-        """Returns path prefix to filter files on, as defined in the workflow."""
-        return self.link.config.get("filter_file_start", "")
-
-    @property
     def filter_file_end(self):
         """Returns path suffix to filter files on, as defined in the workflow."""
         return self.link.config.get("filter_file_end", "")
@@ -215,7 +210,6 @@ class FilesClientScriptJob(ClientScriptJob):
     def submit_tasks(self):
         """Iterate through all matching files for the package, and submit tasks."""
         for file_replacements in self.package.files(
-            filter_filename_start=self.filter_file_start,
             filter_filename_end=self.filter_file_end,
             filter_subdir=self.filter_subdir,
         ):

--- a/src/MCPServer/lib/server/packages.py
+++ b/src/MCPServer/lib/server/packages.py
@@ -646,18 +646,13 @@ class Package(metaclass=abc.ABCMeta):
 
         return mapping
 
-    def files(
-        self, filter_filename_start=None, filter_filename_end=None, filter_subdir=None
-    ):
+    def files(self, filter_filename_end=None, filter_subdir=None):
         """Generator that yields all files associated with the package or that
         should be associated with a package.
         """
         with auto_close_old_connections():
             queryset = self.base_queryset
 
-            if filter_filename_start:
-                # TODO: regex filter
-                raise NotImplementedError("filter_filename_start is not implemented")
             if filter_filename_end:
                 queryset = queryset.filter(
                     currentlocation__endswith=filter_filename_end
@@ -683,12 +678,8 @@ class Package(metaclass=abc.ABCMeta):
 
             for basedir, _, files in os.walk(start_path):
                 for file_name in files:
-                    if (
-                        filter_filename_start
-                        and not file_name.startswith(filter_filename_start)
-                    ) or (
+                    if filter_filename_end and not file_name.endswith(
                         filter_filename_end
-                        and not file_name.endswith(filter_filename_end)
                     ):
                         continue
                     file_path = os.path.join(basedir, file_name)

--- a/tests/MCPServer/test_package.py
+++ b/tests/MCPServer/test_package.py
@@ -185,7 +185,7 @@ def test_reload_file_list(tmp_path):
 
     # One file will be returned from the database  with a UUID, another from
     # the filesystem without a UUID.
-    for _file_count, file_info in enumerate(transfer.files(None, None, "/objects"), 1):
+    for _file_count, file_info in enumerate(transfer.files(None, "/objects"), 1):
         assert "%fileUUID%" in file_info
         assert "%fileGrpUse%" in file_info
         assert "%relativeLocation%" in file_info
@@ -215,7 +215,7 @@ def test_reload_file_list(tmp_path):
     sub_dir.mkdir()
     new_file = sub_dir / "another_new_file.txt"
     new_file.touch()
-    for _file_count, file_info in enumerate(transfer.files(None, None, "/objects"), 1):
+    for _file_count, file_info in enumerate(transfer.files(None, "/objects"), 1):
         if file_info.get("%fileUUID%") != "None":
             continue
         file_path = Path(
@@ -237,7 +237,7 @@ def test_reload_file_list(tmp_path):
 
     # Now the database is updated, we will still have the same file count, but
     # all objects will be returned from the database and we will have uuids.
-    for _file_count, file_info in enumerate(transfer.files(None, None, "/objects"), 1):
+    for _file_count, file_info in enumerate(transfer.files(None, "/objects"), 1):
         if file_info.get("%fileUUID%") == "None":
             raise AssertionError(
                 "Non-database entries returned from package.files(): {}".format(
@@ -253,7 +253,7 @@ def test_reload_file_list(tmp_path):
         new_file = objects_path / file_
         new_file.touch()
     new_count = 0
-    for _file_count, file_info in enumerate(transfer.files(None, None, "/objects"), 1):
+    for _file_count, file_info in enumerate(transfer.files(None, "/objects"), 1):
         if file_info.get("%fileUUID%") == "None":
             new_count += 1
     assert new_count == 5
@@ -289,7 +289,7 @@ def test_package_files_with_non_ascii_names(tmp_path):
     models.File.objects.create(**kwargs)
 
     # Assert only one file is returned
-    result = list(transfer.files(None, None, "/objects"))
+    result = list(transfer.files(None, "/objects"))
     assert len(result) == 1
 
     # And it is the file we just created


### PR DESCRIPTION
Similar to https://github.com/artefactual/archivematica/pull/1928, no rush on this. `filter_file_start` is unused so there is no point in keeping any related logic unless you have short-term plans to implement it.