### PR TITLE
Enable OIDC tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ module = [
     "src.MCPClient.lib.clientScripts.validate_file",
     "tests.archivematicaCommon.test_execute_functions",
     "tests.dashboard.fpr.test_views",
+    "tests.dashboard.test_oidc",
     "tests.MCPClient.conftest",
     "tests.MCPClient.test_characterize_file",
     "tests.MCPClient.test_has_packages",

--- a/tests/dashboard/test_oidc.py
+++ b/tests/dashboard/test_oidc.py
@@ -3,18 +3,18 @@ from django.test import TestCase
 from django.test import override_settings
 
 
-@override_settings(OIDC_OP_TOKEN_ENDPOINT="https://example.com/token")
-@override_settings(OIDC_OP_USER_ENDPOINT="https://example.com/user")
-@override_settings(OIDC_RP_CLIENT_ID="rp_client_id")
-@override_settings(OIDC_RP_CLIENT_SECRET="rp_client_secret")
 @override_settings(
+    OIDC_OP_TOKEN_ENDPOINT="https://example.com/token",
+    OIDC_OP_USER_ENDPOINT="https://example.com/user",
+    OIDC_RP_CLIENT_ID="rp_client_id",
+    OIDC_RP_CLIENT_SECRET="rp_client_secret",
     OIDC_ACCESS_ATTRIBUTE_MAP={
         "given_name": "first_name",
         "family_name": "last_name",
-    }
+    },
+    OIDC_ID_ATTRIBUTE_MAP={"email": "email"},
+    OIDC_USERNAME_ALGO=lambda email: email,
 )
-@override_settings(OIDC_ID_ATTRIBUTE_MAP={"email": "email"})
-@override_settings(OIDC_USERNAME_ALGO=lambda email: email)
 class TestOIDC(TestCase):
     def test_create_user(self):
         backend = CustomOIDCBackend()

--- a/tests/dashboard/test_oidc.py
+++ b/tests/dashboard/test_oidc.py
@@ -1,45 +1,55 @@
+import pytest
+import pytest_django
 from components.accounts.backends import CustomOIDCBackend
-from django.test import TestCase
-from django.test import override_settings
 
 
-@override_settings(
-    OIDC_OP_TOKEN_ENDPOINT="https://example.com/token",
-    OIDC_OP_USER_ENDPOINT="https://example.com/user",
-    OIDC_RP_CLIENT_ID="rp_client_id",
-    OIDC_RP_CLIENT_SECRET="rp_client_secret",
-    OIDC_ACCESS_ATTRIBUTE_MAP={
+@pytest.fixture
+def settings(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> pytest_django.fixtures.SettingsWrapper:
+    settings.OIDC_OP_TOKEN_ENDPOINT = "https://example.com/token"
+    settings.OIDC_OP_USER_ENDPOINT = "https://example.com/user"
+    settings.OIDC_RP_CLIENT_ID = "rp_client_id"
+    settings.OIDC_RP_CLIENT_SECRET = "rp_client_secret"
+    settings.OIDC_ACCESS_ATTRIBUTE_MAP = {
         "given_name": "first_name",
         "family_name": "last_name",
-    },
-    OIDC_ID_ATTRIBUTE_MAP={"email": "email"},
-    OIDC_USERNAME_ALGO=lambda email: email,
-)
-class TestOIDC(TestCase):
-    def test_create_user(self):
-        backend = CustomOIDCBackend()
-        user = backend.create_user(
-            {"email": "test@example.com", "first_name": "Test", "last_name": "User"}
-        )
+    }
+    settings.OIDC_ID_ATTRIBUTE_MAP = {"email": "email"}
+    settings.OIDC_USERNAME_ALGO = lambda email: email
 
-        user.refresh_from_db()
-        assert user.first_name == "Test"
-        assert user.last_name == "User"
-        assert user.email == "test@example.com"
-        assert user.username == "test@example.com"
-        assert user.api_key
+    return settings
 
-    def test_get_userinfo(self):
-        # Encoded at https://www.jsonwebtoken.io/
-        # {"email": "test@example.com"}
-        id_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJqdGkiOiI1M2QyMzUzMy04NDk0LTQyZWQtYTJiZC03Mzc2MjNmMjUzZjciLCJpYXQiOjE1NzMwMzE4NDQsImV4cCI6MTU3MzAzNTQ0NH0.m3nHgvj_DyVJMcW5eyYuUss1Y0PNzJV2O3bX0b_DCmI"
-        # {"given_name": "Test", "family_name": "User"}
-        access_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJnaXZlbl9uYW1lIjoiVGVzdCIsImZhbWlseV9uYW1lIjoiVXNlciIsImp0aSI6ImRhZjIwNTNiLWE4MTgtNDE1Yy1hM2Y1LTkxYWVhMTMxYjljZCIsImlhdCI6MTU3MzAzMTk3OSwiZXhwIjoxNTczMDM1NTc5fQ.cGcmt7d9IuKndvrqPpAH3Dvb3KyCOMqixUWgS7sg8r4"
 
-        backend = CustomOIDCBackend()
-        info = backend.get_userinfo(
-            access_token=access_token, id_token=id_token, verified_id=None
-        )
-        assert info["email"] == "test@example.com"
-        assert info["first_name"] == "Test"
-        assert info["last_name"] == "User"
+@pytest.mark.django_db
+def test_create_user(settings: pytest_django.fixtures.SettingsWrapper) -> None:
+    backend = CustomOIDCBackend()
+
+    user = backend.create_user(
+        {"email": "test@example.com", "first_name": "Test", "last_name": "User"}
+    )
+
+    user.refresh_from_db()
+    assert user.first_name == "Test"
+    assert user.last_name == "User"
+    assert user.email == "test@example.com"
+    assert user.username == "test@example.com"
+    assert user.api_key
+
+
+@pytest.mark.django_db
+def test_get_userinfo(settings: pytest_django.fixtures.SettingsWrapper) -> None:
+    # Encoded at https://www.jsonwebtoken.io/
+    # {"email": "test@example.com"}
+    id_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJqdGkiOiI1M2QyMzUzMy04NDk0LTQyZWQtYTJiZC03Mzc2MjNmMjUzZjciLCJpYXQiOjE1NzMwMzE4NDQsImV4cCI6MTU3MzAzNTQ0NH0.m3nHgvj_DyVJMcW5eyYuUss1Y0PNzJV2O3bX0b_DCmI"
+    # {"given_name": "Test", "family_name": "User"}
+    access_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJnaXZlbl9uYW1lIjoiVGVzdCIsImZhbWlseV9uYW1lIjoiVXNlciIsImp0aSI6ImRhZjIwNTNiLWE4MTgtNDE1Yy1hM2Y1LTkxYWVhMTMxYjljZCIsImlhdCI6MTU3MzAzMTk3OSwiZXhwIjoxNTczMDM1NTc5fQ.cGcmt7d9IuKndvrqPpAH3Dvb3KyCOMqixUWgS7sg8r4"
+    backend = CustomOIDCBackend()
+
+    info = backend.get_userinfo(
+        access_token=access_token, id_token=id_token, verified_id=None
+    )
+
+    assert info["email"] == "test@example.com"
+    assert info["first_name"] == "Test"
+    assert info["last_name"] == "User"

--- a/tests/dashboard/test_oidc.py
+++ b/tests/dashboard/test_oidc.py
@@ -1,12 +1,7 @@
-import pytest
 from components.accounts.backends import CustomOIDCBackend
-from django.conf import settings
 from django.test import TestCase
 
 
-@pytest.mark.skipif(
-    not settings.OIDC_AUTHENTICATION, reason="tests will only pass if OIDC is enabled"
-)
 class TestOIDC(TestCase):
     def test_create_user(self):
         backend = CustomOIDCBackend()

--- a/tests/dashboard/test_oidc.py
+++ b/tests/dashboard/test_oidc.py
@@ -1,7 +1,20 @@
 from components.accounts.backends import CustomOIDCBackend
 from django.test import TestCase
+from django.test import override_settings
 
 
+@override_settings(OIDC_OP_TOKEN_ENDPOINT="https://example.com/token")
+@override_settings(OIDC_OP_USER_ENDPOINT="https://example.com/user")
+@override_settings(OIDC_RP_CLIENT_ID="rp_client_id")
+@override_settings(OIDC_RP_CLIENT_SECRET="rp_client_secret")
+@override_settings(
+    OIDC_ACCESS_ATTRIBUTE_MAP={
+        "given_name": "first_name",
+        "family_name": "last_name",
+    }
+)
+@override_settings(OIDC_ID_ATTRIBUTE_MAP={"email": "email"})
+@override_settings(OIDC_USERNAME_ALGO=lambda email: email)
 class TestOIDC(TestCase):
     def test_create_user(self):
         backend = CustomOIDCBackend()


### PR DESCRIPTION
This removes the condition that makes `pytest` to [skip](https://docs.pytest.org/en/latest/how-to/skipping.html) the existing OIDC authentication backend tests and mocks the settings necessary for the tests to pass.