### PR TITLE
Fix undefined vars build warnings in Dockerfile

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -118,6 +118,8 @@ RUN set ex \
 
 FROM node:${NODE_VERSION} AS archivematica-dashboard-testing
 
+ARG USER_ID=1000
+ARG GROUP_ID=1000
 ARG SELENIUM_DIR=/selenium
 ENV PATH=${SELENIUM_DIR}/bin:$PATH
 


### PR DESCRIPTION
Similar to https://github.com/artefactual/archivematica-storage-service/pull/734 this fixes the following build warnings:

<details>

<summary>Click to expand warnings</summary>

```console
$ docker build --check .
[+] Building 0.7s (4/4) FINISHED                                                                                          docker:default
 => [internal] load build definition from Dockerfile                                                                                0.0s
 => => transferring dockerfile: 9.00kB                                                                                              0.0s
 => [internal] load metadata for docker.io/library/node:20                                                                          0.6s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                     0.7s
 => [internal] load .dockerignore                                                                                                   0.0s
 => => transferring context: 2B                                                                                                     0.0s

WARNING: UndefinedVar - https://docs.docker.com/go/dockerfile/rule/undefined-var/
Usage of undefined variable '$USER_ID'
Dockerfile:139
--------------------
 137 |          && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 138 |     
 139 | >>> COPY --chown=${USER_ID}:${GROUP_ID} --from=browsers-builder --link ${SELENIUM_DIR} ${SELENIUM_DIR}
 140 |     COPY --chown=${USER_ID}:${GROUP_ID} --from=archivematica-dashboard-frontend-builder --link /src/src/dashboard/frontend/node_modules /src/src/dashboard/frontend/node_modules
 141 |     COPY --link src/dashboard/frontend /src/src/dashboard/frontend
--------------------

WARNING: UndefinedVar - https://docs.docker.com/go/dockerfile/rule/undefined-var/
Usage of undefined variable '$GROUP_ID'
Dockerfile:139
--------------------
 137 |          && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 138 |     
 139 | >>> COPY --chown=${USER_ID}:${GROUP_ID} --from=browsers-builder --link ${SELENIUM_DIR} ${SELENIUM_DIR}
 140 |     COPY --chown=${USER_ID}:${GROUP_ID} --from=archivematica-dashboard-frontend-builder --link /src/src/dashboard/frontend/node_modules /src/src/dashboard/frontend/node_modules
 141 |     COPY --link src/dashboard/frontend /src/src/dashboard/frontend
--------------------

WARNING: UndefinedVar - https://docs.docker.com/go/dockerfile/rule/undefined-var/
Usage of undefined variable '$USER_ID'
Dockerfile:140
--------------------
 138 |     
 139 |     COPY --chown=${USER_ID}:${GROUP_ID} --from=browsers-builder --link ${SELENIUM_DIR} ${SELENIUM_DIR}
 140 | >>> COPY --chown=${USER_ID}:${GROUP_ID} --from=archivematica-dashboard-frontend-builder --link /src/src/dashboard/frontend/node_modules /src/src/dashboard/frontend/node_modules
 141 |     COPY --link src/dashboard/frontend /src/src/dashboard/frontend
 142 |     
--------------------

WARNING: UndefinedVar - https://docs.docker.com/go/dockerfile/rule/undefined-var/
Usage of undefined variable '$GROUP_ID'
Dockerfile:140
--------------------
 138 |     
 139 |     COPY --chown=${USER_ID}:${GROUP_ID} --from=browsers-builder --link ${SELENIUM_DIR} ${SELENIUM_DIR}
 140 | >>> COPY --chown=${USER_ID}:${GROUP_ID} --from=archivematica-dashboard-frontend-builder --link /src/src/dashboard/frontend/node_modules /src/src/dashboard/frontend/node_modules
 141 |     COPY --link src/dashboard/frontend /src/src/dashboard/frontend
 142 |     
--------------------
```

</details>