### PR TITLE
Use json.loads in OutputClientScriptJob

### DIFF
--- a/src/MCPServer/lib/server/jobs/client.py
+++ b/src/MCPServer/lib/server/jobs/client.py
@@ -3,6 +3,7 @@ Jobs remotely executed by on MCP client.
 """
 import abc
 import ast
+import json
 import logging
 
 from dbconns import auto_close_old_connections
@@ -241,13 +242,14 @@ class FilesClientScriptJob(ClientScriptJob):
 
 
 class OutputClientScriptJob(ClientScriptJob):
-    """Retrieves output (e.g. a set of choices) from mcp client, for use in a decision.
+    """Retrieves output (e.g. a set of choices) from MCPClient, for use in a decision.
 
     Output is returned via stderr, and parsed via eval. It is stored for access by the
     next job on the `generated_choices` attribute of the job chain, which is used for
     only this purpose.
 
-    TODO: Remove from workflow if possible.
+    TODO: Remove from workflow if possible - this is only used by
+    getAipStorageLocations_v0.0 (twice).
     """
 
     # We always need output for this type of job
@@ -257,8 +259,8 @@ class OutputClientScriptJob(ClientScriptJob):
         logger.debug("stdout emitted by client: %s", task.stdout)
 
         try:
-            choices = ast.literal_eval(task.stdout)
-        except (ValueError, SyntaxError):
+            choices = json.loads(task.stdout)
+        except (TypeError, ValueError):
             logger.exception("Unable to parse output %s", task.stdout)
             choices = {}
 


### PR DESCRIPTION
What [get_aip_storage_locations](https://github.com/artefactual/archivematica/blob/qa/1.x/src/MCPClient/lib/clientScripts/get_aip_storage_locations.py) writes to stdout is a JSON blob so we should use the `json` decoder to deserialize it. The payload looks like the following, always hitting the Storage Service API to build the full list of locations:

```json
{
  "default": {"description": "Default Location", "uri": "/api/v2/location/default/AS/"},
  "3191bf34-c803-4bdf-a37a-cf1aaf1364d9": {"description": "...", "uri": "..."}
}
```

This is done twice in the standard Archivematica workflow, i.e. for AIP (AS) and DIP (DS) store locations.