### PR TITLE
Use timezone aware timestamps for file modification

### DIFF
--- a/tests/MCPClient/test_store_file_modification.py
+++ b/tests/MCPClient/test_store_file_modification.py
@@ -4,6 +4,7 @@ import tempfile
 
 import store_file_modification_dates
 from django.test import TestCase
+from django.test import override_settings
 from main import models
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -25,6 +26,7 @@ class TestStoreFileModification(TestCase):
         )
         shutil.rmtree(transfer_path)
 
+    @override_settings(TIME_ZONE="US/Eastern")
     def test_store_file_modification_dates(self):
         """Test store_file_modification_dates.
 
@@ -47,13 +49,13 @@ class TestStoreFileModification(TestCase):
                 os.makedirs(dirname)
             with open(path, "wb") as f:
                 f.write(path.encode("utf8"))
-            os.utime(path, (1339485682, 1339485682))
+            os.utime(path, (1049597970, 1049597970))
 
         # Store file modification dates
         store_file_modification_dates.main(self.transfer_uuid, self.temp_dir + "/")
 
         # Assert files have expected modification times
-        expected_time = "2012-06-12 07:21:22+00:00"
+        expected_time = "2003-04-06 02:59:30+00:00"
         assert (
             str(
                 models.File.objects.get(

--- a/tests/MCPClient/test_store_file_modification.py
+++ b/tests/MCPClient/test_store_file_modification.py
@@ -5,6 +5,7 @@ import tempfile
 import store_file_modification_dates
 from django.test import TestCase
 from django.test import override_settings
+from django.utils.timezone import get_current_timezone
 from main import models
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -52,7 +53,9 @@ class TestStoreFileModification(TestCase):
             os.utime(path, (1049597970, 1049597970))
 
         # Store file modification dates
-        store_file_modification_dates.main(self.transfer_uuid, self.temp_dir + "/")
+        store_file_modification_dates.main(
+            self.transfer_uuid, self.temp_dir + "/", get_current_timezone()
+        )
 
         # Assert files have expected modification times
         expected_time = "2003-04-06 02:59:30+00:00"

--- a/tests/MCPClient/test_store_file_modification.py
+++ b/tests/MCPClient/test_store_file_modification.py
@@ -53,13 +53,14 @@ class TestStoreFileModification(TestCase):
         store_file_modification_dates.main(self.transfer_uuid, self.temp_dir + "/")
 
         # Assert files have expected modification times
+        expected_time = "2012-06-12 07:21:22+00:00"
         assert (
             str(
                 models.File.objects.get(
                     pk="47813453-6872-442b-9d65-6515be3c5aa1"
                 ).modificationtime
             )
-            == "2012-06-12 07:21:22+00:00"
+            == expected_time
         )
         assert (
             str(
@@ -67,7 +68,7 @@ class TestStoreFileModification(TestCase):
                     pk="60e5c61b-14ef-4e92-89ec-9b9201e68adb"
                 ).modificationtime
             )
-            == "2012-06-12 07:21:22+00:00"
+            == expected_time
         )
         assert (
             str(
@@ -75,7 +76,7 @@ class TestStoreFileModification(TestCase):
                     pk="791e07ea-ad44-4315-b55b-44ec771e95cf"
                 ).modificationtime
             )
-            == "2012-06-12 07:21:22+00:00"
+            == expected_time
         )
         assert (
             str(
@@ -83,5 +84,5 @@ class TestStoreFileModification(TestCase):
                     pk="8a1f0b59-cf94-47ef-8078-647b77c8a147"
                 ).modificationtime
             )
-            == "2012-06-12 07:21:22+00:00"
+            == expected_time
         )


### PR DESCRIPTION
This updates the `Store file modification dates` MCPClient job to store transfer file modification dates using the `TIME_ZONE` setting from Django.

Currently the server logs show that these values are [naive](https://docs.python.org/3/library/datetime.html#aware-and-naive-objects):

```console
Sep 13 11:11:03 am116jammy python[705915]: *** RUNNING TASK: storefilemodificationdates_v0.0***
Sep 13 11:11:03 am116jammy python[705915]: /usr/share/archivematica/virtualenvs/archivematica/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField File.modifi
cationtime received a naive datetime (2024-04-03 07:02:29) while time zone support is active.
Sep 13 11:11:03 am116jammy python[705915]:   warnings.warn(
Sep 13 11:11:03 am116jammy python[705915]: archivematicaClient.py: INFO      2024-09-13 04:11:03,101  archivematica.mcp.client.storeFileModificationDates:main:64:  Stored modification dates of 2 files.
Sep 13 11:11:03 am116jammy python[705915]: archivematicaClient.py: INFO      2024-09-13 04:11:03,102  archivematica.mcp.client.job:log_results:82:  #<storefilemodificationdates_v0.0; exit=0; code=success u
uid=e7ea9514-444b-469c-9eee-561aba85b3ad

```

This could potentially create problems. Recently an Archivematica `1.15.x` user reported [`pytz`](https://pythonhosted.org/pytz/) raising a `NonExistentTimeError` because of this in Django 3.2.

