### PR TITLE
Remove chrome browser from AMAUAT CI tests

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -32,10 +32,6 @@ jobs:
           - "uuids-dirs"
         browser:
           - "Firefox"
-          - "Chrome"
-        exclude:
-          - tag: "black-box"
-            browser: "Chrome"
     steps:
       - name: "Check out repository"
         if: "${{ github.event_name != 'workflow_dispatch' }}"


### PR DESCRIPTION
This PR removes `Chrome` browser from AMAUAT CI tests. 

New versions of Chrome gives [StaleElementReferenceException](https://www.selenium.dev/documentation/webdriver/troubleshooting/errors/#staleelementreferenceexception) error. Chrome encounters this error when navigating to another page. 

As per documentation, the failure can be resolved by adding additional Chrome browser flags such as `--no-sandbox`, `--disable-dev-shm-usage`, and `--disable-gpu` along with giving `Explicit waits` delays, which help ensure smoother operation in the new headless mode within a Docker environment. But the issue still persists, so for now we are removing the Chrome browser from CI runs and will address this in upcoming PRs.

Connected to : https://github.com/orgs/artefactual/projects/8/views/1?pane=issue&itemId=100710609&issue=artefactual%7Cmaintainers-tasks%7C198