### PR TITLE
Allow triggering the test CI workflows manually

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -1,11 +1,18 @@
 ---
 name: "Acceptance Test"
 on:
+  workflow_dispatch:
+    inputs:
+      am_version:
+        description: "Archivematica ref (branch, tag or SHA to checkout)"
+        default: "qa/1.x"
+        required: true
+        type: "string"
   pull_request:
     types: [labeled]
 jobs:
   test:
-    if: github.event.label.name == 'AMAUAT'
+    if: "${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'AMAUAT') }}"
     name: "Test ${{ matrix.tag }} on ${{ matrix.browser }}"
     runs-on: "ubuntu-22.04"
     strategy:
@@ -30,8 +37,15 @@ jobs:
             browser: Firefox
     steps:
       - name: "Check out repository"
+        if: "${{ github.event_name != 'workflow_dispatch' }}"
         uses: "actions/checkout@v4"
         with:
+          submodules: true
+      - name: "Check out repository (manually triggered)"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "${{ inputs.am_version || 'qa/1.x' }}"
           submodules: true
       - name: "Create external volumes"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 ---
 name: "Test"
 on:
+  workflow_dispatch:
+    inputs:
+      am_version:
+        description: "Archivematica ref (branch, tag or SHA to checkout)"
+        default: "qa/1.x"
+        required: true
+        type: "string"
   pull_request:
   push:
     branches:
@@ -38,7 +45,13 @@ jobs:
             python-version: "3.9"
     steps:
       - name: "Check out repository"
+        if: "${{ github.event_name != 'workflow_dispatch' }}"
         uses: "actions/checkout@v4"
+      - name: "Check out repository (manually triggered)"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "${{ inputs.am_version || 'qa/1.x' }}"
       - name: "Check out the archivematica-storage-service submodule"
         run: |
           git submodule update --init hack/submodules/archivematica-storage-service/
@@ -97,7 +110,13 @@ jobs:
         working-directory: "./src/dashboard/frontend/"
     steps:
       - name: "Check out repository"
+        if: "${{ github.event_name != 'workflow_dispatch' }}"
         uses: "actions/checkout@v4"
+      - name: "Check out repository (manually triggered)"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "${{ inputs.am_version || 'qa/1.x' }}"
       - name: "Set up Node JS"
         uses: "actions/setup-node@v4"
         with:
@@ -116,7 +135,13 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: "Check out repository"
+        if: "${{ github.event_name != 'workflow_dispatch' }}"
         uses: "actions/checkout@v4"
+      - name: "Check out repository (manually triggered)"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "${{ inputs.am_version || 'qa/1.x' }}"
       - name: "Set up Python 3.9"
         uses: "actions/setup-python@v5"
         with:


### PR DESCRIPTION
With this PR the `test` and `acceptance-test` workflows can be [triggered manually](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) from the Actions tab and they accept a branch, tag or commit hash for the Archivematica checkout.