### PR TITLE
Fix backlog files removal in purge data command

### DIFF
--- a/src/archivematicaCommon/lib/elasticSearchFunctions.py
+++ b/src/archivematicaCommon/lib/elasticSearchFunctions.py
@@ -1248,7 +1248,7 @@ def _document_ids_from_field_query(client, index, field, value):
     document_ids = []
 
     # Escape /'s with \\
-    searchvalue = value.replace("/", "\\/")
+    searchvalue = str(value).replace("/", "\\/")
     query = {"query": {"term": {field: searchvalue}}}
     documents = search_all_results(client, body=query, index=index)
 

--- a/tests/archivematicaCommon/test_elasticsearch_functions.py
+++ b/tests/archivematicaCommon/test_elasticsearch_functions.py
@@ -1201,17 +1201,26 @@ def test_get_transfer_file_info_logs_multiple_results(search_all_results, es_cli
 
 @pytest.mark.django_db
 @mock.patch("elasticSearchFunctions.get_client")
-@mock.patch("elasticSearchFunctions._document_ids_from_field_query")
-def test_remove_backlog_transfer_files(
-    _document_ids_from_field_query, client, transfer
-):
-    file_doc_id = str(uuid.uuid4())
-    _document_ids_from_field_query.return_value = [file_doc_id]
+@mock.patch("elasticSearchFunctions.search_all_results")
+def test_remove_backlog_transfer_files(search_all_results, client, transfer):
+    file_doc_id = "123"
+    search_all_results.return_value = {
+        "hits": {
+            "hits": [
+                {
+                    "_id": file_doc_id,
+                    "_source": {"filename": "file.txt", "fileuuid": str(uuid.uuid4())},
+                }
+            ]
+        }
+    }
 
     elasticSearchFunctions.remove_backlog_transfer_files(client, transfer.uuid)
 
-    _document_ids_from_field_query.assert_called_once_with(
-        client, elasticSearchFunctions.TRANSFER_FILES_INDEX, "sipuuid", transfer.uuid
+    search_all_results.assert_called_once_with(
+        client,
+        body={"query": {"term": {"sipuuid": str(transfer.uuid)}}},
+        index=elasticSearchFunctions.TRANSFER_FILES_INDEX,
     )
     client.delete.assert_called_once_with(
         index=elasticSearchFunctions.TRANSFER_FILES_INDEX,
@@ -1222,17 +1231,26 @@ def test_remove_backlog_transfer_files(
 
 @pytest.mark.django_db
 @mock.patch("elasticSearchFunctions.get_client")
-@mock.patch("elasticSearchFunctions._document_ids_from_field_query")
-def test_remove_sip_transfer_files(
-    _document_ids_from_field_query, client, transfer, transfer_file
-):
-    file_doc_id = str(uuid.uuid4())
-    _document_ids_from_field_query.return_value = [file_doc_id]
+@mock.patch("elasticSearchFunctions.search_all_results")
+def test_remove_sip_transfer_files(search_all_results, client, transfer, transfer_file):
+    file_doc_id = "123"
+    search_all_results.return_value = {
+        "hits": {
+            "hits": [
+                {
+                    "_id": file_doc_id,
+                    "_source": {"filename": "file.txt", "fileuuid": str(uuid.uuid4())},
+                }
+            ]
+        }
+    }
 
     elasticSearchFunctions.remove_sip_transfer_files(client, transfer.uuid)
 
-    _document_ids_from_field_query.assert_called_once_with(
-        client, elasticSearchFunctions.TRANSFER_FILES_INDEX, "sipuuid", transfer.uuid
+    search_all_results.assert_called_once_with(
+        client,
+        body={"query": {"term": {"sipuuid": str(transfer.uuid)}}},
+        index=elasticSearchFunctions.TRANSFER_FILES_INDEX,
     )
     client.delete.assert_called_once_with(
         index=elasticSearchFunctions.TRANSFER_FILES_INDEX,


### PR DESCRIPTION
The `elasticSearchFunctions._document_ids_from_field_query` helper [assumes/expects the search value passed to it to be a string](https://github.com/artefactual/archivematica/blob/49833a02f9dce5eaf91130ab6d5869ad3b085952/src/archivematicaCommon/lib/elasticSearchFunctions.py#L1251). However the `purge_transient_processing_data` [passes the Transfer primary key which is a UUID](https://github.com/artefactual/archivematica/blob/49833a02f9dce5eaf91130ab6d5869ad3b085952/src/dashboard/src/main/management/commands/purge_transient_processing_data.py#L184) raising an error. This updates the helper to convert the search value explicitly.

Connected to https://github.com/archivematica/Issues/issues/1714