### PR TITLE
Add fixture for Dashboard UUID setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ module = [
     "src.archivematica.MCPClient.clientScripts.transcribe_file",
     "src.archivematica.MCPClient.clientScripts.validate_file",
     "tests.archivematicaCommon.test_execute_functions",
+    "tests.conftest",
     "tests.dashboard.components.accounts.test_views",
     "tests.dashboard.components.administration.test_administration",
     "tests.dashboard.fpr.test_command_get_fpr_changes",

--- a/tests/archivematicaCommon/test_elasticsearch_functions.py
+++ b/tests/archivematicaCommon/test_elasticsearch_functions.py
@@ -9,7 +9,6 @@ from django.utils.timezone import make_aware
 from lxml import etree
 
 from archivematica.archivematicaCommon import elasticSearchFunctions
-from archivematica.dashboard.components import helpers
 from archivematica.dashboard.main.models import SIP
 from archivematica.dashboard.main.models import Directory
 from archivematica.dashboard.main.models import File
@@ -332,13 +331,9 @@ def test_set_tags_fails_when_file_cant_be_found(perform_request, es_client):
 
 
 @pytest.mark.django_db
-@mock.patch(
-    "archivematica.archivematicaCommon.elasticSearchFunctions.get_dashboard_uuid"
-)
 @mock.patch("archivematica.archivematicaCommon.elasticSearchFunctions.bulk")
-def test_index_mets_file_metadata(bulk, get_dashboard_uuid, es_client):
+def test_index_mets_file_metadata(bulk, dashboard_uuid, es_client):
     # Set up mocked functions
-    get_dashboard_uuid.return_value = "test-uuid"
     indexed_data = {}
 
     def _bulk(client, actions, stats_only=False, *args, **kwargs):
@@ -580,12 +575,9 @@ fileuuid_premisv2_no_ns = (
         ),
     ],
 )
-@mock.patch(
-    "archivematica.archivematicaCommon.elasticSearchFunctions.get_dashboard_uuid"
-)
 @mock.patch("archivematica.archivematicaCommon.elasticSearchFunctions.bulk")
 def test_index_aipfile_fileuuid(
-    bulk, get_dashboard_uuid, metsfile, fileuuid_dict, aipuuid, aipname
+    bulk, dashboard_uuid, metsfile, fileuuid_dict, aipuuid, aipname
 ):
     """Check AIP file uuids are being correctly parsed from METS files.
 
@@ -593,8 +585,6 @@ def test_index_aipfile_fileuuid(
     indexed_data, with the fileuuids that _index_aip_files() obtained
     from the METS
     """
-
-    get_dashboard_uuid.return_value = "test-uuid"
 
     indexed_data = {}
 
@@ -638,19 +628,14 @@ dmdsec_dconly = {
         ),
     ],
 )
-@mock.patch(
-    "archivematica.archivematicaCommon.elasticSearchFunctions.get_dashboard_uuid"
-)
 @mock.patch("archivematica.archivematicaCommon.elasticSearchFunctions.bulk")
-def test_index_aipfile_dmdsec(bulk, get_dashboard_uuid, metsfile, dmdsec_dict):
+def test_index_aipfile_dmdsec(bulk, dashboard_uuid, metsfile, dmdsec_dict):
     """Check AIP file dmdSec is correctly parsed from METS files.
 
     Mock _try_to_index() with a function that populates a dict
     indexed_data, with the dmdSec data that _index_aip_files() obtained
     from the METS
     """
-
-    get_dashboard_uuid.return_value = "test-uuid"
 
     indexed_data = {}
 
@@ -943,9 +928,9 @@ def test_index_aip_and_files_logs_error_if_mets_does_not_exist(
     return_value={"status": "green"},
 )
 @mock.patch("archivematica.archivematicaCommon.elasticSearchFunctions._index_aip_files")
-def test_index_aip_and_files(_index_aip_files, health, index, es_client, tmp_path):
-    dashboard_uuid = uuid.uuid4()
-    helpers.set_setting("dashboard_uuid", str(dashboard_uuid))
+def test_index_aip_and_files(
+    _index_aip_files, health, index, es_client, tmp_path, dashboard_uuid
+):
     printfn = mock.Mock()
     aip_name = "aip"
     aip_uuid = str(uuid.uuid4())
@@ -1067,9 +1052,9 @@ def transfer_file(transfer):
     "elasticsearch.client.cluster.ClusterClient.health",
     return_value={"status": "green"},
 )
-def test_index_transfer_and_files(health, index, es_client, transfer, transfer_file):
-    dashboard_uuid = uuid.uuid4()
-    helpers.set_setting("dashboard_uuid", str(dashboard_uuid))
+def test_index_transfer_and_files(
+    health, index, es_client, transfer, transfer_file, dashboard_uuid
+):
     printfn = mock.Mock()
     expected_transfer_name = "transfer"
     expected_file_count = 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import uuid
+
+import pytest
+
+from archivematica.dashboard.components import helpers
+
+
+@pytest.fixture
+def dashboard_uuid(db: None) -> uuid.UUID:
+    result = uuid.uuid4()
+    helpers.set_setting("dashboard_uuid", str(result))
+
+    return result

--- a/tests/dashboard/components/accounts/test_views.py
+++ b/tests/dashboard/components/accounts/test_views.py
@@ -13,7 +13,6 @@ from django.test import RequestFactory
 from django.urls import reverse
 from tastypie.models import ApiKey
 
-from archivematica.dashboard.components import helpers
 from archivematica.dashboard.components.accounts.views import get_oidc_logout_url
 
 
@@ -55,11 +54,6 @@ def test_get_oidc_logout_url_returns_logout_url(
 
 
 @pytest.fixture
-def dashboard_uuid() -> None:
-    helpers.set_setting("dashboard_uuid", str(uuid.uuid4()))
-
-
-@pytest.fixture
 def non_administrative_user(django_user_model: type[User]) -> User:
     return django_user_model.objects.create_user(
         username="test",
@@ -72,7 +66,7 @@ def non_administrative_user(django_user_model: type[User]) -> User:
 
 @pytest.mark.django_db
 def test_edit_user_view_denies_access_to_non_admin_users_editing_others(
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     non_administrative_user: User,
     admin_user: User,
     client: Client,
@@ -96,7 +90,7 @@ def non_administrative_user_apikey(non_administrative_user: User) -> ApiKey:
 
 @pytest.mark.django_db
 def test_edit_user_view_renders_user_profile_fields(
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     non_administrative_user: User,
     non_administrative_user_apikey: ApiKey,
     admin_client: Client,
@@ -121,7 +115,7 @@ def test_edit_user_view_renders_user_profile_fields(
 
 @pytest.mark.django_db
 def test_edit_user_view_updates_user_profile_fields(
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     non_administrative_user: User,
     admin_client: Client,
 ) -> None:
@@ -161,7 +155,7 @@ def test_edit_user_view_updates_user_profile_fields(
 
 @pytest.mark.django_db
 def test_edit_user_view_regenerates_api_key(
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     non_administrative_user: User,
     non_administrative_user_apikey: ApiKey,
     admin_client: Client,
@@ -195,7 +189,7 @@ def test_edit_user_view_regenerates_api_key(
 
 @pytest.mark.django_db
 def test_user_profile_view_allows_users_to_edit_their_profile_fields(
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     non_administrative_user: User,
     non_administrative_user_apikey: ApiKey,
     client: Client,
@@ -224,7 +218,7 @@ def test_user_profile_view_allows_users_to_edit_their_profile_fields(
 
 @pytest.mark.django_db
 def test_user_profile_view_denies_editing_profile_fields_if_setting_disables_it(
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     non_administrative_user: User,
     non_administrative_user_apikey: ApiKey,
     client: Client,
@@ -258,7 +252,7 @@ def test_user_profile_view_denies_editing_profile_fields_if_setting_disables_it(
 
 @pytest.mark.django_db
 def test_user_profile_view_regenerates_api_key_if_setting_disables_editing(
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     non_administrative_user: User,
     non_administrative_user_apikey: ApiKey,
     client: Client,
@@ -296,7 +290,7 @@ def test_user_profile_view_regenerates_api_key_if_setting_disables_editing(
 
 @pytest.mark.django_db
 def test_user_profile_view_does_not_regenerate_api_key_if_not_requested(
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     non_administrative_user: User,
     non_administrative_user_apikey: ApiKey,
     client: Client,

--- a/tests/dashboard/components/administration/test_administration.py
+++ b/tests/dashboard/components/administration/test_administration.py
@@ -14,17 +14,8 @@ from archivematica.dashboard.components import helpers
 from archivematica.dashboard.main.models import Report
 
 
-@pytest.fixture
 @pytest.mark.django_db
-def dashboard_uuid() -> str:
-    value = str(uuid.uuid4())
-    helpers.set_setting("dashboard_uuid", value)
-
-    return value
-
-
-@pytest.mark.django_db
-def test_admin_set_language(dashboard_uuid: str, admin_client: Client) -> None:
+def test_admin_set_language(dashboard_uuid: uuid.UUID, admin_client: Client) -> None:
     response = admin_client.get(reverse("administration:admin_set_language"))
     assert response.status_code == 200
 
@@ -34,7 +25,7 @@ def test_admin_set_language(dashboard_uuid: str, admin_client: Client) -> None:
 
 
 @pytest.mark.django_db
-def test_failure_report_delete(dashboard_uuid: str, admin_client: Client) -> None:
+def test_failure_report_delete(dashboard_uuid: uuid.UUID, admin_client: Client) -> None:
     report = Report.objects.create(content="my report")
 
     response = admin_client.post(
@@ -49,7 +40,7 @@ def test_failure_report_delete(dashboard_uuid: str, admin_client: Client) -> Non
 
 
 @pytest.mark.django_db
-def test_failure_report(dashboard_uuid: str, admin_client: Client) -> None:
+def test_failure_report(dashboard_uuid: uuid.UUID, admin_client: Client) -> None:
     report = Report.objects.create(content="my report")
 
     response = admin_client.get(reverse("administration:reports_failures_index"))
@@ -107,7 +98,7 @@ def checksum_type() -> str:
 )
 def test_general_view_renders_initial_dashboard_settings(
     get: mock.Mock,
-    dashboard_uuid: str,
+    dashboard_uuid: uuid.UUID,
     site_url: str,
     storage_service_url: str,
     storage_service_user: str,
@@ -134,7 +125,7 @@ def test_general_view_renders_initial_dashboard_settings(
 @mock.patch("requests.Session.get")
 def test_general_view_renders_warning_if_it_cannot_connect_to_pipeline(
     get: mock.Mock,
-    dashboard_uuid: str,
+    dashboard_uuid: uuid.UUID,
     admin_client: Client,
 ) -> None:
     error = "connection refused"
@@ -155,7 +146,7 @@ def test_general_view_renders_warning_if_it_cannot_connect_to_pipeline(
 )
 def test_general_view_updates_dashboard_settings(
     get: mock.Mock,
-    dashboard_uuid: str,
+    dashboard_uuid: uuid.UUID,
     site_url: str,
     storage_service_url: str,
     storage_service_user: str,
@@ -208,7 +199,7 @@ def test_general_view_registers_pipeline_in_storage_service(
     node: mock.Mock,
     post: mock.Mock,
     get_pipeline: mock.Mock,
-    dashboard_uuid: str,
+    dashboard_uuid: uuid.UUID,
     site_url: str,
     storage_service_url: str,
     storage_service_user: str,
@@ -239,7 +230,7 @@ def test_general_view_registers_pipeline_in_storage_service(
     post.assert_called_once_with(
         f"{storage_service_url}api/v2/pipeline/",
         json={
-            "uuid": dashboard_uuid,
+            "uuid": str(dashboard_uuid),
             "description": f"Archivematica on {hostname}",
             "create_default_locations": True,
             "shared_path": shared_directory,
@@ -257,7 +248,7 @@ def test_general_view_registers_pipeline_in_storage_service(
 )
 def test_general_view_updates_dashboard_settings_when_storage_service_apikey_is_not_set(
     get: mock.Mock,
-    dashboard_uuid: str,
+    dashboard_uuid: uuid.UUID,
     site_url: str,
     storage_service_url: str,
     storage_service_user: str,

--- a/tests/dashboard/components/administration/test_dip_upload_configs.py
+++ b/tests/dashboard/components/administration/test_dip_upload_configs.py
@@ -1,9 +1,9 @@
 import pathlib
 
+import pytest
 from django.test import TestCase
 from django.urls import reverse
 
-from archivematica.dashboard.components import helpers
 from archivematica.dashboard.components.administration.views_dip_upload import (
     _AS_DICTNAME,
 )
@@ -20,10 +20,13 @@ TEST_USER_FIXTURE = (
 class TestDipUploadAsConfig(TestCase):
     fixtures = [TEST_USER_FIXTURE]
 
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
+
     def setUp(self):
         self.client.login(username="test", password="test")
         self.url = reverse("administration:dips_as")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
 
     def test_get(self):
         response = self.client.get(self.url)
@@ -96,10 +99,13 @@ class TestDipUploadAsConfig(TestCase):
 class TestDipUploadAtomConfig(TestCase):
     fixtures = [TEST_USER_FIXTURE]
 
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
+
     def setUp(self):
         self.client.login(username="test", password="test")
         self.url = reverse("administration:dips_atom_index")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
 
     def test_get(self):
         response = self.client.get(self.url)

--- a/tests/dashboard/components/administration/test_processing_config.py
+++ b/tests/dashboard/components/administration/test_processing_config.py
@@ -32,9 +32,12 @@ def shared_directory(settings):
 class TestProcessingConfig(TestCase):
     fixtures = [TEST_USER_FIXTURE]
 
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
+
     def setUp(self):
         self.client.login(username="test", password="test")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
 
     @mock.patch(
         "archivematica.dashboard.components.administration.views_processing.os.path.isfile"

--- a/tests/dashboard/components/administration/test_storage.py
+++ b/tests/dashboard/components/administration/test_storage.py
@@ -1,9 +1,8 @@
 import pathlib
 from unittest import mock
 
+import pytest
 from django.test import TestCase
-
-from archivematica.dashboard.components import helpers
 
 TEST_USER_FIXTURE = (
     pathlib.Path(__file__).parent.parent.parent / "fixtures" / "test_user.json"
@@ -13,10 +12,13 @@ TEST_USER_FIXTURE = (
 class TestStorage(TestCase):
     fixtures = [TEST_USER_FIXTURE]
 
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
+
     def setUp(self):
         self.client.login(username="test", password="test")
         self.url = "/administration/storage/"
-        helpers.set_setting("dashboard_uuid", "test-uuid")
 
     @mock.patch(
         "archivematica.dashboard.components.administration.views.storage_service.get_location",

--- a/tests/dashboard/components/administration/test_usage.py
+++ b/tests/dashboard/components/administration/test_usage.py
@@ -2,10 +2,9 @@ import pathlib
 import subprocess
 from unittest import mock
 
+import pytest
 from django.conf import settings
 from django.test import TestCase
-
-from archivematica.dashboard.components import helpers
 
 TEST_USER_FIXTURE = (
     pathlib.Path(__file__).parent.parent.parent / "fixtures" / "test_user.json"
@@ -15,9 +14,12 @@ TEST_USER_FIXTURE = (
 class TestUsage(TestCase):
     fixtures = [TEST_USER_FIXTURE]
 
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
+
     def setUp(self):
         self.client.login(username="test", password="test")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
 
     def test_no_calculation(self):
         for calculate in [None, "False", "false", "no", "0", "random"]:

--- a/tests/dashboard/components/file/test_views.py
+++ b/tests/dashboard/components/file/test_views.py
@@ -1,19 +1,12 @@
 import json
 import logging
-import uuid
 from unittest import mock
 
 import pytest
 from django.urls import reverse
 
 from archivematica.archivematicaCommon import elasticSearchFunctions
-from archivematica.dashboard.components import helpers
 from archivematica.dashboard.main import models
-
-
-@pytest.fixture
-def dashboard_uuid(db):
-    helpers.set_setting("dashboard_uuid", str(uuid.uuid4()))
 
 
 @pytest.fixture

--- a/tests/dashboard/fpr/test_views.py
+++ b/tests/dashboard/fpr/test_views.py
@@ -4,17 +4,11 @@ import pytest
 from django.test import Client
 from django.urls import reverse
 
-from archivematica.dashboard.components import helpers
 from archivematica.dashboard.fpr import models
 
 
-@pytest.fixture
-def dashboard_uuid() -> None:
-    helpers.set_setting("dashboard_uuid", str(uuid.uuid4()))
-
-
 @pytest.mark.django_db
-def test_idcommand_create(dashboard_uuid: None, admin_client: Client) -> None:
+def test_idcommand_create(dashboard_uuid: uuid.UUID, admin_client: Client) -> None:
     url = reverse("fpr:idcommand_create")
     tool = models.IDTool.objects.create(
         uuid="37f3bd7c-bb24-4899-b7c4-785ff1c764ac",
@@ -33,7 +27,7 @@ def test_idcommand_create(dashboard_uuid: None, admin_client: Client) -> None:
 
 
 @pytest.mark.django_db
-def test_fpcommand_create(dashboard_uuid: None, admin_client: Client) -> None:
+def test_fpcommand_create(dashboard_uuid: uuid.UUID, admin_client: Client) -> None:
     url = reverse("fpr:fpcommand_create")
     tool = models.FPTool.objects.create(
         uuid="37f3bd7c-bb24-4899-b7c4-785ff1c764ac",
@@ -52,7 +46,7 @@ def test_fpcommand_create(dashboard_uuid: None, admin_client: Client) -> None:
 
 
 @pytest.mark.django_db
-def test_fpcommand_edit(dashboard_uuid: None, admin_client: Client) -> None:
+def test_fpcommand_edit(dashboard_uuid: uuid.UUID, admin_client: Client) -> None:
     tool = models.FPTool.objects.create()
     verification_command = models.FPCommand.objects.create(
         command_usage="verification", tool=tool
@@ -105,7 +99,7 @@ def test_fpcommand_edit(dashboard_uuid: None, admin_client: Client) -> None:
 
 
 @pytest.mark.django_db
-def test_fpcommand_delete(dashboard_uuid: None, admin_client: Client) -> None:
+def test_fpcommand_delete(dashboard_uuid: uuid.UUID, admin_client: Client) -> None:
     command = models.FPCommand.objects.create(
         enabled=True,
         command_usage="normalization",
@@ -129,7 +123,7 @@ def test_fpcommand_delete(dashboard_uuid: None, admin_client: Client) -> None:
 
 
 @pytest.mark.django_db
-def test_fpcommand_revisions(dashboard_uuid: None, admin_client: Client) -> None:
+def test_fpcommand_revisions(dashboard_uuid: uuid.UUID, admin_client: Client) -> None:
     initial_command = models.FPCommand.objects.create(
         description="initial command", tool=models.FPTool.objects.create()
     )
@@ -151,7 +145,7 @@ def test_fpcommand_revisions(dashboard_uuid: None, admin_client: Client) -> None
 
 @pytest.mark.django_db
 def test_format_create_creates_format(
-    dashboard_uuid: None, admin_client: Client
+    dashboard_uuid: uuid.UUID, admin_client: Client
 ) -> None:
     # Add a new format to the Unknown group.
     unknown_group, _ = models.FormatGroup.objects.get_or_create(description="Unknown")
@@ -178,7 +172,9 @@ def test_format_create_creates_format(
 
 
 @pytest.mark.django_db
-def test_format_edit_updates_format(dashboard_uuid: None, admin_client: Client) -> None:
+def test_format_edit_updates_format(
+    dashboard_uuid: uuid.UUID, admin_client: Client
+) -> None:
     # Get details of the Matroska format from the Video group.
     video_group, _ = models.FormatGroup.objects.get_or_create(description="Video")
     format, _ = models.Format.objects.get_or_create(
@@ -220,7 +216,7 @@ def test_format_edit_updates_format(dashboard_uuid: None, admin_client: Client) 
 
 
 @pytest.mark.django_db
-def test_idrule_create(dashboard_uuid: None, admin_client: Client) -> None:
+def test_idrule_create(dashboard_uuid: uuid.UUID, admin_client: Client) -> None:
     url = reverse("fpr:idrule_create")
 
     resp = admin_client.get(url)
@@ -262,7 +258,7 @@ def test_idrule_create(dashboard_uuid: None, admin_client: Client) -> None:
 
 
 @pytest.mark.django_db
-def test_fprule_create(dashboard_uuid: None, admin_client: Client) -> None:
+def test_fprule_create(dashboard_uuid: uuid.UUID, admin_client: Client) -> None:
     url = reverse("fpr:fprule_create")
 
     resp = admin_client.get(url)

--- a/tests/dashboard/test_access.py
+++ b/tests/dashboard/test_access.py
@@ -9,7 +9,6 @@ from django.test.client import Client
 from django.urls import reverse
 
 from archivematica.archivematicaCommon import archivematicaFunctions
-from archivematica.dashboard.components import helpers
 from archivematica.dashboard.main import models
 
 TEST_USER_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "test_user.json"
@@ -19,10 +18,13 @@ ACCESS_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "access.json"
 class TestAccessAPI(TestCase):
     fixtures = [TEST_USER_FIXTURE, ACCESS_FIXTURE]
 
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
+
     def setUp(self):
         self.client = Client()
         self.client.login(username="test", password="test")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
 
     def test_creating_arrange_directory(self):
         record_id = "/repositories/2/archival_objects/2"
@@ -60,12 +62,6 @@ class TestAccessAPI(TestCase):
             in response_dict["entries"]
         )
         assert len(response_dict["entries"]) == 1
-
-
-@pytest.mark.django_db
-@pytest.fixture
-def dashboard_uuid():
-    helpers.set_setting("dashboard_uuid", "test-uuid")
 
 
 @pytest.fixture()

--- a/tests/dashboard/test_api_v2beta.py
+++ b/tests/dashboard/test_api_v2beta.py
@@ -2,13 +2,13 @@ import json
 import pathlib
 from unittest import mock
 
+import pytest
 from django.test import Client
 from django.test import TestCase
 from django.urls import reverse
 
 from archivematica.archivematicaCommon.archivematicaFunctions import b64encode_string
 from archivematica.archivematicaCommon.version import get_full_version
-from archivematica.dashboard.components import helpers
 from archivematica.dashboard.components.api import validators
 
 TEST_USER_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "test_user.json"
@@ -47,15 +47,20 @@ class TestAPIv2(TestCase):
         )
     )
 
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        self.dashboard_uuid = dashboard_uuid
+
+        return dashboard_uuid
+
     def setUp(self):
         self.client = Client()
         self.client.login(username="test", password="test")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
 
     def test_headers(self):
         resp = self.client.get("/api/v2beta/package/")
         assert resp.get("X-Archivematica-Version") == get_full_version()
-        assert resp.get("X-Archivematica-ID") == "test-uuid"
+        assert resp.get("X-Archivematica-ID") == str(self.dashboard_uuid)
 
     def test_package_list(self):
         resp = self.client.get("/api/v2beta/package/")
@@ -138,10 +143,13 @@ objects/8e758e7545212966d0256a6ac70d81db6a6d6a6d_008.tif,copyright,copyrighted,2
 objects/8e758e7545212966d0256a6ac70d81db6a6d6a6d_008.tif,policy,,,,1974-01-01,open,,,Village Green Preservation Society records are open.,disseminate,,2014-01-01,open,,,,
 """
 
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
+
     def setUp(self):
         self.client = Client()
         self.client.login(username="test", password="test")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
 
     def _post(self, validator_name, payload, content_type="text/csv; charset=utf-8"):
         return self.client.post(

--- a/tests/dashboard/test_auth.py
+++ b/tests/dashboard/test_auth.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 
+import pytest
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -8,7 +9,6 @@ from django.test.client import Client
 from django.urls import reverse
 from tastypie.models import ApiKey
 
-from archivematica.dashboard.components import helpers
 from archivematica.dashboard.components.helpers import generate_api_key
 
 TEST_USER_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "test_user.json"
@@ -25,8 +25,9 @@ class TestAuth(TestCase):
         reverse("api:get_levels_of_description"),
     )
 
-    def setUp(self):
-        helpers.set_setting("dashboard_uuid", "test-uuid")
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
 
     def authenticate(self):
         self.client = Client()

--- a/tests/dashboard/test_backlog.py
+++ b/tests/dashboard/test_backlog.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 
+import pytest
 from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
@@ -13,10 +14,13 @@ TEST_USER_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "test_user.json
 class TestBacklogAPI(TestCase):
     fixtures = [TEST_USER_FIXTURE]
 
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
+
     def setUp(self):
         self.client = Client()
         self.client.login(username="test", password="test")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
         self.data = '{"time":1586880124134,"columns":[{"visible":true},{"visible":true},{"visible":true},{"visible":false},{"visible":false},{"visible":true},{"visible":false},{"visible":true}]}'
 
     def test_save_datatable_state(self):

--- a/tests/dashboard/test_filesystem_ajax.py
+++ b/tests/dashboard/test_filesystem_ajax.py
@@ -12,7 +12,6 @@ from django.test.client import RequestFactory
 from django.urls import reverse
 
 from archivematica.archivematicaCommon.archivematicaFunctions import b64encode_string
-from archivematica.dashboard.components import helpers
 from archivematica.dashboard.components.filesystem_ajax import views
 from archivematica.dashboard.main import models
 
@@ -23,10 +22,13 @@ SIP_ARRANGE_FIXTURE = Path(__file__).parent / "fixtures" / "sip_arrange.json"
 class TestSIPArrange(TestCase):
     fixtures = [TEST_USER_FIXTURE, SIP_ARRANGE_FIXTURE]
 
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
+
     def setUp(self):
         self.client = Client()
         self.client.login(username="test", password="test")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
 
     def test_arrange_contents_data_no_path(self):
         # Call endpoint
@@ -613,12 +615,11 @@ def test_download_by_uuid(
         )
 
 
-def test_contents_sorting(db, tmp_path, admin_client):
+def test_contents_sorting(db, tmp_path, admin_client, dashboard_uuid):
     (tmp_path / "1").mkdir()
     (tmp_path / "e").mkdir()
     (tmp_path / "a").mkdir()
     (tmp_path / "0").mkdir()
-    helpers.set_setting("dashboard_uuid", "test-uuid")
 
     response = admin_client.get(
         reverse("filesystem_ajax:contents"), {"path": str(tmp_path)}
@@ -667,10 +668,8 @@ def test_contents_sorting(db, tmp_path, admin_client):
     },
 )
 def test_copy_within_arrange(
-    browse_location, get_file_metadata, get_first_location, admin_client
+    browse_location, get_file_metadata, get_first_location, admin_client, dashboard_uuid
 ):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
-
     # Expected attributes for the new SIPArrange instances.
     attrs = ("original_path", "arrange_path", "file_uuid", "transfer_uuid")
     expected = {

--- a/tests/dashboard/test_ingest.py
+++ b/tests/dashboard/test_ingest.py
@@ -12,7 +12,6 @@ from django.test.client import Client
 from django.urls import reverse
 
 from archivematica.archivematicaCommon.archivematicaFunctions import b64decode_string
-from archivematica.dashboard.components import helpers
 from archivematica.dashboard.components.ingest.views import (
     _adjust_directories_draggability,
 )
@@ -34,10 +33,13 @@ JOBS_SIP_COMPLETE_FIXTURE = (
 class TestIngest(TestCase):
     fixtures = [TEST_USER_FIXTURE, SIP_FIXTURE, JOBS_SIP_COMPLETE_FIXTURE]
 
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
+
     def setUp(self):
         self.client = Client()
         self.client.login(username="test", password="test")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
 
     @mock.patch("agentarchives.archivesspace.ArchivesSpaceClient._login")
     def test_get_as_system_client(self, __):
@@ -371,11 +373,6 @@ def test_adjust_directories_draggability():
 
     # small turtles has some draggable children so it's draggable
     assert not small_turtles["not_draggable"]
-
-
-@pytest.fixture
-def dashboard_uuid(db):
-    helpers.set_setting("dashboard_uuid", str(uuid.uuid4()))
 
 
 def test_ingest_upload_as_match_shows_deleted_rows(

--- a/tests/dashboard/test_shibboleth_login.py
+++ b/tests/dashboard/test_shibboleth_login.py
@@ -3,16 +3,15 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
 
-from archivematica.dashboard.components import helpers
-
 
 @pytest.mark.skipif(
     not settings.SHIBBOLETH_AUTHENTICATION,
     reason="tests will only pass if Shibboleth is enabled",
 )
 class TestShibbolethLogin(TestCase):
-    def setUp(self):
-        helpers.set_setting("dashboard_uuid", "test-uuid")
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
 
     def test_with_no_shibboleth_headers(self):
         response = self.client.get("/transfer/")

--- a/tests/dashboard/test_transfer.py
+++ b/tests/dashboard/test_transfer.py
@@ -5,7 +5,6 @@ from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 
-from archivematica.dashboard.components import helpers
 from archivematica.dashboard.main.models import DublinCore
 from archivematica.dashboard.main.models import MetadataAppliesToType
 from archivematica.dashboard.main.models import Taxonomy
@@ -20,10 +19,13 @@ TRANSFER_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "transfer.json"
 class TestTransferViews(TestCase):
     fixtures = [TEST_USER_FIXTURE, TRANSFER_FIXTURE]
 
+    @pytest.fixture(autouse=True)
+    def dashboard_uuid(self, dashboard_uuid):
+        return dashboard_uuid
+
     def setUp(self):
         self.client = Client()
         self.client.login(username="test", password="test")
-        helpers.set_setting("dashboard_uuid", "test-uuid")
 
     def test_metadata_edit(self):
         """Test the metadata form of a transfer"""
@@ -62,8 +64,7 @@ class TestTransferViews(TestCase):
 
 
 @pytest.mark.django_db
-def test_component_get(admin_client):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
+def test_component_get(admin_client, dashboard_uuid):
     # This TransferMetadataSet is going to be created in the view.
     transfer_uuid = "43965fdb-37f3-4ec8-aa67-b49b2733f88a"
     TransferMetadataField.objects.create(fieldlabel="Image fixity")
@@ -82,8 +83,7 @@ def test_component_get(admin_client):
 
 
 # @pytest.mark.django_db
-def test_component_post(admin_client):
-    helpers.set_setting("dashboard_uuid", "test-uuid")
+def test_component_post(admin_client, dashboard_uuid):
     # This TransferMetadataSet is going to be created in the view.
     transfer_uuid = "43965fdb-37f3-4ec8-aa67-b49b2733f88a"
     taxonomy = Taxonomy.objects.create(name="Disk media formats")

--- a/tests/integration/test_oidc_auth.py
+++ b/tests/integration/test_oidc_auth.py
@@ -8,15 +8,8 @@ from playwright.sync_api import Page
 from pytest_django.fixtures import SettingsWrapper
 from pytest_django.live_server_helper import LiveServer
 
-from archivematica.dashboard.components import helpers
-
 if "RUN_INTEGRATION_TESTS" not in os.environ:
     pytest.skip("Skipping integration tests", allow_module_level=True)
-
-
-@pytest.fixture
-def dashboard_uuid() -> None:
-    helpers.set_setting("dashboard_uuid", str(uuid.uuid4()))
 
 
 @pytest.fixture
@@ -37,7 +30,7 @@ def user(django_user_model: type[User]) -> User:
 def test_oidc_backend_creates_local_user(
     page: Page,
     live_server: LiveServer,
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     django_user_model: type[User],
 ) -> None:
     page.goto(live_server.url)
@@ -77,7 +70,7 @@ def test_oidc_backend_creates_local_user(
 
 @pytest.mark.django_db
 def test_local_authentication_backend_authenticates_existing_user(
-    page: Page, live_server: LiveServer, dashboard_uuid: None, user: User
+    page: Page, live_server: LiveServer, dashboard_uuid: uuid.UUID, user: User
 ) -> None:
     page.goto(live_server.url)
 
@@ -111,7 +104,7 @@ def test_local_authentication_backend_authenticates_existing_user(
 def test_removing_model_authentication_backend_disables_local_authentication(
     page: Page,
     live_server: LiveServer,
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     user: User,
     settings: SettingsWrapper,
 ) -> None:
@@ -137,7 +130,7 @@ def test_removing_model_authentication_backend_disables_local_authentication(
 def test_setting_login_url_redirects_to_oidc_login_page(
     page: Page,
     live_server: LiveServer,
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     user: User,
     settings: SettingsWrapper,
 ) -> None:
@@ -155,7 +148,7 @@ def test_setting_login_url_redirects_to_oidc_login_page(
 def test_setting_request_parameter_in_local_login_url_redirects_to_secondary_provider_admin_role(
     page: Page,
     live_server: LiveServer,
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     settings: SettingsWrapper,
 ) -> None:
     page.goto(
@@ -178,7 +171,7 @@ def test_setting_request_parameter_in_local_login_url_redirects_to_secondary_pro
 def test_setting_request_parameter_in_local_login_url_redirects_to_secondary_provider_default_role(
     page: Page,
     live_server: LiveServer,
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     user: User,
     settings: SettingsWrapper,
 ) -> None:
@@ -217,7 +210,7 @@ def test_setting_request_parameter_in_local_login_url_redirects_to_secondary_pro
 def test_logging_out_logs_out_user_from_secondary_provider_admin_role(
     page: Page,
     live_server: LiveServer,
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     settings: SettingsWrapper,
 ) -> None:
     page.goto(
@@ -250,7 +243,7 @@ def test_logging_out_logs_out_user_from_secondary_provider_admin_role(
 def test_logging_out_logs_out_user_from_secondary_provider_default_role(
     page: Page,
     live_server: LiveServer,
-    dashboard_uuid: None,
+    dashboard_uuid: uuid.UUID,
     settings: SettingsWrapper,
 ) -> None:
     page.goto(


### PR DESCRIPTION
This consolidates all helper calls and mocks used to set up the `dashboard_uuid` `DashboardSetting` objects into a single `pytest` fixture.

Connected to https://github.com/archivematica/Issues/issues/1720