### PR TITLE
Fix failure reports index

### DIFF
--- a/src/dashboard/src/templates/_pager.html
+++ b/src/dashboard/src/templates/_pager.html
@@ -4,11 +4,11 @@
   <div style='float:right;'>
     {% if page.has_previous %}
       <span style='margin-right: 2em'>
-        {% ifnotequal page.previous_page_number 1 %}
+        {% if not page.previous_page_number == 1 %}
           <span style='margin-right: 1em'>
             <a href='?{{ search_params }}&page=1'>{% trans "First" %}</a>
           </span>
-        {% endifnotequal %}
+        {% endif %}
 
         <a href='?{{ search_params }}&page={{ page.previous_page_number }}'>{% trans "Previous" %}</a>
       </span>
@@ -34,11 +34,11 @@
       <span style='margin-left: 2em'>
         <a href='?{{ search_params }}&page={{ page.next_page_number }}'>{% trans "Next" %}</a>
 
-        {% ifnotequal page.next_page_number page.paginator.num_pages %}
+        {% if not page.next_page_number == page.paginator.num_pages %}
           <span style='margin-left: 1em'>
             <a href='?{{ search_params }}&page={{ page.paginator.num_pages }}' title='Page {{ page.paginator.num_pages }}'>{% trans "Last" %}</a>
           </span>
-        {% endifnotequal %}
+        {% endif %}
       </span>
     {% endif %}
 

--- a/tests/dashboard/components/administration/test_administration.py
+++ b/tests/dashboard/components/administration/test_administration.py
@@ -1,13 +1,19 @@
+import uuid
+
 import pytest
 from components import helpers
 from django.urls import reverse
 from main.models import Report
 
 
+@pytest.fixture
 @pytest.mark.django_db
-def test_admin_set_language(admin_client):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
+def dashboard_uuid():
+    helpers.set_setting("dashboard_uuid", str(uuid.uuid4()))
 
+
+@pytest.mark.django_db
+def test_admin_set_language(dashboard_uuid, admin_client):
     response = admin_client.get(reverse("administration:admin_set_language"))
     assert response.status_code == 200
 
@@ -17,8 +23,7 @@ def test_admin_set_language(admin_client):
 
 
 @pytest.mark.django_db
-def test_failure_report_delete(admin_client):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
+def test_failure_report_delete(dashboard_uuid, admin_client):
     report = Report.objects.create(content="my report")
 
     response = admin_client.post(
@@ -30,3 +35,15 @@ def test_failure_report_delete(admin_client):
 
     assert "No reports found." in response.content.decode()
     assert Report.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_failure_report(dashboard_uuid, admin_client):
+    report = Report.objects.create(content="my report")
+
+    response = admin_client.get(reverse("administration:reports_failures_index"))
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert "<h3>Failure report</h3>" in content
+    assert reverse("administration:failure_report", args=[report.pk]) in content


### PR DESCRIPTION
The `ifnotequal` template tag was [deprecated in Django 4.0](https://docs.djangoproject.com/en/5.0/releases/4.0/#features-removed-in-4-0). This replaces it with the `if` template tag.