### PR TITLE
Show format version and PRONOM ID in FPRule views

### DIFF
--- a/src/dashboard/src/fpr/templates/fpr/fprule/detail.html
+++ b/src/dashboard/src/fpr/templates/fpr/fprule/detail.html
@@ -27,8 +27,12 @@
         <dd>{{ fprule.uuid }}</dd>
         <dt>{% trans "Purpose" %}</dt>
         <dd>{{ fprule.get_purpose_display }} Rule</dd>
-        <dt>{% trans "Format" %}</dt>
-        <dd><a href="{% url 'fpr:formatversion_detail' fprule.format.format.slug fprule.format.slug %}">{{ fprule.format.description }}</a></dd>
+        <dt>{% trans "Format version" %}</dt>
+        {% spaceless %}
+        {% with version=fprule.format.version pronom_id=fprule.format.pronom_id %}
+        <dd><a href="{% url 'fpr:formatversion_detail' fprule.format.format.slug fprule.format.slug %}">{{ fprule.format.description }}{% if version or pronom_id %} ({% if version %}{% trans "version" %}: {{ version }}{% if pronom_id %}, {% endif %}{% endif %}{% if pronom_id %}{{ pronom_id }}{% endif %}){% endif %}</a></dd>
+        {% endwith %}
+        {% endspaceless %}
         <dt>{% trans "Command" %}</dt>
         <dd><a href="{% url 'fpr:fpcommand_detail' fprule.command.uuid %}">{{ fprule.command.description }}</a></dd>
         <dt>{% trans "Stats" %}</dt>

--- a/src/dashboard/src/fpr/templates/fpr/fprule/list.html
+++ b/src/dashboard/src/fpr/templates/fpr/fprule/list.html
@@ -38,7 +38,11 @@
         {% for fprule in fprules %}
           <tr>
             <td><a href="{% url 'fpr:fprule_detail' fprule.uuid %}">{{ fprule.get_purpose_display }}</a></td>
-            <td>{{ fprule.format.description }}</td>
+            {% spaceless %}
+            {% with version=fprule.format.version pronom_id=fprule.format.pronom_id %}
+            <td>{{ fprule.format.description }}{% if version or pronom_id %} ({% if version %}{% trans "version" %}: {{ version }}{% if pronom_id %}, {% endif %}{% endif %}{% if pronom_id %}{{ pronom_id }}{% endif %}){% endif %}</td>
+            {% endwith %}
+            {% endspaceless %}
             <td>{{ fprule.command.description }}</td>
             <td>{{ fprule.count_okay }} out of {{ fprule.count_attempts }}</td>
             <td>{{ fprule.enabled|yesno:_('Yes,No') }}</td>


### PR DESCRIPTION
This updates the `FPRule` tables and detail views of the `Preservation planning` tab to show the format version and PRONOM ID of each rule when available.