### PR TITLE
Fix test-at-check target in hack/Makefile

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -337,7 +337,7 @@ test-at-build:  ## AMAUAT: build image.
 
 test-at-check: test-at-build  ## AMAUAT: test browsers.
 	$(call compose_amauat, \
-		run --rm --no-deps archivematica-acceptance-tests /home/archivematica/acceptance-tests/simplebrowsertest.py)
+		run --rm --no-deps archivematica-acceptance-tests /home/artefactual/acceptance-tests/simplebrowsertest.py)
 
 define AT_HELP
 


### PR DESCRIPTION
The correct user in the AMAUATs container filesystem is [`artefactual`](https://github.com/artefactual-labs/archivematica-acceptance-tests/blob/255cca0f129230cbf9102305895d82f0ca8f6f16/Dockerfile#L125-L133).

Connected to https://github.com/archivematica/Issues/issues/1720