### PR TITLE
Fix mypy hook in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         src/(MCPClient/MCPServer|dashboard)/osdeps/.*\.json
       )
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.1
+  rev: v0.5.6
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
@@ -46,7 +46,9 @@ repos:
   hooks:
     - id: validate-cff
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.10.1
+  rev: v1.11.1
   hooks:
   - id: mypy
-    additional_dependencies: [types-all]
+    additional_dependencies:
+    - types-requests
+    - types-python-dateutil

--- a/src/dashboard/src/fpr/south_migrations/0001_initial.py
+++ b/src/dashboard/src/fpr/south_migrations/0001_initial.py
@@ -1,3 +1,6 @@
+from typing import Any
+from typing import Dict
+
 from south.db import db
 from south.v2 import SchemaMigration
 
@@ -449,7 +452,7 @@ class Migration(SchemaMigration):
         # Deleting model 'FileIDsBySingleID'
         db.delete_table("FileIDsBySingleID")
 
-    models = {
+    models: Dict[str, Any] = {
         "fpr.agent": {
             "Meta": {"object_name": "Agent", "db_table": "u'Agent'"},
             "agentIdentifierType": (

--- a/src/dashboard/src/fpr/south_migrations/0002_api_v2.py
+++ b/src/dashboard/src/fpr/south_migrations/0002_api_v2.py
@@ -1,3 +1,6 @@
+from typing import Any
+from typing import Dict
+
 from south.db import db
 from south.v2 import SchemaMigration
 
@@ -549,7 +552,7 @@ class Migration(SchemaMigration):
             ),
         )
 
-    models = {
+    models: Dict[str, Any] = {
         "fpr.agent": {
             "Meta": {"object_name": "Agent", "db_table": "u'Agent'"},
             "agentIdentifierType": (


### PR DESCRIPTION
This updates the `pre-commit` configuration to list our typing dependencies explicitly in the `mypy` hook.

We were previously using `types-all` to indirectly import a lot of [`typeshed` stubs](https://github.com/python/typeshed/tree/main/stubs), but `types-pkg-resources` has been deprecated and [yanked from PyPI](https://pypi.org/project/types-pkg-resources/).