### PR TITLE
Fix broken links in Markdown files

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^http://(127.0.0.1|localhost)"
+    }
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,7 @@ repos:
   - id: markdown-link-check
     stages: [manual]
     args: [--quiet, --config, .markdown-link-check.json]
+    exclude: |
+      (?x)^(
+        src/dashboard/src/media/vendor/.*\.md
+      )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,3 +53,9 @@ repos:
     - types-requests
     - types-python-dateutil
     - pytest
+- repo: https://github.com/tcort/markdown-link-check
+  rev: v3.12.2
+  hooks:
+  - id: markdown-link-check
+    stages: [manual]
+    args: [--quiet, --config, .markdown-link-check.json]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -426,9 +426,9 @@ Further content comes after a blank line.
 [GitHub]: https://github.com/
 [guide]: https://help.github.com/articles/fork-a-repo
 [excellent]: https://help.github.com/articles/using-pull-requests
-[Line comment]: http://i.imgur.com/FsWppGN.png
+[Line comment]: https://i.imgur.com/FsWppGN.png
 [code review guidelines]: https://github.com/artefactual/archivematica/blob/qa/1.x/code_review.md
-[interactive rebase feature]: http://www.git-scm.com/book/en/Git-Tools-Rewriting-History
+[interactive rebase feature]: https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History
 [Contributor's Agreement]: https://wiki.archivematica.org/images/e/e6/Archivematica-CLA-firstname-lastname-YYYY.pdf
 [Apache Foundation]: http://apache.org
 [contributor license]: http://www.apache.org/licenses/icla.txt

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ see the [getting started] page.
 [Test workflow]: https://github.com/artefactual/archivematica/actions/workflows/test.yml
 [User Group]: https://groups.google.com/forum/#!forum/archivematica
 [Website]: https://www.archivematica.org/
-[Wiki]: https://www.archivematica.org/wiki/Development
+[Wiki]: https://wiki.archivematica.org/Development
 [YouTube channel]: https://www.youtube.com/@ArtefactualSystems

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,7 +50,7 @@ the original report, there are a couple steps you can take:
 
 - Email the Archivematica Program Manager directly at
   [sromkey@artefactual.com](mailto:sromkey@artefactual.com)
-- Email Artefactual's info address: [info@artefactual.com](info@artefactual.com)
+- Email Artefactual's info address: [info@artefactual.com](mailto:info@artefactual.com)
 
 Any information you share with the Archivematica development team as a part of
 this process will be kept confidential within the team. If we determine that the

--- a/hack/README.md
+++ b/hack/README.md
@@ -44,7 +44,7 @@ Artefactual developers use Docker Compose on Linux heavily so it's important
 that you're familiar with it, and some choices in the configuration of this
 environment break in other operative systems.
 
-[audience-compose-reference]: https://docs.docker.com/compose/reference/overview/
+[audience-compose-reference]: https://docs.docker.com/reference/cli/docker/compose/
 
 ## Requirements
 

--- a/src/dashboard/frontend/README.md
+++ b/src/dashboard/frontend/README.md
@@ -315,8 +315,6 @@ cleaner. For example, instance methods on controller objects can be easily
 referenced from templates, which obviates the need to assign functions to
 properties.
 
-Here's a good guide that covers over how this works: <https://angular-tips.com/blog/2015/06/using-angular-1-dot-x-with-es6-and-webpack/>
-
 ### Modules
 
 ES6 provides support for real modules with their own separate namespaces.
@@ -380,7 +378,7 @@ The contents of `app/locale` should be tracked in git.
 
 [webpack]: https://webpack.github.io
 [community Angular style-guide]: https://github.com/johnpapa/angular-styleguide#application-structure
-[Jasmine]: https://jasmine.github.io/2.3/introduction.html
+[Jasmine]: https://jasmine.github.io/
 [Babel]: https://babeljs.io
 [in the Babel documentation]: https://babeljs.io/docs/learn-es2015/
 [template string]: https://babeljs.io/docs/learn-es2015/#template-strings

--- a/src/dashboard/install/README.md
+++ b/src/dashboard/install/README.md
@@ -792,7 +792,7 @@ provides an example that implements the logging behaviour used in Archivematica
 [DATABASES]: https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 [Sending email]: https://docs.djangoproject.com/en/1.8/topics/email/
 [USER]: https://docs.gunicorn.org/en/stable/settings.html#user
-[GROUP]: https://docs.gunicorn.org/en/styable/settings.html#group
+[GROUP]: https://docs.gunicorn.org/en/stable/settings.html#group
 [BIND]: https://docs.gunicorn.org/en/stable/settings.html#bind
 [WORKERS]: https://docs.gunicorn.org/en/stable/settings.html#workers
 [How Many Workers?]: https://docs.gunicorn.org/en/stable/design.html#how-many-workers
@@ -805,4 +805,4 @@ provides an example that implements the logging behaviour used in Archivematica
 [ERRORLOG]: https://docs.gunicorn.org/en/stable/settings.html#errorlog
 [LOGLEVEL]: https://docs.gunicorn.org/en/stable/settings.html#loglevel
 [PROC-NAME]: https://docs.gunicorn.org/en/stable/settings.html#proc-name
-[django-csp policy settings]: (<https://django-csp.readthedocs.io/en/latest/configuration.html#policy-settings>
+[django-csp policy settings]: https://django-csp.readthedocs.io/en/latest/configuration.html#policy-settings


### PR DESCRIPTION
This also introduces [markdown-link-check](https://github.com/tcort/markdown-link-check/) as a `pre-commit` hook to check broken links in the Markdown files of the repository. The hook has been set as [manual](https://pre-commit.com/#confining-hooks-to-run-at-certain-stages) to not interfere in the usual development workflow.

For example, to check links in a specific file:

```shell
pre-commit run --hook-stage manual markdown-link-check --files src/dashboard/frontend/README.md
```

Or to check all the Markdown files in the repository:

```shell
pre-commit run --hook-stage manual markdown-link-check --all-files
```

We should not include this in the pull request workflow because link checking is flaky. Sometimes working links fail from GitHub hosts because websites block them. But we could potentially create a separate workflow that developers could trigger manually.
