### PR TITLE
Add mypy to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,4 +50,3 @@ repos:
   hooks:
   - id: mypy
     additional_dependencies: [types-all]
-    args: [--explicit-package-bases]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,9 @@ repos:
   rev: 054bda51dbe278b3e86f27c890e3f3ac877d616c
   hooks:
     - id: validate-cff
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.10.1
+  hooks:
+  - id: mypy
+    additional_dependencies: [types-all]
+    args: [--explicit-package-bases]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+
+explicit_package_bases = True

--- a/src/MCPClient/lib/client/job.py
+++ b/src/MCPClient/lib/client/job.py
@@ -9,6 +9,7 @@ import logging
 import sys
 import traceback
 from contextlib import contextmanager
+from logging.handlers import BufferingHandler
 
 from django.conf import settings
 from django.utils import timezone
@@ -149,7 +150,7 @@ class Job:
                 logger.removeHandler(handler)
 
 
-class JobLogHandler(logging.handlers.BufferingHandler):
+class JobLogHandler(BufferingHandler):
     """
     A handler that buffers log messages, and writes them to Job output
     when the buffer is full.

--- a/src/MCPClient/lib/clientScripts/determine_aip_version_key_exit_code.py
+++ b/src/MCPClient/lib/clientScripts/determine_aip_version_key_exit_code.py
@@ -17,11 +17,13 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import sys
+from typing import Dict
+from typing import Optional
 
 import namespaces as ns
 from lxml import etree
 
-VERSION_MAP = {
+VERSION_MAP: Dict[Optional[str], int] = {
     # Only change exit code if AIP format changes. If unknown, default to latest
     # version. Currently, all AIPs are the same format so no special cases
     # required.

--- a/src/MCPClient/lib/clientScripts/fits.py
+++ b/src/MCPClient/lib/clientScripts/fits.py
@@ -34,7 +34,6 @@ from main.models import FPCommandOutput
 
 logger = get_script_logger("archivematica.mcp.client.FITS")
 
-formats = []
 FITSNS = "{http://hul.harvard.edu/ois/xml/ns/fits/fits_output}"
 
 

--- a/src/MCPClient/lib/clientScripts/manual_normalization_create_metadata_and_restructure.py
+++ b/src/MCPClient/lib/clientScripts/manual_normalization_create_metadata_and_restructure.py
@@ -149,9 +149,9 @@ def main(job):
         # fileUUID, eventIdentifierUUID, eventType, eventDateTime, eventDetail
         # probably already correct, and we only set eventOutcomeDetailNote here
         # Not using .filter().update() because that doesn't generate an exception
-        e = Event.objects.get(event_type="normalization", file_uuid=original_file)
-        e.event_outcome_detail = dstR
-        e.save()
+        event = Event.objects.get(event_type="normalization", file_uuid=original_file)
+        event.event_outcome_detail = dstR
+        event.save()
         job.print_output(
             "Updated the eventOutcomeDetailNote of an existing normalization"
             f" Event for file {fileUUID}. Not creating a Derivation object"

--- a/src/MCPClient/lib/clientScripts/pid_declaration.py
+++ b/src/MCPClient/lib/clientScripts/pid_declaration.py
@@ -36,6 +36,20 @@ class DeclarePIDsExceptionNonCritical(Exception):
 
     exit_code = 0
 
+def exit_on_known_exception(func):
+    """Decorator to allows us to raise an exception but still exit-zero when
+    the exception is cleaner to return than ad-hoc integer values.
+    """
+
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except DeclarePIDsExceptionNonCritical as err:
+            return err.exit_code
+
+    return wrapped
+
 
 class DeclarePIDs:
     """Class to wrap PID declaration features and provide some mechanism of
@@ -49,20 +63,6 @@ class DeclarePIDs:
         self.job = job
         self.identifier_count = 0
         self.actual_count = 0
-
-    def exit_on_known_exception(func):
-        """Decorator to allows us to raise an exception but still exit-zero when
-        the exception is cleaner to return than ad-hoc integer values.
-        """
-
-        @wraps(func)
-        def wrapped(*args, **kwargs):
-            try:
-                func(*args, **kwargs)
-            except DeclarePIDsExceptionNonCritical as err:
-                return err.exit_code
-
-        return wrapped
 
     def _fixup_path_input_by_user(self, path):
         """Fix-up paths submitted by a user, e.g. in custom structmap examples

--- a/src/MCPClient/lib/clientScripts/pid_declaration.py
+++ b/src/MCPClient/lib/clientScripts/pid_declaration.py
@@ -36,6 +36,7 @@ class DeclarePIDsExceptionNonCritical(Exception):
 
     exit_code = 0
 
+
 def exit_on_known_exception(func):
     """Decorator to allows us to raise an exception but still exit-zero when
     the exception is cleaner to return than ad-hoc integer values.

--- a/src/MCPClient/lib/settings/common.py
+++ b/src/MCPClient/lib/settings/common.py
@@ -350,7 +350,7 @@ LOGGING = {
 
 if os.path.isfile(LOGGING_CONFIG_FILE):
     with open(LOGGING_CONFIG_FILE) as f:
-        LOGGING = logging.config.dictConfig(json.load(f))
+        logging.config.dictConfig(json.load(f))
 else:
     logging.config.dictConfig(LOGGING)
 

--- a/src/MCPServer/lib/settings/common.py
+++ b/src/MCPServer/lib/settings/common.py
@@ -246,7 +246,7 @@ LOGGING = {
 
 if os.path.isfile(LOGGING_CONFIG_FILE):
     with open(LOGGING_CONFIG_FILE) as f:
-        LOGGING = logging.config.dictConfig(json.load(f))
+        logging.config.dictConfig(json.load(f))
 else:
     logging.config.dictConfig(LOGGING)
 

--- a/src/archivematicaCommon/lib/bindpid.py
+++ b/src/archivematicaCommon/lib/bindpid.py
@@ -135,12 +135,9 @@ import argparse
 import configparser
 import os
 
-try:
-    from jinja2 import Template
-except ImportError:
-    from django.template import Context
-    from django.template import Template
 import requests
+from django.template import Context
+from django.template import Template
 
 # Parameters required when requesting the binding of a handle PID.
 REQ_PARAMS = (

--- a/src/archivematicaCommon/lib/dbconns.py
+++ b/src/archivematicaCommon/lib/dbconns.py
@@ -21,6 +21,7 @@ import logging
 import threading
 import traceback
 from contextlib import ContextDecorator
+from typing import Type
 
 from django.conf import settings
 from django.db import close_old_connections
@@ -83,6 +84,8 @@ class CheckCloseConnectionsHandler(logging.Handler):
                 "\n".join(traceback.format_stack()),
             )
 
+
+auto_close_old_connections: Type[AutoCloseOldConnections]
 
 if settings.DEBUG:
     logger.debug("Using DEBUG auto_close_old_connections")

--- a/src/archivematicaCommon/lib/externals/xmltodict.py
+++ b/src/archivematicaCommon/lib/externals/xmltodict.py
@@ -145,8 +145,8 @@ if __name__ == "__main__":
     import marshal
     import sys
 
-    (item_depth,) = sys.argv[1:]
-    item_depth = int(item_depth)
+    (item_depth_argv,) = sys.argv[1:]
+    item_depth = int(item_depth_argv)
 
     def handle_item(item_type, item):
         marshal.dump((item_type, item), sys.stdout)

--- a/src/dashboard/frontend/tools/extract_features.py
+++ b/src/dashboard/frontend/tools/extract_features.py
@@ -43,4 +43,4 @@ if __name__ == "__main__":
     try:
         sys.exit(main(args.uuid, args.log_path, args.output))
     except Exception as e:
-        sys.exit(e)
+        sys.exit(str(e))

--- a/src/dashboard/src/components/accounts/forms.py
+++ b/src/dashboard/src/components/accounts/forms.py
@@ -15,8 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 from django import forms
-from django.contrib.auth.forms import UserChangeForm
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import UserChangeForm as DjangoUserChangeForm
+from django.contrib.auth.forms import UserCreationForm as DjangoUserCreationForm
 from django.contrib.auth.models import User
 from django.contrib.auth.password_validation import password_validators_help_text_html
 from django.contrib.auth.password_validation import validate_password
@@ -25,7 +25,7 @@ from django.utils.translation import gettext as _
 from main.models import UserProfile
 
 
-class UserCreationForm(UserCreationForm):
+class UserCreationForm(DjangoUserCreationForm):
     email = forms.EmailField(required=True)
     is_superuser = forms.BooleanField(label="Administrator", required=False)
 
@@ -68,7 +68,7 @@ class UserCreationForm(UserCreationForm):
                 self.add_error("password1", error)
 
 
-class UserChangeForm(UserChangeForm):
+class UserChangeForm(DjangoUserChangeForm):
     error_messages = {
         "password_mismatch": _(
             "The two password fields didn’t match. Enter the same password as before, for verification."

--- a/src/dashboard/src/components/administration/migrations/0001_initial.py
+++ b/src/dashboard/src/components/administration/migrations/0001_initial.py
@@ -1,5 +1,6 @@
 import uuid
 from typing import List
+from typing import Tuple
 
 import main.models
 from django.db import migrations
@@ -7,7 +8,7 @@ from django.db import models
 
 
 class Migration(migrations.Migration):
-    dependencies: List[str] = []
+    dependencies: List[Tuple[str, str]] = []
 
     operations = [
         migrations.CreateModel(

--- a/src/dashboard/src/components/administration/migrations/0001_initial.py
+++ b/src/dashboard/src/components/administration/migrations/0001_initial.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import List
 
 import main.models
 from django.db import migrations
@@ -6,7 +7,7 @@ from django.db import models
 
 
 class Migration(migrations.Migration):
-    dependencies = []
+    dependencies: List[str] = []
 
     operations = [
         migrations.CreateModel(

--- a/src/dashboard/src/fpr/management/commands/import_pronom_ids.py
+++ b/src/dashboard/src/fpr/management/commands/import_pronom_ids.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import uuid
+from typing import Dict
 
 from django.core.management.base import BaseCommand
 from django.db import connection
@@ -14,7 +15,7 @@ from lxml import etree
 # Introduced in fpr/migrations/0035_python3_compatibility.py
 FILE_BY_EXTENSION_CMD_UUID = "8546b624-7894-4201-8df6-f239d5e0d5ba"
 
-archivematica_formats = {}
+archivematica_formats: Dict[str, Format] = {}
 unknown_format_group = FormatGroup.objects.get(description="Unknown")
 file_by_extension = IDCommand.objects.get(uuid=FILE_BY_EXTENSION_CMD_UUID)
 

--- a/src/dashboard/src/fpr/migrations/0001_initial.py
+++ b/src/dashboard/src/fpr/migrations/0001_initial.py
@@ -1,4 +1,6 @@
 import uuid
+from typing import List
+from typing import Tuple
 
 import autoslug.fields
 import main.models
@@ -7,7 +9,7 @@ from django.db import models
 
 
 class Migration(migrations.Migration):
-    dependencies = []
+    dependencies: List[Tuple[str, str]] = []
 
     operations = [
         migrations.CreateModel(

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -18,6 +18,9 @@ import json
 import logging.config
 import os
 from io import StringIO
+from typing import Any
+from typing import Dict
+from typing import List
 
 import email_settings
 from appconfig import Config
@@ -369,7 +372,7 @@ STORAGES = {
     },
 }
 
-TEMPLATES = [
+TEMPLATES: List[Dict[str, Any]] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [os.path.join(BASE_PATH, "templates")],

--- a/src/dashboard/src/settings/base.py
+++ b/src/dashboard/src/settings/base.py
@@ -493,7 +493,7 @@ LOGGING = {
 
 if os.path.isfile(LOGGING_CONFIG_FILE):
     with open(LOGGING_CONFIG_FILE) as f:
-        LOGGING = logging.config.dictConfig(json.load(f))
+        logging.config.dictConfig(json.load(f))
 else:
     logging.config.dictConfig(LOGGING)
 

--- a/src/dashboard/src/settings/components/ldap_auth.py
+++ b/src/dashboard/src/settings/components/ldap_auth.py
@@ -95,7 +95,7 @@ if environ.get("AUTH_LDAP_TLS_KEYFILE", None):
         "AUTH_LDAP_TLS_KEYFILE"
     )
 if environ.get("AUTH_LDAP_TLS_REQUIRE_CERT", None):
-    require_cert = environ.get("AUTH_LDAP_TLS_REQUIRE_CERT").lower()
+    require_cert = environ.get("AUTH_LDAP_TLS_REQUIRE_CERT", "").lower()
     if require_cert == "never":
         AUTH_LDAP_GLOBAL_OPTIONS[ldap.OPT_X_TLS_REQUIRE_CERT] = ldap.OPT_X_TLS_NEVER
     elif require_cert == "allow":

--- a/tests/MCPClient/test_create_aip_mets.py
+++ b/tests/MCPClient/test_create_aip_mets.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from typing import List
 
 import archivematicaCreateMETSMetadataCSV
 import archivematicaCreateMETSRights
@@ -26,7 +27,7 @@ THIS_DIR = pathlib.Path(__file__).parent
 class TestNormativeStructMap(TempDirMixin, TestCase):
     """Test creation of normative structMap."""
 
-    fixture_files = []
+    fixture_files: List[str] = []
     fixtures = [os.path.join(THIS_DIR, "fixtures", p) for p in fixture_files]
 
     def setUp(self):


### PR DESCRIPTION
[Start small](https://mypy.readthedocs.io/en/stable/existing_code.html#start-small) recommends to add the type checker and just make it run. Then type annotate existing code gradually.

This represents that first step by introducing `mypy` in the `pre-commit` configuration and fixing the initial linting errors.

Co-authored-by: Dhwani Patel <dpatel@artefactual.com>