### PR TITLE
Remove references to Binder

### DIFF
--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -69,9 +69,9 @@
     },
     "0fe9842f-9519-4067-a691-8a363132ae24": {
       "description": {
-        "en": "Upload DIP to AtoM/Binder",
-        "no": "Last opp DIP til AtoM/Binder",
-        "pt_BR": "Carregar DIP no AtoM/Binder"
+        "en": "Upload DIP to AtoM",
+        "no": "Last opp DIP til AtoM",
+        "pt_BR": "Carregar DIP no AtoM"
       },
       "link_id": "7f975ba6-2185-434c-b507-2911f3c77213"
     },
@@ -6746,9 +6746,9 @@
         "replacements": []
       },
       "description": {
-        "en": "Choose config for AtoM/Binder DIP upload",
-        "no": "Velg konfigurasjon for AtoM/Binder DIP opplasting",
-        "pt_BR": "Escolher configuração para carregar DIP no AtoM/Binder"
+        "en": "Choose config for AtoM DIP upload",
+        "no": "Velg konfigurasjon for AtoM DIP opplasting",
+        "pt_BR": "Escolher configuração para carregar DIP no AtoM"
       },
       "exit_codes": {
         "0": {

--- a/src/dashboard/src/components/administration/forms_dip_upload.py
+++ b/src/dashboard/src/components/administration/forms_dip_upload.py
@@ -90,24 +90,24 @@ class AtomConfigForm(forms.Form):
     url = forms.CharField(
         label=_("Upload URL"),
         help_text=_(
-            "URL where the AtoM/Binder index.php frontend lives, SWORD services path will be appended."
+            "URL where the AtoM index.php frontend lives, SWORD services path will be appended."
         ),
     )
     email = forms.CharField(
         label=_("Login email"),
-        help_text=_("E-mail account used to log into AtoM/Binder."),
+        help_text=_("E-mail account used to log into AtoM."),
     )
     password = forms.CharField(
-        label=_("Login password"), help_text=_("Password used to log into AtoM/Binder.")
+        label=_("Login password"), help_text=_("Password used to log into AtoM.")
     )
     version = forms.ChoiceField(
-        label=_("AtoM/Binder version"), choices=((1, "1.x"), (2, "2.x"))
+        label=_("AtoM version"), choices=((1, "1.x"), (2, "2.x"))
     )
     rsync_target = forms.CharField(
         required=False,
         label=_("Rsync target"),
         help_text=_(
-            "The DIP can be sent with Rsync to a remote host before is deposited in AtoM/Binder. This is the destination value passed to Rsync (see man 1 rsync). For example: foobar.com:~/dips/."
+            "The DIP can be sent with Rsync to a remote host before is deposited in AtoM. This is the destination value passed to Rsync (see man 1 rsync). For example: foobar.com:~/dips/."
         ),
     )
     rsync_command = forms.CharField(

--- a/src/dashboard/src/media/js/ingest.js
+++ b/src/dashboard/src/media/js/ingest.js
@@ -313,8 +313,8 @@ $(function()
             return false;
           }
 
-          // "Upload DIP to AtoM/Binder" chain matched by its UUID.
-          // If no identifier for the AtoM or Binder SWORD V1 deposit endpoint
+          // "Upload DIP to AtoM" chain matched by its UUID.
+          // If no identifier for the AtoM SWORD V1 deposit endpoint
           // provided at start of transfer, display a modal dialog to request
           // such here.
           if (chainId == '0fe9842f-9519-4067-a691-8a363132ae24')
@@ -407,11 +407,6 @@ $(function()
 
                 .modal('show');
             } else {
-              // The access system ID that the user supplies at the start of
-              // transfer must contain the correct target prefix if the upload
-              // is to Binder, i.e., the 'ar:' prefix for an artwork record and
-              // the 'tr:' prefix for a technical record. This is explained in
-              // the modal dialog help text. See templates/ingest/grid.html.
               var xhr = $.ajax(url, {
                 type: 'POST',
                 data: {'target': this.model.sip.attributes.access_system_id},

--- a/src/dashboard/src/templates/administration/dips_atom_edit.html
+++ b/src/dashboard/src/templates/administration/dips_atom_edit.html
@@ -35,9 +35,9 @@
       <form class="form-stacked" method="post" action="{% url 'administration:dips_atom_index' %}">
         {% csrf_token %}
 
-        <h3>{% trans "AtoM/Binder DIP upload" %}</h3>
+        <h3>{% trans "AtoM DIP upload" %}</h3>
 
-        <p>{% trans "The settings below configure DIP uploading to AtoM/Binder." %}</p>
+        <p>{% trans "The settings below configure DIP uploading to AtoM." %}</p>
 
         {% include "_form.html" %}
 

--- a/src/dashboard/src/templates/administration/sidebar.html
+++ b/src/dashboard/src/templates/administration/sidebar.html
@@ -31,7 +31,7 @@
     <li>
       {% trans "DIP upload" %}
       <ul>
-        <li class="{% active request url_atom_dip %}"><a href="{{ url_atom_dip }}">{% trans "AtoM/Binder" %}</a></li>
+        <li class="{% active request url_atom_dip %}"><a href="{{ url_atom_dip }}">{% trans "AtoM" %}</a></li>
         <li class="{% active request url_as_dips %}"><a href="{{ url_as_dips }}">{% trans "ArchivesSpace" %}</a></li>
       </ul>
     </li>

--- a/src/dashboard/src/templates/ingest/grid.html
+++ b/src/dashboard/src/templates/ingest/grid.html
@@ -155,10 +155,9 @@
           <h3>{% trans "Upload DIP" %} <img id="upload-dip-modal-spinner" src="/media/images/ajax-loader.gif" /></h3>
         </div>
         <div class="modal-body">
-          <p>{% trans "Please provide the identifier required by the AtoM or Binder SWORD V1 deposit endpoint." %}</p>
+          <p>{% trans "Please provide the identifier required by the AtoM SWORD V1 deposit endpoint." %}</p>
           <ul>
             <li>{% trans "<strong>AtoM:</strong> In AtoM, this is the permalink or slug of the target archival description where the DIP will be attached as a child. For example, if the URL of the archival description is 'http://myAtoM.ca/newsletters-2;rad', then you would enter 'newsletters-2'." %}</li>
-            <li>{% trans "<strong>Binder:</strong> In Binder, this is an identifier that indicates which resource or technology record the DIP will be attached to. Resources are preceded by 'ar:' (e.g. 'ar:123') and technology records are preceded by 'tr:' (e.g. 'tr:456')." %}</li>
           </ul>
           <form class="form-stacked">
             <div class="clearfix">


### PR DESCRIPTION
The Binder project was marked as [deprecated in 2022](https://github.com/artefactual/binder/commit/f42a749a3fcbb9e73de4f61b218f06cbd6c4d207).

This removes references to it in the user interface.