### PR TITLE
Update FPR format groups to match PRONOM classifications

### DIFF
--- a/src/archivematica/dashboard/fpr/migrations/0047_update_format_groups.py
+++ b/src/archivematica/dashboard/fpr/migrations/0047_update_format_groups.py
@@ -1,0 +1,47 @@
+from django.db import migrations
+
+# This maps the existing FPR format group descriptions with the PRONOM
+# classification that should become the new format group descriptions.
+FORMAT_GROUP_TO_PRONOM_CLASSIFICATION = {
+    "Text (Markup)": "Text (Mark-up)",
+    "Word Processing": "Word Processor",
+}
+
+NEW_FORMAT_GROUPS = ["Text (Unstructured)"]
+
+
+def data_migration_up(apps, schema_editor):
+    FormatGroup = apps.get_model("fpr", "FormatGroup")
+
+    # Update existing format group descriptions.
+    for old_desc, new_desc in FORMAT_GROUP_TO_PRONOM_CLASSIFICATION.items():
+        format_groups = FormatGroup.objects.filter(description=old_desc)
+        if format_groups.exists():
+            format_groups.update(description=new_desc)
+
+    # Add new format groups.
+    FormatGroup.objects.bulk_create(
+        [
+            FormatGroup(description=desc)
+            for desc in NEW_FORMAT_GROUPS
+            if not FormatGroup.objects.filter(description=desc).exists()
+        ]
+    )
+
+
+def data_migration_down(apps, schema_editor):
+    FormatGroup = apps.get_model("fpr", "FormatGroup")
+
+    # Revert format groups descriptions.
+    for old_desc, new_desc in FORMAT_GROUP_TO_PRONOM_CLASSIFICATION.items():
+        format_groups = FormatGroup.objects.filter(description=new_desc)
+        if format_groups.exists():
+            format_groups.update(description=old_desc)
+
+    # Delete format groups added in this migration.
+    FormatGroup.objects.filter(description__in=NEW_FORMAT_GROUPS).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [("fpr", "0046_update_jhove_module_validation")]
+    operations = [migrations.RunPython(data_migration_up, data_migration_down)]


### PR DESCRIPTION
This adds a data migration to synchronize the descriptions of the FPR format groups with the [PRONOM classification](https://github.com/digital-preservation/PRONOM_Research?tab=readme-ov-file#format-types) values.

It renames the following format groups:

* `Text (Markup)` is converted to `Text (Mark-up)`
* `Word Processing` is converted to `Word Processor`

The slugs of these existing groups remain unchanged.

And it adds the following format group:

* `Text (Unstructured)`

Connected to https://github.com/archivematica/Issues/issues/1725