### PR TITLE
Include management commands in coverage report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ norecursedirs = ".svn _build tmp* node_modules bower_components share .tox"
 omit = [
     "**/src/archivematicaCommon/lib/externals/*",
     "**/migrations/*",
-    "**/management/commands/*",
     "**/settings/*",
     "**/tests/*",
     "**/wsgi.py",


### PR DESCRIPTION
This adds the dashboard management commands such as the `purge_transient_processing_data` command to the test coverage report.

Connected to https://github.com/archivematica/Issues/issues/1720