### PR TITLE
Fix exception handling in json.loads

### DIFF
--- a/src/MCPServer/server/jobs/client.py
+++ b/src/MCPServer/server/jobs/client.py
@@ -202,7 +202,7 @@ class FilesClientScriptJob(ClientScriptJob):
         if var:
             try:
                 script_override = json.loads(var.variablevalue)
-            except (SyntaxError, ValueError):
+            except (TypeError, ValueError):
                 pass
             else:
                 filter_subdir = script_override.get("filterSubDir")


### PR DESCRIPTION
This commit updates the snippet that uses `json.loads` to catch `TypeError` instead of `SyntaxError`.

Tiny follow-up for https://github.com/artefactual/archivematica/pull/2037.
Connected to https://github.com/archivematica/Issues/issues/1735.