### PR TITLE
Defer FPRule counter updates during normalization

### DIFF
--- a/src/MCPClient/lib/clientScripts/normalize.py
+++ b/src/MCPClient/lib/clientScripts/normalize.py
@@ -573,8 +573,8 @@ def main(job: Job, opts: NormalizeArgs, counter: DeferredFPRuleCounter) -> int:
     if (
         exitstatus != 0
         and opts.purpose in ("access", "thumbnail")
-        and cl.commandObject.output_location
-        and (not os.path.isfile(cl.commandObject.output_location))
+        and cl.output_location
+        and (not os.path.isfile(cl.output_location))
     ):
         # Fall back to default rule
         try:
@@ -614,7 +614,7 @@ def main(job: Job, opts: NormalizeArgs, counter: DeferredFPRuleCounter) -> int:
     # Store thumbnails locally for use during AIP searches
     # TODO is this still needed, with the storage service?
     if "thumbnail" in opts.purpose:
-        thumbnail_filepath = cl.commandObject.output_location
+        thumbnail_filepath = cl.output_location
         thumbnail_storage_dir = os.path.join(
             mcpclient_settings.SHARED_DIRECTORY, "www", "thumbnails", opts.sip_uuid
         )

--- a/src/MCPClient/lib/clientScripts/transcoder.py
+++ b/src/MCPClient/lib/clientScripts/transcoder.py
@@ -112,26 +112,22 @@ class CommandLinker:
         self, job, fprule, command, replacement_dict, opts, on_success, counter
     ):
         self.fprule = fprule
-        self.command = command
-        self.replacement_dict = replacement_dict
-        self.opts = opts
-        self.on_success = on_success
-        self.commandObject = Command(
-            job, self.command, replacement_dict, self.on_success, opts
-        )
+        self.cmd = Command(job, command, replacement_dict, on_success, opts)
         self.counter = counter
 
     def __str__(self):
-        return (
-            f"[Command Linker] FPRule: {self.fprule.uuid} Command: {self.commandObject}"
-        )
+        return f"[Command Linker] FPRule: {self.fprule.uuid} Command: {self.cmd}"
+
+    @property
+    def output_location(self):
+        return self.cmd.output_location
 
     def execute(self):
         """Execute the command, and track the success statistics.
 
         Returns 0 on success, non-0 on failure."""
         self.counter.record_attempt(self.fprule)
-        ret = self.commandObject.execute()
+        ret = self.cmd.execute()
         if ret:
             self.counter.record_failure(self.fprule)
         else:

--- a/tests/MCPClient/test_normalize.py
+++ b/tests/MCPClient/test_normalize.py
@@ -45,7 +45,8 @@ def test_normalization_fails_if_original_file_does_not_exist() -> None:
     job = mock.Mock(spec=Job)
     opts = mock.Mock(file_uuid=file_uuid)
 
-    result = normalize.main(job, opts)
+    with normalize.DeferredFPRuleCounter() as counter:
+        result = normalize.main(job, opts, counter)
 
     assert result == normalize.NO_RULE_FOUND
     job.print_error.assert_called_once_with(
@@ -67,7 +68,8 @@ def test_normalization_skips_submission_documentation_file_if_group_use_does_not
         normalize_file_grp_use="original",
     )
 
-    result = normalize.main(job, opts)
+    with normalize.DeferredFPRuleCounter() as counter:
+        result = normalize.main(job, opts, counter)
 
     assert result == normalize.SUCCESS
     assert job.print_output.mock_calls == [
@@ -93,7 +95,8 @@ def test_normalization_skips_file_if_group_use_does_not_match(
         normalize_file_grp_use="access",
     )
 
-    result = normalize.main(job, opts)
+    with normalize.DeferredFPRuleCounter() as counter:
+        result = normalize.main(job, opts, counter)
 
     assert result == normalize.SUCCESS
     assert job.print_output.mock_calls == [
@@ -178,7 +181,8 @@ def test_manual_normalization_creates_event_and_derivation(
         normalize_file_grp_use="original",
     )
 
-    result = normalize.main(job, opts)
+    with normalize.DeferredFPRuleCounter() as counter:
+        result = normalize.main(job, opts, counter)
 
     assert result == normalize.SUCCESS
     assert job.print_output.mock_calls == [
@@ -250,7 +254,8 @@ def test_manual_normalization_fails_with_invalid_normalization_csv(
         normalize_file_grp_use="original",
     )
 
-    result = normalize.main(job, opts)
+    with normalize.DeferredFPRuleCounter() as counter:
+        result = normalize.main(job, opts, counter)
 
     assert result == normalize.NO_RULE_FOUND
     assert job.print_error.mock_calls == [
@@ -297,7 +302,8 @@ def test_manual_normalization_matches_by_filename_instead_of_normalization_csv(
         normalize_file_grp_use="original",
     )
 
-    result = normalize.main(job, opts)
+    with normalize.DeferredFPRuleCounter() as counter:
+        result = normalize.main(job, opts, counter)
 
     assert result == normalize.SUCCESS
     assert job.print_error.mock_calls == []
@@ -350,7 +356,8 @@ def test_manual_normalization_matches_from_multiple_filenames(
         normalize_file_grp_use="original",
     )
 
-    result = normalize.main(job, opts)
+    with normalize.DeferredFPRuleCounter() as counter:
+        result = normalize.main(job, opts, counter)
 
     assert result == normalize.SUCCESS
     assert job.print_error.mock_calls == []
@@ -413,7 +420,8 @@ def test_normalization_falls_back_to_default_rule(
         normalize_file_grp_use="original",
     )
 
-    result = normalize.main(job, opts)
+    with normalize.DeferredFPRuleCounter() as counter:
+        result = normalize.main(job, opts, counter)
 
     assert result == normalize.SUCCESS
     command_linker.assert_called_once()
@@ -474,7 +482,8 @@ def test_normalization_finds_rule_by_file_format_version(
         normalize_file_grp_use="original",
     )
 
-    result = normalize.main(job, opts)
+    with normalize.DeferredFPRuleCounter() as counter:
+        result = normalize.main(job, opts, counter)
 
     assert result == normalize.SUCCESS
     command_linker.assert_called_once()


### PR DESCRIPTION
This pull request introduces a context manager (`DeferredFPRuleCounter`) to defer the tracked FPRule execution until the `call` function completes the execution of the entire batch, reducing the risk of deadlocks when multiple MCPClients attempt to update the same FPRule concurrently.

This change helps prevent deadlocks, but keep in mind that normalize.py might be reworked later to avoid using long database transactions altogether.

Tentative fix for https://github.com/archivematica/Issues/issues/752 and https://github.com/archivematica/Issues/issues/1525.
Relates to https://github.com/archivematica/Issues/issues/1161.

Updated analysis:
https://gist.github.com/sevein/2ff98ef96e0e195ab57f806796a71000