### PR TITLE
Add OIDC session refresh middleware

### DIFF
--- a/src/archivematica/dashboard/install/README.md
+++ b/src/archivematica/dashboard/install/README.md
@@ -784,6 +784,17 @@ This only has an effect if ``OIDC_USE_PKCE`` is ``True``.
   - **Type:** `string`
   - **Default:** `S256`
 
+- **`OIDC_USE_SESSION_REFRESH_MIDDLEWARE`**:
+  - **Description:** Allows existing sessions to be refreshed when OIDC tokens expire
+  - **Type:** `boolean`
+  - **Default:** `false`
+
+- **`OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS`**:
+  - **Description:** Time in seconds before reauthentication is required to
+    refresh the ID token. Should align with the token lifetime set by your OIDC Provider.
+  - **Type:** `integer`
+  - **Default:** `900`
+
 ### CSP variables
 
 **CSP support is experimental, please share your feedback!**

--- a/src/archivematica/dashboard/settings/base.py
+++ b/src/archivematica/dashboard/settings/base.py
@@ -665,6 +665,26 @@ if OIDC_AUTHENTICATION:
         "archivematica.dashboard.middleware.common.OidcCaptureQueryParamMiddleware",
     )
 
+    OIDC_USE_SESSION_REFRESH_MIDDLEWARE = os.environ.get(
+        "OIDC_USE_SESSION_REFRESH_MIDDLEWARE", "false"
+    ).lower() in (
+        "true",
+        "yes",
+        "on",
+        "1",
+    )
+
+    if OIDC_USE_SESSION_REFRESH_MIDDLEWARE:
+        OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = int(
+            os.environ.get("OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS", 60 * 15)
+        )
+
+        MIDDLEWARE.insert(
+            MIDDLEWARE.index("django.contrib.auth.middleware.AuthenticationMiddleware")
+            + 1,
+            "mozilla_django_oidc.middleware.SessionRefresh",
+        )
+
     from archivematica.dashboard.settings.components.oidc_auth import *
 
 CSP_ENABLED = config.get("csp_enabled")


### PR DESCRIPTION
mozilla_django_oidc session refresh middleware will be available when OIDC authentication is in use. Session refresh will default to OFF.