### PR TITLE
Remove migration data dependency from Dashboard tests

### DIFF
--- a/tests/dashboard/fpr/test_views.py
+++ b/tests/dashboard/fpr/test_views.py
@@ -53,16 +53,31 @@ def test_fpcommand_create(dashboard_uuid: None, admin_client: Client) -> None:
 
 @pytest.mark.django_db
 def test_fpcommand_edit(dashboard_uuid: None, admin_client: Client) -> None:
-    fpcommand_id = "41112047-7ddf-4bf0-9156-39fe96b32d53"
+    tool = models.FPTool.objects.create()
+    verification_command = models.FPCommand.objects.create(
+        command_usage="verification", tool=tool
+    )
+    format_version = models.FormatVersion.objects.create(
+        format=models.Format.objects.create(group=models.FormatGroup.objects.create())
+    )
+    command = models.FPCommand.objects.create(
+        description="Copying file to access directory",
+        enabled=True,
+        command_usage="normalization",
+        tool=tool,
+        output_format=format_version,
+    )
+
+    fpcommand_id = str(command.uuid)
     url = reverse("fpr:fpcommand_edit", args=[fpcommand_id])
 
     fpcommand = models.FPCommand.active.get(uuid=fpcommand_id)
     assert fpcommand.description == "Copying file to access directory"
 
     form_data = {
-        "verification_command": ["ef3ea000-0c3c-4cae-adc2-aa2a6ccbffce"],
+        "verification_command": [str(verification_command.uuid)],
         "description": ["new description"],
-        "tool": ["0efc346e-6373-4799-819d-17cc0f21f827"],
+        "tool": [str(tool.uuid)],
         "event_detail_command": [""],
         "output_location": [
             "%outputDirectory%%prefix%%fileName%%postfix%%fileExtensionWithDot%"
@@ -74,7 +89,7 @@ def test_fpcommand_edit(dashboard_uuid: None, admin_client: Client) -> None:
         "csrfmiddlewaretoken": [
             "k5UUufiJuSOLNOGJYlU2ODow5iKPhOuLc9Q0EmUoIXsQLZ7r5Ede7Pf0pSQEm0lP"
         ],
-        "output_format": ["0ab4cd40-90e7-4d75-b294-498177b3897d"],
+        "output_format": [str(format_version.uuid)],
         "script_type": ["command"],
     }
     resp = admin_client.post(url, follow=True, data=form_data)
@@ -91,7 +106,18 @@ def test_fpcommand_edit(dashboard_uuid: None, admin_client: Client) -> None:
 
 @pytest.mark.django_db
 def test_fpcommand_delete(dashboard_uuid: None, admin_client: Client) -> None:
-    fpcommand_id = "0fd7935a-ed0d-4f67-aa25-1b44684f6aca"
+    command = models.FPCommand.objects.create(
+        enabled=True,
+        command_usage="normalization",
+        tool=models.FPTool.objects.create(),
+        output_format=models.FormatVersion.objects.create(
+            format=models.Format.objects.create(
+                group=models.FormatGroup.objects.create()
+            )
+        ),
+    )
+
+    fpcommand_id = str(command.uuid)
     url = reverse("fpr:fpcommand_delete", args=[fpcommand_id])
 
     assert models.FPCommand.active.filter(uuid=fpcommand_id).exists()
@@ -104,7 +130,14 @@ def test_fpcommand_delete(dashboard_uuid: None, admin_client: Client) -> None:
 
 @pytest.mark.django_db
 def test_fpcommand_revisions(dashboard_uuid: None, admin_client: Client) -> None:
-    fpcommand_id = "fd8edea2-e251-4fa7-9592-f033d965696c"
+    initial_command = models.FPCommand.objects.create(
+        description="initial command", tool=models.FPTool.objects.create()
+    )
+    new_command = models.FPCommand.objects.create(
+        description="new command", replaces=initial_command, tool=initial_command.tool
+    )
+
+    fpcommand_id = str(new_command.uuid)
     url = reverse("fpr:revision_list", args=["fpcommand", fpcommand_id])
     fpcommand = models.FPCommand.active.get(uuid=fpcommand_id)
 
@@ -121,7 +154,7 @@ def test_format_create_creates_format(
     dashboard_uuid: None, admin_client: Client
 ) -> None:
     # Add a new format to the Unknown group.
-    unknown_group = models.FormatGroup.objects.get(description="Unknown")
+    unknown_group, _ = models.FormatGroup.objects.get_or_create(description="Unknown")
     format_description = "My test format"
 
     assert models.Format.objects.filter(description=format_description).count() == 0
@@ -147,13 +180,15 @@ def test_format_create_creates_format(
 @pytest.mark.django_db
 def test_format_edit_updates_format(dashboard_uuid: None, admin_client: Client) -> None:
     # Get details of the Matroska format from the Video group.
-    video_group = models.FormatGroup.objects.get(description="Video")
-    format = models.Format.objects.get(description="Matroska", group=video_group)
+    video_group, _ = models.FormatGroup.objects.get_or_create(description="Video")
+    format, _ = models.Format.objects.get_or_create(
+        description="Matroska", group=video_group
+    )
     format_uuid = format.uuid
     format_slug = format.slug
 
     # Update the group and description of the Matroska format.
-    unknown_group = models.FormatGroup.objects.get(description="Unknown")
+    unknown_group, _ = models.FormatGroup.objects.get_or_create(description="Unknown")
     new_format_description = "My matroska format"
 
     assert (

--- a/tests/dashboard/test_access.py
+++ b/tests/dashboard/test_access.py
@@ -67,6 +67,13 @@ def dashboard_uuid():
     helpers.set_setting("dashboard_uuid", "test-uuid")
 
 
+@pytest.fixture()
+def metadata_applies_to_type():
+    models.MetadataAppliesToType.objects.get_or_create(
+        pk="3e48343d-e2d2-4956-aaa3-b54d26eb9761", description="SIP"
+    )
+
+
 def _encode_record_id(record_id):
     return record_id.replace("/", "")
 
@@ -172,6 +179,7 @@ def test_access_arrange_start_sip(
     dashboard_uuid,
     admin_client,
     caplog,
+    metadata_applies_to_type,
 ):
     # Mock expected responses from ArchivesSpace.
     archival_object = {

--- a/tests/dashboard/test_api.py
+++ b/tests/dashboard/test_api.py
@@ -1353,15 +1353,13 @@ def test_fetch_levels_of_description_from_atom(get, admin_client):
     helpers.set_setting("dashboard_uuid", "test-uuid")
 
     # Set up the AtoM settings used on the Administration tab.
-    DashboardSetting.objects.create(
-        name="upload-qubit_v0.0",
-        value=str(
-            {
-                "url": "http://example.com",
-                "email": "demo@example.com",
-                "password": "password",
-            }
-        ),
+    DashboardSetting.objects.set_dict(
+        "upload-qubit_v0.0",
+        {
+            "url": "http://example.com",
+            "email": "demo@example.com",
+            "password": "password",
+        },
     )
 
     # Simulate interaction with AtoM.
@@ -1403,15 +1401,13 @@ def test_fetch_levels_of_description_from_atom_communication_failure(get, admin_
     helpers.set_setting("dashboard_uuid", "test-uuid")
 
     # Set up the AtoM settings used on the Administration tab.
-    DashboardSetting.objects.create(
-        name="upload-qubit_v0.0",
-        value=str(
-            {
-                "url": "http://example.com",
-                "email": "demo@example.com",
-                "password": "password",
-            }
-        ),
+    DashboardSetting.objects.set_dict(
+        "upload-qubit_v0.0",
+        {
+            "url": "http://example.com",
+            "email": "demo@example.com",
+            "password": "password",
+        },
     )
 
     response = admin_client.get(reverse("api:fetch_atom_lods"))

--- a/tests/dashboard/test_rights.py
+++ b/tests/dashboard/test_rights.py
@@ -187,8 +187,15 @@ def file(db):
     return File.objects.create(uuid=uuid.uuid4())
 
 
+@pytest.fixture()
+def metadata_applies_to_type():
+    MetadataAppliesToType.objects.get_or_create(description="SIP")
+    MetadataAppliesToType.objects.get_or_create(description="Transfer")
+    MetadataAppliesToType.objects.get_or_create(description="File")
+
+
 @pytest.mark.django_db
-def test_mdtype():
+def test_mdtype(metadata_applies_to_type):
     assert isinstance(load._mdtype(File()), MetadataAppliesToType)
     assert isinstance(load._mdtype(Transfer()), MetadataAppliesToType)
     assert isinstance(load._mdtype(SIP()), MetadataAppliesToType)
@@ -202,7 +209,9 @@ def test_mdtype():
 
 
 @pytest.mark.django_db
-def test_load_rights(file, rights_statement_with_basis_copyright):
+def test_load_rights(
+    file, rights_statement_with_basis_copyright, metadata_applies_to_type
+):
     stmt = load.load_rights(file, rights_statement_with_basis_copyright)
     assert stmt.metadataappliestotype.description == "File"
     assert stmt.metadataappliestoidentifier == file.uuid
@@ -229,7 +238,9 @@ def test_load_rights(file, rights_statement_with_basis_copyright):
 
 
 @pytest.mark.django_db
-def test_load_rights_with_basis_copyright(file, rights_statement_with_basis_copyright):
+def test_load_rights_with_basis_copyright(
+    file, rights_statement_with_basis_copyright, metadata_applies_to_type
+):
     stmt = load.load_rights(file, rights_statement_with_basis_copyright)
 
     assert stmt.rightsbasis == "Copyright"
@@ -263,7 +274,9 @@ def test_load_rights_with_basis_copyright(file, rights_statement_with_basis_copy
 
 
 @pytest.mark.django_db
-def test_load_rights_with_basis_license(file, rights_statement_with_basis_license):
+def test_load_rights_with_basis_license(
+    file, rights_statement_with_basis_license, metadata_applies_to_type
+):
     stmt = load.load_rights(file, rights_statement_with_basis_license)
 
     assert stmt.rightsbasis == "License"
@@ -294,7 +307,9 @@ def test_load_rights_with_basis_license(file, rights_statement_with_basis_licens
 
 
 @pytest.mark.django_db
-def test_load_rights_with_basis_statute(file, rights_statement_with_basis_statute):
+def test_load_rights_with_basis_statute(
+    file, rights_statement_with_basis_statute, metadata_applies_to_type
+):
     stmt = load.load_rights(file, rights_statement_with_basis_statute)
 
     assert stmt.rightsbasis == "Statute"
@@ -328,7 +343,9 @@ def test_load_rights_with_basis_statute(file, rights_statement_with_basis_statut
 
 
 @pytest.mark.django_db
-def test_load_rights_with_basis_other(file, rights_statement_with_basis_other):
+def test_load_rights_with_basis_other(
+    file, rights_statement_with_basis_other, metadata_applies_to_type
+):
     stmt = load.load_rights(file, rights_statement_with_basis_other)
 
     assert stmt.rightsbasis == "Other"

--- a/tests/dashboard/test_transfer.py
+++ b/tests/dashboard/test_transfer.py
@@ -7,6 +7,10 @@ from django.urls import reverse
 
 from archivematica.dashboard.components import helpers
 from archivematica.dashboard.main.models import DublinCore
+from archivematica.dashboard.main.models import MetadataAppliesToType
+from archivematica.dashboard.main.models import Taxonomy
+from archivematica.dashboard.main.models import TaxonomyTerm
+from archivematica.dashboard.main.models import TransferMetadataField
 from archivematica.dashboard.main.models import TransferMetadataFieldValue
 
 TEST_USER_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "test_user.json"
@@ -24,6 +28,7 @@ class TestTransferViews(TestCase):
     def test_metadata_edit(self):
         """Test the metadata form of a transfer"""
         transfer_uuid = "3e1e56ed-923b-4b53-84fe-c5c1c0b0cf8e"
+        MetadataAppliesToType.objects.get_or_create(description="Transfer")
         url = reverse("transfer:transfer_metadata_add", args=[transfer_uuid])
         # Post metadata in Spanish
         response = self.client.post(
@@ -61,6 +66,9 @@ def test_component_get(admin_client):
     helpers.set_setting("dashboard_uuid", "test-uuid")
     # This TransferMetadataSet is going to be created in the view.
     transfer_uuid = "43965fdb-37f3-4ec8-aa67-b49b2733f88a"
+    TransferMetadataField.objects.create(fieldlabel="Image fixity")
+    TransferMetadataField.objects.create(fieldlabel="Media number")
+    TransferMetadataField.objects.create(fieldlabel="Serial number")
 
     response = admin_client.get(
         reverse("transfer:component", args=[transfer_uuid]),
@@ -78,6 +86,16 @@ def test_component_post(admin_client):
     helpers.set_setting("dashboard_uuid", "test-uuid")
     # This TransferMetadataSet is going to be created in the view.
     transfer_uuid = "43965fdb-37f3-4ec8-aa67-b49b2733f88a"
+    taxonomy = Taxonomy.objects.create(name="Disk media formats")
+    TaxonomyTerm.objects.create(term='3.5" floppy', taxonomy=taxonomy)
+    TransferMetadataField.objects.create(
+        fieldlabel="Media format",
+        fieldname="media_format",
+        optiontaxonomy=taxonomy,
+    )
+    TransferMetadataField.objects.create(
+        fieldlabel="Media number", fieldname="media_number"
+    )
 
     # Verify there are no field values for the metadata set.
     assert TransferMetadataFieldValue.objects.filter(set=transfer_uuid).count() == 0


### PR DESCRIPTION
This updates the Dashboard tests to eliminate its dependency on migration data which makes the tests compatible with Django's transactional test cases, similar to those used in MCPServer.

With this change the tests pass when executed with `env PYTEST_ADDOPTS='--no-migrations' make test-dashboard` in the development environment.

<details>
<summary>Click to expand test run log</summary>

```console
replaceafill@vm1:~/archivematica/hack$ env PYTEST_ADDOPTS='--no-migrations' make test-dashboard 
docker build \
        -t archivematica-tests \
        -f /home/replaceafill/archivematica/hack/Dockerfile \
        --build-arg TARGET=archivematica-tests \
        --build-arg UBUNTU_VERSION \
        --build-arg PYTHON_VERSION \
                ../
[+] Building 2.8s (18/18) FINISHED                                                                                                                                                                 docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                         0.0s
 => => transferring dockerfile: 9.92kB                                                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/ubuntu:24.04                                                                                                                                              0.8s
 => [internal] load .dockerignore                                                                                                                                                                            0.0s
 => => transferring context: 314B                                                                                                                                                                            0.0s
 => [base-builder 1/4] FROM docker.io/library/ubuntu:24.04@sha256:6015f66923d7afbc53558d7ccffd325d43b4e249f41a6e93eef074c9505d2233                                                                           0.0s
 => [internal] load build context                                                                                                                                                                            1.8s
 => => transferring context: 138.34kB                                                                                                                                                                        1.8s
 => CACHED [base-builder 2/4] RUN set -ex  && id -u ubuntu >/dev/null 2>&1  && userdel --remove ubuntu || true                                                                                               0.0s
 => CACHED [base-builder 3/4] RUN set -ex  && apt-get update  && apt-get install -y --no-install-recommends   ca-certificates   curl   git   gnupg   libldap2-dev   libmysqlclient-dev   libsasl2-dev   lib  0.0s
 => CACHED [base-builder 4/4] RUN locale-gen en_US.UTF-8                                                                                                                                                     0.0s
 => CACHED [base 1/5] RUN set -ex  && curl --retry 3 -fsSL https://packages.archivematica.org/1.18.x/key.asc | gpg --dearmor -o /etc/apt/keyrings/archivematica-1.18.x.gpg  && echo "deb [arch=amd64 signed  0.0s
 => CACHED [base 2/5] RUN set -ex  && groupadd --gid 1000 --system archivematica  && useradd --uid 1000 --gid 1000 --home-dir /var/archivematica --system archivematica  && mkdir -p /var/archivematica/sha  0.0s
 => CACHED [base 3/5] RUN freshclam --quiet                                                                                                                                                                  0.0s
 => CACHED [pyenv-builder 1/4] RUN set -ex  && apt-get update  && apt-get install -y --no-install-recommends   build-essential   libbz2-dev   libffi-dev   liblzma-dev   libncursesw5-dev   libreadline-dev  0.0s
 => CACHED [pyenv-builder 2/4] RUN set -ex  && curl --retry 3 -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash  && pyenv install 3.9  && pyenv global 3.9                   0.0s
 => CACHED [pyenv-builder 3/4] COPY --link requirements-dev.txt /src/requirements-dev.txt                                                                                                                    0.0s
 => CACHED [pyenv-builder 4/4] RUN set -ex  && pyenv exec python3 -m pip install --upgrade pip setuptools  && pyenv exec python3 -m pip install --requirement /src/requirements-dev.txt  && pyenv rehash     0.0s
 => CACHED [base 4/5] COPY --chown=1000:1000 --from=pyenv-builder --link /pyenv /pyenv                                                                                                                       0.0s
 => CACHED [base 5/5] COPY --chown=1000:1000 --link . /src                                                                                                                                                   0.0s
 => exporting to image                                                                                                                                                                                       0.0s
 => => exporting layers                                                                                                                                                                                      0.0s
 => => writing image sha256:e184c423223c9045cd748ab30178a8a742cc794fef67e9a7e9c9577c70ffcbc0                                                                                                                 0.0s
 => => naming to docker.io/library/archivematica-tests                                                                                                                                                       0.0s
docker compose -f docker-compose.yml -f docker-compose.tests.yml  run --user 1000:1000 --rm --entrypoint bash archivematica-tests /src/hack/wait-for-it.sh mysql:3306 --timeout=30
[+] Creating 1/1
 ✔ Container am-mysql-1  Running                                                                                                                                                                             0.0s 
wait-for-it.sh: waiting 30 seconds for mysql:3306
wait-for-it.sh: mysql:3306 is available after 0 seconds
docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e ' GRANT ALL ON `DASHBOARDTEST`.* TO "archivematica"@"%";';     docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e ' GRANT ALL ON `test_DASHBOARDTEST`.* TO "archivematica"@"%";';  docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e ' GRANT ALL ON `test_DASHBOARDTEST_dashboard`.* TO "archivematica"@"%";';      docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e ' GRANT ALL ON `test_DASHBOARDTEST_archivematica-common`.* TO "archivematica"@"%";';
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
docker compose -f docker-compose.yml -f docker-compose.tests.yml  run -e DJANGO_SETTINGS_MODULE=archivematica.dashboard.settings.testmysql -e PYTEST_ADDOPTS=--no-migrations --user 1000:1000 --workdir /src --rm --entrypoint tox archivematica-tests -e dashboard 
[+] Creating 1/1
 ✔ Container am-mysql-1  Running                                                                                                                                                                             0.0s 
.pkg: _optional_hooks> python /pyenv/data/versions/3.9.22/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: get_requires_for_build_editable> python /pyenv/data/versions/3.9.22/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: build_editable> python /pyenv/data/versions/3.9.22/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta
dashboard: install_package> python -I -m pip install --force-reinstall --no-deps /src/.tox/.tmp/package/401/archivematica-1.18.0-0.editable-py3-none-any.whl
dashboard: commands[0] /src/tests/dashboard> py.test
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.9.22, pytest-8.3.5, pluggy-1.5.0
Using --randomly-seed=3612881837
django: version: 4.2.21, settings: archivematica.dashboard.settings.testmysql (from env)
rootdir: /src
configfile: pyproject.toml
plugins: randomly-3.16.0, base-url-2.1.0, cov-6.1.1, playwright-0.7.0, django-4.11.1
collected 345 items                                                                                                                                                                                              

fpr/test_forms.py ..                                                                                                                                                                                       [  0%]
test_dashboardsetting_manager.py .....                                                                                                                                                                     [  2%]
components/test_advanced_search.py ......                                                                                                                                                                  [  3%]
test_api.py ..........................................................                                                                                                                                     [ 20%]
main/test_command_purge_transient_processing_data.py .........                                                                                                                                             [ 23%]
test_backlog.py ...                                                                                                                                                                                        [ 24%]
test_api_v2beta.py ...........                                                                                                                                                                             [ 27%]
components/unit/test_views.py ............                                                                                                                                                                 [ 30%]
test_templatetags.py ....                                                                                                                                                                                  [ 31%]
test_helpers.py .......                                                                                                                                                                                    [ 33%]
test_models.py ..............                                                                                                                                                                              [ 37%]
test_signals.py ..                                                                                                                                                                                         [ 38%]
components/administration/test_dip_upload_configs.py ......                                                                                                                                                [ 40%]
test_oidc.py .........                                                                                                                                                                                     [ 42%]
test_password_validation.py ............                                                                                                                                                                   [ 46%]
test_rights.py ......                                                                                                                                                                                      [ 48%]
components/mcp/test_views.py .                                                                                                                                                                             [ 48%]
test_access.py ......                                                                                                                                                                                      [ 50%]
components/administration/test_usage.py ...                                                                                                                                                                [ 51%]
components/file/test_views.py ....................                                                                                                                                                         [ 56%]
test_ingest.py ..............                                                                                                                                                                              [ 60%]
fpr/test_utils.py .                                                                                                                                                                                        [ 61%]
test_cas.py sssssss                                                                                                                                                                                        [ 63%]
test_auth.py .....                                                                                                                                                                                         [ 64%]
test_middleware.py ........                                                                                                                                                                                [ 66%]
components/administration/test_forms.py .                                                                                                                                                                  [ 67%]
components/administration/test_storage.py ..                                                                                                                                                               [ 67%]
fpr/test_command_import_pronom_ids.py .....                                                                                                                                                                [ 69%]
main/test_transfer.py .....                                                                                                                                                                                [ 70%]
components/administration/test_processing_config.py .........                                                                                                                                              [ 73%]
components/administration/test_administration.py ........                                                                                                                                                  [ 75%]
fpr/test_views.py .........                                                                                                                                                                                [ 78%]
components/archival_storage/test_archival_storage.py .................                                                                                                                                     [ 83%]
test_migrations.py ...............                                                                                                                                                                         [ 87%]
test_ldap.py s                                                                                                                                                                                             [ 87%]
test_filesystem_ajax.py ......................                                                                                                                                                             [ 94%]
test_transfer.py ...                                                                                                                                                                                       [ 95%]
components/accounts/test_views.py ...........                                                                                                                                                              [ 98%]
test_shibboleth_login.py sssss                                                                                                                                                                             [ 99%]
fpr/test_command_get_fpr_changes.py .                                                                                                                                                                      [100%]

================================================================================================ warnings summary ================================================================================================
../../.tox/dashboard/lib/python3.9/site-packages/django/conf/__init__.py:241
  /src/.tox/dashboard/lib/python3.9/site-packages/django/conf/__init__.py:241: RemovedInDjango50Warning: The default value of USE_TZ will change from False to True in Django 5.0. Set USE_TZ to False in your project settings if you want to keep the current default behavior.
    warnings.warn(

../../.tox/dashboard/lib/python3.9/site-packages/django/db/models/options.py:210
tests/dashboard/fpr/test_forms.py::TestForms::test_IDToolForm
  /src/.tox/dashboard/lib/python3.9/site-packages/django/db/models/options.py:210: RemovedInDjango51Warning: 'index_together' is deprecated. Use 'Meta.indexes' in 'main.File' instead.
    warnings.warn(

../../.tox/dashboard/lib/python3.9/site-packages/django/db/models/options.py:210
tests/dashboard/fpr/test_forms.py::TestForms::test_IDToolForm
  /src/.tox/dashboard/lib/python3.9/site-packages/django/db/models/options.py:210: RemovedInDjango51Warning: 'index_together' is deprecated. Use 'Meta.indexes' in 'main.Job' instead.
    warnings.warn(

../../.tox/dashboard/lib/python3.9/site-packages/tastypie/compat.py:22
  /src/.tox/dashboard/lib/python3.9/site-packages/tastypie/compat.py:22: RemovedInDjango50Warning: The django.utils.datetime_safe module is deprecated.
    from django.utils import datetime_safe  # noqa: F401

../../.tox/dashboard/lib/python3.9/site-packages/_pytest/fixtures.py:1313
  /src/.tox/dashboard/lib/python3.9/site-packages/_pytest/fixtures.py:1313: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    return fixture_marker(fixture_function)

test_access.py:66
  /src/tests/dashboard/test_access.py:66: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    def dashboard_uuid():

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 332 passed, 13 skipped, 8 warnings in 121.47s (0:02:01) =============================================================================
  dashboard: OK (126.67=setup[4.04]+cmd[122.63] seconds)
  congratulations :) (126.96 seconds)
```

</details>

Connected to https://github.com/archivematica/Issues/issues/1720