### PR TITLE
Add SYS_NICE capability to MySQL container

### DIFF
--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       - "mysql_data:/var/lib/mysql"
     ports:
       - "127.0.0.1:62001:3306"
+    cap_add:
+      - "SYS_NICE"
 
   elasticsearch:
     image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.23"


### PR DESCRIPTION
MySQL uses mbind to bind processes and threads to CPUs which is not allowed by the default configuration of Docker's seccomp profile. This causes MySQL to log the following error repeatedly:

    mbind: Operation not permitted

Adding the `SYS_NICE` capability to the container forces Docker to adjust the default seccomp profile to include the necessary permissions. For more details, visit https://github.com/docker-library/mysql/issues/303.

It looks like MySQL fixed the problem in [v8.0.13] but Percona doesn't seem to have received this update.

Related discussion: https://github.com/artefactual/archivematica/pull/1931#discussion_r1614053964.

[v8.0.13]: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-13.html