### PR TITLE
Handle NULL values when creating transfer METS

### DIFF
--- a/src/MCPClient/lib/clientScripts/create_transfer_mets.py
+++ b/src/MCPClient/lib/clientScripts/create_transfer_mets.py
@@ -403,8 +403,8 @@ def get_premis_rights_documentation_identifiers(rights_type, identifiers):
         identifier_value = getattr(
             identifier, f"{rights_type}documentationidentifiervalue"
         )
-        identifier_role = getattr(
-            identifier, f"{rights_type}documentationidentifierrole"
+        identifier_role = (
+            getattr(identifier, f"{rights_type}documentationidentifierrole") or ""
         )
 
         data += (
@@ -483,7 +483,7 @@ def get_premis_license_information(rights):
             "license",
             license_section.rightsstatementlicensedocumentationidentifier_set.all(),
         )
-        license_information += (("license_terms", license_section.licenseterms),)
+        license_information += (("license_terms", license_section.licenseterms or ""),)
         for note in license_section.rightsstatementlicensenote_set.all():
             license_information += (("license_note", note.licensenote),)
         license_information += (
@@ -698,8 +698,8 @@ def event_to_premis(event):
         premis_data += (
             (
                 "linking_agent_identifier",
-                ("linking_agent_identifier_type", agent.identifiertype),
-                ("linking_agent_identifier_value", str(agent.identifiervalue)),
+                ("linking_agent_identifier_type", agent.identifiertype or ""),
+                ("linking_agent_identifier_value", str(agent.identifiervalue or "")),
             ),
         )
 
@@ -720,10 +720,10 @@ def agent_to_premis(agent):
         PREMIS_META,
         (
             "agent_identifier",
-            ("agent_identifier_type", agent.identifiertype),
-            ("agent_identifier_value", str(agent.identifiervalue)),
+            ("agent_identifier_type", agent.identifiertype or ""),
+            ("agent_identifier_value", str(agent.identifiervalue or "")),
         ),
-        ("agent_name", agent.name),
+        ("agent_name", agent.name or ""),
         ("agent_type", agent.agenttype),
     )
 

--- a/tests/MCPClient/test_create_transfer_mets.py
+++ b/tests/MCPClient/test_create_transfer_mets.py
@@ -4,7 +4,14 @@ import uuid
 
 import metsrw
 import pytest
+from create_transfer_mets import FSEntriesTree
+from create_transfer_mets import agent_to_premis
+from create_transfer_mets import dir_obj_to_premis
+from create_transfer_mets import event_to_premis
+from create_transfer_mets import file_obj_to_premis
+from create_transfer_mets import rights_to_premis
 from create_transfer_mets import write_mets
+from django.db.models import prefetch_related_objects
 from fpr.models import Format
 from fpr.models import FormatGroup
 from fpr.models import FormatVersion
@@ -18,7 +25,23 @@ from main.models import Directory
 from main.models import Event
 from main.models import File
 from main.models import FPCommandOutput
+from main.models import MetadataAppliesToType
 from main.models import RightsStatement
+from main.models import RightsStatementCopyright
+from main.models import RightsStatementCopyrightDocumentationIdentifier
+from main.models import RightsStatementCopyrightNote
+from main.models import RightsStatementLicense
+from main.models import RightsStatementLicenseDocumentationIdentifier
+from main.models import RightsStatementLicenseNote
+from main.models import RightsStatementOtherRightsDocumentationIdentifier
+from main.models import RightsStatementOtherRightsInformation
+from main.models import RightsStatementOtherRightsInformationNote
+from main.models import RightsStatementRightsGranted
+from main.models import RightsStatementRightsGrantedNote
+from main.models import RightsStatementRightsGrantedRestriction
+from main.models import RightsStatementStatuteDocumentationIdentifier
+from main.models import RightsStatementStatuteInformation
+from main.models import RightsStatementStatuteInformationNote
 from main.models import Transfer
 from metsrw.plugins.premisrw import PREMIS_3_0_NAMESPACES
 from version import get_preservation_system_identifier
@@ -864,3 +887,296 @@ def test_transfer_mets_file_identifiers(tmp_path, transfer, file_obj):
     assert identifiers[0][1].text == str(file_obj.uuid)
     assert identifiers[1][0].text == expected_identifier.type
     assert identifiers[1][1].text == expected_identifier.value
+
+
+def _assert_xpath_selector_value(element, selector, expected_value):
+    assert [
+        e.text
+        for e in element.xpath(
+            selector,
+            namespaces=PREMIS_NAMESPACES,
+        )
+    ] == [expected_value]
+
+
+def _assert_expected_rights_basis(result, expected_rights_basis):
+    selector = ".//premis:rightsStatement/premis:rightsBasis"
+    _assert_xpath_selector_value(result, selector, expected_rights_basis)
+
+
+def _assert_linking_object_identifier_value(
+    result, expected_linking_object_identifier_value
+):
+    selector = ".//premis:rightsStatement/premis:linkingObjectIdentifier/premis:linkingObjectIdentifierValue"
+    _assert_xpath_selector_value(
+        result, selector, expected_linking_object_identifier_value
+    )
+
+
+@pytest.mark.django_db
+def test_file_obj_to_premis_with_blank_fields():
+    file = File.objects.create()
+    # Prefetching for File related objects is done in the write_mets function
+    # when FSEntriesTree is instantiated, but we want to test file_obj_to_premis
+    # in as much isolation as possible so we do it here.
+    prefetch_related_objects([file], *FSEntriesTree.file_queryset_prefetches)
+
+    result = file_obj_to_premis(file)
+
+    _assert_xpath_selector_value(
+        result,
+        ".//premis:objectIdentifier/premis:objectIdentifierValue",
+        str(file.uuid),
+    )
+
+
+@pytest.mark.django_db
+def test_dir_obj_to_premis_with_blank_fields():
+    directory = Directory.objects.create()
+
+    result = dir_obj_to_premis(directory)
+
+    _assert_xpath_selector_value(
+        result,
+        ".//premis:objectIdentifier/premis:objectIdentifierValue",
+        str(directory.uuid),
+    )
+
+
+@pytest.mark.django_db
+def test_event_to_premis_with_blank_fields():
+    event = Event.objects.create()
+    event.agents.set([Agent.objects.create()])
+    expected_linking_agent_identifier_type = ""
+
+    result = event_to_premis(event)
+
+    _assert_xpath_selector_value(
+        result,
+        ".//premis:eventIdentifier/premis:eventIdentifierValue",
+        str(event.event_id),
+    )
+
+    assert {
+        e.text
+        for e in result.xpath(
+            ".//premis:linkingAgentIdentifier/premis:linkingAgentIdentifierType",
+            namespaces=PREMIS_NAMESPACES,
+        )
+    } == {"preservation system", expected_linking_agent_identifier_type}
+
+
+@pytest.mark.django_db
+def test_agent_to_premis_with_blank_fields():
+    agent = Agent.objects.create()
+    expected_identifier_value = ""
+
+    result = agent_to_premis(agent)
+
+    _assert_xpath_selector_value(
+        result,
+        ".//premis:agentIdentifier/premis:agentIdentifierValue",
+        expected_identifier_value,
+    )
+
+
+@pytest.fixture
+def empty_rights_statement(db):
+    return RightsStatement.objects.create(
+        metadataappliestotype=MetadataAppliesToType.objects.create()
+    )
+
+
+def set_right_basis(rights_statement, rights_basis):
+    rights_statement.rightsbasis = rights_basis
+    rights_statement.save()
+
+
+@pytest.fixture
+def copyright_basis(empty_rights_statement):
+    rights_basis = "Copyright"
+
+    copyright = RightsStatementCopyright.objects.create(
+        rightsstatement=empty_rights_statement
+    )
+    RightsStatementCopyrightDocumentationIdentifier.objects.create(
+        rightscopyright=copyright
+    )
+    RightsStatementCopyrightNote.objects.create(rightscopyright=copyright)
+
+    set_right_basis(empty_rights_statement, rights_basis)
+
+    return rights_basis
+
+
+@pytest.mark.django_db
+def test_rights_to_premis_with_blank_copyright_fields(
+    empty_rights_statement, copyright_basis
+):
+    expected_copyright_documentation_role = ""
+    file_uuid = uuid.uuid4()
+    expected_linking_object_identifier_value = str(file_uuid)
+
+    result = rights_to_premis(empty_rights_statement, file_uuid)
+
+    _assert_expected_rights_basis(result, copyright_basis)
+    _assert_linking_object_identifier_value(
+        result, expected_linking_object_identifier_value
+    )
+    _assert_xpath_selector_value(
+        result,
+        ".//premis:rightsStatement/premis:copyrightInformation//premis:copyrightDocumentationRole",
+        expected_copyright_documentation_role,
+    )
+
+
+@pytest.fixture
+def license_basis(empty_rights_statement):
+    rights_basis = "License"
+
+    license = RightsStatementLicense.objects.create(
+        rightsstatement=empty_rights_statement
+    )
+    RightsStatementLicenseDocumentationIdentifier.objects.create(
+        rightsstatementlicense=license
+    )
+    RightsStatementLicenseNote.objects.create(rightsstatementlicense=license)
+
+    set_right_basis(empty_rights_statement, rights_basis)
+
+    return rights_basis
+
+
+@pytest.mark.django_db
+def test_rights_to_premis_with_blank_license_fields(
+    empty_rights_statement, license_basis
+):
+    expected_license_terms = ""
+    file_uuid = uuid.uuid4()
+    expected_linking_object_identifier_value = str(file_uuid)
+
+    result = rights_to_premis(empty_rights_statement, file_uuid)
+
+    _assert_expected_rights_basis(result, license_basis)
+    _assert_linking_object_identifier_value(
+        result, expected_linking_object_identifier_value
+    )
+    _assert_xpath_selector_value(
+        result,
+        ".//premis:rightsStatement/premis:licenseInformation//premis:licenseTerms",
+        expected_license_terms,
+    )
+
+
+@pytest.fixture
+def statute_basis(empty_rights_statement):
+    rights_basis = "Statute"
+
+    statute = RightsStatementStatuteInformation.objects.create(
+        rightsstatement=empty_rights_statement
+    )
+    RightsStatementStatuteDocumentationIdentifier.objects.create(
+        rightsstatementstatute=statute
+    )
+    RightsStatementStatuteInformationNote.objects.create(rightsstatementstatute=statute)
+
+    set_right_basis(empty_rights_statement, rights_basis)
+
+    return rights_basis
+
+
+@pytest.mark.django_db
+def test_rights_to_premis_with_blank_statute_fields(
+    empty_rights_statement, statute_basis
+):
+    expected_statute_documentation_role = ""
+    file_uuid = uuid.uuid4()
+    expected_linking_object_identifier_value = str(file_uuid)
+
+    result = rights_to_premis(empty_rights_statement, file_uuid)
+
+    _assert_expected_rights_basis(result, statute_basis)
+    _assert_linking_object_identifier_value(
+        result, expected_linking_object_identifier_value
+    )
+    _assert_xpath_selector_value(
+        result,
+        ".//premis:rightsStatement/premis:statuteInformation//premis:statuteDocumentationRole",
+        expected_statute_documentation_role,
+    )
+
+
+@pytest.fixture
+def other_rights_basis(empty_rights_statement):
+    rights_basis = "Other"
+
+    other_rights = RightsStatementOtherRightsInformation.objects.create(
+        rightsstatement=empty_rights_statement
+    )
+    RightsStatementOtherRightsDocumentationIdentifier.objects.create(
+        rightsstatementotherrights=other_rights
+    )
+    RightsStatementOtherRightsInformationNote.objects.create(
+        rightsstatementotherrights=other_rights
+    )
+
+    set_right_basis(empty_rights_statement, rights_basis)
+
+    return rights_basis
+
+
+@pytest.mark.django_db
+def test_rights_to_premis_with_blank_other_rights_fields(
+    empty_rights_statement, other_rights_basis
+):
+    expected_other_rights_documentation_role = ""
+    file_uuid = uuid.uuid4()
+    expected_linking_object_identifier_value = str(file_uuid)
+
+    result = rights_to_premis(empty_rights_statement, file_uuid)
+
+    _assert_expected_rights_basis(result, other_rights_basis)
+    _assert_linking_object_identifier_value(
+        result, expected_linking_object_identifier_value
+    )
+    _assert_xpath_selector_value(
+        result,
+        ".//premis:rightsStatement/premis:otherRightsInformation//premis:otherRightsDocumentationRole",
+        expected_other_rights_documentation_role,
+    )
+
+
+@pytest.fixture
+def rights_granted_basis(empty_rights_statement):
+    rights_basis = "Copyright"
+
+    rights_granted = RightsStatementRightsGranted.objects.create(
+        rightsstatement=empty_rights_statement
+    )
+    RightsStatementRightsGrantedNote.objects.create(rightsgranted=rights_granted)
+    RightsStatementRightsGrantedRestriction.objects.create(rightsgranted=rights_granted)
+
+    set_right_basis(empty_rights_statement, rights_basis)
+
+    return rights_basis
+
+
+@pytest.mark.django_db
+def test_rights_to_premis_with_blank_rights_granted_fields(
+    empty_rights_statement, rights_granted_basis
+):
+    expected_rights_granted_note = ""
+    file_uuid = uuid.uuid4()
+    expected_linking_object_identifier_value = str(file_uuid)
+
+    result = rights_to_premis(empty_rights_statement, file_uuid)
+
+    _assert_expected_rights_basis(result, rights_granted_basis)
+    _assert_linking_object_identifier_value(
+        result, expected_linking_object_identifier_value
+    )
+    _assert_xpath_selector_value(
+        result,
+        ".//premis:rightsStatement/premis:rightsGranted/premis:rightsGrantedNote",
+        expected_rights_granted_note,
+    )


### PR DESCRIPTION
This converts the nullable fields of the models involved into empty strings during the creation of the transfer METS file.

Connected to https://github.com/archivematica/Issues/issues/1581