### PR TITLE
Extend test coverage of FPR management commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ module = [
     "tests.archivematicaCommon.test_execute_functions",
     "tests.dashboard.components.accounts.test_views",
     "tests.dashboard.components.administration.test_administration",
+    "tests.dashboard.fpr.test_command_get_fpr_changes",
+    "tests.dashboard.fpr.test_command_import_pronom_ids",
     "tests.dashboard.fpr.test_views",
     "tests.dashboard.test_oidc",
     "tests.integration.test_oidc_auth",

--- a/tests/dashboard/fpr/test_command_get_fpr_changes.py
+++ b/tests/dashboard/fpr/test_command_get_fpr_changes.py
@@ -1,0 +1,117 @@
+import json
+import pathlib
+
+import pytest
+from django.core.management import call_command
+
+
+@pytest.mark.django_db
+def test_command_outputs_new_fpr_entries(
+    tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    old_json = [
+        {
+            "model": "fpr.formatgroup",
+            "pk": 1,
+            "fields": {
+                "uuid": "c94ce0e6-c275-4c09-b802-695a18b7bf2a",
+                "description": "Audio",
+                "slug": "audio",
+            },
+        },
+        {
+            "model": "fpr.format",
+            "pk": 1,
+            "fields": {
+                "uuid": "22147b00-0fdc-4653-aa7b-618d1f4b6ffb",
+                "description": "Audio Interchange File Format",
+                "group": "c94ce0e6-c275-4c09-b802-695a18b7bf2a",
+                "slug": "audio-interchange-file-format",
+            },
+        },
+        {
+            "model": "fpr.formatversion",
+            "pk": 152,
+            "fields": {
+                "replaces": None,
+                "enabled": True,
+                "lastmodified": "2013-11-15T01:18:31Z",
+                "uuid": "36800d63-1bb5-4324-ba8c-90e222eeddbc",
+                "format": "22147b00-0fdc-4653-aa7b-618d1f4b6ffb",
+                "version": "1.2",
+                "pronom_id": "fmt/414",
+                "description": "Audio Interchange File Format ",
+                "access_format": False,
+                "preservation_format": False,
+                "slug": "audio-interchange-file-format-12",
+            },
+        },
+    ]
+    new_format_groups = [
+        {
+            "model": "fpr.formatgroup",
+            "pk": 2,
+            "fields": {
+                "uuid": "5b14d57c-d6f1-4807-b98d-0a574d6bf8fc",
+                "description": "Email",
+                "slug": "email",
+            },
+        },
+    ]
+    new_formats = [
+        {
+            "model": "fpr.format",
+            "pk": 6,
+            "fields": {
+                "uuid": "187d9216-7a53-4ef6-b9dd-4a397c414543",
+                "description": "Archivematica Maildir",
+                "group": "5b14d57c-d6f1-4807-b98d-0a574d6bf8fc",
+                "slug": "archivematica-maildir",
+            },
+        },
+    ]
+    new_format_versions = [
+        {
+            "model": "fpr.formatversion",
+            "pk": 259,
+            "fields": {
+                "replaces": None,
+                "enabled": True,
+                "lastmodified": "2013-11-15T01:18:32Z",
+                "uuid": "c6a208a1-8abc-47b9-9b1e-47c877aa4a0f",
+                "format": "187d9216-7a53-4ef6-b9dd-4a397c414543",
+                "version": "",
+                "pronom_id": "",
+                "description": "Archivematica Maildir",
+                "access_format": False,
+                "preservation_format": True,
+                "slug": "archivematica-maildir",
+            },
+        },
+    ]
+    new_entries = new_formats + new_format_groups + new_format_versions
+    new_json = old_json + new_entries
+
+    old_json_path = tmp_path / "old.json"
+    new_json_path = tmp_path / "new.json"
+    output_path = tmp_path / "output"
+    old_json_path.write_text(json.dumps(old_json))
+    new_json_path.write_text(json.dumps(new_json))
+
+    call_command(
+        "get_fpr_changes", str(old_json_path), str(new_json_path), str(output_path)
+    )
+
+    captured = capsys.readouterr()
+    assert (
+        "\n".join(
+            [
+                f"{len(new_entries)} new entries total",
+                f"{len(new_formats)} new entries for fpr.format",
+                f"{len(new_format_groups)} new entries for fpr.formatgroup",
+                f"{len(new_format_versions)} new entries for fpr.formatversion",
+            ]
+        )
+        in captured.out
+    )
+    assert json.loads(output_path.read_text()) == new_entries

--- a/tests/dashboard/fpr/test_command_import_pronom_ids.py
+++ b/tests/dashboard/fpr/test_command_import_pronom_ids.py
@@ -1,0 +1,89 @@
+import pathlib
+import uuid
+from unittest import mock
+
+import pytest
+import pytest_django
+from django.core.management import call_command
+
+
+@pytest.mark.django_db
+def test_command_fails_if_xml_file_does_not_exist(tmp_path: pathlib.Path) -> None:
+    with pytest.raises(SystemExit, match="Pronom XML file does not exist!"):
+        call_command("import_pronom_ids", str(tmp_path / "bogus.xml"))
+
+
+@pytest.mark.django_db
+def test_command_saves_data_migration_to_file(
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    # Enable connection.queries used in the command.
+    settings.DEBUG = True
+
+    # These identifiers are hardcoded in the command.
+    file_by_extension_command_uuid = uuid.UUID("8546b624-7894-4201-8df6-f239d5e0d5ba")
+    unknown_group_uuid = uuid.UUID("00abbdd0-51b3-4162-b93a-45deb4ed8654")
+
+    format_uuid = uuid.uuid4()
+    format_version_uuid = uuid.uuid4()
+    idrule_uuid = uuid.uuid4()
+
+    xml_format_puid = "fmt/9999999"
+    xml_format_name = "My new format"
+    xml_format_version = "1.0"
+    xml_format_pronom_id = "1"
+    xml_format_extension = "foobar"
+    xml_format_signature_name = "My signature name"
+
+    output_file_path = tmp_path / "output.xml"
+    pronom_xml_path = tmp_path / "pronom.xml"
+    pronom_xml_path.write_text(f"""
+        <formats>
+            <format>
+                <puid>{xml_format_puid}</puid>
+                <name>{xml_format_name}</name>
+                <version>{xml_format_version}</version>
+                <pronom_id>{xml_format_pronom_id}</pronom_id>
+                <extension>{xml_format_extension}</extension>
+                <signature>
+                    <name>{xml_format_signature_name}</name>
+                </signature>
+            </format>
+        </formats>
+    """)
+
+    with mock.patch(
+        "uuid.uuid4", side_effect=[format_uuid, format_version_uuid, idrule_uuid]
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            call_command(
+                "import_pronom_ids",
+                "--output-filename",
+                str(output_file_path),
+                "--output-format",
+                "migration",
+                str(pronom_xml_path),
+            )
+        assert excinfo.value.code is None
+
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "\n".join(
+        [
+            f"Format {xml_format_puid} does not exist",
+            f"Importing {xml_format_signature_name} {xml_format_puid}",
+        ]
+    )
+    assert output_file_path.read_text().strip() == "\n".join(
+        [
+            "def data_migration(apps, schema_editor):",
+            "    Format = apps.get_model('fpr', 'Format')",
+            "    FormatVersion = apps.get_model('fpr', 'FormatVersion')",
+            "    IDRule = apps.get_model('fpr', 'IDRule')",
+            "",
+            f'    Format.objects.create(description="""{xml_format_name}""", group_id="{unknown_group_uuid}", uuid="{format_uuid}")',
+            f'    FormatVersion.objects.create(format_id="{format_uuid}", pronom_id="{xml_format_puid}", description="""{xml_format_signature_name}""", version="{xml_format_version}", uuid="{format_version_uuid}")',
+            f'    IDRule.objects.create(format_id="{format_version_uuid}", command_id="{file_by_extension_command_uuid}", command_output=".{xml_format_extension}")',
+        ]
+    )


### PR DESCRIPTION
This adds tests for the two FPR management commands used in [PRONOM upgrades](https://wiki.archivematica.org/Release_Process#Update_workflow):
* `import_pronom_ids`: used first to convert `fido`'s formats XML file into a Django migration
* `get_fpr_changes`: used later to extract the QA updates analysts perform during the upgrade

Connected to https://github.com/archivematica/Issues/issues/1725