### PR TITLE
Add ability to set admin from OIDC claims

### DIFF
--- a/src/archivematica/dashboard/components/accounts/backends.py
+++ b/src/archivematica/dashboard/components/accounts/backends.py
@@ -1,7 +1,11 @@
 import json
+from typing import Any
+from typing import Optional
 
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpRequest
 from django_auth_ldap.backend import LDAPBackend
 from django_cas_ng.backends import CASBackend
 from josepy.jws import JWS
@@ -44,7 +48,40 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
     Provide OpenID Connect authentication
     """
 
-    def get_settings(self, attr, *args):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Store additional settings as instance attributes.
+        self.OIDC_OP_SET_ROLES_FROM_CLAIMS = getattr(
+            settings, "OIDC_OP_SET_ROLES_FROM_CLAIMS", False
+        )
+
+        self.OIDC_OP_ROLE_CLAIM_PATH = getattr(
+            settings, "OIDC_OP_ROLE_CLAIM_PATH", "realm_access.roles"
+        )
+
+        self.OIDC_ACCESS_ATTRIBUTE_MAP = getattr(
+            settings, "OIDC_ACCESS_ATTRIBUTE_MAP", settings.DEFAULT_OIDC_CLAIMS
+        )
+
+        # Valid role claim name which may be extracted from OIDC token.
+        self.OIDC_ROLE_CLAIM_ADMIN = getattr(settings, "OIDC_ROLE_CLAIM_ADMIN", "admin")
+        self.OIDC_ROLE_CLAIM_DEFAULT = getattr(
+            settings, "OIDC_ROLE_CLAIM_DEFAULT", "default"
+        )
+        # Valid user roles.
+        self.USER_ROLE_ADMIN = "admin"
+        self.USER_ROLE_DEFAULT = "default"
+
+        # The roles are ordered from highest to lowest permission in this list.
+        # This feature is used in OIDC authentication to determine the highest
+        # permission role of a user based on the claims received when multiple
+        # roles are received.
+        self.USER_ROLE_TO_ROLE_CLAIM_MAP = {
+            self.USER_ROLE_ADMIN: self.OIDC_ROLE_CLAIM_ADMIN,
+            self.USER_ROLE_DEFAULT: self.OIDC_ROLE_CLAIM_DEFAULT,
+        }
+
+    def get_settings(self, attr: str, *args: Any) -> Any:
         if attr in [
             "OIDC_RP_CLIENT_ID",
             "OIDC_RP_CLIENT_SECRET",
@@ -53,6 +90,9 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
             "OIDC_OP_USER_ENDPOINT",
             "OIDC_OP_JWKS_ENDPOINT",
             "OIDC_OP_LOGOUT_ENDPOINT",
+            "OIDC_OP_SET_ROLES_FROM_CLAIMS",
+            "OIDC_OP_ROLE_CLAIM_PATH",
+            "OIDC_ACCESS_ATTRIBUTE_MAP",
         ]:
             # Retrieve the request object stored in the instance.
             request = getattr(self, "request", None)
@@ -74,17 +114,24 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
         # not in the list, call the superclass's get_settings method.
         return OIDCAuthenticationBackend.get_settings(attr, *args)
 
-    def authenticate(self, request, **kwargs):
+    def authenticate(self, request: HttpRequest, **kwargs: Any) -> Any:
         self.request = request
         self.OIDC_RP_CLIENT_ID = self.get_settings("OIDC_RP_CLIENT_ID")
         self.OIDC_RP_CLIENT_SECRET = self.get_settings("OIDC_RP_CLIENT_SECRET")
         self.OIDC_OP_TOKEN_ENDPOINT = self.get_settings("OIDC_OP_TOKEN_ENDPOINT")
         self.OIDC_OP_USER_ENDPOINT = self.get_settings("OIDC_OP_USER_ENDPOINT")
         self.OIDC_OP_JWKS_ENDPOINT = self.get_settings("OIDC_OP_JWKS_ENDPOINT")
+        self.OIDC_OP_SET_ROLES_FROM_CLAIMS = self.get_settings(
+            "OIDC_OP_SET_ROLES_FROM_CLAIMS"
+        )
+        self.OIDC_OP_ROLE_CLAIM_PATH = self.get_settings("OIDC_OP_ROLE_CLAIM_PATH")
+        self.OIDC_ACCESS_ATTRIBUTE_MAP = self.get_settings("OIDC_ACCESS_ATTRIBUTE_MAP")
 
         return super().authenticate(request, **kwargs)
 
-    def get_userinfo(self, access_token, id_token, verified_id):
+    def get_userinfo(
+        self, access_token: str, id_token: str, verified_id: dict[str, Any]
+    ) -> dict[str, Any]:
         """
         Extract user details from JSON web tokens
         These map to fields on the user field.
@@ -98,9 +145,9 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
         access_info = decode_token(access_token)
         id_info = decode_token(id_token)
 
-        info = {}
+        info: dict[str, Any] = {}
 
-        for oidc_attr, user_attr in settings.OIDC_ACCESS_ATTRIBUTE_MAP.items():
+        for oidc_attr, user_attr in self.OIDC_ACCESS_ATTRIBUTE_MAP.items():
             if oidc_attr in access_info:
                 info.setdefault(user_attr, access_info[oidc_attr])
 
@@ -110,10 +157,66 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
 
         return info
 
-    def create_user(self, user_info):
+    def create_user(self, user_info: dict[str, Any]) -> Optional[User]:
+        role = self.get_user_role(user_info)
+        if role is None:
+            return None
+
         user = super().create_user(user_info)
         for attr, value in user_info.items():
             setattr(user, attr, value)
-        user.save()
+        self.set_user_role(user, role)
         generate_api_key(user)
         return user
+
+    def update_user(self, user: User, user_info: dict[str, Any]) -> Optional[User]:
+        """
+        Updates the user's role only if the setting allows roles to be set from OIDC claims.
+        If the setting is False roles are being managed by an admin so do not update the role.
+        """
+        if self.OIDC_OP_SET_ROLES_FROM_CLAIMS:
+            role = self.get_user_role(user_info)
+            if role is None:
+                return None
+            self.set_user_role(user, role)
+        return user
+
+    def set_user_role(self, user: User, role: str) -> None:
+        """Assign a new role to a User given the role codename."""
+        # Only users with the admin role are Django superusers.
+        user.is_superuser = role == self.USER_ROLE_ADMIN
+        user.save()
+
+    def get_user_role(self, user_info: dict[str, Any]) -> Optional[str]:
+        """
+        Returns the highest-permission valid role found in the OIDC token claims.
+        Returns the default user role if the setting is False.
+        Returns None if no valid roles are found.
+        """
+        if not self.OIDC_OP_SET_ROLES_FROM_CLAIMS:
+            return self.USER_ROLE_DEFAULT
+
+        claim_path = self.OIDC_OP_ROLE_CLAIM_PATH.split(".")
+        role_claims = user_info
+
+        # Traverse the claim path to find the role claims.
+        for key in claim_path:
+            if isinstance(role_claims, dict):
+                role_claims = role_claims.get(key, {})
+            else:
+                return None
+
+        # If the claim contains a single role, convert to list.
+        if isinstance(role_claims, str):
+            role_claims = [role_claims]
+
+        # Neither a string nor a list of roles.
+        if not isinstance(role_claims, list):
+            return None
+
+        # Iterate over USER_ROLE_TO_ROLE_CLAIM_MAP and return the first matching role.
+        for role_key, token_claim in self.USER_ROLE_TO_ROLE_CLAIM_MAP.items():
+            if token_claim in role_claims:
+                return role_key
+
+        return None  # No match found.

--- a/src/archivematica/dashboard/install/README.md
+++ b/src/archivematica/dashboard/install/README.md
@@ -741,6 +741,32 @@ set.
   - **Type:** `string`
   - **Default:** ``
 
+- **`OIDC_OP_SET_ROLES_FROM_CLAIMS`**:
+  - **Description:** Set user roles from OIDC token claims
+  - **Type:** `boolean`
+  - **Default:** `False`
+
+- **`OIDC_OP_ROLE_CLAIM_PATH`**:
+  - **Description:** Set OIDC token path for extracting role info
+  - **Type:** `string`
+  - **Default:** `'realm_access.roles'`
+
+- **`OIDC_ROLE_CLAIM_ADMIN`**:
+  - **Description:** The OIDC role claim value which maps to the Admin role.
+  - **Type:** `string`
+  - **Default:** `admin`
+
+- **`OIDC_ROLE_CLAIM_DEFAULT`**:
+  - **Description:** The OIDC role claim value which maps to the default role.
+  - **Type:** `string`
+  - **Default:** `default`
+
+- **`OIDC_ACCESS_ATTRIBUTE_MAP`**
+  - **Description:** Set OIDC token details to extract. This string should be
+    JSON-decodable.
+  - **Type:** `string`
+  - **Default:** `{"given_name": "first_name", "family_name": "last_name"}`
+
 - **`OIDC_RP_SIGN_ALGO`**:
   - **Description:** Algorithm used by the ID provider to sign ID tokens
   - **Type:** `string`

--- a/src/archivematica/dashboard/settings/components/oidc_auth.py
+++ b/src/archivematica/dashboard/settings/components/oidc_auth.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from archivematica.archivematicaCommon.archivematicaFunctions import (
@@ -36,13 +37,31 @@ else:
     OIDC_OP_JWKS_ENDPOINT = os.environ.get("OIDC_OP_JWKS_ENDPOINT", "")
     OIDC_OP_LOGOUT_ENDPOINT = os.environ.get("OIDC_OP_LOGOUT_ENDPOINT", "")
 
+OIDC_OP_SET_ROLES_FROM_CLAIMS = os.environ.get(
+    "OIDC_OP_SET_ROLES_FROM_CLAIMS", ""
+).lower() in (
+    "true",
+    "yes",
+    "on",
+    "1",
+)
+OIDC_OP_ROLE_CLAIM_PATH = os.environ.get(
+    "OIDC_OP_ROLE_CLAIM_PATH", "realm_access.roles"
+)
+OIDC_ROLE_CLAIM_ADMIN = os.environ.get("OIDC_ROLE_CLAIM_ADMIN", "admin")
+OIDC_ROLE_CLAIM_DEFAULT = os.environ.get("OIDC_ROLE_CLAIM_DEFAULT", "default")
+
+DEFAULT_OIDC_CLAIMS = {"given_name": "first_name", "family_name": "last_name"}
+
 OIDC_SECONDARY_PROVIDER_NAMES = os.environ.get(
     "OIDC_SECONDARY_PROVIDER_NAMES", ""
 ).split(",")
 OIDC_PROVIDER_QUERY_PARAM_NAME = os.environ.get(
     "OIDC_PROVIDER_QUERY_PARAM_NAME", "secondary"
 )
-OIDC_PROVIDERS = get_oidc_secondary_providers(OIDC_SECONDARY_PROVIDER_NAMES)
+OIDC_PROVIDERS = get_oidc_secondary_providers(
+    OIDC_SECONDARY_PROVIDER_NAMES, DEFAULT_OIDC_CLAIMS
+)
 
 if OIDC_OP_LOGOUT_ENDPOINT:
     OIDC_OP_LOGOUT_URL_METHOD = (
@@ -71,7 +90,12 @@ def _get_email(email):
 OIDC_USERNAME_ALGO = _get_email
 
 # map attributes from access token
-OIDC_ACCESS_ATTRIBUTE_MAP = {"given_name": "first_name", "family_name": "last_name"}
+try:
+    OIDC_ACCESS_ATTRIBUTE_MAP = json.loads(
+        os.environ.get("OIDC_ACCESS_ATTRIBUTE_MAP", json.dumps(DEFAULT_OIDC_CLAIMS))
+    )
+except json.JSONDecodeError:
+    OIDC_ACCESS_ATTRIBUTE_MAP = DEFAULT_OIDC_CLAIMS
 
 # map attributes from id token
 OIDC_ID_ATTRIBUTE_MAP = {"email": "email"}

--- a/tests/archivematicaCommon/test_archivematica_functions.py
+++ b/tests/archivematicaCommon/test_archivematica_functions.py
@@ -118,13 +118,21 @@ def test_get_oidc_secondary_providers_ignores_provider_if_client_id_and_secret_a
     monkeypatch.setenv("OIDC_RP_CLIENT_ID_BAR", "bar-client-id")
     monkeypatch.setenv("OIDC_RP_CLIENT_SECRET_BAZ", "foo-secret")
 
-    assert am.get_oidc_secondary_providers(["FOO", "BAR", "BAZ"]) == {
+    assert am.get_oidc_secondary_providers(
+        ["FOO", "BAR", "BAZ"], {"given_name": "first_name", "family_name": "last_name"}
+    ) == {
         "FOO": {
             "OIDC_OP_AUTHORIZATION_ENDPOINT": "",
             "OIDC_OP_JWKS_ENDPOINT": "",
             "OIDC_OP_LOGOUT_ENDPOINT": "",
             "OIDC_OP_TOKEN_ENDPOINT": "",
             "OIDC_OP_USER_ENDPOINT": "",
+            "OIDC_OP_SET_ROLES_FROM_CLAIMS": False,
+            "OIDC_OP_ROLE_CLAIM_PATH": "realm_access.roles",
+            "OIDC_ACCESS_ATTRIBUTE_MAP": {
+                "given_name": "first_name",
+                "family_name": "last_name",
+            },
             "OIDC_RP_CLIENT_ID": "foo-client-id",
             "OIDC_RP_CLIENT_SECRET": "foo-client-secret",
         }
@@ -139,13 +147,21 @@ def test_get_oidc_secondary_providers_strips_provider_names(
     monkeypatch.setenv("OIDC_RP_CLIENT_ID_BAR", "bar-client-id")
     monkeypatch.setenv("OIDC_RP_CLIENT_SECRET_BAR", "bar-client-secret")
 
-    assert am.get_oidc_secondary_providers(["  FOO", " BAR  "]) == {
+    assert am.get_oidc_secondary_providers(
+        ["  FOO", " BAR  "], {"given_name": "first_name", "family_name": "last_name"}
+    ) == {
         "FOO": {
             "OIDC_OP_AUTHORIZATION_ENDPOINT": "",
             "OIDC_OP_JWKS_ENDPOINT": "",
             "OIDC_OP_LOGOUT_ENDPOINT": "",
             "OIDC_OP_TOKEN_ENDPOINT": "",
             "OIDC_OP_USER_ENDPOINT": "",
+            "OIDC_OP_SET_ROLES_FROM_CLAIMS": False,
+            "OIDC_OP_ROLE_CLAIM_PATH": "realm_access.roles",
+            "OIDC_ACCESS_ATTRIBUTE_MAP": {
+                "given_name": "first_name",
+                "family_name": "last_name",
+            },
             "OIDC_RP_CLIENT_ID": "foo-client-id",
             "OIDC_RP_CLIENT_SECRET": "foo-client-secret",
         },
@@ -155,6 +171,12 @@ def test_get_oidc_secondary_providers_strips_provider_names(
             "OIDC_OP_LOGOUT_ENDPOINT": "",
             "OIDC_OP_TOKEN_ENDPOINT": "",
             "OIDC_OP_USER_ENDPOINT": "",
+            "OIDC_OP_SET_ROLES_FROM_CLAIMS": False,
+            "OIDC_OP_ROLE_CLAIM_PATH": "realm_access.roles",
+            "OIDC_ACCESS_ATTRIBUTE_MAP": {
+                "given_name": "first_name",
+                "family_name": "last_name",
+            },
             "OIDC_RP_CLIENT_ID": "bar-client-id",
             "OIDC_RP_CLIENT_SECRET": "bar-client-secret",
         },
@@ -169,13 +191,21 @@ def test_get_oidc_secondary_providers_capitalizes_provider_names(
     monkeypatch.setenv("OIDC_RP_CLIENT_ID_BAR", "bar-client-id")
     monkeypatch.setenv("OIDC_RP_CLIENT_SECRET_BAR", "bar-client-secret")
 
-    assert am.get_oidc_secondary_providers(["fOo", "bar"]) == {
+    assert am.get_oidc_secondary_providers(
+        ["fOo", "bar"], {"given_name": "first_name", "family_name": "last_name"}
+    ) == {
         "FOO": {
             "OIDC_OP_AUTHORIZATION_ENDPOINT": "",
             "OIDC_OP_JWKS_ENDPOINT": "",
             "OIDC_OP_LOGOUT_ENDPOINT": "",
             "OIDC_OP_TOKEN_ENDPOINT": "",
             "OIDC_OP_USER_ENDPOINT": "",
+            "OIDC_OP_SET_ROLES_FROM_CLAIMS": False,
+            "OIDC_OP_ROLE_CLAIM_PATH": "realm_access.roles",
+            "OIDC_ACCESS_ATTRIBUTE_MAP": {
+                "given_name": "first_name",
+                "family_name": "last_name",
+            },
             "OIDC_RP_CLIENT_ID": "foo-client-id",
             "OIDC_RP_CLIENT_SECRET": "foo-client-secret",
         },
@@ -185,6 +215,12 @@ def test_get_oidc_secondary_providers_capitalizes_provider_names(
             "OIDC_OP_LOGOUT_ENDPOINT": "",
             "OIDC_OP_TOKEN_ENDPOINT": "",
             "OIDC_OP_USER_ENDPOINT": "",
+            "OIDC_OP_SET_ROLES_FROM_CLAIMS": False,
+            "OIDC_OP_ROLE_CLAIM_PATH": "realm_access.roles",
+            "OIDC_ACCESS_ATTRIBUTE_MAP": {
+                "given_name": "first_name",
+                "family_name": "last_name",
+            },
             "OIDC_RP_CLIENT_ID": "bar-client-id",
             "OIDC_RP_CLIENT_SECRET": "bar-client-secret",
         },

--- a/tests/dashboard/test_oidc.py
+++ b/tests/dashboard/test_oidc.py
@@ -15,7 +15,14 @@ def settings(
     settings.OIDC_ACCESS_ATTRIBUTE_MAP = {
         "given_name": "first_name",
         "family_name": "last_name",
+        "realm_access": "realm_access",
     }
+    settings.DEFAULT_OIDC_CLAIMS = {
+        "given_name": "first_name",
+        "family_name": "last_name",
+    }
+    settings.OIDC_OP_SET_ROLES_FROM_CLAIMS = False
+    settings.OIDC_OP_ROLE_CLAIM_PATH = "realm_access.roles"
     settings.OIDC_ID_ATTRIBUTE_MAP = {"email": "email"}
     settings.OIDC_USERNAME_ALGO = lambda email: email
 
@@ -23,11 +30,22 @@ def settings(
 
 
 @pytest.mark.django_db
-def test_create_user(settings: pytest_django.fixtures.SettingsWrapper) -> None:
+def test_create_user(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    """
+    Test that the user is created with the correct attributes and that the API key is generated.
+    User will not be superuser because the setting OIDC_OP_SET_ROLES_FROM_CLAIMS is False.
+    """
     backend = CustomOIDCBackend()
 
     user = backend.create_user(
-        {"email": "test@example.com", "first_name": "Test", "last_name": "User"}
+        {
+            "email": "test@example.com",
+            "first_name": "Test",
+            "last_name": "User",
+            "realm_access": {"roles": ["admin"]},
+        }
     )
 
     user.refresh_from_db()
@@ -35,6 +53,229 @@ def test_create_user(settings: pytest_django.fixtures.SettingsWrapper) -> None:
     assert user.last_name == "User"
     assert user.email == "test@example.com"
     assert user.username == "test@example.com"
+    assert not user.is_superuser
+    assert user.api_key
+
+
+@pytest.mark.django_db
+def test_create_user_set_admin_from_claim(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    """
+    Test that the user is created with the correct attributes and that the API key is generated.
+    User will be superuser because the setting OIDC_OP_SET_ROLES_FROM_CLAIMS is True
+    and the role claim is set to "admin".
+    """
+    settings.OIDC_OP_SET_ROLES_FROM_CLAIMS = True
+    settings.OIDC_OP_ROLE_CLAIM_PATH = "realm_access.roles"
+    settings.OIDC_ACCESS_ATTRIBUTE_MAP = {
+        "given_name": "first_name",
+        "family_name": "last_name",
+        "realm_access": "realm_access",
+    }
+    backend = CustomOIDCBackend()
+
+    user = backend.create_user(
+        {
+            "email": "test@example.com",
+            "first_name": "Test",
+            "last_name": "User",
+            "realm_access": {"roles": ["admin"]},
+        }
+    )
+
+    user.refresh_from_db()
+    assert user.first_name == "Test"
+    assert user.last_name == "User"
+    assert user.email == "test@example.com"
+    assert user.username == "test@example.com"
+    assert user.is_superuser
+    assert user.api_key
+
+
+@pytest.mark.django_db
+def test_create_user_role_from_claims(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    """
+    The role given to a new user is based on token contents.
+    In this test, we're ensuring that the highest-permission valid role
+    found in the OIDC token claims is assigned.
+    """
+    settings.OIDC_OP_SET_ROLES_FROM_CLAIMS = True
+    settings.OIDC_OP_ROLE_CLAIM_PATH = "realm_access.roles"
+    settings.OIDC_ACCESS_ATTRIBUTE_MAP = {
+        "given_name": "first_name",
+        "family_name": "last_name",
+        "realm_access": "realm_access",
+    }
+    backend = CustomOIDCBackend()
+
+    user = backend.create_user(
+        {
+            "email": "test@example.com",
+            "first_name": "Test",
+            "last_name": "User",
+            "realm_access": {"roles": ["admin", "default"]},
+        }
+    )
+
+    user.refresh_from_db()
+    assert user.first_name == "Test"
+    assert user.last_name == "User"
+    assert user.email == "test@example.com"
+    assert user.username == "test@example.com"
+    assert user.is_superuser
+    assert user.api_key
+
+
+@pytest.mark.django_db
+def test_create_user_role_from_claims_reverese_token_role_order(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    """
+    The role given to a new user is based on token contents.
+    In this test, we're ensuring that the highest-permission valid role
+    found in the OIDC token claims is assigned.
+    """
+    settings.OIDC_OP_SET_ROLES_FROM_CLAIMS = True
+    settings.OIDC_OP_ROLE_CLAIM_PATH = "realm_access.roles"
+    settings.OIDC_ACCESS_ATTRIBUTE_MAP = {
+        "given_name": "first_name",
+        "family_name": "last_name",
+        "realm_access": "realm_access",
+    }
+    backend = CustomOIDCBackend()
+
+    user = backend.create_user(
+        {
+            "email": "test@example.com",
+            "first_name": "Test",
+            "last_name": "User",
+            "realm_access": {"roles": ["reader", "admin"]},
+        }
+    )
+
+    user.refresh_from_db()
+    assert user.first_name == "Test"
+    assert user.last_name == "User"
+    assert user.email == "test@example.com"
+    assert user.username == "test@example.com"
+    assert user.is_superuser
+    assert user.api_key
+
+
+@pytest.mark.django_db
+def test_create_user_set_admin_from_alternate_token_value(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    settings.OIDC_OP_SET_ROLES_FROM_CLAIMS = True
+    settings.OIDC_OP_ROLE_CLAIM_PATH = "realm_access.roles"
+    settings.OIDC_ACCESS_ATTRIBUTE_MAP = {
+        "given_name": "first_name",
+        "family_name": "last_name",
+        "realm_access": "realm_access",
+    }
+    settings.OIDC_ROLE_CLAIM_ADMIN = "test"
+    backend = CustomOIDCBackend()
+
+    user = backend.create_user(
+        {
+            "email": "test@example.com",
+            "first_name": "Test",
+            "last_name": "User",
+            "realm_access": {"roles": ["test"]},
+        }
+    )
+
+    user.refresh_from_db()
+    assert user.first_name == "Test"
+    assert user.last_name == "User"
+    assert user.email == "test@example.com"
+    assert user.username == "test@example.com"
+    assert user.is_superuser
+    assert user.api_key
+
+
+@pytest.mark.django_db
+def test_create_user_failure_no_claims_in_token(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    settings.OIDC_OP_SET_ROLES_FROM_CLAIMS = True
+    settings.OIDC_OP_ROLE_CLAIM_PATH = "realm_access.roles"
+    settings.OIDC_ACCESS_ATTRIBUTE_MAP = {
+        "given_name": "first_name",
+        "family_name": "last_name",
+        "realm_access": "realm_access",
+    }
+    backend = CustomOIDCBackend()
+
+    user = backend.create_user(
+        {"email": "test@example.com", "first_name": "Test", "last_name": "User"}
+    )
+
+    assert user is None
+
+
+@pytest.mark.django_db
+def test_create_user_set_admin_from_alt_claim_path(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    settings.OIDC_OP_SET_ROLES_FROM_CLAIMS = True
+    settings.OIDC_OP_ROLE_CLAIM_PATH = "custom_claims.user_roles"
+    settings.OIDC_ACCESS_ATTRIBUTE_MAP = {
+        "given_name": "first_name",
+        "family_name": "last_name",
+        "realm_access": "realm_access",
+    }
+    backend = CustomOIDCBackend()
+
+    user = backend.create_user(
+        {
+            "email": "test@example.com",
+            "first_name": "Test",
+            "last_name": "User",
+            "custom_claims": {"user_roles": ["admin"]},
+        }
+    )
+
+    user.refresh_from_db()
+    assert user.first_name == "Test"
+    assert user.last_name == "User"
+    assert user.email == "test@example.com"
+    assert user.username == "test@example.com"
+    assert user.is_superuser
+    assert user.api_key
+
+
+@pytest.mark.django_db
+def test_create_user_admin_from_claims_simple_role(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    settings.OIDC_OP_SET_ROLES_FROM_CLAIMS = True
+    settings.OIDC_OP_ROLE_CLAIM_PATH = "role"
+    settings.OIDC_ACCESS_ATTRIBUTE_MAP = {
+        "given_name": "first_name",
+        "family_name": "last_name",
+        "realm_access": "realm_access",
+    }
+    backend = CustomOIDCBackend()
+
+    user = backend.create_user(
+        {
+            "email": "test@example.com",
+            "first_name": "Test",
+            "last_name": "User",
+            "role": "admin",
+        }
+    )
+
+    user.refresh_from_db()
+    assert user.first_name == "Test"
+    assert user.last_name == "User"
+    assert user.email == "test@example.com"
+    assert user.username == "test@example.com"
+    assert user.is_superuser
     assert user.api_key
 
 

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -63,6 +63,10 @@ services:
       OIDC_OP_USER_ENDPOINT: "http://keycloak:8080/realms/demo/protocol/openid-connect/userinfo"
       OIDC_OP_JWKS_ENDPOINT: "http://keycloak:8080/realms/demo/protocol/openid-connect/certs"
       OIDC_OP_LOGOUT_ENDPOINT: "http://keycloak:8080/realms/demo/protocol/openid-connect/logout"
+      OIDC_OP_SET_ROLES_FROM_CLAIMS: "true"
+      OIDC_OP_ROLE_CLAIM_PATH: "realm_access.roles"
+      OIDC_ACCESS_ATTRIBUTE_MAP: >
+        {"given_name": "first_name", "family_name": "last_name", "realm_access": "realm_access"}
       OIDC_SECONDARY_PROVIDER_NAMES: "secondary"
       OIDC_RP_CLIENT_ID_SECONDARY: "am-dashboard-secondary"
       OIDC_RP_CLIENT_SECRET_SECONDARY: "example-secret-secondary"
@@ -71,6 +75,10 @@ services:
       OIDC_OP_USER_ENDPOINT_SECONDARY: "http://keycloak:8080/realms/secondary/protocol/openid-connect/userinfo"
       OIDC_OP_JWKS_ENDPOINT_SECONDARY: "http://keycloak:8080/realms/secondary/protocol/openid-connect/certs"
       OIDC_OP_LOGOUT_ENDPOINT_SECONDARY: "http://keycloak:8080/realms/secondary/protocol/openid-connect/logout"
+      OIDC_OP_SET_ROLES_FROM_CLAIMS_SECONDARY: "true"
+      OIDC_OP_ROLE_CLAIM_PATH_SECONDARY: "realm_access.roles"
+      OIDC_ACCESS_ATTRIBUTE_MAP_SECONDARY: >
+        {"given_name": "first_name", "family_name": "last_name", "realm_access": "realm_access"}
       OIDC_RP_SIGN_ALGO: "RS256"
     volumes:
       - "../../:/src"

--- a/tests/integration/etc/keycloak/realm.json
+++ b/tests/integration/etc/keycloak/realm.json
@@ -11,6 +11,18 @@
     "attributes": {
       "adminEventsExpiration": "900"
     },
+    "roles": {
+      "realm": [
+        {
+          "name": "admin",
+          "description": "Administrator role"
+        },
+        {
+          "name": "default",
+          "description": "Default role"
+        }
+      ]
+    },
     "clients": [
       {
         "id": "am-dashboard",
@@ -49,6 +61,28 @@
             "type": "password",
             "value": "demo"
           }
+        ],
+        "realmRoles": [
+          "default"
+        ]
+      },
+      {
+        "id": "admin",
+        "email": "admin@example.com",
+        "username": "admin",
+        "firstName": "Admin",
+        "lastName": "User",
+        "enabled": true,
+        "emailVerified": true,
+        "credentials": [
+          {
+            "temporary": false,
+            "type": "password",
+            "value": "admin"
+          }
+        ],
+        "realmRoles": [
+          "admin"
         ]
       }
     ]
@@ -64,6 +98,18 @@
     "adminEventsDetailsEnabled": true,
     "attributes": {
       "adminEventsExpiration": "900"
+    },
+    "roles": {
+      "realm": [
+        {
+          "name": "admin",
+          "description": "Administrator role"
+        },
+        {
+          "name": "default",
+          "description": "Default role"
+        }
+      ]
     },
     "clients": [
       {
@@ -90,10 +136,10 @@
     ],
     "users": [
       {
-        "id": "support",
-        "email": "support@example.com",
-        "username": "support",
-        "firstName": "Support",
+        "id": "support-admin",
+        "email": "supportadmin@example.com",
+        "username": "supportadmin",
+        "firstName": "SupportAdmin",
         "lastName": "User",
         "enabled": true,
         "emailVerified": true,
@@ -103,6 +149,28 @@
             "type": "password",
             "value": "support"
           }
+        ],
+        "realmRoles": [
+          "admin"
+        ]
+      },
+      {
+        "id": "support-default",
+        "email": "supportdefault@example.com",
+        "username": "supportdefault",
+        "firstName": "SupportDefault",
+        "lastName": "User",
+        "enabled": true,
+        "emailVerified": true,
+        "credentials": [
+          {
+            "temporary": false,
+            "type": "password",
+            "value": "support"
+          }
+        ],
+        "realmRoles": [
+          "default"
         ]
       }
     ]


### PR DESCRIPTION
Adds new OIDC setting that will allow admins to configure whether user
roles will be set from the OIDC claims, or assigned the system default
role. The setting name is 'OIDC_OP_SET_ROLES_FROM_CLAIMS' and default
is False.

Adds new OIDC setting that will configure the token path for retrieving
the role info. The setting name is 'OIDC_OP_ROLE_CLAIM_PATH' and
defaults to "realm_access.roles" which is the standard Keycloak location
for user role info.

Added new OIDC setting that will configure what information is extracted
from the OIDC token. The setting name is 'OIDC_ACCESS_ATTRIBUTE_MAP'
and the setting contents should be JSON-decodable.

These settings should be configured individually for each provider by
appending the provider name for secondary providers as necessary.