### PR TITLE
Fix Docker build failures

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -32,10 +32,6 @@ jobs:
           - "uuids-dirs"
         browser:
           - "Firefox"
-          - "Chrome"
-        exclude:
-          - tag: "black-box"
-            browser: Firefox
     steps:
       - name: "Check out repository"
         if: "${{ github.event_name != 'workflow_dispatch' }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
             **/package-lock.json
       - name: "Install frontend dependencies"
         run: |
-          npm install
+          npm ci
       - name: "Run tests"
         run: |
           npm run "test-single-run"

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -6,7 +6,7 @@ ARG PYTHON_VERSION=3.9
 ARG NODE_VERSION=20
 ARG PYENV_DIR=/pyenv
 ARG SELENIUM_DIR=/selenium
-ARG MEDIAAREA_VERSION=1.0-24
+ARG MEDIAAREA_VERSION=1.0-25
 
 # -----------------------------------------------------------------------------
 

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -112,7 +112,7 @@ COPY --link src/dashboard/frontend /src/src/dashboard/frontend
 WORKDIR /src/src/dashboard/frontend
 
 RUN set ex \
-	&& npm install --no-package-lock
+	&& npm ci
 
 # -----------------------------------------------------------------------------
 

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -185,7 +185,7 @@ bootstrap-dashboard-frontend:  ## Build front-end assets.
 		--volume "$(SRCDIR)/dashboard:/src/src/dashboard" \
 		--entrypoint npm \
 			archivematica-dashboard-frontend-builder \
-				install --no-package-lock
+				ci
 
 restart-am-services:  ## Restart Archivematica services: MCPServer, MCPClient, Dashboard and Storage Service.
 	docker compose restart --no-deps archivematica-mcp-server


### PR DESCRIPTION
These are cherry picks of the following fixes from the `qa/1.x` branch:

* Upgrade MediaArea version https://github.com/artefactual/archivematica/commit/09b00252c1397baf0808db2667f79c466c617276
* Use package-lock.json on Dashboard frontend build https://github.com/artefactual/archivematica/commit/d31e8b0ec45b2970c31056d759b37d43171c45de
* Remove chrome browser from AMAUAT CI tests https://github.com/artefactual/archivematica/commit/8ac76be7e9a08cba1acb02076663a5a2ad7e0a49

Connected to https://github.com/archivematica/Issues/issues/1747