### PR TITLE
Do not create amdSec when bag metadata is empty

### DIFF
--- a/src/MCPClient/lib/clientScripts/create_mets_v2.py
+++ b/src/MCPClient/lib/clientScripts/create_mets_v2.py
@@ -1420,7 +1420,7 @@ def create_object_metadata(job, struct_map, baseDirectoryPath, state):
     )
     bag_info = [find_bag_metadata(job, path) for path in paths]
 
-    if not transfer and not source and not bag_info:
+    if not transfer and not source and not any(bag_info):
         return
 
     state.globalAmdSecCounter += 1

--- a/tests/MCPClient/test_create_mets_v2.py
+++ b/tests/MCPClient/test_create_mets_v2.py
@@ -431,15 +431,24 @@ def bag_path(sip_directory_path: pathlib.Path, sip: SIP) -> pathlib.Path:
 
 @pytest.mark.django_db
 @mock.patch("create_mets_v2.Bag")
+@pytest.mark.parametrize(
+    "info",
+    [
+        {"Bagging-Date": "2025-01-08", "Payload-Oxum": "0.2"},
+    ],
+    ids=[
+        "populated",
+    ],
+)
 def test_bag_metadata_is_recorded_in_a_amdsec(
     bag_class: mock.Mock,
+    info: dict[str, str],
     mcp_job: Job,
     sip_directory_path: pathlib.Path,
     sip: SIP,
     sip_file: File,
     bag_path: pathlib.Path,
 ) -> None:
-    info = {"Bagging-Date": "2025-01-08", "Payload-Oxum": "0.2"}
     bag_class.return_value = mock.Mock(info=info)
     mets_path = sip_directory_path / f"METS.{sip.uuid}.xml"
 

--- a/tests/MCPClient/test_create_mets_v2.py
+++ b/tests/MCPClient/test_create_mets_v2.py
@@ -435,9 +435,11 @@ def bag_path(sip_directory_path: pathlib.Path, sip: SIP) -> pathlib.Path:
     "info",
     [
         {"Bagging-Date": "2025-01-08", "Payload-Oxum": "0.2"},
+        {},
     ],
     ids=[
         "populated",
+        "empty",
     ],
 )
 def test_bag_metadata_is_recorded_in_a_amdsec(


### PR DESCRIPTION
This prevents the creation and association of a `amdSec` element to the `objects` directory in the `structMap` when the transfer bag metadata is missing or unreadable.

Connected to https://github.com/archivematica/Issues/issues/1129