### PR TITLE
Use json.loads to decode unit vars

### DIFF
--- a/src/MCPClient/clientScripts/identify_file_format.py
+++ b/src/MCPClient/clientScripts/identify_file_format.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import dataclasses
+import json
 import multiprocessing
 import uuid
 from typing import Optional
@@ -56,7 +57,7 @@ def _save_id_preference(file_: File, value: bool) -> None:
     rd = {"%IDCommand%": str(value)}
 
     UnitVariable.objects.create(
-        unituuid=unit.pk, variable="replacementDict", variablevalue=str(rd)
+        unituuid=unit.pk, variable="replacementDict", variablevalue=json.dumps(rd)
     )
 
 

--- a/src/MCPServer/assets/workflow.json
+++ b/src/MCPServer/assets/workflow.json
@@ -6773,7 +6773,7 @@
         "@manager": "linkTaskManagerSetUnitVariable",
         "@model": "TaskConfigSetUnitVariable",
         "variable": "normalize_v1.0",
-        "variable_value": "{'filterSubDir':'objects/attachments'}"
+        "variable_value": "{\"filterSubDir\":\"objects/attachments\"}"
       },
       "description": {
         "en": "Set files to normalize",
@@ -9216,7 +9216,7 @@
         "@manager": "linkTaskManagerSetUnitVariable",
         "@model": "TaskConfigSetUnitVariable",
         "variable": "identifyFileFormat_v0.0",
-        "variable_value": "{'filterSubDir':'objects/attachments'}"
+        "variable_value": "{\"filterSubDir\":\"objects/attachments\"}"
       },
       "description": {
         "en": "Set files to identify",

--- a/src/MCPServer/server/jobs/client.py
+++ b/src/MCPServer/server/jobs/client.py
@@ -3,7 +3,6 @@ Jobs remotely executed by on MCP client.
 """
 
 import abc
-import ast
 import json
 import logging
 
@@ -202,7 +201,7 @@ class FilesClientScriptJob(ClientScriptJob):
 
         if var:
             try:
-                script_override = ast.literal_eval(var.variablevalue)
+                script_override = json.loads(var.variablevalue)
             except (SyntaxError, ValueError):
                 pass
             else:

--- a/src/MCPServer/server/packages.py
+++ b/src/MCPServer/server/packages.py
@@ -1,8 +1,8 @@
 """Package management."""
 
 import abc
-import ast
 import collections
+import json
 import logging
 import os
 from pathlib import Path
@@ -926,9 +926,8 @@ class PackageContext:
         # Distinct helps here, at least
         unit_vars_queryset = unit_vars_queryset.values_list("variablevalue").distinct()
         for unit_var_value in unit_vars_queryset:
-            # TODO: nope nope nope, fix eval usage
             try:
-                unit_var = ast.literal_eval(unit_var_value[0])
+                unit_var = json.loads(unit_var_value[0])
             except (ValueError, SyntaxError):
                 logger.exception(
                     "Failed to eval unit variable value %s", unit_var_value[0]

--- a/src/MCPServer/server/packages.py
+++ b/src/MCPServer/server/packages.py
@@ -928,7 +928,7 @@ class PackageContext:
         for unit_var_value in unit_vars_queryset:
             try:
                 unit_var = json.loads(unit_var_value[0])
-            except (ValueError, SyntaxError):
+            except (ValueError, TypeError):
                 logger.exception(
                     "Failed to eval unit variable value %s", unit_var_value[0]
                 )

--- a/tests/MCPClient/test_identify_file_format.py
+++ b/tests/MCPClient/test_identify_file_format.py
@@ -216,7 +216,7 @@ def test_job_saves_unit_variable_indicating_file_format_identification_use(
         models.UnitVariable.objects.filter(
             unituuid=sip.pk,
             variable="replacementDict",
-            variablevalue="{'%IDCommand%': 'True'}",
+            variablevalue='{"%IDCommand%": "True"}',
         ).count()
         == 1
     )


### PR DESCRIPTION
This pull request removes the remaining uses of ast.literal_eval, excluding an old database migration that doesn't seem worth addressing.

Relates to #2035 and #2036.

Connected to https://github.com/archivematica/Issues/issues/1735