### PR TITLE
Reduce amount of jobs in test CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         rule: [
-          "mcp-server",
-          "mcp-client",
-          "dashboard",
-          "archivematica-common",
+          "archivematica",
         ]
         ubuntu-version: [
           "24.04",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,6 @@
 name: "Test"
 on:
   workflow_dispatch:
-    inputs:
-      am_version:
-        description: "Archivematica ref (branch, tag or SHA to checkout)"
-        default: "qa/1.x"
-        required: true
-        type: "string"
   pull_request:
   push:
     branches:
@@ -41,13 +35,7 @@ jobs:
             python-version: "3.9"
     steps:
       - name: "Check out repository"
-        if: "${{ github.event_name != 'workflow_dispatch' }}"
         uses: "actions/checkout@v4"
-      - name: "Check out repository (manually triggered)"
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
-        uses: "actions/checkout@v4"
-        with:
-          ref: "${{ inputs.am_version || 'qa/1.x' }}"
       - name: "Check out the archivematica-storage-service submodule"
         run: |
           git submodule update --init hack/submodules/archivematica-storage-service/

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -329,10 +329,10 @@ test-linting:  ## Check linting.
 test-all: start-mysql  ## Run all tests.
 	$(call grant_all_on_dbs,$(__TEST_DBS_MCPSERVER) $(__TEST_DBS_MCPCLIENT) $(__TEST_DBS_DASHBOARD) $(__TEST_DBS_STORAGE_SERVICE) $(__TEST_DBS_ARCHIVEMATICA_COMMON))
 	$(call run_toxenv,$(__TOXENVS_MCPSERVER),archivematica.MCPServer.settings.testmysql)
-	$(call run_toxenv,$(__TEST_DBS_MCPCLIENT),archivematica.MCPClient.settings.testmysql)
-	$(call run_toxenv,$(__TEST_DBS_DASHBOARD),archivematica.dashboard.settings.testmysql)
-	$(call run_toxenv,$(__TEST_DBS_ARCHIVEMATICA_COMMON),archivematica.dashboard.settings.testmysql)
-	$(call run_toxenv,$(__TEST_DBS_STORAGE_SERVICE),settings.testmysql)
+	$(call run_toxenv,$(__TOXENVS_MCPCLIENT),archivematica.MCPClient.settings.testmysql)
+	$(call run_toxenv,$(__TOXENVS_DASHBOARD),archivematica.dashboard.settings.testmysql)
+	$(call run_toxenv,$(__TOXENVS_ARCHIVEMATICA_COMMON),archivematica.dashboard.settings.testmysql)
+	$(call run_toxenv,$(__TOXENVS_STORAGE_SERVICE),archivematica.storage_service.storage_service.settings.testmysql)
 
 
 test-at-build:  ## AMAUAT: build image.

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -275,8 +275,9 @@ __TEST_DBS_MCPCLIENT = MCPCLIENTTEST test_MCPCLIENTTEST test_MCPCLIENTTEST_mcp-c
 __TEST_DBS_MIGRATIONS = DASHBOARDTEST SSTEST
 __TEST_DBS_DASHBOARD = DASHBOARDTEST test_DASHBOARDTEST test_DASHBOARDTEST_dashboard test_DASHBOARDTEST_archivematica-common
 __TEST_DBS_MCPSERVER = MCPSERVERTEST test_MCPSERVERTEST test_MCPSERVERTEST_mcp-server
+__TEST_DBS_ARCHIVEMATICA = ARCHIVEMATICATEST test_ARCHIVEMATICATEST%
 __TEST_DBS_STORAGE_SERVICE = test_SSTEST test_SSTEST_storage-service
-__TEST_DBS := $(__TEST_DBS_MCPCLIENT) $(__TEST_DBS_MIGRATIONS) $(__TEST_DBS_DASHBOARD) $(__TEST_DBS_MCPSERVER) $(__TEST_DBS_STORAGE_SERVICE) test_MCP test_SS
+__TEST_DBS := $(__TEST_DBS_MCPCLIENT) $(__TEST_DBS_MIGRATIONS) $(__TEST_DBS_DASHBOARD) $(__TEST_DBS_MCPSERVER) $(__TEST_DBS_ARCHIVEMATICA) $(__TEST_DBS_STORAGE_SERVICE) test_MCP test_SS
 flush-test-dbs: start-mysql
 	$(foreach test_db,$(__TEST_DBS),$(call drop_db,$(test_db));)
 
@@ -334,6 +335,10 @@ test-all: start-mysql  ## Run all tests.
 	$(call run_toxenv,$(__TOXENVS_ARCHIVEMATICA_COMMON),archivematica.dashboard.settings.testmysql)
 	$(call run_toxenv,$(__TOXENVS_STORAGE_SERVICE),archivematica.storage_service.storage_service.settings.testmysql)
 
+__TOXENVS_ARCHIVEMATICA = archivematica
+test-archivematica: start-mysql  ## Run Archivematica tests in a single run.
+	$(call grant_all_on_dbs,$(__TEST_DBS_ARCHIVEMATICA))
+	$(call run_toxenv,$(__TOXENVS_ARCHIVEMATICA),archivematica.testing.settings.testmysql)
 
 test-at-build:  ## AMAUAT: build image.
 	$(call compose_amauat, \

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -338,7 +338,10 @@ test-all: start-mysql  ## Run all tests.
 __TOXENVS_ARCHIVEMATICA = archivematica
 test-archivematica: start-mysql  ## Run Archivematica tests in a single run.
 	$(call grant_all_on_dbs,$(__TEST_DBS_ARCHIVEMATICA))
-	$(call run_toxenv,$(__TOXENVS_ARCHIVEMATICA),archivematica.testing.settings.testmysql)
+	$(call run_toxenv,$(__TOXENVS_ARCHIVEMATICA),archivematica.settings.testmysql)
+
+test-integration:  ## Run integration tests.
+	$(CURDIR)/tests/integration/run.sh
 
 test-at-build:  ## AMAUAT: build image.
 	$(call compose_amauat, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,9 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"src/archivematica/*/settings/*" = ["F403"]
+"src/archivematica/**/settings/*" = ["F403"]
 "src/archivematica/dashboard/settings/*" = ["F405"]
+"src/archivematica/settings/testmysql.py" = ["I001"]
 
 [tool.ruff.lint.isort]
 force-single-line = true
@@ -142,6 +143,7 @@ legacy_tox_ini = """
         migrations-dashboard
         migrations-storage-service
         linting
+        archivematica
 
     [testenv]
     package = editable
@@ -169,6 +171,9 @@ legacy_tox_ini = """
         mcp-server: {toxinidir}/tests/MCPServer
         mcp-client: {toxinidir}/tests/MCPClient
         storage-service: {env:STORAGE_SERVICE_ROOT}
+
+    [testenv:archivematica]
+    change_dir = {toxinidir}/tests
 
     [testenv:storage-service]
     deps =

--- a/src/archivematica/settings/testmysql.py
+++ b/src/archivematica/settings/testmysql.py
@@ -1,0 +1,18 @@
+import os
+
+from archivematica.MCPClient.settings.testmysql import *
+from archivematica.MCPServer.settings.testmysql import *
+from archivematica.dashboard.settings.testmysql import *
+
+DATABASES = {
+    "default": {
+        "ENGINE": os.environ.get("TEST_DB_ENGINE", "django.db.backends.mysql"),
+        "NAME": os.environ.get("TEST_DB_NAME", "ARCHIVEMATICATEST"),
+        "USER": os.environ.get("TEST_DB_USER", "archivematica"),
+        "PASSWORD": os.environ.get("TEST_DB_PASSWORD", "demo"),
+        "HOST": os.environ.get("TEST_DB_HOST", "mysql"),
+        "PORT": os.environ.get("TEST_DB_PORT", "3306"),
+        "CONN_MAX_AGE": 600,
+        "TEST": {"NAME": f"test_{os.environ.get('TEST_DB_NAME', 'ARCHIVEMATICATEST')}"},
+    }
+}

--- a/tests/dashboard/test_access.py
+++ b/tests/dashboard/test_access.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import pathlib
 from unittest import mock
 
@@ -181,6 +182,7 @@ def test_access_arrange_start_sip(
     caplog,
     metadata_applies_to_type,
 ):
+    caplog.set_level(logging.DEBUG, logger="archivematica.dashboard")
     # Mock expected responses from ArchivesSpace.
     archival_object = {
         "resource": {"ref": "/repositories/2/resources/10"},

--- a/tests/dashboard/test_ingest.py
+++ b/tests/dashboard/test_ingest.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import pathlib
 import uuid
@@ -380,6 +381,7 @@ def dashboard_uuid(db):
 def test_ingest_upload_as_match_shows_deleted_rows(
     admin_client, dashboard_uuid, caplog
 ):
+    caplog.set_level(logging.DEBUG, "archivematica.dashboard")
     dip_uuid = uuid.uuid4()
     file_uuid = uuid.uuid4()
     resource_id = "/repositories/2/archival_objects/1"


### PR DESCRIPTION
This adds a `make test-archivematica` rule to `hack/Makefile` that runs all component tests in a single pass. The `test.yml` CI workflow is updated to use this rule, reducing the number of test jobs from 16 to 4. All existing `make test-*` rules remain unchanged and fully usable.

Connected to https://github.com/archivematica/Issues/issues/1720