### PR TITLE
Use package-lock.json on Dashboard frontend build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
             **/package-lock.json
       - name: "Install frontend dependencies"
         run: |
-          npm install
+          npm ci
       - name: "Run tests"
         run: |
           npm run "test-single-run"

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -121,7 +121,7 @@ COPY --link src/archivematica/dashboard/frontend /src/src/archivematica/dashboar
 WORKDIR /src/src/archivematica/dashboard/frontend
 
 RUN set ex \
-	&& npm install --no-package-lock
+	&& npm ci
 
 # -----------------------------------------------------------------------------
 

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -185,7 +185,7 @@ bootstrap-dashboard-frontend:  ## Build front-end assets.
 		--volume "$(SRCDIR)/archivematica/dashboard:/src/src/archivematica/dashboard" \
 		--entrypoint npm \
 			archivematica-dashboard-frontend-builder \
-				install --no-package-lock
+				ci
 
 restart-am-services:  ## Restart Archivematica services: MCPServer, MCPClient, Dashboard and Storage Service.
 	docker compose restart --no-deps archivematica-mcp-server


### PR DESCRIPTION
This fixes the Dashboard frontend build that has started failing with:

<details>
<summary>Error log</summary>

```console
#64 [archivematica-dashboard archivematica-dashboard-frontend-builder 4/4] RUN set ex 	&& npm install --no-package-lock
#64 14.66 npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
#64 14.84 npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
#64 14.96 npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
#64 15.48 npm warn deprecated angular-cookies@1.5.11: For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.
#64 15.50 npm warn deprecated angular-route@1.5.11: For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.
#64 15.99 npm warn deprecated angular@1.5.11: For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.
#64 16.65 
#64 16.65 > dashboard@0.0.0 prepare
#64 16.65 > webpack --entry ./app.js
#64 16.65 
#64 19.41 asset dashboard.js 5.1 MiB [emitted] (name: main)
#64 19.41 runtime modules 1.7 KiB 8 modules
#64 19.41 modules by path ../node_modules/ 4.67 MiB
#64 19.41   modules by path ../node_modules/moment/ 688 KiB 139 modules
#64 19.41   modules by path ../node_modules/angular-tree-control/ 61.4 KiB 13 modules
#64 19.41   modules by path ../node_modules/font-awesome/ 1.46 MiB 8 modules
#64 19.41   modules by path ../node_modules/style-loader/dist/runtime/*.js 5.84 KiB 6 modules
#64 19.41   modules by path ../node_modules/css-loader/dist/runtime/*.js 2.89 KiB 3 modules
#64 19.41   modules by path ../node_modules/angular/*.js 1.16 MiB 2 modules
#64 19.41   modules by path ../node_modules/angular-gettext/ 31.7 KiB 2 modules
#64 19.41  @ ./app.js 61:0-44
#64 19.41 
#64 19.41 ERROR in ./services/source_locations.service.js 3:29-84
#64 19.41 Module not found: Error: Can't resolve '@babel/runtime/helpers/interopRequireDefault' in '/src/src/archivematica/dashboard/frontend/app/services'
#64 19.41  @ ./app.js 62:0-49
#64 19.41 
#64 19.41 ERROR in ./services/tag.service.js 3:29-84
#64 19.41 Module not found: Error: Can't resolve '@babel/runtime/helpers/interopRequireDefault' in '/src/src/archivematica/dashboard/frontend/app/services'
#64 19.41  @ ./app.js 63:0-36
#64 19.41 
#64 19.41 ERROR in ./services/transfer.service.js 3:29-84
#64 19.41 Module not found: Error: Can't resolve '@babel/runtime/helpers/interopRequireDefault' in '/src/src/archivematica/dashboard/frontend/app/services'
#64 19.41  @ ./app.js 64:0-41
#64 19.41 
#64 19.41 ERROR in ./services/transfer_browser_transfer.service.js 3:29-84
#64 19.41 Module not found: Error: Can't resolve '@babel/runtime/helpers/interopRequireDefault' in '/src/src/archivematica/dashboard/frontend/app/services'
#64 19.41  @ ./app.js 65:0-58
#64 19.41 
#64 19.41 ERROR in ./services/transfer_browser_transfer.service.js 8:39-80
#64 19.41 Module not found: Error: Can't resolve '@babel/runtime/helpers/extends' in '/src/src/archivematica/dashboard/frontend/app/services'
#64 19.41  @ ./app.js 65:0-58
#64 19.41 
#64 19.41 ERROR in ./tree/tree.controller.js 3:29-84
#64 19.41 Module not found: Error: Can't resolve '@babel/runtime/helpers/interopRequireDefault' in '/src/src/archivematica/dashboard/frontend/app/tree'
#64 19.41  @ ./app.js 48:0-36
#64 19.41 
#64 19.41 ERROR in ./tree/tree.directive.js 3:29-84
#64 19.41 Module not found: Error: Can't resolve '@babel/runtime/helpers/interopRequireDefault' in '/src/src/archivematica/dashboard/frontend/app/tree'
#64 19.41  @ ./app.js 51:0-35
#64 19.41 
#64 19.41 ERROR in ./ui/ui.directive.js 3:29-84
#64 19.41 Module not found: Error: Can't resolve '@babel/runtime/helpers/interopRequireDefault' in '/src/src/archivematica/dashboard/frontend/app/ui'
#64 19.41  @ ./app.js 52:0-31
#64 19.41 
#64 19.41 ERROR in ./visualizations/visualizations.controller.js 3:29-84
#64 19.41 Module not found: Error: Can't resolve '@babel/runtime/helpers/interopRequireDefault' in '/src/src/archivematica/dashboard/frontend/app/visualizations'
#64 19.41  @ ./app.js 49:0-56
#64 19.41 
#64 19.41 33 errors have detailed information that is not shown.
#64 19.41 Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
#64 19.41 
#64 19.41 webpack 5.99.8 compiled with 33 errors in 2388 ms
#64 19.44 npm error code 1
#64 19.44 npm error path /src/src/archivematica/dashboard/frontend
failed to solve: process "/bin/sh -c set ex \t&& npm install --no-package-lock" did not complete successfully: exit code: 1
#64 19.44 npm error command failed
#64 19.44 npm error command sh -c webpack --entry ./app.js
#64 19.45 npm notice
#64 19.45 npm notice New major version of npm available! 10.8.2 -> 11.3.0
#64 19.45 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.3.0
#64 19.45 npm notice To update run: npm install -g npm@11.3.0
#64 19.45 npm notice
#64 19.45 npm error A complete log of this run can be found in: /root/.npm/_logs/2025-05-08T16_22_00_998Z-debug-0.log
#64 ERROR: process "/bin/sh -c set ex \t&& npm install --no-package-lock" did not complete successfully: exit code: 1
------
 > [archivematica-dashboard archivematica-dashboard-frontend-builder 4/4] RUN set ex 	&& npm install --no-package-lock:
19.44 npm error code 1
19.44 npm error path /src/src/archivematica/dashboard/frontend
19.44 npm error command failed
19.44 npm error command sh -c webpack --entry ./app.js
19.45 npm notice
19.45 npm notice New major version of npm available! 10.8.2 -> 11.3.0
19.45 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.3.0
19.45 npm notice To update run: npm install -g npm@11.3.0
19.45 npm notice
19.45 npm error A complete log of this run can be found in: /root/.npm/_logs/2025-05-08T16_22_00_998Z-debug-0.log
------
make: *** [Makefile:94: build] Error 1
make: Leaving directory '/home/runner/work/archivematica/archivematica/hack'
```
</details>

It replaces the `npm install --no-package-lock` commands with `npm ci` which is closer to the functionality of the previous `yarn install --frozen-lockfile` command used before.


Connected to https://github.com/archivematica/Issues/issues/1720