### PR TITLE
Prevent unnecessary grid repaint

### DIFF
--- a/src/dashboard/src/media/js/jobs.js
+++ b/src/dashboard/src/media/js/jobs.js
@@ -864,9 +864,9 @@ BaseAppView = Backbone.View.extend({
   // Check if the response from the API has changed since the last poll.
   hasResponseChanged: function(response)
     {
-      var next = JSON.stringify(response);
-      var changed = this.firstPoll || this.previousVersion !== next;
-      this.previousVersion = next;
+      var changed = this.firstPoll || this.previousVersion !== response;
+
+      this.previousVersion = response;
 
       return changed;
     },
@@ -877,7 +877,7 @@ BaseAppView = Backbone.View.extend({
 
       $.ajax({
         context: this,
-        dataType: 'json',
+        dataType: 'text',
         type: 'GET',
         url: this.statusUrl + '?' + new Date().getTime(),
         beforeSend: function()
@@ -894,7 +894,9 @@ BaseAppView = Backbone.View.extend({
               return;
             }
 
-            var objects = response.objects;
+            var data = JSON.parse(response);
+            var objects = data.objects;
+
             if (getURLParameter('paged'))
               {
                 this.updateSips(objects);
@@ -933,7 +935,7 @@ BaseAppView = Backbone.View.extend({
             }
 
             // MCP status
-            if (response.mcp)
+            if (data.mcp)
             {
               window.statusWidget.connect();
             }

--- a/src/dashboard/src/media/js/jobs.js
+++ b/src/dashboard/src/media/js/jobs.js
@@ -877,6 +877,7 @@ BaseAppView = Backbone.View.extend({
 
       $.ajax({
         context: this,
+        // Use text instead of json to cache raw bytes. We'll parse manually.
         dataType: 'text',
         type: 'GET',
         url: this.statusUrl + '?' + new Date().getTime(),

--- a/src/dashboard/src/media/js/jobs.js
+++ b/src/dashboard/src/media/js/jobs.js
@@ -861,6 +861,16 @@ BaseAppView = Backbone.View.extend({
         }
     },
 
+  // Check if the response from the API has changed since the last poll.
+  hasResponseChanged: function(response)
+    {
+      var next = JSON.stringify(response);
+      var changed = this.firstPoll || this.previousVersion !== next;
+      this.previousVersion = next;
+
+      return changed;
+    },
+
   poll: function(start)
     {
       this.firstPoll = undefined !== start;
@@ -880,8 +890,11 @@ BaseAppView = Backbone.View.extend({
           },
         success: function(response)
           {
-            var objects = response.objects;
+            if (!this.hasResponseChanged(response)) {
+              return;
+            }
 
+            var objects = response.objects;
             if (getURLParameter('paged'))
               {
                 this.updateSips(objects);


### PR DESCRIPTION
This is a simplistic client-based approach to avoid repainting the jobs grid if the server response hasn't changed. It reduces the frequency of grid repaints significantly, minimizing interference with user interactions, especially with decision dropdowns.