### PR TITLE
Add test for the extract_contents client script

### DIFF
--- a/src/MCPClient/lib/clientScripts/extract_contents.py
+++ b/src/MCPClient/lib/clientScripts/extract_contents.py
@@ -134,7 +134,7 @@ def main(job, transfer_uuid, sip_directory, date, task_uuid, delete=False):
 
     for file_ in files:
         try:
-            format_id = FileFormatVersion.objects.get(file_uuid=file_.uuid)
+            file_format_version = FileFormatVersion.objects.get(file_uuid=file_.uuid)
         # Can't do anything if the file wasn't identified in the previous step
         except Exception:
             job.pyprint(
@@ -144,7 +144,7 @@ def main(job, transfer_uuid, sip_directory, date, task_uuid, delete=False):
                 file=sys.stderr,
             )
             continue
-        if format_id.format_version is None:
+        if file_format_version.format_version is None:
             job.pyprint(
                 "Not extracting contents from",
                 os.path.basename(file_.currentlocation.decode()),
@@ -156,7 +156,7 @@ def main(job, transfer_uuid, sip_directory, date, task_uuid, delete=False):
         # commands
         try:
             command = FPCommand.active.get(
-                fprule__format=format_id.format_version,
+                fprule__format=file_format_version.format_version,
                 fprule__purpose="extract",
                 fprule__enabled=True,
             )

--- a/tests/MCPClient/conftest.py
+++ b/tests/MCPClient/conftest.py
@@ -91,10 +91,8 @@ def fptool():
 
 
 @pytest.fixture
-def fpcommand(fptool, sip_file):
-    return fprmodels.FPCommand.objects.create(
-        tool=fptool, output_location=sip_file.currentlocation.decode()
-    )
+def fpcommand(fptool):
+    return fprmodels.FPCommand.objects.create(tool=fptool)
 
 
 @pytest.fixture

--- a/tests/MCPClient/conftest.py
+++ b/tests/MCPClient/conftest.py
@@ -176,6 +176,13 @@ def preservation_file(sip, transfer):
 
 
 @pytest.fixture
+def transfer_file_format_version(transfer_file, format_version):
+    return models.FileFormatVersion.objects.create(
+        file_uuid=transfer_file, format_version=format_version
+    )
+
+
+@pytest.fixture
 def sip_file_format_version(sip_file, format_version):
     return models.FileFormatVersion.objects.create(
         file_uuid=sip_file, format_version=format_version

--- a/tests/MCPClient/conftest.py
+++ b/tests/MCPClient/conftest.py
@@ -178,7 +178,7 @@ def preservation_file(sip, transfer):
 
 
 @pytest.fixture
-def file_format_version(sip_file, format_version):
+def sip_file_format_version(sip_file, format_version):
     return models.FileFormatVersion.objects.create(
         file_uuid=sip_file, format_version=format_version
     )

--- a/tests/MCPClient/test_characterize_file.py
+++ b/tests/MCPClient/test_characterize_file.py
@@ -83,7 +83,7 @@ def test_job_executes_command(
     sip_file,
     sip,
     fprule_characterization,
-    file_format_version,
+    sip_file_format_version,
 ):
     fprule_characterization.command.script_type = script_type
     fprule_characterization.command.save()
@@ -117,7 +117,7 @@ def test_job_executes_command(
 @pytest.mark.django_db
 @mock.patch("characterize_file.executeOrRun")
 def test_job_fails_if_command_fails(
-    execute_or_run, sip_file, sip, fprule_characterization, file_format_version
+    execute_or_run, sip_file, sip, fprule_characterization, sip_file_format_version
 ):
     exit_code = 1
     stdout = ""
@@ -157,7 +157,7 @@ def test_job_saves_valid_xml_command_output(
     sip_file,
     sip,
     rule_with_xml_output_format,
-    file_format_version,
+    sip_file_format_version,
 ):
     exit_code = 0
     stdout = "<mock>success</mock>"
@@ -197,7 +197,7 @@ def test_job_fails_with_invalid_xml_command_output(
     sip_file,
     sip,
     rule_with_xml_output_format,
-    file_format_version,
+    sip_file_format_version,
 ):
     exit_code = 0
     stdout = "invalid xml"

--- a/tests/MCPClient/test_extract_contents.py
+++ b/tests/MCPClient/test_extract_contents.py
@@ -1,0 +1,465 @@
+import pathlib
+from unittest import mock
+
+import extract_contents
+import pytest
+from client.job import Job
+from main import models
+
+
+@pytest.mark.django_db
+def test_job_fails_if_transfer_contains_no_files(
+    transfer, transfer_directory_path, task
+):
+    date = "2024-08-01"
+    delete = str(False)
+    job = mock.Mock(
+        args=[
+            "extract_contents",
+            str(transfer.uuid),
+            f"{transfer_directory_path}/",
+            date,
+            str(task.taskuuid),
+            delete,
+        ],
+        spec=Job,
+    )
+    job.JobContext = mock.MagicMock()
+
+    extract_contents.call([job])
+    job.set_status.assert_called_once_with(255)
+
+    assert job.pyprint.mock_calls == [
+        mock.call(f"Deleting?: {delete}", file=mock.ANY),
+        mock.call("No files found for transfer: ", str(transfer.uuid)),
+    ]
+
+
+@pytest.mark.django_db
+def test_job_fails_if_transfer_file_format_was_not_identified(
+    transfer, transfer_directory_path, task, transfer_file
+):
+    date = "2024-08-01"
+    delete = str(False)
+    job = mock.Mock(
+        args=[
+            "extract_contents",
+            str(transfer.uuid),
+            f"{transfer_directory_path}/",
+            date,
+            str(task.taskuuid),
+            delete,
+        ],
+        spec=Job,
+    )
+    job.JobContext = mock.MagicMock()
+
+    extract_contents.call([job])
+    job.set_status.assert_called_once_with(255)
+
+    assert job.pyprint.mock_calls == [
+        mock.call(f"Deleting?: {delete}", file=mock.ANY),
+        mock.call(
+            "Not extracting contents from",
+            pathlib.Path(transfer_file.currentlocation.decode()).name,
+            " - file format not identified",
+            file=mock.ANY,
+        ),
+    ]
+
+
+@pytest.mark.django_db
+def test_job_fails_if_extraction_command_does_not_exist(
+    transfer,
+    transfer_directory_path,
+    task,
+    transfer_file,
+    transfer_file_format_version,
+    fpcommand,
+):
+    date = "2024-08-01"
+    delete = str(False)
+    job = mock.Mock(
+        args=[
+            "extract_contents",
+            str(transfer.uuid),
+            f"{transfer_directory_path}/",
+            date,
+            str(task.taskuuid),
+            delete,
+        ],
+        spec=Job,
+    )
+    job.JobContext = mock.MagicMock()
+
+    extract_contents.call([job])
+    job.set_status.assert_called_once_with(255)
+
+    assert job.pyprint.mock_calls == [
+        mock.call(f"Deleting?: {delete}", file=mock.ANY),
+        mock.call(
+            "Not extracting contents from",
+            pathlib.Path(transfer_file.currentlocation.decode()).name,
+            " - No rule found to extract",
+            file=mock.ANY,
+        ),
+    ]
+
+
+@pytest.fixture
+def unpacked_file(transfer, transfer_file):
+    location = f"{transfer_file.currentlocation.decode()}/unpacked".encode()
+    return models.File.objects.create(
+        transfer=transfer, originallocation=location, currentlocation=location
+    )
+
+
+@pytest.fixture
+def unpacking_event(unpacked_file):
+    return models.Event.objects.create(
+        file_uuid=unpacked_file,
+        event_type="unpacking",
+        event_detail=unpacked_file.currentlocation.decode(),
+    )
+
+
+@pytest.mark.django_db
+def test_job_fails_if_file_has_been_extracted_already(
+    transfer,
+    transfer_directory_path,
+    task,
+    transfer_file,
+    transfer_file_format_version,
+    fprule_extraction,
+    unpacked_file,
+    unpacking_event,
+):
+    date = "2024-08-01"
+    delete = str(False)
+    job = mock.Mock(
+        args=[
+            "extract_contents",
+            str(transfer.uuid),
+            f"{transfer_directory_path}/",
+            date,
+            str(task.taskuuid),
+            delete,
+        ],
+        spec=Job,
+    )
+    job.JobContext = mock.MagicMock()
+
+    extract_contents.call([job])
+    job.set_status.assert_called_once_with(255)
+
+    expected_pyprint_calls = [
+        mock.call(f"Deleting?: {delete}", file=mock.ANY),
+        mock.call(
+            "Not extracting contents from",
+            pathlib.Path(transfer_file.currentlocation.decode()).name,
+            " - extraction already happened.",
+            file=mock.ANY,
+        ),
+        mock.call(
+            "Not extracting contents from",
+            pathlib.Path(unpacked_file.currentlocation.decode()).name,
+            " - file format not identified",
+            file=mock.ANY,
+        ),
+    ]
+    assert len(job.pyprint.mock_calls) == len(expected_pyprint_calls)
+    # This uses any_order because we do not control the order in which the
+    # jo iterates the files in the transfer.
+    job.pyprint.assert_has_calls(expected_pyprint_calls, any_order=True)
+
+
+@pytest.fixture
+def transfer_file_path(transfer_directory_path, transfer_file):
+    transfer_file_relative_path = pathlib.Path(
+        transfer_file.currentlocation.decode().replace(
+            extract_contents.TRANSFER_DIRECTORY, ""
+        )
+    )
+    result = transfer_directory_path / transfer_file_relative_path
+    (result.parent).mkdir(parents=True)
+    result.touch()
+
+    return result
+
+
+@pytest.mark.django_db
+@mock.patch("extract_contents.executeOrRun", return_value=(-1, "", "error!"))
+def test_job_fails_if_extraction_command_fails(
+    execute_or_run,
+    transfer,
+    transfer_directory_path,
+    task,
+    transfer_file,
+    transfer_file_format_version,
+    fpcommand,
+    fprule_extraction,
+    caplog,
+    transfer_file_path,
+):
+    date = "2024-08-01"
+    delete = str(False)
+    job = mock.Mock(
+        args=[
+            "extract_contents",
+            str(transfer.uuid),
+            f"{transfer_directory_path}/",
+            date,
+            str(task.taskuuid),
+            delete,
+        ],
+        spec=Job,
+    )
+    job.JobContext = mock.MagicMock()
+
+    extract_contents.call([job])
+    job.set_status.assert_called_once_with(255)
+
+    execute_or_run.assert_called_once_with(
+        fpcommand.script_type,
+        fpcommand.command,
+        arguments=[f"{transfer_file_path}", f"{transfer_file_path}-{date}"],
+        printing=True,
+        capture_output=True,
+    )
+
+    assert [r.message for r in caplog.records] == [
+        f"Command to execute is: {fpcommand.command}"
+    ]
+    assert job.pyprint.mock_calls == [
+        mock.call(f"Deleting?: {delete}", file=mock.ANY),
+        mock.call("Command", fpcommand.description, "failed!", file=mock.ANY),
+    ]
+
+
+@pytest.mark.django_db
+@mock.patch("extract_contents.executeOrRun", return_value=(0, "success!", ""))
+def test_job_deletes_compressed_file(
+    execute_or_run,
+    transfer,
+    transfer_directory_path,
+    task,
+    transfer_file,
+    transfer_file_format_version,
+    fpcommand,
+    fprule_extraction,
+    caplog,
+    transfer_file_path,
+):
+    date = "2024-08-01"
+    delete = str(True)
+    job = mock.Mock(
+        args=[
+            "extract_contents",
+            str(transfer.uuid),
+            f"{transfer_directory_path}/",
+            date,
+            str(task.taskuuid),
+            delete,
+        ],
+        spec=Job,
+    )
+    job.JobContext = mock.MagicMock()
+
+    extract_contents.call([job])
+    job.set_status.assert_called_once_with(0)
+
+    execute_or_run.assert_called_once_with(
+        fpcommand.script_type,
+        fpcommand.command,
+        arguments=[f"{transfer_file_path}", f"{transfer_file_path}-{date}"],
+        printing=True,
+        capture_output=True,
+    )
+
+    # The compressed file was deleted.
+    assert not transfer_file_path.exists()
+    assert (
+        models.Event.objects.filter(
+            file_uuid=transfer_file,
+            event_type="file removed",
+            event_detail=f"removed from: {transfer_file.currentlocation.decode()}",
+        ).count()
+        == 1
+    )
+
+    assert [r.message for r in caplog.records] == [
+        f"Command to execute is: {fpcommand.command}"
+    ]
+    assert job.pyprint.mock_calls == [
+        mock.call(f"Deleting?: {delete}", file=mock.ANY),
+        mock.call(
+            "Extracted contents from",
+            pathlib.Path(transfer_file.currentlocation.decode()).name,
+        ),
+        mock.call(f"Package removed: {transfer_file_path}"),
+    ]
+
+
+@pytest.mark.django_db
+@mock.patch("extract_contents.executeOrRun")
+def test_job_assign_uuids_to_extracted_files_and_directories(
+    execute_or_run,
+    transfer,
+    transfer_directory_path,
+    task,
+    transfer_file,
+    transfer_file_format_version,
+    fpcommand,
+    fprule_extraction,
+    caplog,
+    transfer_file_path,
+    unpacked_file,
+):
+    unpacked_file_relative_path = pathlib.Path(unpacked_file.currentlocation.decode())
+
+    def execute_or_run_side_effect(*args, **kwargs):
+        """Mock extraction by creating a new temporary file."""
+        compressed_file_path, extraction_tmp_path = (
+            pathlib.Path(p) for p in kwargs["arguments"]
+        )
+        assert compressed_file_path == transfer_file_path
+
+        extraction_tmp_path.mkdir()
+        (extraction_tmp_path / unpacked_file_relative_path.name).touch()
+
+        return (0, "success!", "")
+
+    execute_or_run.side_effect = execute_or_run_side_effect
+
+    date = "2024-08-01"
+    delete = str(False)
+    job = mock.Mock(
+        args=[
+            "extract_contents",
+            str(transfer.uuid),
+            f"{transfer_directory_path}/",
+            date,
+            str(task.taskuuid),
+            delete,
+        ],
+        spec=Job,
+    )
+    job.JobContext = mock.MagicMock()
+
+    extract_contents.call([job])
+    job.set_status.assert_called_once_with(0)
+
+    execute_or_run.assert_called_once_with(
+        fpcommand.script_type,
+        fpcommand.command,
+        arguments=[f"{transfer_file_path}", f"{transfer_file_path}-{date}"],
+        printing=True,
+        capture_output=True,
+    )
+
+    # The new extracted file was created in the database.
+    extracted_file = models.File.objects.get(
+        originallocation=unpacked_file.originallocation,
+        currentlocation=f"{transfer_file.currentlocation.decode()}-{date}/{unpacked_file_relative_path.name}".encode(),
+    )
+
+    # PREMIS events for unpacking and checksum calculation were created for
+    # the new extracted file.
+    assert set(
+        models.Event.objects.filter(
+            file_uuid=extracted_file,
+        ).values_list("event_type", "event_detail", "event_outcome_detail")
+    ) == {
+        (
+            "unpacking",
+            f"Unpacked from: {transfer_file.currentlocation.decode()} ({transfer_file.uuid})",
+            "",
+        ),
+        (
+            "message digest calculation",
+            'program="python"; module="hashlib.sha256()"',
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ),
+    }
+
+    # A directory was created to contain the new extracted file.
+    extracted_directory = models.Directory.objects.get(
+        transfer=transfer,
+        originallocation=f"{pathlib.Path(extracted_file.originallocation.decode()).parent}/".encode(),
+        currentlocation=f"{pathlib.Path(extracted_file.currentlocation.decode()).parent}/".encode(),
+    )
+
+    assert [r.message for r in caplog.records] == [
+        f"Command to execute is: {fpcommand.command}",
+        f"Assigning UUID {extracted_directory.uuid} to directory path {extracted_directory.currentlocation.decode()}",
+    ]
+    assert job.pyprint.mock_calls == [
+        mock.call(f"Deleting?: {delete}", file=mock.ANY),
+        mock.call(
+            "Extracted contents from",
+            pathlib.Path(transfer_file.currentlocation.decode()).name,
+        ),
+        mock.call(
+            "Assigning new file UUID:",
+            str(extracted_file.uuid),
+            "to file",
+            f"{transfer_file_path}-{date}/{unpacked_file_relative_path.name}",
+        ),
+        mock.call(
+            f"Assigning UUID {extracted_directory.uuid} to directory path {extracted_directory.currentlocation.decode()}",
+        ),
+        mock.call(
+            "Not extracting contents from",
+            unpacked_file_relative_path.name,
+            " - file format not identified",
+            file=mock.ANY,
+        ),
+    ]
+
+
+@pytest.mark.django_db
+@mock.patch("extract_contents.executeOrRun", return_value=(0, "success", ""))
+def test_job_uses_replacement_keys_in_bash_command(
+    execute_or_run,
+    transfer,
+    transfer_directory_path,
+    task,
+    transfer_file,
+    transfer_file_format_version,
+    fpcommand,
+    fprule_extraction,
+    caplog,
+    transfer_file_path,
+    unpacked_file,
+):
+    # Set a bash script command that uses the replacement keys.
+    fpcommand.script_type = "bashScript"
+    fpcommand.command = r"input: %inputFile%, output: %outputDirectory%"
+    fpcommand.save()
+
+    date = "2024-08-01"
+    delete = str(False)
+    job = mock.Mock(
+        args=[
+            "extract_contents",
+            str(transfer.uuid),
+            f"{transfer_directory_path}/",
+            date,
+            str(task.taskuuid),
+            delete,
+        ],
+        spec=Job,
+    )
+    job.JobContext = mock.MagicMock()
+
+    extract_contents.call([job])
+    job.set_status.assert_called_once_with(0)
+
+    # The keys were replaced in the command to execute.
+    execute_or_run.assert_called_once_with(
+        fpcommand.script_type,
+        f"input: {transfer_file_path}, output: {transfer_file_path}-{date}",
+        arguments=[],
+        printing=True,
+        capture_output=True,
+    )

--- a/tests/MCPClient/test_normalize.py
+++ b/tests/MCPClient/test_normalize.py
@@ -422,7 +422,7 @@ def test_normalization_finds_rule_by_file_format_version(
     task,
     fpcommand,
     format_version,
-    file_format_version,
+    sip_file_format_version,
     fprule_preservation,
 ):
     original_file_path = pathlib.Path(sip_file.currentlocation.decode())

--- a/tests/MCPClient/test_transcribe_file.py
+++ b/tests/MCPClient/test_transcribe_file.py
@@ -57,7 +57,7 @@ def test_main(
     sip_file,
     task,
     fprule_transcription,
-    file_format_version,
+    sip_file_format_version,
     settings,
     sip_directory_path,
     create_sip_file,
@@ -107,7 +107,7 @@ def test_main(
 
 @pytest.mark.django_db
 def test_main_if_filegroup_is_not_original(
-    preservation_file, task, fprule_transcription, file_format_version, capsys
+    preservation_file, task, fprule_transcription, sip_file_format_version, capsys
 ):
     job = mock.Mock(spec=Job)
 
@@ -125,7 +125,7 @@ def test_main_if_filegroup_is_not_original(
 
 
 @pytest.mark.django_db
-def test_main_if_no_rules_exist(sip_file, task, file_format_version, capsys):
+def test_main_if_no_rules_exist(sip_file, task, sip_file_format_version, capsys):
     job = mock.Mock(spec=Job)
 
     result = transcribe_file.main(job, task_uuid=task.taskuuid, file_uuid=sip_file.uuid)
@@ -143,7 +143,7 @@ def test_main_if_no_rules_exist(sip_file, task, file_format_version, capsys):
 
 @pytest.mark.django_db
 def test_fetch_rules_for_derivatives_if_rules_are_absent_for_derivates(
-    derivation, fprule_transcription, file_format_version
+    derivation, fprule_transcription, sip_file_format_version
 ):
     result = transcribe_file.fetch_rules_for_derivatives(file_=derivation.source_file)
 
@@ -180,7 +180,7 @@ def disabled_fprule_transcription(fprule_transcription):
 
 @pytest.mark.django_db
 def test_main_if_fprule_is_disabled(
-    sip_file, task, disabled_fprule_transcription, file_format_version
+    sip_file, task, disabled_fprule_transcription, sip_file_format_version
 ):
     job = mock.Mock(spec=Job)
 
@@ -231,7 +231,7 @@ def test_main_if_command_is_not_bash_script(
     sip_file,
     task,
     fprule_transcription,
-    file_format_version,
+    sip_file_format_version,
 ):
     _execute_or_run.return_value = (0, fpcommand.command, "")
     job = mock.Mock(spec=Job)

--- a/tests/MCPClient/test_transcribe_file.py
+++ b/tests/MCPClient/test_transcribe_file.py
@@ -39,6 +39,14 @@ def create_sip_file(sip_directory_path, sip_file):
 
 
 @pytest.fixture
+def fpcommand(fpcommand, sip_file):
+    fpcommand.output_location = sip_file.currentlocation.decode()
+    fpcommand.save()
+
+    return fpcommand
+
+
+@pytest.fixture
 def derivation(sip_file, preservation_file):
     return models.Derivation.objects.create(
         source_file=sip_file, derived_file=preservation_file

--- a/tests/MCPClient/test_validate_file.py
+++ b/tests/MCPClient/test_validate_file.py
@@ -14,7 +14,7 @@ def test_main(
     format_version,
     fprule_validation,
     fpcommand,
-    file_format_version,
+    sip_file_format_version,
     mcp_job,
 ):
     exit_status = 0


### PR DESCRIPTION
This also updates a couple of shared fixtures in the `conftest` module of the `MCPClient` to make them more generic.