### PR TITLE
Use importlib package to get assets and metadata

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -108,7 +108,6 @@ idna==3.10
     #   requests
 importlib-metadata==8.6.1
     # via
-    #   -r /src/requirements.txt
     #   build
     #   pytest-randomly
 importlib-resources==6.5.2

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,6 @@ elasticsearch>=6.0.0,<7.0.0
 git+https://github.com/artefactual-labs/python-gearman.git@b68efc868c7a494dd6a2d2e820fb098a6da9f797#egg=gearman3
 gevent
 gunicorn
-importlib-metadata
 inotify_simple
 jsonschema
 lazy-paged-sequence

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,8 +67,6 @@ gunicorn==23.0.0
     # via -r requirements.in
 idna==3.10
     # via requests
-importlib-metadata==8.6.1
-    # via -r requirements.in
 importlib-resources==6.5.2
     # via opf-fido
 inotify-simple==1.3.5
@@ -162,9 +160,7 @@ urllib3==2.3.0
 whitenoise==6.9.0
     # via -r requirements.in
 zipp==3.21.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources
+    # via importlib-resources
 zope-event==5.0
     # via gevent
 zope-interface==7.2

--- a/src/archivematica/MCPClient/client/mcp.py
+++ b/src/archivematica/MCPClient/client/mcp.py
@@ -2,9 +2,9 @@
 Main MCPClient entrypoint.
 """
 
+import importlib.resources
 import logging
 import os
-import pathlib
 import signal
 from types import FrameType
 from typing import Optional
@@ -20,7 +20,10 @@ def main() -> None:
 
     # Use local XML schemas for validation.
     os.environ["XML_CATALOG_FILES"] = str(
-        pathlib.Path(__file__).parent.parent / "assets" / "catalog" / "catalog.xml"
+        importlib.resources.files("archivematica.MCPClient")
+        / "assets"
+        / "catalog"
+        / "catalog.xml"
     )
 
     pool = WorkerPool()

--- a/src/archivematica/MCPClient/clientScripts/archivematicaCreateMETSMetadataXML.py
+++ b/src/archivematica/MCPClient/clientScripts/archivematicaCreateMETSMetadataXML.py
@@ -19,13 +19,13 @@
 """Management of XML metadata files."""
 
 import csv
+from importlib.metadata import version
 from pathlib import Path
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
 import requests
 from django.core.exceptions import ValidationError
-from importlib_metadata import version
 from lxml import etree
 
 from archivematica.archivematicaCommon import namespaces as ns

--- a/src/archivematica/MCPServer/server/workflow.py
+++ b/src/archivematica/MCPServer/server/workflow.py
@@ -14,8 +14,8 @@ classes ``Chain``, ``Link`` and ``WatchedDir``. They have different method
 sets.
 """
 
+import importlib.resources
 import json
-import os
 
 from django.conf import settings as django_settings
 from jsonschema import FormatChecker
@@ -27,11 +27,9 @@ from archivematica.MCPServer.server.translation import FALLBACK_LANG
 from archivematica.MCPServer.server.translation import TranslationLabel
 
 _LATEST_SCHEMA = "workflow-schema-v1.json"
-ASSETS_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(os.path.join(__file__)))), "assets"
-)
+ASSETS_DIR = importlib.resources.files("archivematica.MCPServer") / "assets"
 
-DEFAULT_WORKFLOW = os.path.join(ASSETS_DIR, "workflow.json")
+DEFAULT_WORKFLOW = ASSETS_DIR / "workflow.json"
 
 
 def _invert_job_statuses():
@@ -262,6 +260,5 @@ def _validate(blob):
 
 def _get_schema():
     """Decode the default schema and return it."""
-    schema = os.path.join(ASSETS_DIR, _LATEST_SCHEMA)
-    with open(schema) as fp:
+    with open(ASSETS_DIR / _LATEST_SCHEMA) as fp:
         return json.load(fp)

--- a/tests/MCPClient/conftest.py
+++ b/tests/MCPClient/conftest.py
@@ -1,3 +1,4 @@
+import importlib.resources
 import pathlib
 
 import pytest
@@ -15,9 +16,7 @@ def set_xml_catalog_files(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(
         "XML_CATALOG_FILES",
         str(
-            pathlib.Path(__file__).parent.parent.parent
-            / "src"
-            / "MCPClient"
+            importlib.resources.files("archivematica.MCPClient")
             / "assets"
             / "catalog"
             / "catalog.xml"

--- a/tests/MCPClient/test_create_aip_mets.py
+++ b/tests/MCPClient/test_create_aip_mets.py
@@ -1,5 +1,6 @@
 import collections
 import csv
+import importlib.resources
 import os
 import pathlib
 import random
@@ -753,8 +754,11 @@ class TestCustomStructMap(TestCase):
         os.path.join("custom_structmaps", "model", "files.json"),
     ]
     fixtures = [os.path.join(THIS_DIR, "fixtures", p) for p in fixture_files]
-    mets_xsd_path = os.path.abspath(
-        os.path.join(THIS_DIR, "../../src/archivematica/MCPClient/assets/mets/mets.xsd")
+    mets_xsd_path = (
+        importlib.resources.files("archivematica.MCPClient")
+        / "assets"
+        / "mets"
+        / "mets.xsd"
     )
 
     @pytest.fixture(autouse=True)

--- a/tests/MCPClient/test_load_premis_events_from_xml.py
+++ b/tests/MCPClient/test_load_premis_events_from_xml.py
@@ -1,4 +1,4 @@
-import os
+import importlib.resources
 import pathlib
 import sys
 import uuid
@@ -17,10 +17,11 @@ THIS_DIR = pathlib.Path(__file__).parent
 
 @pytest.fixture()
 def xsd_path():
-    return os.path.abspath(
-        os.path.join(
-            THIS_DIR, "../../src/archivematica/MCPClient/assets/premis/premis.xsd"
-        )
+    return (
+        importlib.resources.files("archivematica.MCPClient")
+        / "assets"
+        / "premis"
+        / "premis.xsd"
     )
 
 

--- a/tests/MCPServer/test_processing_config.py
+++ b/tests/MCPServer/test_processing_config.py
@@ -1,5 +1,4 @@
-import os
-import pathlib
+import importlib.resources
 from unittest import mock
 
 import pytest
@@ -15,19 +14,14 @@ from archivematica.MCPServer.server.processing_config import (
 from archivematica.MCPServer.server.processing_config import processing_fields
 from archivematica.MCPServer.server.workflow import load
 
-ASSETS_DIR = (
-    pathlib.Path(__file__).parent.parent.parent
-    / "src"
-    / "archivematica"
-    / "MCPServer"
-    / "assets"
-)
-
 
 @pytest.fixture
 def _workflow():
-    path = os.path.join(ASSETS_DIR, "workflow.json")
-    with open(path) as fp:
+    with open(
+        importlib.resources.files("archivematica.MCPServer")
+        / "assets"
+        / "workflow.json"
+    ) as fp:
         return load(fp)
 
 

--- a/tests/MCPServer/test_rpc_server.py
+++ b/tests/MCPServer/test_rpc_server.py
@@ -1,4 +1,4 @@
-import pathlib
+import importlib.resources
 import threading
 import uuid
 from unittest import mock
@@ -9,14 +9,6 @@ from django.utils import timezone
 from archivematica.dashboard.main import models
 from archivematica.MCPServer.server import rpc_server
 from archivematica.MCPServer.server import workflow
-
-ASSETS_DIR = (
-    pathlib.Path(__file__).parent.parent.parent
-    / "src"
-    / "archivematica"
-    / "MCPServer"
-    / "assets"
-)
 
 
 @pytest.mark.django_db
@@ -29,7 +21,11 @@ def test_approve_partial_reingest_handler():
         currentstep=models.Job.STATUS_AWAITING_DECISION,
     )
     package_queue = mock.MagicMock()
-    with open(ASSETS_DIR / "workflow.json") as fp:
+    with open(
+        importlib.resources.files("archivematica.MCPServer")
+        / "assets"
+        / "workflow.json"
+    ) as fp:
         wf = workflow.load(fp)
     shutdown_event = threading.Event()
     shutdown_event.set()

--- a/tests/MCPServer/test_workflow.py
+++ b/tests/MCPServer/test_workflow.py
@@ -1,4 +1,4 @@
-import os
+import importlib.resources
 import pathlib
 from io import StringIO
 from unittest import mock
@@ -9,13 +9,7 @@ from django.utils.translation import gettext_lazy
 from archivematica.MCPServer.server import translation
 from archivematica.MCPServer.server import workflow
 
-ASSETS_DIR = (
-    pathlib.Path(__file__).parent.parent.parent
-    / "src"
-    / "archivematica"
-    / "MCPServer"
-    / "assets"
-)
+ASSETS_DIR = importlib.resources.files("archivematica.MCPServer") / "assets"
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 
 
@@ -47,8 +41,8 @@ def test_load_invalid_json():
 @pytest.mark.parametrize(
     "path",
     (
-        os.path.join(ASSETS_DIR, "workflow.json"),
-        os.path.join(FIXTURES_DIR, "workflow-sample.json"),
+        ASSETS_DIR / "workflow.json",
+        FIXTURES_DIR / "workflow-sample.json",
     ),
 )
 def test_load_valid_document(path):
@@ -105,7 +99,7 @@ def test_load_valid_document(path):
 
 
 def test_link_browse_methods():
-    with open(os.path.join(ASSETS_DIR, "workflow.json")) as fp:
+    with open(ASSETS_DIR / "workflow.json") as fp:
         wf = workflow.load(fp)
     ln = wf.get_link("1ba589db-88d1-48cf-bb1a-a5f9d2b17378")
     assert ln.get_next_link(code="0").id == "087d27be-c719-47d8-9bbb-9a7d8b609c44"

--- a/tests/MCPServer/test_workflow_abilities.py
+++ b/tests/MCPServer/test_workflow_abilities.py
@@ -1,19 +1,9 @@
-import os
-import pathlib
+import importlib.resources
 
 import pytest
 
 from archivematica.MCPServer.server import workflow
 from archivematica.MCPServer.server.workflow_abilities import choice_is_available
-
-ASSETS_DIR = (
-    pathlib.Path(__file__).parent.parent.parent
-    / "src"
-    / "archivematica"
-    / "MCPServer"
-    / "assets"
-)
-
 
 CREATE_SIP_LINK_ID = "bb194013-597c-4e4a-8493-b36d190f8717"
 SEND_TO_BACKLOG_CHAIN_ID = "7065d256-2f47-4b7d-baec-2c4699626121"
@@ -21,8 +11,11 @@ SEND_TO_BACKLOG_CHAIN_ID = "7065d256-2f47-4b7d-baec-2c4699626121"
 
 @pytest.fixture
 def _workflow():
-    path = os.path.join(ASSETS_DIR, "workflow.json")
-    with open(path) as fp:
+    with open(
+        importlib.resources.files("archivematica.MCPServer")
+        / "assets"
+        / "workflow.json"
+    ) as fp:
         return workflow.load(fp)
 
 


### PR DESCRIPTION
This update replaces the third-party `importlib-metadata` package with
Python's built-in `importlib.metadata` module for retrieving the
package version. It also switches to `importlib.resources` for
locating asset files, avoiding manual path calculations.

Connected to https://github.com/archivematica/Issues/issues/1720