### PR TITLE
Use only active rules for transcription

### DIFF
--- a/src/MCPClient/lib/clientScripts/transcribe_file.py
+++ b/src/MCPClient/lib/clientScripts/transcribe_file.py
@@ -79,7 +79,7 @@ def insert_file_into_database(
 def fetch_rules_for(file_):
     try:
         format = FileFormatVersion.objects.get(file_uuid=file_)
-        return FPRule.objects.filter(
+        return FPRule.active.filter(
             format=format.format_version, purpose="transcription"
         )
     except (FileFormatVersion.DoesNotExist, ValidationError):


### PR DESCRIPTION
Active `FPRule` for Tessaract is now correctly filtered by this change.

connected to https://github.com/archivematica/Issues/issues/1630