### PR TITLE
Use menu for processing config in Re-ingest form

### DIFF
--- a/src/dashboard/src/components/archival_storage/forms.py
+++ b/src/dashboard/src/components/archival_storage/forms.py
@@ -14,7 +14,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+import pathlib
+
 from agentarchives.atom.client import CommunicationError
+from components import helpers
 from components.archival_storage.atom import get_atom_client
 from django import forms
 from django.utils.translation import gettext as _
@@ -59,6 +62,19 @@ class UploadMetadataOnlyAtomForm(forms.Form):
         return slug
 
 
+def get_processing_configurations():
+    processing_configs_dir = pathlib.Path(helpers.processing_config_path())
+    suffix = "ProcessingMCP.xml"
+    return (
+        (processing_config, processing_config)
+        for processing_config in sorted(
+            path.name[: -len(suffix)]
+            for path in processing_configs_dir.iterdir()
+            if path.name.endswith(suffix)
+        )
+    )
+
+
 class ReingestAIPForm(forms.Form):
     METADATA_ONLY = "metadata"
     OBJECTS = "objects"
@@ -71,10 +87,10 @@ class ReingestAIPForm(forms.Form):
     reingest_type = forms.ChoiceField(
         choices=REINGEST_CHOICES, widget=forms.RadioSelect, required=True
     )
-    processing_config = forms.CharField(
+    processing_config = forms.ChoiceField(
+        choices=get_processing_configurations,
         required=False,
         initial="default",
-        widget=forms.TextInput(attrs={"placeholder": _("default")}),
     )
 
 


### PR DESCRIPTION
This updates the `Re-ingest` form of the AIP view in `Archival storage` to use a dropdown menu instead of a text field for specifying the processing configuration to use in the re-ingest request. It looks like this:

![Captura desde 2024-08-23 09-38-35](https://github.com/user-attachments/assets/210ea491-0a42-4c80-a8ef-a429a0d618c8)

The `default` processing configuration is the initial value of the menu and the XML files are listed similarly to how the [processing-configuration](https://www.archivematica.org/en/docs/archivematica-latest/dev-manual/api/api-reference-archivematica/#processing-configuration) API endpoint lists them.