### PR TITLE
Add type hints to the characterize_file script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,11 +57,13 @@ warn_unused_configs = true
 [[tool.mypy.overrides]]
 module = [
     "src.MCPClient.lib.client.*",
+    "src.MCPClient.lib.clientScripts.characterize_file",
     "src.MCPClient.lib.clientScripts.identify_file_format",
     "src.MCPClient.lib.clientScripts.normalize",
     "src.MCPClient.lib.clientScripts.policy_check",
     "src.MCPClient.lib.clientScripts.validate_file",
     "tests.MCPClient.conftest",
+    "tests.MCPClient.test_characterize_file",
     "tests.MCPClient.test_identify_file_format",
     "tests.MCPClient.test_normalize",
     "tests.MCPClient.test_policy_check",

--- a/src/MCPServer/lib/assets/workflow.json
+++ b/src/MCPServer/lib/assets/workflow.json
@@ -1286,7 +1286,7 @@
       "config": {
         "@manager": "linkTaskManagerFiles",
         "@model": "StandardTaskConfig",
-        "arguments": "\"%relativeLocation%\" \"%fileUUID%\" \"%SIPUUID%\"",
+        "arguments": "\"%fileUUID%\" \"%SIPUUID%\"",
         "execute": "characterizeFile_v0.0",
         "filter_subdir": "objects/metadata/"
       },
@@ -3480,7 +3480,7 @@
       "config": {
         "@manager": "linkTaskManagerFiles",
         "@model": "StandardTaskConfig",
-        "arguments": "\"%relativeLocation%\" \"%fileUUID%\" \"%SIPUUID%\"",
+        "arguments": "\"%fileUUID%\" \"%SIPUUID%\"",
         "execute": "characterizeFile_v0.0",
         "filter_subdir": "objects"
       },
@@ -3703,7 +3703,7 @@
       "config": {
         "@manager": "linkTaskManagerFiles",
         "@model": "StandardTaskConfig",
-        "arguments": "\"%relativeLocation%\" \"%fileUUID%\" \"%SIPUUID%\"",
+        "arguments": "\"%fileUUID%\" \"%SIPUUID%\"",
         "execute": "characterizeFile_v0.0",
         "filter_subdir": "objects/submissionDocumentation"
       },

--- a/src/archivematicaCommon/lib/dicts.py
+++ b/src/archivematicaCommon/lib/dicts.py
@@ -17,6 +17,7 @@
 import ast
 import os
 import re
+import uuid
 
 from main import models
 
@@ -83,9 +84,9 @@ class ReplacementDict(dict):
         # In order to make this code accessible to MCPServer,
         # we need to support passing in UUID strings instead
         # of models.
-        if isinstance(file_, str):
+        if isinstance(file_, (str, uuid.UUID)):
             file_ = models.File.objects.get(uuid=file_)
-        if isinstance(sip, str):
+        if isinstance(sip, (str, uuid.UUID)):
             # sip can be a SIP or Transfer
             try:
                 sip = models.SIP.objects.get(uuid=sip)


### PR DESCRIPTION
This also removes an unnecessary argument from the workflow definition and adds a typed argument parser to the script.