### PR TITLE
Fix error in duplicate PREMIS event ID handling

### DIFF
--- a/src/MCPClient/lib/clientScripts/load_premis_events_from_xml.py
+++ b/src/MCPClient/lib/clientScripts/load_premis_events_from_xml.py
@@ -663,7 +663,7 @@ def ensure_event_id_is_uuid(event_id, printfn=print):
         if Event.objects.filter(event_id=event_id).exists():
             raise ValueError(f"There is already an event with this event_id {event_id}")
     except ValueError:
-        new_event_id = uuid.uuid4()
+        new_event_id = str(uuid.uuid4())
         log_event_id_change(event_id, new_event_id, printfn)
         event_id = new_event_id
     return event_id

--- a/tests/MCPClient/test_load_premis_events_from_xml.py
+++ b/tests/MCPClient/test_load_premis_events_from_xml.py
@@ -691,11 +691,14 @@ def test_get_event_files(mocker, params):
 )
 def test_ensure_event_id_is_uuid(mocker, params):
     if params["message_logged"]:
-        mocker.patch("uuid.uuid4", return_value="f4eea76b-1921-4152-b1b4-a93dbbfeaaef")
+        mocker.patch(
+            "uuid.uuid4", return_value=uuid.UUID("f4eea76b-1921-4152-b1b4-a93dbbfeaaef")
+        )
     printfn = mocker.Mock()
     result = load_premis_events_from_xml.ensure_event_id_is_uuid(
         params["event_id"], printfn
     )
+    assert isinstance(result, str)
     if not params["message_logged"]:
         assert result == params["event_id"]
         printfn.assert_not_called()
@@ -719,6 +722,7 @@ def test_ensure_event_id_is_uuid_with_existent_event(mocker, existent_event_id):
         existent_event_id, printfn
     )
     assert result != existent_event_id
+    assert isinstance(result, str)
     printfn.assert_called_once_with(
         f"Changed event identifier from {existent_event_id} to {expected_uuid}"
     )


### PR DESCRIPTION
Attempting to create a UUID object using an existing UUID object, rather than a string, results in an error. Changed duplicate PREMIS event identifier handling to avoid ending up doing this.