### PR TITLE
Do not show user API keys

### DIFF
--- a/src/archivematica/dashboard/components/accounts/forms.py
+++ b/src/archivematica/dashboard/components/accounts/forms.py
@@ -85,7 +85,7 @@ class UserChangeForm(DjangoUserChangeForm):
     is_superuser = forms.BooleanField(label="Administrator", required=False)
     regenerate_api_key = forms.CharField(
         widget=forms.CheckboxInput,
-        label="Regenerate API key (shown below)?",
+        label="Regenerate API key?",
         required=False,
     )
 
@@ -152,7 +152,7 @@ class UserChangeForm(DjangoUserChangeForm):
 class ApiKeyForm(forms.Form):
     regenerate_api_key = forms.BooleanField(
         widget=forms.CheckboxInput,
-        label="Regenerate API key (shown below)?",
+        label="Regenerate API key?",
         required=False,
     )
 

--- a/src/archivematica/dashboard/components/accounts/views.py
+++ b/src/archivematica/dashboard/components/accounts/views.py
@@ -79,7 +79,7 @@ def add(request):
 def profile(request):
     # If users are editable in this setup, go to the editable profile view
     if settings.ALLOW_USER_EDITS:
-        return edit(request)
+        return edit(request, return_view="accounts:profile")
 
     user = request.user
     user_profile = UserProfile.objects.get(user=user)
@@ -105,7 +105,7 @@ def profile(request):
     )
 
 
-def edit(request, id=None):
+def edit(request, id=None, return_view=None):
     # Forbidden if user isn't an admin and is trying to edit another user
     if str(request.user.id) != str(id) and id is not None:
         if request.user.is_superuser is False:
@@ -147,7 +147,11 @@ def edit(request, id=None):
 
             # determine where to redirect to
             if request.user.is_superuser:
-                return_view = "accounts:accounts_index"
+                return_view = request.POST.get("return_view")
+                if return_view:
+                    return_view = return_view
+                else:
+                    return_view = reverse("accounts:edit", kwargs={"id": user.pk})
             else:
                 return_view = "accounts:profile"
 
@@ -170,6 +174,7 @@ def edit(request, id=None):
             "userprofileform": userprofileform,
             "user": user,
             "title": title,
+            "return_view": return_view,
         },
     )
 

--- a/src/archivematica/dashboard/components/accounts/views.py
+++ b/src/archivematica/dashboard/components/accounts/views.py
@@ -26,6 +26,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
 from django.shortcuts import render
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from mozilla_django_oidc.views import OIDCAuthenticationRequestView
@@ -76,6 +77,13 @@ def add(request):
     )
 
 
+def _show_api_key_alert(request, key):
+    messages.success(
+        request,
+        render_to_string("accounts/user_api_key_alert.html", {"key": key}, request),
+    )
+
+
 def profile(request):
     # If users are editable in this setup, go to the editable profile view
     if settings.ALLOW_USER_EDITS:
@@ -90,7 +98,9 @@ def profile(request):
         userprofileform = UserProfileForm(request.POST, instance=user_profile)
         if form.is_valid() and userprofileform.is_valid():
             if form.cleaned_data["regenerate_api_key"]:
-                generate_api_key(user)
+                key = generate_api_key(user)
+                _show_api_key_alert(request, key)
+
             userprofileform.save()
 
             return redirect("accounts:profile")
@@ -143,7 +153,8 @@ def edit(request, id=None, return_view=None):
             # regenerate API key if requested
             regenerate_api_key = request.POST.get("regenerate_api_key", "")
             if regenerate_api_key != "":
-                generate_api_key(user)
+                key = generate_api_key(user)
+                _show_api_key_alert(request, key)
 
             # determine where to redirect to
             if request.user.is_superuser:

--- a/src/archivematica/dashboard/components/administration/forms.py
+++ b/src/archivematica/dashboard/components/administration/forms.py
@@ -231,6 +231,8 @@ class StorageSettingsForm(SettingsForm):
         help_text=_(
             "API key of the storage service user. E.g. 45f7684483044809b2de045ba59dc876b11b9810"
         ),
+        required=False,
+        widget=forms.PasswordInput,
     )
     storage_service_use_default_config = forms.BooleanField(
         required=False,
@@ -240,6 +242,13 @@ class StorageSettingsForm(SettingsForm):
             "You have to manually set up a custom configuration if the default configuration is not selected."
         ),
     )
+
+    def save(self, *args, **kwargs):
+        if not self.cleaned_data["storage_service_apikey"]:
+            # If the API key was not provided, remove it from the cleaned data
+            # to avoid overwriting its existing stored value.
+            del self.cleaned_data["storage_service_apikey"]
+        return super().save(*args, **kwargs)
 
 
 class ChecksumSettingsForm(SettingsForm):

--- a/src/archivematica/dashboard/components/helpers.py
+++ b/src/archivematica/dashboard/components/helpers.py
@@ -452,8 +452,11 @@ def generate_api_key(user):
     Generate API key for a user
     """
     api_key, _ = ApiKey.objects.get_or_create(user=user)
-    api_key.key = api_key.generate_key()
+    result = api_key.generate_key()
+    api_key.key = result
     api_key.save()
+
+    return result
 
 
 def get_api_allowlist():

--- a/src/archivematica/dashboard/media/js/misc.js
+++ b/src/archivematica/dashboard/media/js/misc.js
@@ -138,4 +138,31 @@ $(document).ready(
                 $(this).closest('.content').hide();
                 $(this).closest('.preview-help-text').children('.preview').show();
               });
+
+      // Enable tooltip for the button which allows users to copy the API key to the clipboard.
+      $('#copy-api-key-button').tooltip();
+
+      // Copy the API key to the clipboard on button click, then update the tooltip and icon accordingly.
+      $('#copy-api-key-button').click(function () {
+        var button = $(this);
+        navigator.clipboard.writeText($('#api-key').val()).then(function () {
+          var button_icon = $('#copy-button-icon');
+          var icon_original_class = button_icon.data('icon-original-class');
+          var icon_clicked_class = button_icon.data('icon-clicked-class');
+
+          // Update the button icon.
+          button_icon.removeClass(icon_original_class).addClass(icon_clicked_class).css('color', 'green');
+
+          // Update the button tooltip.
+          button.tooltip('option', 'content', button.data('clicked-label')).tooltip('open');
+
+          // Reset the button after 2 seconds.
+          setTimeout(function () {
+            button_icon.removeClass(icon_clicked_class).addClass(icon_original_class).css('color', '');
+            button.tooltip('option', 'content', button.data('original-label')).tooltip('close');
+          }, 2000);
+        }).catch(function (err) {
+          console.error('Failed to copy API key to clipboard: ', err);
+        });
+      });
 });

--- a/src/archivematica/dashboard/media/js/misc.js
+++ b/src/archivematica/dashboard/media/js/misc.js
@@ -139,11 +139,8 @@ $(document).ready(
                 $(this).closest('.preview-help-text').children('.preview').show();
               });
 
-      // Enable tooltip for the button which allows users to copy the API key to the clipboard.
-      $('#copy-api-key-button').tooltip();
-
-      // Copy the API key to the clipboard on button click, then update the tooltip and icon accordingly.
-      $('#copy-api-key-button').click(function () {
+      // Set up the button which allows users to copy the API key to the clipboard.
+      $('#copy-api-key-button').tooltip().click(function () {
         var button = $(this);
         navigator.clipboard.writeText($('#api-key').val()).then(function () {
           var button_icon = $('#copy-button-icon');

--- a/src/archivematica/dashboard/templates/accounts/edit.html
+++ b/src/archivematica/dashboard/templates/accounts/edit.html
@@ -29,10 +29,6 @@
 
         {% include "_form.html" %}
 
-        <div>
-          <div class='input'><code>{{ user|api_key }}</code></div>
-        </div>
-
         {% include "_form.html" with form=userprofileform %}
 
         <div class="actions">

--- a/src/archivematica/dashboard/templates/accounts/edit.html
+++ b/src/archivematica/dashboard/templates/accounts/edit.html
@@ -31,6 +31,10 @@
 
         {% include "_form.html" with form=userprofileform %}
 
+        {% if return_view %}
+        <input type="hidden" name="return_view" value="{{ return_view }}" />
+        {% endif %}
+
         <div class="actions">
           <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
           <a class="btn btn-default" href="{% url 'accounts:accounts_index' %}">{% trans "Cancel" %}</a>

--- a/src/archivematica/dashboard/templates/accounts/profile.html
+++ b/src/archivematica/dashboard/templates/accounts/profile.html
@@ -38,10 +38,6 @@
 
         {% include "_form.html" %}
 
-        <div>
-          <div class='input'><code>{{ user|api_key }}</code></div>
-        </div>
-
         {% include "_form.html" with form=userprofileform %}
 
         <div class="actions">

--- a/src/archivematica/dashboard/templates/accounts/user_api_key_alert.html
+++ b/src/archivematica/dashboard/templates/accounts/user_api_key_alert.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+<p>{% trans "Make sure to copy the API key now as you will not be able to see it again." %}</p>
+<br>
+{% trans 'Copy' as label_copy %}
+{% trans 'Copied!' as label_copied %}
+<div class="input-group">
+  <span class="input-group-btn">
+    <button id="copy-api-key-button" class="btn btn-default" style="height: 34px; line-height: 1;"
+        title="{{ label_copy }}"
+        data-original-label="{{ label_copy }}"
+        data-clicked-label="{{ label_copied }}">
+        <span id="copy-button-icon" class="glyphicon glyphicon-copy" data-icon-original-class="glyphicon-copy" data-icon-clicked-class="glyphicon-ok"></span>
+    </button>
+  </span>
+  <input type="text" id="api-key" value="{{ key }}" class="form-control" disabled style="cursor: default; height: 34px;">
+</div>

--- a/tests/dashboard/components/accounts/test_views.py
+++ b/tests/dashboard/components/accounts/test_views.py
@@ -101,6 +101,8 @@ def test_edit_user_view_renders_user_profile_fields(
     non_administrative_user_apikey: ApiKey,
     admin_client: Client,
 ) -> None:
+    expected_apikey = non_administrative_user_apikey.key
+
     response = admin_client.get(
         reverse("accounts:edit", kwargs={"id": non_administrative_user.id}), follow=True
     )
@@ -112,7 +114,9 @@ def test_edit_user_view_renders_user_profile_fields(
     assert f'name="first_name" value="{non_administrative_user.first_name}"' in content
     assert f'name="last_name" value="{non_administrative_user.last_name}"' in content
     assert f'name="email" value="{non_administrative_user.email}"' in content
-    assert f"<code>{non_administrative_user_apikey.key}</code>" in content
+
+    non_administrative_user_apikey.refresh_from_db()
+    assert non_administrative_user_apikey.key == expected_apikey
 
 
 @pytest.mark.django_db
@@ -196,6 +200,7 @@ def test_user_profile_view_allows_users_to_edit_their_profile_fields(
 ) -> None:
     settings.ALLOW_USER_EDITS = True
     client.force_login(non_administrative_user)
+    expected_apikey = non_administrative_user_apikey.key
 
     response = client.get(
         reverse("accounts:profile"),
@@ -209,7 +214,9 @@ def test_user_profile_view_allows_users_to_edit_their_profile_fields(
     assert f'name="first_name" value="{non_administrative_user.first_name}"' in content
     assert f'name="last_name" value="{non_administrative_user.last_name}"' in content
     assert f'name="email" value="{non_administrative_user.email}"' in content
-    assert f"<code>{non_administrative_user_apikey.key}</code>" in content
+
+    non_administrative_user_apikey.refresh_from_db()
+    assert non_administrative_user_apikey.key == expected_apikey
 
 
 @pytest.mark.django_db
@@ -222,6 +229,7 @@ def test_user_profile_view_denies_editing_profile_fields_if_setting_disables_it(
 ) -> None:
     settings.ALLOW_USER_EDITS = False
     client.force_login(non_administrative_user)
+    expected_apikey = non_administrative_user_apikey.key
 
     response = client.get(
         reverse("accounts:profile"),
@@ -240,7 +248,9 @@ def test_user_profile_view_denies_editing_profile_fields_if_setting_disables_it(
     assert (
         f"<dd>{'yes' if non_administrative_user.is_superuser else 'no'}</dd>" in content
     )
-    assert f"<code>{non_administrative_user_apikey.key}</code>" in content
+
+    non_administrative_user_apikey.refresh_from_db()
+    assert non_administrative_user_apikey.key == expected_apikey
 
 
 @pytest.mark.django_db
@@ -276,7 +286,9 @@ def test_user_profile_view_regenerates_api_key_if_setting_disables_editing(
     assert (
         f"<dd>{'yes' if non_administrative_user.is_superuser else 'no'}</dd>" in content
     )
-    assert f"<code>{expected_key}</code>" in content
+
+    non_administrative_user_apikey.refresh_from_db()
+    assert non_administrative_user_apikey.key == expected_key
 
 
 @pytest.mark.django_db
@@ -289,6 +301,7 @@ def test_user_profile_view_does_not_regenerate_api_key_if_not_requested(
 ) -> None:
     settings.ALLOW_USER_EDITS = False
     client.force_login(non_administrative_user)
+    expected_apikey = non_administrative_user_apikey.key
 
     response = client.post(reverse("accounts:profile"), {}, follow=True)
     assert response.status_code == 200
@@ -304,4 +317,6 @@ def test_user_profile_view_does_not_regenerate_api_key_if_not_requested(
     assert (
         f"<dd>{'yes' if non_administrative_user.is_superuser else 'no'}</dd>" in content
     )
-    assert f"<code>{non_administrative_user_apikey.key}</code>" in content
+
+    non_administrative_user_apikey.refresh_from_db()
+    assert non_administrative_user_apikey.key == expected_apikey

--- a/tests/dashboard/components/accounts/test_views.py
+++ b/tests/dashboard/components/accounts/test_views.py
@@ -147,15 +147,15 @@ def test_edit_user_view_updates_user_profile_fields(
     assert response.status_code == 200
 
     content = response.content.decode()
-    assert "Saved" in content
-    assert (
-        f'<a href="{reverse("accounts:edit", kwargs={"id": non_administrative_user.id})}">{new_username}</a>'
-        in content
-    )
-    assert f"<td>{new_first_name} {new_last_name}</td>" in content
-    assert f"<td>{new_email}</td>" in content
-
     non_administrative_user.refresh_from_db()
+
+    assert "Saved" in content
+    assert f"Edit user {non_administrative_user.username}" in content
+    assert f'name="username" value="{non_administrative_user.username}"' in content
+    assert f'name="first_name" value="{non_administrative_user.first_name}"' in content
+    assert f'name="last_name" value="{non_administrative_user.last_name}"' in content
+    assert f'name="email" value="{non_administrative_user.email}"' in content
+
     assert non_administrative_user.check_password(new_password)
 
 

--- a/tests/dashboard/components/accounts/test_views.py
+++ b/tests/dashboard/components/accounts/test_views.py
@@ -184,7 +184,10 @@ def test_edit_user_view_regenerates_api_key(
         )
     assert response.status_code == 200
 
-    assert "Saved" in response.content.decode()
+    content = response.content.decode()
+    assert "Saved" in content
+    assert "Make sure to copy the API key now as you will not be able to see it again."
+    assert f'value="{expected_key}"' in content
 
     non_administrative_user_apikey.refresh_from_db()
     assert non_administrative_user_apikey.key == expected_key


### PR DESCRIPTION
This updates the `Administration > General` view of the Dashboard to not show the API key of the user that connects with the Storage Service. The current plain text field has been replaced with a password field to do so.

Also the Dashboard user views and their redirects have been updated to show the API key only once on re-generation. This uses Django's [messages framework](https://docs.djangoproject.com/en/4.2/ref/contrib/messages/) to render an alert with a button to copy the API key to the browser's clipboard.

![Captura desde 2025-03-28 16-41-49](https://github.com/user-attachments/assets/cd01221e-2cfe-45c8-9a29-c74bdc0e9edc)


![Captura desde 2025-03-28 16-41-57](https://github.com/user-attachments/assets/b078383f-e71c-4690-8336-8f81852c53a5)


Connected to https://github.com/archivematica/Issues/issues/1738