### PR TITLE
Fix parsing in load labels from file_labels.csv job

### DIFF
--- a/src/MCPClient/lib/clientScripts/load_labels_from_csv.py
+++ b/src/MCPClient/lib/clientScripts/load_labels_from_csv.py
@@ -41,7 +41,7 @@ def call(jobs):
                     continue
 
                 # use universal newline mode to support unusual newlines, like \r
-                with open(fileLabels, "rb") as f:
+                with open(fileLabels) as f:
                     reader = csv.reader(f)
                     for row in reader:
                         if labelFirst:

--- a/tests/MCPClient/test_load_labels_from_csv.py
+++ b/tests/MCPClient/test_load_labels_from_csv.py
@@ -1,0 +1,78 @@
+import pathlib
+from unittest import mock
+
+import load_labels_from_csv
+import pytest
+from client.job import Job
+from main import models
+
+LABEL = "my file"
+OBJECTS_DIRECTORY = "%transferDirectory%objects"
+
+
+@pytest.fixture()
+def transfer():
+    return models.Transfer.objects.create()
+
+
+@pytest.mark.django_db
+def test_load_labels_from_csv_fails_if_file_labels_csv_does_not_exist(
+    transfer, tmp_path
+):
+    non_existent_file_labels_csv = tmp_path / "file_labels.csv"
+    job = mock.Mock(
+        args=[
+            "load_labels_from_csv.py",
+            str(transfer.uuid),
+            str(non_existent_file_labels_csv),
+        ],
+        JobContext=mock.MagicMock(),
+        spec=Job,
+    )
+
+    load_labels_from_csv.call([job])
+
+    job.pyprint.assert_called_once_with(
+        "No such file:", str(non_existent_file_labels_csv)
+    )
+    job.set_status.assert_called_once_with(0)
+
+
+@pytest.fixture()
+def file(transfer):
+    location = f"{OBJECTS_DIRECTORY}/file.txt".encode()
+
+    return models.File.objects.create(
+        transfer=transfer, originallocation=location, currentlocation=location
+    )
+
+
+@pytest.fixture()
+def file_labels_csv(tmp_path, file):
+    result = tmp_path / "file_labels.csv"
+    original_file_path = pathlib.Path(file.originallocation.decode()).relative_to(
+        OBJECTS_DIRECTORY
+    )
+    result.write_text(f"{original_file_path},{LABEL}")
+
+    return result
+
+
+@pytest.mark.django_db
+def test_load_labels_from_csv_sets_label_for_files_in_csv(
+    transfer, file_labels_csv, file
+):
+    job = mock.Mock(
+        args=["load_labels_from_csv.py", str(transfer.uuid), str(file_labels_csv)],
+        JobContext=mock.MagicMock(),
+        spec=Job,
+    )
+
+    load_labels_from_csv.call([job])
+
+    assert (
+        models.File.objects.filter(
+            transfer=transfer, originallocation=file.originallocation, label=LABEL
+        ).count()
+        == 1
+    )


### PR DESCRIPTION
While working on https://github.com/archivematica/Issues/issues/1556 I noticed the ` Load labels from metadata/file_labels.csv` job had a similar problem, so this fixes it and adds a test for the client script.