### PR TITLE
Fix API key generation when user edits are disabled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ module = [
     "src.MCPClient.lib.clientScripts.transcribe_file",
     "src.MCPClient.lib.clientScripts.validate_file",
     "tests.archivematicaCommon.test_execute_functions",
+    "tests.dashboard.components.administration.test_administration",
     "tests.dashboard.fpr.test_views",
     "tests.dashboard.test_oidc",
     "tests.integration.test_oidc_auth",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ module = [
     "src.MCPClient.lib.clientScripts.transcribe_file",
     "src.MCPClient.lib.clientScripts.validate_file",
     "tests.archivematicaCommon.test_execute_functions",
+    "tests.dashboard.components.accounts.test_views",
     "tests.dashboard.components.administration.test_administration",
     "tests.dashboard.fpr.test_views",
     "tests.dashboard.test_oidc",

--- a/src/dashboard/src/components/accounts/forms.py
+++ b/src/dashboard/src/components/accounts/forms.py
@@ -149,7 +149,7 @@ class UserChangeForm(DjangoUserChangeForm):
 
 
 class ApiKeyForm(forms.Form):
-    regenerate_api_key = forms.CharField(
+    regenerate_api_key = forms.BooleanField(
         widget=forms.CheckboxInput,
         label="Regenerate API key (shown below)?",
         required=False,

--- a/src/dashboard/src/components/accounts/views.py
+++ b/src/dashboard/src/components/accounts/views.py
@@ -88,7 +88,7 @@ def profile(request):
         form = ApiKeyForm(request.POST)
         userprofileform = UserProfileForm(request.POST, instance=user_profile)
         if form.is_valid() and userprofileform.is_valid():
-            if form["regenerate_api_key"] != "":
+            if form.cleaned_data["regenerate_api_key"]:
                 generate_api_key(user)
             userprofileform.save()
 

--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -211,6 +211,8 @@ class StorageSettingsForm(SettingsForm):
         """
 
         def to_python(self, value):
+            if value is None:
+                value = ""
             return super(forms.CharField, self).to_python(value).strip()
 
     storage_service_url = forms.CharField(

--- a/tests/dashboard/components/accounts/test_views.py
+++ b/tests/dashboard/components/accounts/test_views.py
@@ -1,10 +1,20 @@
+import hmac
+import uuid
+from hashlib import sha1
+from typing import Type
+from unittest import mock
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
 
 import pytest
 import pytest_django
+from components import helpers
 from components.accounts.views import get_oidc_logout_url
+from django.contrib.auth.models import User
+from django.test import Client
 from django.test import RequestFactory
+from django.urls import reverse
+from tastypie.models import ApiKey
 
 
 def test_get_oidc_logout_url_fails_if_token_is_not_set(rf: RequestFactory) -> None:
@@ -42,3 +52,135 @@ def test_get_oidc_logout_url_returns_logout_url(
     assert set(query_dict) == {"id_token_hint", "post_logout_redirect_uri"}
     assert query_dict["id_token_hint"] == [token]
     assert query_dict["post_logout_redirect_uri"] == ["http://testserver/"]
+
+
+@pytest.fixture
+def dashboard_uuid() -> None:
+    helpers.set_setting("dashboard_uuid", str(uuid.uuid4()))
+
+
+@pytest.fixture
+def non_administrative_user(django_user_model: Type[User]) -> User:
+    return django_user_model.objects.create_user(
+        username="test",
+        password="test",
+        first_name="Foo",
+        last_name="Bar",
+        email="foobar@example.com",
+    )
+
+
+@pytest.mark.django_db
+def test_edit_user_view_denies_access_to_non_admin_users_editing_others(
+    dashboard_uuid: None,
+    non_administrative_user: User,
+    admin_user: User,
+    client: Client,
+) -> None:
+    client.force_login(non_administrative_user)
+
+    response = client.get(
+        reverse("accounts:edit", kwargs={"id": admin_user.id}), follow=True
+    )
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert "Forbidden" in content
+    assert "You do not have enough access privileges for this operation" in content
+
+
+@pytest.fixture
+def non_administrative_user_apikey(non_administrative_user: User) -> ApiKey:
+    return ApiKey.objects.create(user=non_administrative_user)
+
+
+@pytest.mark.django_db
+def test_edit_user_view_renders_user_profile_fields(
+    dashboard_uuid: None,
+    non_administrative_user: User,
+    non_administrative_user_apikey: ApiKey,
+    admin_client: Client,
+) -> None:
+    response = admin_client.get(
+        reverse("accounts:edit", kwargs={"id": non_administrative_user.id}), follow=True
+    )
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert f"Edit user {non_administrative_user.username}" in content
+    assert f'name="username" value="{non_administrative_user.username}"' in content
+    assert f'name="first_name" value="{non_administrative_user.first_name}"' in content
+    assert f'name="last_name" value="{non_administrative_user.last_name}"' in content
+    assert f'name="email" value="{non_administrative_user.email}"' in content
+    assert f"<code>{non_administrative_user_apikey.key}</code>" in content
+
+
+@pytest.mark.django_db
+def test_edit_user_view_updates_user_profile_fields(
+    dashboard_uuid: None,
+    non_administrative_user: User,
+    admin_client: Client,
+) -> None:
+    new_username = "newusername"
+    new_password = "newpassword"
+    new_first_name = "bar"
+    new_last_name = "foo"
+    new_email = "newemail@example.com"
+    data = {
+        "username": new_username,
+        "password": new_password,
+        "password_confirmation": new_password,
+        "first_name": new_first_name,
+        "last_name": new_last_name,
+        "email": new_email,
+    }
+
+    response = admin_client.post(
+        reverse("accounts:edit", kwargs={"id": non_administrative_user.id}),
+        data,
+        follow=True,
+    )
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert "Saved" in content
+    assert (
+        f'<a href="{reverse("accounts:edit", kwargs={"id": non_administrative_user.id})}">{new_username}</a>'
+        in content
+    )
+    assert f"<td>{new_first_name} {new_last_name}</td>" in content
+    assert f"<td>{new_email}</td>" in content
+
+    non_administrative_user.refresh_from_db()
+    assert non_administrative_user.check_password(new_password)
+
+
+@pytest.mark.django_db
+def test_edit_user_view_regenerates_api_key(
+    dashboard_uuid: None,
+    non_administrative_user: User,
+    non_administrative_user_apikey: ApiKey,
+    admin_client: Client,
+) -> None:
+    data = {
+        "username": non_administrative_user.username,
+        "first_name": non_administrative_user.first_name,
+        "last_name": non_administrative_user.last_name,
+        "email": non_administrative_user.email,
+        "regenerate_api_key": True,
+    }
+    expected_uuid = uuid.uuid4()
+    expected_key = hmac.new(expected_uuid.bytes, digestmod=sha1).hexdigest()
+
+    with mock.patch("uuid.uuid4", return_value=expected_uuid):
+        response = admin_client.post(
+            reverse("accounts:edit", kwargs={"id": non_administrative_user.id}),
+            data,
+            follow=True,
+        )
+    assert response.status_code == 200
+
+    assert "Saved" in response.content.decode()
+
+    non_administrative_user_apikey.refresh_from_db()
+    assert non_administrative_user_apikey.key == expected_key

--- a/tests/dashboard/components/accounts/test_views.py
+++ b/tests/dashboard/components/accounts/test_views.py
@@ -2,10 +2,12 @@ from urllib.parse import parse_qs
 from urllib.parse import urlparse
 
 import pytest
+import pytest_django
 from components.accounts.views import get_oidc_logout_url
+from django.test import RequestFactory
 
 
-def test_get_oidc_logout_url_fails_if_token_is_not_set(rf):
+def test_get_oidc_logout_url_fails_if_token_is_not_set(rf: RequestFactory) -> None:
     request = rf.get("/")
     request.session = {}
 
@@ -13,7 +15,9 @@ def test_get_oidc_logout_url_fails_if_token_is_not_set(rf):
         get_oidc_logout_url(request)
 
 
-def test_get_oidc_logout_url_fails_if_logout_endpoint_is_not_set(rf):
+def test_get_oidc_logout_url_fails_if_logout_endpoint_is_not_set(
+    rf: RequestFactory,
+) -> None:
     request = rf.get("/")
     request.session = {"oidc_id_token": "mytoken"}
 
@@ -23,7 +27,9 @@ def test_get_oidc_logout_url_fails_if_logout_endpoint_is_not_set(rf):
         get_oidc_logout_url(request)
 
 
-def test_get_oidc_logout_url_returns_logout_url(rf, settings):
+def test_get_oidc_logout_url_returns_logout_url(
+    rf: RequestFactory, settings: pytest_django.fixtures.SettingsWrapper
+) -> None:
     settings.OIDC_OP_LOGOUT_ENDPOINT = "http://example.com/logout"
     token = "mytoken"
     request = rf.get("/")

--- a/tests/dashboard/components/administration/test_administration.py
+++ b/tests/dashboard/components/administration/test_administration.py
@@ -2,18 +2,19 @@ import uuid
 
 import pytest
 from components import helpers
+from django.test import Client
 from django.urls import reverse
 from main.models import Report
 
 
 @pytest.fixture
 @pytest.mark.django_db
-def dashboard_uuid():
+def dashboard_uuid() -> None:
     helpers.set_setting("dashboard_uuid", str(uuid.uuid4()))
 
 
 @pytest.mark.django_db
-def test_admin_set_language(dashboard_uuid, admin_client):
+def test_admin_set_language(dashboard_uuid: None, admin_client: Client) -> None:
     response = admin_client.get(reverse("administration:admin_set_language"))
     assert response.status_code == 200
 
@@ -23,7 +24,7 @@ def test_admin_set_language(dashboard_uuid, admin_client):
 
 
 @pytest.mark.django_db
-def test_failure_report_delete(dashboard_uuid, admin_client):
+def test_failure_report_delete(dashboard_uuid: None, admin_client: Client) -> None:
     report = Report.objects.create(content="my report")
 
     response = admin_client.post(
@@ -38,7 +39,7 @@ def test_failure_report_delete(dashboard_uuid, admin_client):
 
 
 @pytest.mark.django_db
-def test_failure_report(dashboard_uuid, admin_client):
+def test_failure_report(dashboard_uuid: None, admin_client: Client) -> None:
     report = Report.objects.create(content="my report")
 
     response = admin_client.get(reverse("administration:reports_failures_index"))

--- a/tests/dashboard/components/administration/test_administration.py
+++ b/tests/dashboard/components/administration/test_administration.py
@@ -1,20 +1,29 @@
 import uuid
+from unittest import mock
 
 import pytest
+import pytest_django
+import requests
 from components import helpers
+from django.contrib.auth.models import User
+from django.http import HttpResponseNotFound
 from django.test import Client
 from django.urls import reverse
 from main.models import Report
+from tastypie.models import ApiKey
 
 
 @pytest.fixture
 @pytest.mark.django_db
-def dashboard_uuid() -> None:
-    helpers.set_setting("dashboard_uuid", str(uuid.uuid4()))
+def dashboard_uuid() -> str:
+    value = str(uuid.uuid4())
+    helpers.set_setting("dashboard_uuid", value)
+
+    return value
 
 
 @pytest.mark.django_db
-def test_admin_set_language(dashboard_uuid: None, admin_client: Client) -> None:
+def test_admin_set_language(dashboard_uuid: str, admin_client: Client) -> None:
     response = admin_client.get(reverse("administration:admin_set_language"))
     assert response.status_code == 200
 
@@ -24,7 +33,7 @@ def test_admin_set_language(dashboard_uuid: None, admin_client: Client) -> None:
 
 
 @pytest.mark.django_db
-def test_failure_report_delete(dashboard_uuid: None, admin_client: Client) -> None:
+def test_failure_report_delete(dashboard_uuid: str, admin_client: Client) -> None:
     report = Report.objects.create(content="my report")
 
     response = admin_client.post(
@@ -39,7 +48,7 @@ def test_failure_report_delete(dashboard_uuid: None, admin_client: Client) -> No
 
 
 @pytest.mark.django_db
-def test_failure_report(dashboard_uuid: None, admin_client: Client) -> None:
+def test_failure_report(dashboard_uuid: str, admin_client: Client) -> None:
     report = Report.objects.create(content="my report")
 
     response = admin_client.get(reverse("administration:reports_failures_index"))
@@ -48,3 +57,194 @@ def test_failure_report(dashboard_uuid: None, admin_client: Client) -> None:
     content = response.content.decode()
     assert "<h3>Failure report</h3>" in content
     assert reverse("administration:failure_report", args=[report.pk]) in content
+
+
+@pytest.fixture
+def site_url() -> str:
+    value = "https://example.com/"
+    helpers.set_setting("site_url", value)
+
+    return value
+
+
+@pytest.fixture
+def storage_service_url() -> str:
+    value = "https://ss.example.com/"
+    helpers.set_setting("storage_service_url", value)
+
+    return value
+
+
+@pytest.fixture
+def storage_service_user() -> str:
+    value = "test"
+    helpers.set_setting("storage_service_user", value)
+
+    return value
+
+
+@pytest.fixture
+def storage_service_apikey() -> str:
+    value = "api-key"
+    helpers.set_setting("storage_service_apikey", value)
+
+    return value
+
+
+@pytest.fixture
+def checksum_type() -> str:
+    value = "md5"
+    helpers.set_setting("checksum_type", value)
+
+    return value
+
+
+@pytest.mark.django_db
+@mock.patch(
+    "requests.Session.get",
+    side_effect=[mock.Mock(status_code=200, spec=requests.Response)],
+)
+def test_general_view_renders_initial_dashboard_settings(
+    get: mock.Mock,
+    dashboard_uuid: str,
+    site_url: str,
+    storage_service_url: str,
+    storage_service_user: str,
+    storage_service_apikey: str,
+    checksum_type: str,
+    admin_client: Client,
+) -> None:
+    response = admin_client.get(reverse("administration:general"))
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert f"<b>Dashboard UUID</b> {dashboard_uuid}" in content
+    assert f'name="general-site_url" value="{site_url}"' in content
+    assert (
+        f'name="storage-storage_service_url" value="{storage_service_url}"' in content
+    )
+    assert (
+        f'name="storage-storage_service_user" value="{storage_service_user}"' in content
+    )
+    assert (
+        f'name="storage-storage_service_apikey" value="{storage_service_apikey}"'
+        in content
+    )
+    assert f'<option value="{checksum_type}" selected>' in content
+
+
+@pytest.mark.django_db
+@mock.patch("requests.Session.get")
+def test_general_view_renders_warning_if_it_cannot_connect_to_pipeline(
+    get: mock.Mock,
+    dashboard_uuid: str,
+    admin_client: Client,
+) -> None:
+    error = "connection refused"
+    get.side_effect = [requests.exceptions.ConnectionError(error)]
+
+    response = admin_client.get(reverse("administration:general"))
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert "Storage Service inaccessible" in content
+    assert error in content
+
+
+@pytest.mark.django_db
+@mock.patch(
+    "requests.Session.get",
+    side_effect=[mock.Mock(status_code=200, spec=requests.Response)],
+)
+def test_general_view_updates_dashboard_settings(
+    get: mock.Mock,
+    dashboard_uuid: str,
+    site_url: str,
+    storage_service_url: str,
+    storage_service_user: str,
+    storage_service_apikey: str,
+    checksum_type: str,
+    admin_client: Client,
+) -> None:
+    new_site_url = "https://other.example.com"
+    new_storage_service_url = "https://other.ss.example.com"
+    new_storage_service_user = "foobar"
+    new_storage_service_apikey = "foobar"
+    new_checksum_type = "sha512"
+
+    data = {
+        "general-site_url": new_site_url,
+        "storage-storage_service_url": new_storage_service_url,
+        "storage-storage_service_user": new_storage_service_user,
+        "storage-storage_service_apikey": new_storage_service_apikey,
+        "checksum algorithm-checksum_type": new_checksum_type,
+    }
+
+    response = admin_client.post(reverse("administration:general"), data)
+    assert response.status_code == 200
+
+    assert "Saved" in response.content.decode()
+    assert helpers.get_setting("site_url", new_site_url)
+    assert helpers.get_setting("storage_service_url", new_storage_service_url)
+    assert helpers.get_setting("storage_service_user", new_storage_service_user)
+    assert helpers.get_setting("storage_service_apikey", new_storage_service_apikey)
+    assert helpers.get_setting("checksum_type", new_checksum_type)
+
+
+class NotFound(Exception):
+    response = HttpResponseNotFound()
+
+
+@pytest.fixture
+def admin_user_apikey(admin_user: User) -> ApiKey:
+    return ApiKey.objects.create(user=admin_user)
+
+
+@pytest.mark.django_db
+@mock.patch("storageService.get_pipeline", side_effect=NotFound)
+@mock.patch("requests.Session.post")
+@mock.patch("platform.node")
+def test_general_view_registers_pipeline_in_storage_service(
+    node: mock.Mock,
+    post: mock.Mock,
+    get_pipeline: mock.Mock,
+    dashboard_uuid: str,
+    site_url: str,
+    storage_service_url: str,
+    storage_service_user: str,
+    storage_service_apikey: str,
+    admin_client: Client,
+    admin_user: User,
+    admin_user_apikey: ApiKey,
+    caplog: pytest.LogCaptureFixture,
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    hostname = "myhost"
+    node.return_value = hostname
+    data = {
+        "storage-storage_service_url": storage_service_url,
+        "storage-storage_service_user": storage_service_user,
+        "storage-storage_service_apikey": storage_service_apikey,
+        "storage-storage_service_use_default_config": True,
+    }
+    shared_directory = "/tmp"
+    settings.SHARED_DIRECTORY = shared_directory
+
+    response = admin_client.post(reverse("administration:general"), data)
+    assert response.status_code == 200
+
+    assert "SS inaccessible or pipeline not registered." in [
+        r.message for r in caplog.records
+    ]
+    post.assert_called_once_with(
+        f"{storage_service_url}api/v2/pipeline/",
+        json={
+            "uuid": dashboard_uuid,
+            "description": f"Archivematica on {hostname}",
+            "create_default_locations": True,
+            "shared_path": shared_directory,
+            "remote_name": site_url,
+            "api_username": admin_user.username,
+            "api_key": admin_user_apikey.key,
+        },
+    )


### PR DESCRIPTION
When the [ALLOW_USER_EDITS](https://github.com/artefactual/archivematica/blob/b1e75911632966319d13751c90fe08131d2384a3/src/dashboard/src/settings/base.py#L581) setting of the Dashboard is set to `False` the user profile view shows most fields as read-only but allows the user to regenerate their API key.




However, submission handling of the form is currently broken and the API key is always regenerated when the `Save` button is clicked ignoring the state of the `Regenerate API key` checkbox.

This also extends test coverage of the views of the `accounts` and `administration` packages.