### PR TITLE
Remove migration data dependency from MCPClient tests

### DIFF
--- a/tests/MCPClient/test_archivematicaCreateMETSRights.py
+++ b/tests/MCPClient/test_archivematicaCreateMETSRights.py
@@ -8,6 +8,9 @@ from archivematica.MCPClient.clientScripts.create_mets_v2 import MetsState
 
 @pytest.fixture()
 def rights_statement(db, sip_file):
+    models.MetadataAppliesToType.objects.get_or_create(
+        pk="7f04d9d4-92c2-44a5-93dc-b7bfdf0c1f17", description="File"
+    )
     statement = models.RightsStatement.objects.create(
         metadataappliestotype=models.MetadataAppliesToType.objects.get(
             id=models.MetadataAppliesToType.FILE_TYPE

--- a/tests/MCPClient/test_characterize_file.py
+++ b/tests/MCPClient/test_characterize_file.py
@@ -12,10 +12,12 @@ from archivematica.MCPClient.clientScripts import characterize_file
 def rule_with_xml_output_format(
     format_version: fprmodels.FormatVersion,
 ) -> fprmodels.FPRule:
+    output_format_version, _ = fprmodels.FormatVersion.objects.get_or_create(
+        pronom_id="fmt/101", format=format_version.format
+    )
+
     return fprmodels.FPRule.objects.create(
-        command=fprmodels.FPCommand.objects.create(
-            output_format=fprmodels.FormatVersion.objects.get(pronom_id="fmt/101")
-        ),
+        command=fprmodels.FPCommand.objects.create(output_format=output_format_version),
         format=format_version,
         purpose="characterization",
     )

--- a/tests/MCPClient/test_create_mets_v2.py
+++ b/tests/MCPClient/test_create_mets_v2.py
@@ -95,6 +95,10 @@ def metadata_csv(
 
 @pytest.fixture()
 def sip_dublincore(sip: SIP) -> DublinCore:
+    MetadataAppliesToType.objects.get_or_create(
+        pk="3e48343d-e2d2-4956-aaa3-b54d26eb9761", description="SIP"
+    )
+
     return DublinCore.objects.create(
         metadataappliestotype_id=MetadataAppliesToType.SIP_TYPE,
         metadataappliestoidentifier=sip.pk,

--- a/tests/MCPClient/test_create_transfer_mets.py
+++ b/tests/MCPClient/test_create_transfer_mets.py
@@ -162,6 +162,9 @@ def fpcommand_output(db, fprule_characterization, file_obj):
 
 @pytest.fixture()
 def basic_rights_statement(db, file_obj):
+    MetadataAppliesToType.objects.get_or_create(
+        pk="7f04d9d4-92c2-44a5-93dc-b7bfdf0c1f17", description="File"
+    )
     rights = RightsStatement.objects.create(
         metadataappliestotype_id="7f04d9d4-92c2-44a5-93dc-b7bfdf0c1f17",
         metadataappliestoidentifier=file_obj.uuid,

--- a/tests/MCPClient/test_extract_contents.py
+++ b/tests/MCPClient/test_extract_contents.py
@@ -170,7 +170,7 @@ def test_job_fails_if_file_has_been_extracted_already(
     ]
     assert len(job.pyprint.mock_calls) == len(expected_pyprint_calls)
     # This uses any_order because we do not control the order in which the
-    # jo iterates the files in the transfer.
+    # job iterates the files in the transfer.
     job.pyprint.assert_has_calls(expected_pyprint_calls, any_order=True)
 
 
@@ -400,7 +400,7 @@ def test_job_assign_uuids_to_extracted_files_and_directories(
         f"Command to execute is: {fpcommand.command}",
         f"Assigning UUID {extracted_directory.uuid} to directory path {extracted_directory.currentlocation.decode()}",
     ]
-    assert job.pyprint.mock_calls == [
+    expected_pyprint_calls = [
         mock.call(f"Deleting?: {delete}", file=mock.ANY),
         mock.call(
             "Extracted contents from",
@@ -422,6 +422,10 @@ def test_job_assign_uuids_to_extracted_files_and_directories(
             file=mock.ANY,
         ),
     ]
+    assert len(job.pyprint.mock_calls) == len(expected_pyprint_calls)
+    # This uses any_order because we do not control the order in which the
+    # job iterates the files in the transfer.
+    job.pyprint.assert_has_calls(expected_pyprint_calls, any_order=True)
 
 
 @pytest.mark.django_db

--- a/tests/MCPClient/test_filename_change.py
+++ b/tests/MCPClient/test_filename_change.py
@@ -180,6 +180,16 @@ class TestFilenameChange(TestCase):
         )
 
     @pytest.fixture(autouse=True)
+    def organization_agent(self):
+        return Agent.objects.get_or_create(
+            pk=2,
+            agenttype="organization",
+            identifiervalue="ORG",
+            name="Your Organization Name Here",
+            identifiertype="repository code",
+        )
+
+    @pytest.fixture(autouse=True)
     def microservice_unitvars(self, admin_agent):
         UnitVariable.objects.create(
             unituuid=self.transfer_uuid,
@@ -312,9 +322,25 @@ def test_change_name_raises_valueerror_on_empty_string():
         change_names.change_name("")
 
 
+@pytest.fixture
+def organization_agent():
+    return Agent.objects.get_or_create(
+        pk=2,
+        agenttype="organization",
+        identifiervalue="ORG",
+        name="Your Organization Name Here",
+        identifiertype="repository code",
+    )
+
+
 @pytest.mark.django_db
 def test_change_transfer_with_multiple_files(
-    monkeypatch, tmp_path, transfer, subdir_path, multiple_transfer_file_objs
+    monkeypatch,
+    tmp_path,
+    transfer,
+    subdir_path,
+    multiple_transfer_file_objs,
+    organization_agent,
 ):
     monkeypatch.setattr(change_object_names.NameChanger, "BATCH_SIZE", 10)
 

--- a/tests/MCPClient/test_identify_file_format.py
+++ b/tests/MCPClient/test_identify_file_format.py
@@ -213,6 +213,7 @@ def test_job_saves_unit_variable_indicating_file_format_identification_use(
     execute_or_run: mock.Mock,
     job: mock.Mock,
     sip: models.SIP,
+    idcommand: fprmodels.IDCommand,
 ) -> None:
     identify_file_format.call([job])
 
@@ -271,6 +272,7 @@ def test_job_updates_file_format_version(
     sip_file: models.File,
     format: fprmodels.Format,
     sip_file_format_version: models.FileFormatVersion,
+    idcommand: fprmodels.IDCommand,
 ) -> None:
     command_output = "fmt/111"
     execute_or_run.return_value = (0, command_output, "")

--- a/tests/MCPClient/test_move_to_backlog.py
+++ b/tests/MCPClient/test_move_to_backlog.py
@@ -8,8 +8,19 @@ from archivematica.dashboard.main.models import Agent
 from archivematica.MCPClient.clientScripts import move_to_backlog
 
 
+@pytest.fixture
+def organization_agent():
+    return Agent.objects.get_or_create(
+        pk=2,
+        agenttype="organization",
+        identifiervalue="ORG",
+        name="Your Organization Name Here",
+        identifiertype="repository code",
+    )
+
+
 @pytest.mark.django_db
-def test_premis_event_data(transfer):
+def test_premis_event_data(transfer, organization_agent):
     event_id, event_type, created_at = (
         str(uuid.uuid4()),
         "placement in backlog",
@@ -56,7 +67,7 @@ def test_premis_event_data(transfer):
 
 
 @pytest.mark.django_db
-def test_transfer_agents(transfer):
+def test_transfer_agents(transfer, organization_agent):
     ret = move_to_backlog._transfer_agents(transfer.uuid)
 
     assert len(ret) == 2

--- a/tests/MCPClient/test_parse_external_mets.py
+++ b/tests/MCPClient/test_parse_external_mets.py
@@ -61,6 +61,9 @@ def test_mets_cannot_parse(mcp_job, transfer_directory_path):
 
 
 def test_mets_is_parsed(db, mcp_job, transfer_directory_path):
+    models.MetadataAppliesToType.objects.get_or_create(
+        pk="3e48343d-e2d2-4956-aaa3-b54d26eb9761", description="SIP"
+    )
     exit_code = parse_external_mets.main(
         mcp_job, "a2f1f249-7bd4-4f52-8f1a-84319cb1b6d3", str(transfer_directory_path)
     )

--- a/tests/MCPClient/test_post_store_aip_hook.py
+++ b/tests/MCPClient/test_post_store_aip_hook.py
@@ -20,6 +20,22 @@ def archivesspace_components(sip):
     )
 
 
+@pytest.fixture()
+def archivesspace_setting():
+    models.DashboardSetting.objects.set_dict(
+        "upload-archivesspace_v0.0",
+        {
+            "base_url": "http://foobar.tld",
+            "user": "user",
+            "passwd": "12345",
+            "repository": "5",
+            "use_statement": "",
+            "xlink_show": "",
+            "xlink_actuate": "",
+        },
+    )
+
+
 @pytest.mark.django_db
 def test_no_archivesspace(sip, archivesspace_components, mcp_job):
     """It should abort if no ArchivesSpaceDigitalObject found."""
@@ -69,7 +85,13 @@ def test_no_dspace(get_file_info, sip, mcp_job):
     ),
 )
 def test_dspace_handle_to_archivesspace(
-    requests_get, requests_post, get_file_info, sip, archivesspace_components, mcp_job
+    requests_get,
+    requests_post,
+    get_file_info,
+    sip,
+    archivesspace_components,
+    mcp_job,
+    archivesspace_setting,
 ):
     """It should send the DSpace handle to ArchivesSpace."""
     rc = post_store_aip_hook.dspace_handle_to_archivesspace(mcp_job, sip.uuid)

--- a/tests/MCPClient/test_verify_checksum.py
+++ b/tests/MCPClient/test_verify_checksum.py
@@ -27,6 +27,7 @@ from unittest import mock
 
 import pytest
 
+from archivematica.dashboard.main.models import Agent
 from archivematica.dashboard.main.models import Event
 from archivematica.dashboard.main.models import File
 from archivematica.MCPClient.client.job import Job
@@ -280,6 +281,14 @@ class TestHashsum:
         """Test that the microservice job connects to the database as
         anticipated, writes its data, and that data can then be retrieved.
         """
+        Agent.objects.get_or_create(
+            pk=2,
+            agenttype="organization",
+            identifiervalue="ORG",
+            name="Your Organization Name Here",
+            identifiertype="repository code",
+        )
+
         # Values the job will write.
         algorithms = ["md5", "sha512", "sha1"]
         event_type = "fixity check"


### PR DESCRIPTION
This updates the MCPClient tests to eliminate its dependency on migration data which makes the tests compatible with Django's transactional test cases, similar to those used in MCPServer.

With this change the tests pass when executed with `env PYTEST_ADDOPTS='--no-migrations' make test-mcp-client` in the development environment.


<details>
<summary>Click to expand test run log</summary>

```console
replaceafill@vm1:~/archivematica/hack$ env PYTEST_ADDOPTS='--no-migrations' make test-mcp-client
docker build \
        -t archivematica-tests \
        -f /home/replaceafill/archivematica/hack/Dockerfile \
        --build-arg TARGET=archivematica-tests \
        --build-arg UBUNTU_VERSION \
        --build-arg PYTHON_VERSION \
                ../
[+] Building 3.3s (18/18) FINISHED                                                                                                                                                                                               docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                       0.0s
 => => transferring dockerfile: 9.92kB                                                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/ubuntu:24.04                                                                                                                                                                            0.4s
 => [internal] load .dockerignore                                                                                                                                                                                                          0.0s
 => => transferring context: 314B                                                                                                                                                                                                          0.0s
 => [base-builder 1/4] FROM docker.io/library/ubuntu:24.04@sha256:6015f66923d7afbc53558d7ccffd325d43b4e249f41a6e93eef074c9505d2233                                                                                                         0.0s
 => [internal] load build context                                                                                                                                                                                                          2.6s
 => => transferring context: 138.45kB                                                                                                                                                                                                      2.6s
 => CACHED [base-builder 2/4] RUN set -ex  && id -u ubuntu >/dev/null 2>&1  && userdel --remove ubuntu || true                                                                                                                             0.0s
 => CACHED [base-builder 3/4] RUN set -ex  && apt-get update  && apt-get install -y --no-install-recommends   ca-certificates   curl   git   gnupg   libldap2-dev   libmysqlclient-dev   libsasl2-dev   libsqlite3-dev   locales   make    0.0s
 => CACHED [base-builder 4/4] RUN locale-gen en_US.UTF-8                                                                                                                                                                                   0.0s
 => CACHED [base 1/5] RUN set -ex  && curl --retry 3 -fsSL https://packages.archivematica.org/1.18.x/key.asc | gpg --dearmor -o /etc/apt/keyrings/archivematica-1.18.x.gpg  && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/archivem  0.0s
 => CACHED [base 2/5] RUN set -ex  && groupadd --gid 1000 --system archivematica  && useradd --uid 1000 --gid 1000 --home-dir /var/archivematica --system archivematica  && mkdir -p /var/archivematica/sharedDirectory  && chown -R arch  0.0s
 => CACHED [base 3/5] RUN freshclam --quiet                                                                                                                                                                                                0.0s
 => CACHED [pyenv-builder 1/4] RUN set -ex  && apt-get update  && apt-get install -y --no-install-recommends   build-essential   libbz2-dev   libffi-dev   liblzma-dev   libncursesw5-dev   libreadline-dev   libsqlite3-dev   libssl-dev  0.0s
 => CACHED [pyenv-builder 2/4] RUN set -ex  && curl --retry 3 -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash  && pyenv install 3.9  && pyenv global 3.9                                                 0.0s
 => CACHED [pyenv-builder 3/4] COPY --link requirements-dev.txt /src/requirements-dev.txt                                                                                                                                                  0.0s
 => CACHED [pyenv-builder 4/4] RUN set -ex  && pyenv exec python3 -m pip install --upgrade pip setuptools  && pyenv exec python3 -m pip install --requirement /src/requirements-dev.txt  && pyenv rehash                                   0.0s
 => CACHED [base 4/5] COPY --chown=1000:1000 --from=pyenv-builder --link /pyenv /pyenv                                                                                                                                                     0.0s
 => CACHED [base 5/5] COPY --chown=1000:1000 --link . /src                                                                                                                                                                                 0.0s
 => exporting to image                                                                                                                                                                                                                     0.0s
 => => exporting layers                                                                                                                                                                                                                    0.0s
 => => writing image sha256:7e2b63663234536a55089273ebd46ef228e70fddd1f9bf5cebe885775984c9f3                                                                                                                                               0.0s
 => => naming to docker.io/library/archivematica-tests                                                                                                                                                                                     0.0s
docker compose -f docker-compose.yml -f docker-compose.tests.yml  run --user 1000:1000 --rm --entrypoint bash archivematica-tests /src/hack/wait-for-it.sh mysql:3306 --timeout=30
[+] Creating 1/1
 ✔ Container am-mysql-1  Running                                                                                                                                                                                                           0.0s 
wait-for-it.sh: waiting 30 seconds for mysql:3306
wait-for-it.sh: mysql:3306 is available after 0 seconds
docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e ' GRANT ALL ON `MCPCLIENTTEST`.* TO "archivematica"@"%";';     docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e ' GRANT ALL ON `test_MCPCLIENTTEST`.* TO "archivematica"@"%";';        docker compose exec -T mysql mysql -hlocalhost -uroot -p12345 -e ' GRANT ALL ON `test_MCPCLIENTTEST_mcp-client`.* TO "archivematica"@"%";';
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
docker compose -f docker-compose.yml -f docker-compose.tests.yml  run -e DJANGO_SETTINGS_MODULE=archivematica.MCPClient.settings.testmysql -e PYTEST_ADDOPTS=--no-migrations --user 1000:1000 --workdir /src --rm --entrypoint tox archivematica-tests -e mcp-client 
[+] Creating 1/1
 ✔ Container am-mysql-1  Running                                                                                                                                                                                                           0.0s 
.pkg: _optional_hooks> python /pyenv/data/versions/3.9.22/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: get_requires_for_build_editable> python /pyenv/data/versions/3.9.22/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: build_editable> python /pyenv/data/versions/3.9.22/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta
mcp-client: install_package> python -I -m pip install --force-reinstall --no-deps /src/.tox/.tmp/package/503/archivematica-1.18.0-0.editable-py3-none-any.whl
mcp-client: commands[0] /src/tests/MCPClient> py.test
============================================================================================================= test session starts ==============================================================================================================
platform linux -- Python 3.9.22, pytest-8.3.5, pluggy-1.5.0
Using --randomly-seed=1049968511
django: version: 4.2.21, settings: archivematica.MCPClient.settings.testmysql (from env)
rootdir: /src
configfile: pyproject.toml
plugins: randomly-3.16.0, base-url-2.1.0, cov-6.1.1, playwright-0.7.0, django-4.11.1
collected 425 items                                                                                                                                                                                                                            

test_antivirus_clamdscan.py ....                                                                                                                                                                                                         [  0%]
test_rights_from_csv.py ..                                                                                                                                                                                                               [  1%]
test_upload_qubit.py ..                                                                                                                                                                                                                  [  1%]
test_fpr_commands.py ..s......                                                                                                                                                                                                           [  4%]
test_create_aic_mets.py .                                                                                                                                                                                                                [  4%]
test_extract_contents.py ........                                                                                                                                                                                                        [  6%]
test_ensure_no_mutable_globals.py .                                                                                                                                                                                                      [  6%]
test_transcribe_file.py .......                                                                                                                                                                                                          [  8%]
test_parse_external_mets.py ...                                                                                                                                                                                                          [  8%]
test_parse_mets_to_db.py ..................                                                                                                                                                                                              [ 12%]
test_characterize_file.py .......                                                                                                                                                                                                        [ 14%]
test_store_file_modification.py .                                                                                                                                                                                                        [ 14%]
test_load_premis_events_from_xml.py ........................................                                                                                                                                                             [ 24%]
test_dip_generation_helper.py ....                                                                                                                                                                                                       [ 25%]
test_reingest_mets.py ..........x......................                                                                                                                                                                                  [ 32%]
test_create_aip_mets.py ..............x........                                                                                                                                                                                          [ 38%]
test_archivematicaCreateMETSRights.py .                                                                                                                                                                                                  [ 38%]
test_pid_components.py .......                                                                                                                                                                                                           [ 40%]
test_archivematicaCreateMETSRightsDspaceMDRef.py ..                                                                                                                                                                                      [ 40%]
test_normalize.py ................                                                                                                                                                                                                       [ 44%]
test_upload_archivesspace.py ................                                                                                                                                                                                            [ 48%]
test_identify_file_format.py ............                                                                                                                                                                                                [ 51%]
test_verify_checksum.py .......................                                                                                                                                                                                          [ 56%]
test_check_for_access_directory.py .                                                                                                                                                                                                     [ 56%]
test_create_transfer_mets.py ........................                                                                                                                                                                                    [ 62%]
test_archivematicaCreateMETSMetadataXML.py .....................                                                                                                                                                                         [ 67%]
test_policy_check.py ............                                                                                                                                                                                                        [ 70%]
test_validate_file.py ...........                                                                                                                                                                                                        [ 72%]
test_move_or_merge.py ...........                                                                                                                                                                                                        [ 75%]
test_assign_uuids_to_directories.py .                                                                                                                                                                                                    [ 75%]
test_job.py .                                                                                                                                                                                                                            [ 75%]
test_email_fail_report.py .....                                                                                                                                                                                                          [ 76%]
test_create_mets_v2.py ...............                                                                                                                                                                                                   [ 80%]
test_antivirus.py .........                                                                                                                                                                                                              [ 82%]
test_load_labels_from_csv.py ..                                                                                                                                                                                                          [ 83%]
test_has_packages.py ....                                                                                                                                                                                                                [ 84%]
test_post_store_aip_hook.py ....                                                                                                                                                                                                         [ 84%]
test_create_dataverse_mets.py ........................                                                                                                                                                                                   [ 90%]
test_filename_change.py .........                                                                                                                                                                                                        [ 92%]
test_json_conversion.py ......                                                                                                                                                                                                           [ 94%]
test_parse_dataverse.py ........                                                                                                                                                                                                         [ 96%]
test_move_to_backlog.py ...                                                                                                                                                                                                              [ 96%]
test_archivematicaCreateMETSMetadataCSV.py ..                                                                                                                                                                                            [ 97%]
test_restructure_dip_for_content_dm_upload.py ..                                                                                                                                                                                         [ 97%]
test_assign_file_uuids.py ....                                                                                                                                                                                                           [ 98%]
test_antivirus_clamscan.py ......                                                                                                                                                                                                        [100%]

=============================================================================================================== warnings summary ===============================================================================================================
../../.tox/mcp-client/lib/python3.9/site-packages/django/db/models/options.py:210
tests/MCPClient/test_rights_from_csv.py::TestRightsImportFromCsv::test_rows_processed_and_database_content
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/options.py:210: RemovedInDjango51Warning: 'index_together' is deprecated. Use 'Meta.indexes' in 'main.File' instead.
    warnings.warn(

../../.tox/mcp-client/lib/python3.9/site-packages/django/db/models/options.py:210
tests/MCPClient/test_rights_from_csv.py::TestRightsImportFromCsv::test_rows_processed_and_database_content
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/options.py:210: RemovedInDjango51Warning: 'index_together' is deprecated. Use 'Meta.indexes' in 'main.Job' instead.
    warnings.warn(

../../.tox/mcp-client/lib/python3.9/site-packages/tastypie/compat.py:22
  /src/.tox/mcp-client/lib/python3.9/site-packages/tastypie/compat.py:22: RemovedInDjango50Warning: The django.utils.datetime_safe module is deprecated.
    from django.utils import datetime_safe  # noqa: F401

../../.tox/mcp-client/lib/python3.9/site-packages/clamd/__init__.py:6
  /src/.tox/mcp-client/lib/python3.9/site-packages/clamd/__init__.py:6: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    __version__ = __import__('pkg_resources').get_distribution('clamd').version

../../.tox/mcp-client/lib/python3.9/site-packages/pkg_resources/__init__.py:3147
../../.tox/mcp-client/lib/python3.9/site-packages/pkg_resources/__init__.py:3147
  /src/.tox/mcp-client/lib/python3.9/site-packages/pkg_resources/__init__.py:3147: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

tests/MCPClient/test_reingest_mets.py::TestUpdateObject::test_update_preservation_derivative
tests/MCPClient/test_reingest_mets.py::TestUpdateObject::test_update_all
tests/MCPClient/test_reingest_mets.py::TestAddingNewFiles::test_no_new_files
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField Event.event_datetime received a naive datetime (2016-02-03 18:36:32) while time zone support is active.
    warnings.warn(

tests/MCPClient/test_reingest_mets.py::TestUpdateObject::test_update_all
tests/MCPClient/test_reingest_mets.py::TestUpdateObject::test_update_checksum_type
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField DashboardSetting.lastmodified received a naive datetime (2016-02-03 18:32:43) while time zone support is active.
    warnings.warn(

tests/MCPClient/test_reingest_mets.py::TestUpdateObject::test_update_all
tests/MCPClient/test_reingest_mets.py::TestUpdateObject::test_update_checksum_type
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField Event.event_datetime received a naive datetime (2016-02-03 18:36:36) while time zone support is active.
    warnings.warn(

tests/MCPClient/test_create_aip_mets.py::TestCreateDigiprovMD::test_creates_events
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField Event.event_datetime received a naive datetime (2015-11-30 21:55:35) while time zone support is active.
    warnings.warn(

tests/MCPClient/test_create_aip_mets.py::TestCreateDigiprovMD::test_creates_events
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField Event.event_datetime received a naive datetime (2015-11-30 21:55:36) while time zone support is active.
    warnings.warn(

tests/MCPClient/test_create_aip_mets.py::TestCreateDigiprovMD::test_creates_events
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField Event.event_datetime received a naive datetime (2015-11-30 21:55:38) while time zone support is active.
    warnings.warn(

tests/MCPClient/test_create_aip_mets.py::TestCreateDigiprovMD::test_creates_events
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField Event.event_datetime received a naive datetime (2015-11-30 21:55:39) while time zone support is active.
    warnings.warn(

tests/MCPClient/test_create_aip_mets.py::TestCreateDigiprovMD::test_creates_events
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField Event.event_datetime received a naive datetime (2015-11-30 21:55:40) while time zone support is active.
    warnings.warn(

tests/MCPClient/test_create_aip_mets.py::TestCreateDigiprovMD::test_creates_events
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField Event.event_datetime received a naive datetime (2015-11-30 21:55:44) while time zone support is active.
    warnings.warn(

tests/MCPClient/test_create_mets_v2.py::test_transfer_metadata_xml_is_recorded_in_a_amdsec
tests/MCPClient/test_create_mets_v2.py::test_source_metadata_xml_is_recorded_in_a_amdsec
tests/MCPClient/test_create_mets_v2.py::test_bag_metadata_is_recorded_in_a_amdsec[populated]
  /src/src/archivematica/MCPClient/clientScripts/create_mets_v2.py:1803: FutureWarning: Truth-testing of elements was a source of confusion and will always return True in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
    if el:

tests/MCPClient/test_filename_change.py: 12 warnings
  /src/.tox/mcp-client/lib/python3.9/site-packages/pytest_django/asserts.py:33: RemovedInDjango51Warning: assertQuerysetEqual() is deprecated in favor of assertQuerySetEqual().
    return func(*args, **kwargs)

tests/MCPClient/test_parse_dataverse.py::TestParseDataverse::test_parse_agent
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField File.enteredsystem received a naive datetime (2015-11-05 22:06:41) while time zone support is active.
    warnings.warn(

tests/MCPClient/test_parse_dataverse.py::TestParseDataverse::test_parse_agent
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField File.enteredsystem received a naive datetime (2015-11-05 22:06:49) while time zone support is active.
    warnings.warn(

tests/MCPClient/test_parse_dataverse.py::TestParseDataverse::test_parse_agent
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField File.removedtime received a naive datetime (2015-11-05 22:06:49) while time zone support is active.
    warnings.warn(

tests/MCPClient/test_parse_dataverse.py::TestParseDataverse::test_parse_agent
  /src/.tox/mcp-client/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField File.removedtime received a naive datetime (2019-01-15 23:13:00) while time zone support is active.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================== 422 passed, 1 skipped, 2 xfailed, 40 warnings in 55.69s ============================================================================================
  mcp-client: OK (64.74=setup[7.41]+cmd[57.33] seconds)
  congratulations :) (65.24 seconds)
```
</details>

Connected to https://github.com/archivematica/Issues/issues/1720