### PR TITLE
Allow OIDC role config by provider

### DIFF
--- a/src/archivematica/archivematicaCommon/archivematicaFunctions.py
+++ b/src/archivematica/archivematicaCommon/archivematicaFunctions.py
@@ -567,6 +567,12 @@ def get_oidc_secondary_providers(
         role_claim_path = os.environ.get(
             f"OIDC_OP_ROLE_CLAIM_PATH_{provider_name}", "realm_access.roles"
         )
+        role_claim_admin = os.environ.get(
+            f"OIDC_ROLE_CLAIM_ADMIN_{provider_name}", "admin"
+        )
+        role_claim_default = os.environ.get(
+            f"OIDC_ROLE_CLAIM_DEFAULT_{provider_name}", "default"
+        )
         try:
             access_attribute_map = json.loads(
                 os.environ.get(
@@ -589,6 +595,8 @@ def get_oidc_secondary_providers(
                 "OIDC_OP_SET_ROLES_FROM_CLAIMS": set_roles_from_claims,
                 "OIDC_OP_ROLE_CLAIM_PATH": role_claim_path,
                 "OIDC_ACCESS_ATTRIBUTE_MAP": access_attribute_map,
+                "OIDC_ROLE_CLAIM_ADMIN": role_claim_admin,
+                "OIDC_ROLE_CLAIM_DEFAULT": role_claim_default,
             }
             providers[provider_name] = provider_config
 

--- a/tests/archivematicaCommon/test_archivematica_functions.py
+++ b/tests/archivematicaCommon/test_archivematica_functions.py
@@ -135,6 +135,8 @@ def test_get_oidc_secondary_providers_ignores_provider_if_client_id_and_secret_a
             },
             "OIDC_RP_CLIENT_ID": "foo-client-id",
             "OIDC_RP_CLIENT_SECRET": "foo-client-secret",
+            "OIDC_ROLE_CLAIM_ADMIN": "admin",
+            "OIDC_ROLE_CLAIM_DEFAULT": "default",
         }
     }
 
@@ -164,6 +166,8 @@ def test_get_oidc_secondary_providers_strips_provider_names(
             },
             "OIDC_RP_CLIENT_ID": "foo-client-id",
             "OIDC_RP_CLIENT_SECRET": "foo-client-secret",
+            "OIDC_ROLE_CLAIM_ADMIN": "admin",
+            "OIDC_ROLE_CLAIM_DEFAULT": "default",
         },
         "BAR": {
             "OIDC_OP_AUTHORIZATION_ENDPOINT": "",
@@ -179,6 +183,8 @@ def test_get_oidc_secondary_providers_strips_provider_names(
             },
             "OIDC_RP_CLIENT_ID": "bar-client-id",
             "OIDC_RP_CLIENT_SECRET": "bar-client-secret",
+            "OIDC_ROLE_CLAIM_ADMIN": "admin",
+            "OIDC_ROLE_CLAIM_DEFAULT": "default",
         },
     }
 
@@ -208,6 +214,8 @@ def test_get_oidc_secondary_providers_capitalizes_provider_names(
             },
             "OIDC_RP_CLIENT_ID": "foo-client-id",
             "OIDC_RP_CLIENT_SECRET": "foo-client-secret",
+            "OIDC_ROLE_CLAIM_ADMIN": "admin",
+            "OIDC_ROLE_CLAIM_DEFAULT": "default",
         },
         "BAR": {
             "OIDC_OP_AUTHORIZATION_ENDPOINT": "",
@@ -223,5 +231,7 @@ def test_get_oidc_secondary_providers_capitalizes_provider_names(
             },
             "OIDC_RP_CLIENT_ID": "bar-client-id",
             "OIDC_RP_CLIENT_SECRET": "bar-client-secret",
+            "OIDC_ROLE_CLAIM_ADMIN": "admin",
+            "OIDC_ROLE_CLAIM_DEFAULT": "default",
         },
     }

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -65,6 +65,8 @@ services:
       OIDC_OP_LOGOUT_ENDPOINT: "http://keycloak:8080/realms/demo/protocol/openid-connect/logout"
       OIDC_OP_SET_ROLES_FROM_CLAIMS: "true"
       OIDC_OP_ROLE_CLAIM_PATH: "realm_access.roles"
+      OIDC_ROLE_CLAIM_ADMIN: "admin"
+      OIDC_ROLE_CLAIM_DEFAULT: "default"
       OIDC_ACCESS_ATTRIBUTE_MAP: >
         {"given_name": "first_name", "family_name": "last_name", "realm_access": "realm_access"}
       OIDC_SECONDARY_PROVIDER_NAMES: "secondary"
@@ -77,6 +79,8 @@ services:
       OIDC_OP_LOGOUT_ENDPOINT_SECONDARY: "http://keycloak:8080/realms/secondary/protocol/openid-connect/logout"
       OIDC_OP_SET_ROLES_FROM_CLAIMS_SECONDARY: "true"
       OIDC_OP_ROLE_CLAIM_PATH_SECONDARY: "realm_access.roles"
+      OIDC_ROLE_CLAIM_ADMIN_SECONDARY: "admin-secondary"
+      OIDC_ROLE_CLAIM_DEFAULT_SECONDARY: "default-secondary"
       OIDC_ACCESS_ATTRIBUTE_MAP_SECONDARY: >
         {"given_name": "first_name", "family_name": "last_name", "realm_access": "realm_access"}
       OIDC_RP_SIGN_ALGO: "RS256"

--- a/tests/integration/etc/keycloak/realm.json
+++ b/tests/integration/etc/keycloak/realm.json
@@ -102,11 +102,11 @@
     "roles": {
       "realm": [
         {
-          "name": "admin",
+          "name": "admin-secondary",
           "description": "Administrator role"
         },
         {
-          "name": "default",
+          "name": "default-secondary",
           "description": "Default role"
         }
       ]
@@ -151,7 +151,7 @@
           }
         ],
         "realmRoles": [
-          "admin"
+          "admin-secondary"
         ]
       },
       {
@@ -170,7 +170,7 @@
           }
         ],
         "realmRoles": [
-          "default"
+          "default-secondary"
         ]
       }
     ]


### PR DESCRIPTION
Allow the OIDC role claim settings to be configured individually for each configured provider.