### PR TITLE
Fix the ReplacementDict.to_gnu_options method

### DIFF
--- a/src/MCPClient/lib/clientScripts/transcribe_file.py
+++ b/src/MCPClient/lib/clientScripts/transcribe_file.py
@@ -143,7 +143,7 @@ def main(job, task_uuid, file_uuid):
             (script,) = rd.replace(script)
             args = []
         else:
-            args = rd.to_gnu_options
+            args = rd.to_gnu_options()
 
         exitstatus, stdout, stderr = executeOrRun(
             rule.command.script_type, script, arguments=args, capture_output=True

--- a/src/archivematicaCommon/lib/dicts.py
+++ b/src/archivematicaCommon/lib/dicts.py
@@ -215,9 +215,18 @@ class ReplacementDict(dict):
         """
         args = []
         for key, value in self.items():
-            optname = re.sub(r"([A-Z]+)", r"-\1", key[1:-1]).lower()
-            opt = f"--{optname}={value}"
-            args.append(opt)
+            # Break the replacement dict key and add a dash between the terms, e.g. "fileUUID" -> "file-uuid".
+            #
+            # The inner regex prepends sequences of uppercase letters with a space. Then the outer regex does
+            # the same to uppercase letters followed by a sequence of lowercase letters,
+            # e.g. "SIPLogsDirectory" -> " SIP Logs  Directory".
+            #
+            # Finally, split them all and add dashes between them.
+            terms = re.sub(
+                "([A-Z][a-z]+)", r" \1", re.sub("([A-Z]+)", r" \1", key[1:-1])
+            ).split()
+            optname = "-".join(terms).lower()
+            args.append(f"--{optname}={value}")
 
         return args
 

--- a/tests/MCPClient/test_transcribe_file.py
+++ b/tests/MCPClient/test_transcribe_file.py
@@ -225,7 +225,7 @@ def test_main_if_fprule_is_disabled(
 
 @pytest.mark.django_db
 @mock.patch("transcribe_file.executeOrRun")
-def test_main_if_command_is_python_script(
+def test_main_if_command_is_not_bash_script(
     _execute_or_run,
     fpcommand,
     sip_file,
@@ -233,11 +233,7 @@ def test_main_if_command_is_python_script(
     fprule_transcription,
     file_format_version,
 ):
-    _execute_or_run.return_value = (
-        0,
-        fpcommand.command,
-        "",
-    )
+    _execute_or_run.return_value = (0, fpcommand.command, "")
     job = mock.Mock(spec=Job)
 
     result = transcribe_file.main(job, task_uuid=task.taskuuid, file_uuid=sip_file.uuid)
@@ -249,13 +245,13 @@ def test_main_if_command_is_python_script(
     ]
     assert job.write_output.mock_calls == [mock.call(fpcommand.command)]
 
-    # executeOrRun is called once
+    # executeOrRun is called once.
     transcribe_file.executeOrRun.assert_called_once()
 
-    # Get the call to executeOrRun
+    # Get the call to executeOrRun.
     execute_or_run_call = transcribe_file.executeOrRun.mock_calls[0]
     call_kwargs = execute_or_run_call[-1]
 
-    # Ensure the arguments passed are list of strings
+    # Ensure the arguments passed is a list.
     execute_or_run_args = call_kwargs["arguments"]
     assert isinstance(execute_or_run_args, list)

--- a/tests/archivematicaCommon/test_dicts.py
+++ b/tests/archivematicaCommon/test_dicts.py
@@ -123,6 +123,31 @@ def test_replacementdict_model_constructor_file_only(FILE):
     assert rd["%fileGrpUse%"] == FILE.filegrpuse
 
 
-def test_replacementdict_options():
-    d = ReplacementDict({"%relativeLocation%": "bar"})
-    assert d.to_gnu_options() == ["--relative-location=bar"]
+@pytest.mark.parametrize(
+    "replacementdict_key, regex_key_value",
+    [
+        ("%relativeLocation%", "--relative-location=bar"),
+        ("%SIPUUID%", "--sipuuid=bar"),
+        ("%SIPName%", "--sip-name=bar"),
+        ("%fileUUID%", "--file-uuid=bar"),
+        ("%SIPDirectoryBasename%", "--sip-directory-basename=bar"),
+        ("%SIPLogsDirectory%", "--sip-logs-directory=bar"),
+        ("%sipLogs%", "--sip-logs=bar"),
+        ("%outputLocation%", "--output-location=bar"),
+        ("%TransferDirectory%", "--transfer-directory=bar"),
+    ],
+    ids=[
+        "relative-location",
+        "sipuuid",
+        "sipname",
+        "fileuuid",
+        "sip-directory-basename",
+        "sip-logs-directory",
+        "sip-logs",
+        "output-location",
+        "transfer-directory",
+    ],
+)
+def test_replacementdict_options(replacementdict_key, regex_key_value):
+    d = ReplacementDict({replacementdict_key: "bar"})
+    assert d.to_gnu_options() == [regex_key_value]


### PR DESCRIPTION
This PR fixes two issues related to ReplacementDict method `to_gnu_options`.

1) MCPClient/transcribe_file.py
    - Make `to_gnu_options` as callable method.
    - Create a test that verifies the arguments passed are a list of strings. 
    
2) archivematicaCommon/dicts.py
    - Fix the arguments like `---sipuuid` of ReplacementDict keys. The change into regex adds a dash between sequences of uppercase letters.
    - Create a test to cover this change.