### PR TITLE
Reuse MCPClient fixtures

### DIFF
--- a/tests/MCPClient/conftest.py
+++ b/tests/MCPClient/conftest.py
@@ -3,6 +3,7 @@ import pathlib
 import pytest
 from client.job import Job
 from django.utils import timezone
+from fpr import models as fprmodels
 from main import models
 
 
@@ -28,11 +29,6 @@ def mcp_job():
     return Job("stub", "stub", [])
 
 
-@pytest.fixture
-def job():
-    return models.Job.objects.create(createdtime=timezone.now())
-
-
 @pytest.fixture()
 def user():
     return models.User.objects.create(
@@ -45,6 +41,16 @@ def user():
         is_staff=True,
         email="keladry@mindelan.com",
     )
+
+
+@pytest.fixture
+def job():
+    return models.Job.objects.create(createdtime=timezone.now())
+
+
+@pytest.fixture
+def task(job):
+    return models.Task.objects.create(job=job, createdtime=timezone.now())
 
 
 @pytest.fixture
@@ -62,3 +68,152 @@ def transfer(user):
 @pytest.fixture
 def sip():
     return models.SIP.objects.create(currentpath=r"%SIPDirectory%", diruuids=True)
+
+
+@pytest.fixture
+def format_group():
+    return fprmodels.FormatGroup.objects.create()
+
+
+@pytest.fixture
+def format(format_group):
+    return fprmodels.Format.objects.create(group=format_group)
+
+
+@pytest.fixture
+def format_version(format):
+    return fprmodels.FormatVersion.objects.create(format=format)
+
+
+@pytest.fixture
+def fptool():
+    return fprmodels.FPTool.objects.create()
+
+
+@pytest.fixture
+def fpcommand(fptool, sip_file):
+    return fprmodels.FPCommand.objects.create(
+        tool=fptool, output_location=sip_file.currentlocation.decode()
+    )
+
+
+@pytest.fixture
+def fprule(fpcommand, format_version):
+    return fprmodels.FPRule.objects.create(command=fpcommand, format=format_version)
+
+
+@pytest.fixture()
+def fprule_characterization(fprule):
+    fprule.purpose = fprmodels.FPRule.CHARACTERIZATION
+    fprule.save()
+
+    return fprule
+
+
+@pytest.fixture
+def fprule_extraction(fprule):
+    fprule.purpose = fprmodels.FPRule.EXTRACTION
+    fprule.save()
+
+    return fprule
+
+
+@pytest.fixture
+def fprule_validation(fprule):
+    fprule.purpose = fprmodels.FPRule.VALIDATION
+    fprule.save()
+
+    return fprule
+
+
+@pytest.fixture
+def fprule_transcription(fprule):
+    fprule.purpose = fprmodels.FPRule.TRANSCRIPTION
+    fprule.save()
+
+    return fprule
+
+
+@pytest.fixture
+def fprule_preservation(fprule):
+    fprule.purpose = fprmodels.FPRule.PRESERVATION
+    fprule.save()
+
+    return fprule
+
+
+@pytest.fixture
+def transfer_file(transfer):
+    location = b"%transferDirectory%objects/file.mp3"
+    return models.File.objects.create(
+        transfer=transfer,
+        filegrpuse="original",
+        originallocation=location,
+        currentlocation=location,
+    )
+
+
+@pytest.fixture
+def sip_file(sip, transfer):
+    location = "objects/file.mp3"
+    return models.File.objects.create(
+        transfer=transfer,
+        sip=sip,
+        filegrpuse="original",
+        originallocation=f"%transferDirectory%{location}".encode(),
+        currentlocation=f"%SIPDirectory%{location}".encode(),
+    )
+
+
+@pytest.fixture
+def preservation_file(sip, transfer):
+    location = b"%SIPDirectory%objects/file.wav"
+    return models.File.objects.create(
+        transfer=transfer,
+        sip=sip,
+        filegrpuse="preservation",
+        originallocation=location,
+        currentlocation=location,
+    )
+
+
+@pytest.fixture
+def file_format_version(sip_file, format_version):
+    return models.FileFormatVersion.objects.create(
+        file_uuid=sip_file, format_version=format_version
+    )
+
+
+@pytest.fixture
+def shared_directory_path(tmp_path):
+    result = tmp_path / "sharedDirectory"
+    result.mkdir()
+
+    for directory in ["currentlyProcessing", "tmp"]:
+        (result / directory).mkdir()
+
+    return result
+
+
+@pytest.fixture
+def transfer_directory_path(tmp_path):
+    result = tmp_path / "transfer"
+    result.mkdir()
+
+    return result
+
+
+@pytest.fixture
+def sip_directory_path(tmp_path):
+    result = tmp_path / "sip"
+    result.mkdir()
+
+    return result
+
+
+@pytest.fixture
+def settings(settings, shared_directory_path):
+    settings.SHARED_DIRECTORY = f"{shared_directory_path}/"
+    settings.PROCESSING_DIRECTORY = f'{shared_directory_path / "currentlyProcessing"}/'
+
+    return settings

--- a/tests/MCPClient/test_archivematicaCreateMETSRights.py
+++ b/tests/MCPClient/test_archivematicaCreateMETSRights.py
@@ -1,5 +1,3 @@
-import uuid
-
 import archivematicaCreateMETSRights
 import pytest
 from create_mets_v2 import MetsState
@@ -8,19 +6,12 @@ from namespaces import NSMAP
 
 
 @pytest.fixture()
-def file_(db):
-    return models.File.objects.create(
-        uuid=uuid.uuid4(),
-    )
-
-
-@pytest.fixture()
-def rights_statement(db, file_):
+def rights_statement(db, sip_file):
     statement = models.RightsStatement.objects.create(
         metadataappliestotype=models.MetadataAppliesToType.objects.get(
             id=models.MetadataAppliesToType.FILE_TYPE
         ),
-        metadataappliestoidentifier=file_.uuid,
+        metadataappliestoidentifier=sip_file.uuid,
         rightsbasis="Copyright",
     )
     models.RightsStatementCopyright.objects.create(
@@ -33,14 +24,14 @@ def rights_statement(db, file_):
 def test_archivematicaGetRights_with_non_ascii_copyright_jurisdiction(
     db,
     mcp_job,
-    file_,
+    sip_file,
     rights_statement,
 ):
     metadataAppliesToList = [
-        (file_.uuid, models.MetadataAppliesToType.FILE_TYPE),
+        (sip_file.uuid, models.MetadataAppliesToType.FILE_TYPE),
     ]
     result = archivematicaCreateMETSRights.archivematicaGetRights(
-        mcp_job, metadataAppliesToList, str(file_.uuid), MetsState()
+        mcp_job, metadataAppliesToList, str(sip_file.uuid), MetsState()
     )
     assert len(result) == 1
     element = result[0]

--- a/tests/MCPClient/test_archivematicaCreateMETSRightsDspaceMDRef.py
+++ b/tests/MCPClient/test_archivematicaCreateMETSRightsDspaceMDRef.py
@@ -11,17 +11,11 @@ from create_mets_v2 import MetsState
 from main import models
 
 
-@pytest.mark.django_db
 @pytest.fixture
-def transfer_data(tmp_path):
+def transfer_data(transfer, transfer_directory_path):
     fixtures_dir = pathlib.Path(__file__).parent / "fixtures" / "dspace"
 
-    transfer_dir = tmp_path / "transfer"
-    transfer_dir.mkdir()
-
-    transfer = models.Transfer.objects.create(currentlocation=transfer_dir)
-
-    objects_dir = transfer_dir / "objects"
+    objects_dir = transfer_directory_path / "objects"
     objects_dir.mkdir()
 
     # Add a DSpace item with a PDF and a METS file.
@@ -34,7 +28,7 @@ def transfer_data(tmp_path):
 
     item1_file = models.File.objects.create(
         transfer=transfer,
-        currentlocation=f"%SIPDirectory%{item1_path.relative_to(transfer_dir)}".encode(),
+        currentlocation=f"%SIPDirectory%{item1_path.relative_to(transfer_directory_path)}".encode(),
     )
 
     item1_mets_path = item1_dir / "mets.xml"
@@ -43,7 +37,7 @@ def transfer_data(tmp_path):
 
     item1_mets_file = models.File.objects.create(
         transfer=transfer,
-        currentlocation=f"%SIPDirectory%{item1_mets_path.relative_to(transfer_dir)}".encode(),
+        currentlocation=f"%SIPDirectory%{item1_mets_path.relative_to(transfer_directory_path)}".encode(),
     )
 
     # Add a second DSpace item with a PDF and a METS file.
@@ -56,7 +50,7 @@ def transfer_data(tmp_path):
 
     item2_file = models.File.objects.create(
         transfer=transfer,
-        currentlocation=f"%SIPDirectory%{item2_path.relative_to(transfer_dir)}".encode(),
+        currentlocation=f"%SIPDirectory%{item2_path.relative_to(transfer_directory_path)}".encode(),
     )
 
     item2_mets_path = item2_dir / "mets.xml"
@@ -65,7 +59,7 @@ def transfer_data(tmp_path):
 
     item2_mets_file = models.File.objects.create(
         transfer=transfer,
-        currentlocation=f"%SIPDirectory%{item2_mets_path.relative_to(transfer_dir)}".encode(),
+        currentlocation=f"%SIPDirectory%{item2_mets_path.relative_to(transfer_directory_path)}".encode(),
     )
 
     return {
@@ -77,7 +71,7 @@ def transfer_data(tmp_path):
         "item2_file": item2_file,
         "item2_mets_file": item2_mets_file,
         "item2_mets_path": item2_mets_path,
-        "transfer_dir": transfer_dir,
+        "transfer_dir": transfer_directory_path,
         "transfer": transfer,
     }
 

--- a/tests/MCPClient/test_assign_file_uuids.py
+++ b/tests/MCPClient/test_assign_file_uuids.py
@@ -7,26 +7,23 @@ from main import models
 
 
 @pytest.fixture
-def sip_dir(tmp_path):
-    sip_dir = tmp_path / "dir"
-    sip_dir.mkdir()
-
+def sip_directory_path(sip_directory_path):
     # Create a directory to test subdirectory filtering.
-    contents_dir = sip_dir / "contents"
+    contents_dir = sip_directory_path / "contents"
     contents_dir.mkdir()
     (contents_dir / "file-in.txt").touch()
 
     # Create a file outside the contents directory.
-    (sip_dir / "file-out.txt").touch()
+    (sip_directory_path / "file-out.txt").touch()
 
     # Create a directory to represent a reingest.
-    (sip_dir / "reingest").mkdir()
+    (sip_directory_path / "reingest").mkdir()
 
-    return sip_dir
+    return sip_directory_path
 
 
 @pytest.mark.django_db
-def test_call_creates_transfer_files_and_events(mocker, sip_dir, transfer):
+def test_call_creates_transfer_files_and_events(mocker, sip_directory_path, transfer):
     job = mocker.MagicMock(
         spec=Job,
         args=[
@@ -34,7 +31,7 @@ def test_call_creates_transfer_files_and_events(mocker, sip_dir, transfer):
             "--transferUUID",
             str(transfer.uuid),
             "--sipDirectory",
-            str(sip_dir),
+            str(sip_directory_path),
             "--filterSubdir",
             "contents",
         ],
@@ -87,15 +84,15 @@ def test_call_validates_job_arguments(mocker, job_arguments):
 
 
 @pytest.mark.django_db
-def test_call_updates_transfer_file_on_reingest(mocker, sip_dir, transfer):
+def test_call_updates_transfer_file_on_reingest(mocker, sip_directory_path, transfer):
     # Fake METS parsing and return static file information.
     mocker.patch("metsrw.METSDocument.fromfile")
     mocker.patch("assign_file_uuids.find_mets_file")
     file_info = {
         "uuid": str(uuid.uuid4()),
         "filegrpuse": "original",
-        "original_path": str(sip_dir / "contents" / "file-in.txt"),
-        "current_path": str(sip_dir / "reingest" / "file-in.txt"),
+        "original_path": str(sip_directory_path / "contents" / "file-in.txt"),
+        "current_path": str(sip_directory_path / "reingest" / "file-in.txt"),
     }
     mocker.patch("assign_file_uuids.get_file_info_from_mets", return_value=file_info)
 
@@ -106,7 +103,7 @@ def test_call_updates_transfer_file_on_reingest(mocker, sip_dir, transfer):
             "--transferUUID",
             str(transfer.uuid),
             "--sipDirectory",
-            str(sip_dir),
+            str(sip_directory_path),
             "--filterSubdir",
             "contents",
         ],

--- a/tests/MCPClient/test_assign_uuids_to_directories.py
+++ b/tests/MCPClient/test_assign_uuids_to_directories.py
@@ -5,33 +5,30 @@ from main import models
 
 
 @pytest.fixture
-def transfer_dir(tmp_path):
-    transfer_dir = tmp_path / "dir"
-    transfer_dir.mkdir()
-
+def transfer_directory_path(transfer_directory_path):
     # Create a directory with contents.
-    contents_dir = transfer_dir / "contents"
+    contents_dir = transfer_directory_path / "contents"
     contents_dir.mkdir()
     (contents_dir / "file-in.txt").touch()
 
     # Create a file outside the contents directory.
-    (transfer_dir / "file-out.txt").touch()
+    (transfer_directory_path / "file-out.txt").touch()
 
     # Create a directory to represent a reingest.
-    (transfer_dir / "reingest").mkdir()
+    (transfer_directory_path / "reingest").mkdir()
 
-    return transfer_dir
+    return transfer_directory_path
 
 
 @pytest.mark.django_db
-def test_main(mocker, transfer, transfer_dir):
+def test_main(mocker, transfer, transfer_directory_path):
     job = mocker.Mock(spec=Job)
     include_dirs = True
 
     # Verify there are no directories.
     assert models.Directory.objects.count() == 0
 
-    result = main(job, str(transfer_dir), transfer.uuid, include_dirs)
+    result = main(job, str(transfer_directory_path), transfer.uuid, include_dirs)
 
     assert result == 0
 

--- a/tests/MCPClient/test_check_for_access_directory.py
+++ b/tests/MCPClient/test_check_for_access_directory.py
@@ -2,20 +2,14 @@ import check_for_access_directory
 import pytest
 from client.job import Job
 from django.utils import timezone
-from main.models import SIP
 from main.models import Event
 from main.models import File
 
 
 @pytest.mark.django_db
-def test_main(mocker, tmp_path):
+def test_main(mocker, tmp_path, sip, sip_directory_path):
     job = mocker.Mock(spec=Job)
     date = timezone.now()
-
-    sip_directory = tmp_path / "sip"
-    sip_directory.mkdir()
-
-    sip = SIP.objects.create(currentpath=sip_directory.as_posix())
 
     access_directory = tmp_path / "access"
     access_directory.mkdir()
@@ -82,7 +76,7 @@ def test_main(mocker, tmp_path):
 
     result = check_for_access_directory.main(
         job,
-        sip_directory.as_posix(),
+        sip_directory_path.as_posix(),
         access_directory.as_posix(),
         objects_directory.as_posix(),
         dip_directory.as_posix(),

--- a/tests/MCPClient/test_create_transfer_mets.py
+++ b/tests/MCPClient/test_create_transfer_mets.py
@@ -12,12 +12,6 @@ from create_transfer_mets import file_obj_to_premis
 from create_transfer_mets import rights_to_premis
 from create_transfer_mets import write_mets
 from django.db.models import prefetch_related_objects
-from fpr.models import Format
-from fpr.models import FormatGroup
-from fpr.models import FormatVersion
-from fpr.models import FPCommand
-from fpr.models import FPRule
-from fpr.models import FPTool
 from lxml import etree
 from main.models import Agent
 from main.models import DashboardSetting
@@ -145,26 +139,10 @@ def event(request, db, file_obj):
 
 
 @pytest.fixture()
-def fprule(db):
-    format_group = FormatGroup.objects.create(description="group")
-    format = Format.objects.create(description="format", group=format_group)
-    format_version = FormatVersion.objects.create(
-        format=format, version="1.0", description="Version 1.0"
-    )
-    tool = FPTool.objects.create(description="tool")
-    command = FPCommand.objects.create(tool=tool, description="command")
-    return FPRule.objects.create(
-        purpose=FPRule.CHARACTERIZATION,
-        command=command,
-        format=format_version,
-    )
-
-
-@pytest.fixture()
-def fpcommand_output(db, fprule, file_obj):
+def fpcommand_output(db, fprule_characterization, file_obj):
     return FPCommandOutput.objects.create(
         file=file_obj,
-        rule=fprule,
+        rule=fprule_characterization,
         content='<?xml version="1.0" encoding="UTF-8"?><hello>World</hello>',
     )
 

--- a/tests/MCPClient/test_has_packages.py
+++ b/tests/MCPClient/test_has_packages.py
@@ -1,56 +1,15 @@
 import has_packages
 import pytest
 from client.job import Job
-from fpr.models import Format
-from fpr.models import FormatGroup
-from fpr.models import FormatVersion
-from fpr.models import FPCommand
-from fpr.models import FPRule
-from fpr.models import FPTool
 from main.models import Event
 from main.models import File
 from main.models import FileFormatVersion
 
 
 @pytest.fixture
-def format_version():
-    format_group = FormatGroup.objects.create(description="a format group")
-    format = Format.objects.create(description="a format", group=format_group)
-
-    return FormatVersion.objects.create(description="a format 1.0", format=format)
-
-
-@pytest.fixture
-def command():
-    tool = FPTool.objects.create(description="a tool")
-
-    return FPCommand.objects.create(
-        description="a command",
-        script_type="pythonScript",
-        command="script.py",
-        tool=tool,
-    )
-
-
-@pytest.fixture
-def extract_fprule(format_version, command):
-    return FPRule.objects.create(
-        purpose=FPRule.EXTRACTION, format=format_version, command=command
-    )
-
-
-@pytest.fixture
-def transfer_directory(tmp_path):
-    result = tmp_path / "transfer"
-    result.mkdir()
-
-    return result
-
-
-@pytest.fixture
-def compressed_file(transfer, transfer_directory, format_version):
+def compressed_file(transfer, transfer_directory_path, format_version):
     # Simulate a compressed file being extracted to a directory with the same name.
-    d = transfer_directory / "compressed.zip"
+    d = transfer_directory_path / "compressed.zip"
     d.mkdir()
 
     # Place an extracted file in it.
@@ -59,10 +18,10 @@ def compressed_file(transfer, transfer_directory, format_version):
 
     # Create File models for the compressed and extracted files.
     d_location = (
-        f"{transfer.currentlocation}{d.relative_to(transfer_directory)}".encode()
+        f"{transfer.currentlocation}{d.relative_to(transfer_directory_path)}".encode()
     )
     f_location = (
-        f"{transfer.currentlocation}{f.relative_to(transfer_directory)}".encode()
+        f"{transfer.currentlocation}{f.relative_to(transfer_directory_path)}".encode()
     )
     result = File.objects.create(
         transfer=transfer, originallocation=d_location, currentlocation=d_location
@@ -79,8 +38,8 @@ def compressed_file(transfer, transfer_directory, format_version):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "rule_purpose,expected_exit_code",
-    [(FPRule.EXTRACTION, 0), (FPRule.CHARACTERIZATION, 1)],
+    "fprule_fixture,expected_exit_code",
+    [("fprule_extraction", 0), ("fprule_characterization", 1)],
     ids=["extract_rule", "not_extract_rule"],
 )
 def test_main_detects_file_is_extractable_based_on_extract_fpr_rule(
@@ -88,12 +47,13 @@ def test_main_detects_file_is_extractable_based_on_extract_fpr_rule(
     transfer,
     compressed_file,
     format_version,
-    command,
-    rule_purpose,
+    fpcommand,
+    fprule_fixture,
     expected_exit_code,
+    request,
 ):
     job = mocker.Mock(spec=Job)
-    FPRule.objects.create(purpose=rule_purpose, format=format_version, command=command)
+    request.getfixturevalue(fprule_fixture)
 
     result = has_packages.main(job, str(transfer.uuid))
 
@@ -111,8 +71,8 @@ def test_main_detects_file_was_already_extracted_from_unpacking_event(
     transfer,
     compressed_file,
     format_version,
-    command,
-    extract_fprule,
+    fpcommand,
+    fprule_extraction,
     event_type,
     expected_exit_code,
 ):

--- a/tests/MCPClient/test_load_labels_from_csv.py
+++ b/tests/MCPClient/test_load_labels_from_csv.py
@@ -34,20 +34,11 @@ def test_load_labels_from_csv_fails_if_file_labels_csv_does_not_exist(
 
 
 @pytest.fixture()
-def file(transfer):
-    location = f"{OBJECTS_DIRECTORY}/file.txt".encode()
-
-    return models.File.objects.create(
-        transfer=transfer, originallocation=location, currentlocation=location
-    )
-
-
-@pytest.fixture()
-def file_labels_csv(tmp_path, file):
+def file_labels_csv(tmp_path, transfer_file):
     result = tmp_path / "file_labels.csv"
-    original_file_path = pathlib.Path(file.originallocation.decode()).relative_to(
-        OBJECTS_DIRECTORY
-    )
+    original_file_path = pathlib.Path(
+        transfer_file.originallocation.decode()
+    ).relative_to(OBJECTS_DIRECTORY)
     result.write_text(f"{original_file_path},{LABEL}")
 
     return result
@@ -55,7 +46,7 @@ def file_labels_csv(tmp_path, file):
 
 @pytest.mark.django_db
 def test_load_labels_from_csv_sets_label_for_files_in_csv(
-    transfer, file_labels_csv, file
+    transfer, file_labels_csv, transfer_file
 ):
     job = mock.Mock(
         args=["load_labels_from_csv.py", str(transfer.uuid), str(file_labels_csv)],
@@ -67,7 +58,9 @@ def test_load_labels_from_csv_sets_label_for_files_in_csv(
 
     assert (
         models.File.objects.filter(
-            transfer=transfer, originallocation=file.originallocation, label=LABEL
+            transfer=transfer,
+            originallocation=transfer_file.originallocation,
+            label=LABEL,
         ).count()
         == 1
     )

--- a/tests/MCPClient/test_parse_external_mets.py
+++ b/tests/MCPClient/test_parse_external_mets.py
@@ -9,40 +9,47 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 @pytest.fixture
-def transfer_dir(tmp_path):
-    (tmp_path / "objects").mkdir()
-    (tmp_path / "metadata").mkdir()
+def transfer_directory_path(transfer_directory_path):
+    (transfer_directory_path / "objects").mkdir()
+    (transfer_directory_path / "metadata").mkdir()
 
     shutil.copy(
         os.path.join(THIS_DIR, "fixtures", "mets_sip_dc.xml"),
-        str(tmp_path / "metadata/METS.a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3.xml"),
+        str(
+            transfer_directory_path
+            / "metadata/METS.a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3.xml"
+        ),
     )
 
-    return tmp_path
+    return transfer_directory_path
 
 
-def test_mets_not_found(mcp_job, transfer_dir):
-    (transfer_dir / "metadata/METS.a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3.xml").unlink()
+def test_mets_not_found(mcp_job, transfer_directory_path):
+    (
+        transfer_directory_path
+        / "metadata/METS.a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3.xml"
+    ).unlink()
 
     exit_code = parse_external_mets.main(
-        mcp_job, "a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3", str(transfer_dir)
+        mcp_job, "a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3", str(transfer_directory_path)
     )
     error = mcp_job.error
 
     # It does not fail but the error is recorded.
     assert error == "[Errno 17] No METS file found in {}\n".format(
-        transfer_dir / "metadata"
+        transfer_directory_path / "metadata"
     )
     assert exit_code == 0
 
 
-def test_mets_cannot_parse(mcp_job, transfer_dir):
+def test_mets_cannot_parse(mcp_job, transfer_directory_path):
     (
-        transfer_dir / "metadata/METS.a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3.xml"
+        transfer_directory_path
+        / "metadata/METS.a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3.xml"
     ).write_text("!!! no xml")
 
     exit_code = parse_external_mets.main(
-        mcp_job, "a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3", str(transfer_dir)
+        mcp_job, "a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3", str(transfer_directory_path)
     )
     error = str(mcp_job.output)
 
@@ -52,9 +59,9 @@ def test_mets_cannot_parse(mcp_job, transfer_dir):
     assert exit_code == 0
 
 
-def test_mets_is_parsed(db, mcp_job, transfer_dir):
+def test_mets_is_parsed(db, mcp_job, transfer_directory_path):
     exit_code = parse_external_mets.main(
-        mcp_job, "a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3", str(transfer_dir)
+        mcp_job, "a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3", str(transfer_directory_path)
     )
 
     dc_items = models.DublinCore.objects.filter(

--- a/tests/MCPClient/test_parse_mets_to_db.py
+++ b/tests/MCPClient/test_parse_mets_to_db.py
@@ -457,6 +457,10 @@ class TestParseFiles(TestCase):
     fixture_files = ["formats.json"]
     fixtures = [os.path.join(THIS_DIR, "fixtures", p) for p in fixture_files]
 
+    @pytest.fixture(autouse=True)
+    def set_sip_uuid(self, sip):
+        self.SIP_UUID = str(sip.uuid)
+
     def setUp(self):
         self.ORIG_INFO = {
             "uuid": "ae8d4290-fe52-4954-b72a-0f591bee2e2f",
@@ -498,8 +502,6 @@ class TestParseFiles(TestCase):
             "derivation": None,
             "derivation_event": None,
         }
-        self.SIP_UUID = "8a0cac37-e446-4fa7-9e96-062bf07ccd04"
-        models.SIP.objects.create(uuid=self.SIP_UUID, sip_type="AIP-REIN")
 
     def test_parse_file_info(self):
         """

--- a/tests/MCPClient/test_pid_components.py
+++ b/tests/MCPClient/test_pid_components.py
@@ -218,17 +218,14 @@ def directories(transfer, sip):
 
 
 @pytest.fixture
-def data(db, sip, settings, transfer, files, directories):
-    return
-
-
-@pytest.fixture
 def pid_web_service(mocker):
     mocker.patch("requests.post", return_value=mocker.Mock(status_code=200))
 
 
 @pytest.mark.django_db
-def test_bind_pids_no_config(data, caplog, mcp_job):
+def test_bind_pids_no_config(
+    sip, settings, transfer, files, directories, caplog, mcp_job
+):
     """Test the output of the code without any args.
 
     In this instance, we want bind_pids to think that there is some
@@ -245,7 +242,9 @@ def test_bind_pids_no_config(data, caplog, mcp_job):
 
 
 @pytest.mark.django_db
-def test_bind_pids(data, sip, mocker, mcp_job, pid_web_service):
+def test_bind_pids(
+    sip, settings, transfer, files, directories, mocker, mcp_job, pid_web_service
+):
     """Test the bind_pids function end-to-end and ensure that the
     result is that which is anticipated.
 
@@ -307,7 +306,9 @@ def test_bind_pids(data, sip, mocker, mcp_job, pid_web_service):
 
 
 @pytest.mark.django_db
-def test_bind_pid_no_config(data, sip, caplog, mcp_job):
+def test_bind_pid_no_config(
+    sip, settings, transfer, files, directories, caplog, mcp_job
+):
     """Test the output of the code when bind_pids is set to True but there
     are no handle settings in the Dashboard. Conceivably then the dashboard
     settings could be in-between two states, complete and not-complete,
@@ -320,7 +321,9 @@ def test_bind_pid_no_config(data, sip, caplog, mcp_job):
 
 
 @pytest.mark.django_db
-def test_bind_pid(data, sip, mcp_job, pid_web_service):
+def test_bind_pid(
+    sip, settings, transfer, files, directories, mcp_job, pid_web_service
+):
     """Test the bind_pid function end-to-end and ensure that the
     result is that which is anticipated.
 
@@ -371,7 +374,9 @@ def test_bind_pid(data, sip, mcp_job, pid_web_service):
 
 
 @pytest.mark.django_db
-def test_bind_pid_no_settings(data, sip, caplog, mcp_job):
+def test_bind_pid_no_settings(
+    sip, settings, transfer, files, directories, caplog, mcp_job
+):
     """Test the output of the code when bind_pids is set to True but there
     are no handle settings in the Dashboard. Conceivably then the dashboard
     settings could be in-between two states, complete and not-complete,
@@ -389,7 +394,9 @@ def test_bind_pid_no_settings(data, sip, caplog, mcp_job):
 
 
 @pytest.mark.django_db
-def test_pid_declaration(data, sip, mocker, mcp_job, pid_web_service):
+def test_pid_declaration(
+    sip, settings, transfer, files, directories, mocker, mcp_job, pid_web_service
+):
     """Test that the overall functionality of the PID declaration functions
     work as expected.
     """
@@ -474,7 +481,9 @@ def test_pid_declaration(data, sip, mocker, mcp_job, pid_web_service):
 
 
 @pytest.mark.django_db
-def test_pid_declaration_exceptions(data, mocker, mcp_job):
+def test_pid_declaration_exceptions(
+    sip, settings, transfer, files, directories, mocker, mcp_job
+):
     """Ensure that the PID declaration feature exits when the JSOn cannot
     be loaded.
     """

--- a/tests/MCPClient/test_post_store_aip_hook.py
+++ b/tests/MCPClient/test_post_store_aip_hook.py
@@ -76,54 +76,26 @@ def test_dspace_handle_to_archivesspace(
 
 
 @pytest.fixture
-def shared_dir(tmp_path):
-    result = tmp_path / "sharedDirectory"
-    result.mkdir()
-    return result
-
-
-@pytest.fixture
-def processing_dir(shared_dir):
-    result = shared_dir / "currentlyProcessing"
-    result.mkdir()
-    return result
-
-
-@pytest.fixture
-def transfer(transfer, shared_dir, processing_dir):
-    transfer_location = processing_dir / "transfer"
+def transfer(transfer, shared_directory_path):
+    transfer_location = shared_directory_path / "currentlyProcessing" / "transfer"
     transfer_location.mkdir()
 
     transfer.currentlocation = (
-        f"%sharedPath%{transfer_location.relative_to(shared_dir)}"
+        f"%sharedPath%{transfer_location.relative_to(shared_directory_path)}"
     )
     transfer.save()
 
     return transfer
 
 
-@pytest.fixture
-def file_(db, sip, transfer):
-    return models.File.objects.create(sip=sip, transfer=transfer)
-
-
-@pytest.fixture
-def custom_settings(settings, shared_dir, processing_dir):
-    settings.SHARED_DIRECTORY = f"{shared_dir}/"
-    settings.PROCESSING_DIRECTORY = f"{processing_dir}/"
-    return settings
-
-
 def test_post_store_hook_deletes_transfer_directory(
-    db, sip, transfer, file_, custom_settings
+    db, sip, transfer, sip_file, settings
 ):
     job = mock.Mock(spec=Job)
 
     # The transfer directory exists before calling the delete function
     transfer_path = pathlib.Path(
-        transfer.currentlocation.replace(
-            "%sharedPath%", custom_settings.SHARED_DIRECTORY, 1
-        )
+        transfer.currentlocation.replace("%sharedPath%", settings.SHARED_DIRECTORY, 1)
     )
     assert transfer_path.exists()
 

--- a/tests/MCPClient/test_restructure_dip_for_content_dm_upload.py
+++ b/tests/MCPClient/test_restructure_dip_for_content_dm_upload.py
@@ -8,38 +8,44 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 @pytest.fixture
-def dip_directory(tmpdir):
+def dip_directory_path(tmp_path):
+    result = tmp_path / "dip"
+    result.mkdir()
+    (result / "objects").mkdir()
+
     shutil.copy(
         os.path.join(THIS_DIR, "fixtures", "mets_sip_dc.xml"),
-        str(tmpdir / "METS.a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3.xml"),
+        result / "METS.a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3.xml",
     )
-    (tmpdir / "objects").mkdir()
 
-    return tmpdir
+    return result
 
 
 @pytest.fixture
-def dip_directory_optional_dc_columns(tmpdir):
+def dip_directory_with_optional_dc_columns_path(tmp_path):
+    result = tmp_path / "dip"
+    result.mkdir()
+    (result / "objects").mkdir()
+
     shutil.copy(
         os.path.join(THIS_DIR, "fixtures", "mets_sip_dc_with_optional_columns.xml"),
-        str(tmpdir / "METS.a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3.xml"),
+        result / "METS.a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3.xml",
     )
-    (tmpdir / "objects").mkdir()
 
-    return tmpdir
+    return result
 
 
-def test_restructure_dip_for_content_dm_upload(mcp_job, dip_directory):
+def test_restructure_dip_for_content_dm_upload(mcp_job, dip_directory_path):
     mcp_job.args = (
         None,
         "--uuid=a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3",
-        f"--dipDir={dip_directory}",
+        f"--dipDir={dip_directory_path}",
     )
     jobs = [mcp_job]
 
     restructure_dip_for_content_dm_upload.call(jobs)
     csv_data = (
-        (dip_directory / "objects/compound.txt")
+        (dip_directory_path / "objects/compound.txt")
         .read_text(encoding="utf-8")
         .splitlines()
     )
@@ -57,18 +63,18 @@ def test_restructure_dip_for_content_dm_upload(mcp_job, dip_directory):
 
 
 def test_restructure_dip_for_content_dm_upload_with_optional_dc_columns(
-    mcp_job, dip_directory_optional_dc_columns
+    mcp_job, dip_directory_with_optional_dc_columns_path
 ):
     mcp_job.args = (
         None,
         "--uuid=a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3",
-        f"--dipDir={dip_directory_optional_dc_columns}",
+        f"--dipDir={dip_directory_with_optional_dc_columns_path}",
     )
     jobs = [mcp_job]
 
     restructure_dip_for_content_dm_upload.call(jobs)
     csv_data = (
-        (dip_directory_optional_dc_columns / "objects/compound.txt")
+        (dip_directory_with_optional_dc_columns_path / "objects/compound.txt")
         .read_text(encoding="utf-8")
         .splitlines()
     )

--- a/tests/MCPClient/test_upload_qubit.py
+++ b/tests/MCPClient/test_upload_qubit.py
@@ -8,11 +8,6 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 @pytest.fixture
-def file(sip, transfer):
-    return models.File.objects.create(sip=sip, transfer=transfer)
-
-
-@pytest.fixture
 def sip_job(job, sip, tmp_path):
     job_dir = tmp_path / "job"
     job_dir.mkdir()
@@ -62,7 +57,7 @@ def test_start_synchronously(db, mocker, mcp_job, sip, sip_job, access):
     assert access.target == "atom-description-id"
 
 
-def test_first_run(db, mocker, mcp_job, sip_job, sip, file):
+def test_first_run(db, mocker, mcp_job, sip_job, sip, sip_file):
     mocker.patch(
         "requests.request",
         return_value=mocker.Mock(

--- a/tests/MCPClient/test_validate_file.py
+++ b/tests/MCPClient/test_validate_file.py
@@ -1,78 +1,32 @@
+from unittest import mock
+
 import pytest
-from client.job import Job
-from fpr.models import Format
-from fpr.models import FormatGroup
-from fpr.models import FormatVersion
-from fpr.models import FPCommand
-from fpr.models import FPRule
-from fpr.models import FPTool
 from main.models import Event
-from main.models import File
-from main.models import FileFormatVersion
 from validate_file import main
 
 
-@pytest.fixture
-def file_obj(tmp_path, sip):
-    d = tmp_path / "dir"
-    d.mkdir()
-    txt_file = d / "file.txt"
-    txt_file.write_text("hello world")
-
-    return File.objects.create(
-        sip=sip, originallocation=txt_file, currentlocation=txt_file
-    )
-
-
-@pytest.fixture
-def format_version():
-    format_group = FormatGroup.objects.create(description="a format group")
-    format = Format.objects.create(description="a format", group=format_group)
-
-    return FormatVersion.objects.create(description="a format 1.0", format=format)
-
-
-@pytest.fixture
-def command():
-    tool = FPTool.objects.create(description="a tool")
-
-    return FPCommand.objects.create(
-        description="a command",
-        script_type="pythonScript",
-        command="script.py",
-        tool=tool,
-    )
-
-
-@pytest.fixture
-def fprule(format_version, command):
-    return FPRule.objects.create(
-        purpose=FPRule.VALIDATION, format=format_version, command=command
-    )
-
-
-@pytest.fixture
-def file_format_version(file_obj, format_version):
-    FileFormatVersion.objects.create(file_uuid=file_obj, format_version=format_version)
-
-
 @pytest.mark.django_db
+@mock.patch("validate_file.executeOrRun")
 def test_main(
-    mocker, sip, file_obj, format_version, fprule, command, file_format_version
+    execute_or_run,
+    sip,
+    sip_file,
+    format_version,
+    fprule_validation,
+    fpcommand,
+    file_format_version,
+    mcp_job,
 ):
     exit_status = 0
     stdout = '{"eventOutcomeInformation": "pass", "eventOutcomeDetailNote": "a note"}'
     stderr = ""
-    execute_or_run = mocker.patch(
-        "validate_file.executeOrRun", return_value=(exit_status, stdout, stderr)
-    )
-    job = mocker.Mock(spec=Job)
+    execute_or_run.return_value = (exit_status, stdout, stderr)
     file_type = "original"
 
     main(
-        job=job,
-        file_path=file_obj.currentlocation,
-        file_uuid=file_obj.uuid,
+        job=mcp_job,
+        file_path=sip_file.currentlocation,
+        file_uuid=sip_file.uuid,
         sip_uuid=sip.uuid,
         shared_path=sip.currentpath,
         file_type=file_type,
@@ -80,17 +34,17 @@ def test_main(
 
     # Check the executed script.
     execute_or_run.assert_called_once_with(
-        type=command.script_type,
-        text=command.command,
+        type=fpcommand.script_type,
+        text=fpcommand.command,
         printing=False,
-        arguments=[file_obj.currentlocation],
+        arguments=[sip_file.currentlocation],
     )
 
     # Verify a PREMIS validation event was created with the output of the
     # validation command.
     assert (
         Event.objects.filter(
-            file_uuid=file_obj.uuid,
+            file_uuid=sip_file.uuid,
             event_type="validation",
             event_outcome="pass",
             event_outcome_detail="a note",

--- a/tests/MCPClient/test_verify_checksum.py
+++ b/tests/MCPClient/test_verify_checksum.py
@@ -41,20 +41,6 @@ class TestHashsum:
     assert_exception_string = "Hashsum exception string returned is incorrect"
     assert_return_value = "Hashsum comparison returned something other than 1: {}"
 
-    @pytest.fixture
-    def file(self, transfer):
-        return File.objects.create(
-            checksumtype="sha256",
-            transfer=transfer,
-            filegrpuse="original",
-            checksum="f78615cd834f7fb84832177e73f13e3479f5b5b22ae7a9506c7fa0a14fd9df9e",
-            enteredsystem="2017-01-04T19:35:20Z",
-            modificationtime="2017-01-04T19:35:20Z",
-            originallocation=b"%transferDirectory%objects/has space/lion.svg",
-            currentlocation=b"%transferDirectory%objects/has space/lion.svg",
-            size=18324,
-        )
-
     @staticmethod
     def setup_hashsum(path, job):
         """Return a hashsum instance to calling functions and perform any
@@ -272,7 +258,7 @@ class TestHashsum:
         ), "Invalid version string decoded by Hashsum"
 
     @pytest.mark.django_db
-    def test_write_premis_event_to_db(self, transfer, file):
+    def test_write_premis_event_to_db(self, transfer, transfer_file):
         """Test that the microservice job connects to the database as
         anticipated, writes its data, and that data can then be retrieved.
         """
@@ -356,7 +342,7 @@ class TestHashsum:
         ), "No all algorithms written to PREMIS events"
 
     @pytest.mark.django_db
-    def test_get_file_obj_queryset(self, transfer, file):
+    def test_get_file_obj_queryset(self, transfer, transfer_file):
         """Test the retrieval and failure of the queryset used for creating
         events for all the file objects associated with the transfer checksums.
         """


### PR DESCRIPTION
This is a follow up to https://github.com/artefactual/archivematica/pull/1962 and extracts the remaining common `MCPClient` `pytest` fixtures to the `conftest.py` module.