### PR TITLE
Remove git ident attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
-*.py ident
-*.sh ident
 src/archivematica/dashboard/frontend/app/locale/*.po linguist-generated=true
 src/archivematica/dashboard/frontend/app/locale/*.pot linguist-generated=true
 src/archivematica/dashboard/frontend/app/locale/translations.json linguist-generated=true

--- a/src/archivematica/MCPClient/clientScripts/change_names.py
+++ b/src/archivematica/MCPClient/clientScripts/change_names.py
@@ -21,8 +21,6 @@ import shutil
 
 from unidecode import unidecode
 
-VERSION = "1.10." + "$Id$".split(" ")[1]
-
 # Letters, digits and a few punctuation characters
 ALLOWED_CHARS = re.compile(r"[^a-zA-Z0-9\-_.\(\)]")
 REPLACEMENT_CHAR = "_"

--- a/src/archivematica/MCPClient/clientScripts/change_object_names.py
+++ b/src/archivematica/MCPClient/clientScripts/change_object_names.py
@@ -25,6 +25,7 @@ django.setup()
 from django.db import transaction
 
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
+from archivematica.archivematicaCommon.version import get_full_version
 from archivematica.dashboard.main.models import SIP
 from archivematica.dashboard.main.models import Directory
 from archivematica.dashboard.main.models import Event
@@ -44,7 +45,7 @@ class NameChanger:
     BATCH_SIZE = 2000
     EVENT_DETAIL = (
         'prohibited characters removed: program="change_names"; version="'
-        + change_names.VERSION
+        + get_full_version()
         + '"'
     )
     EVENT_OUTCOME_DETAIL = 'Original name="{}"; new name="{}"'

--- a/tests/MCPClient/test_filename_change.py
+++ b/tests/MCPClient/test_filename_change.py
@@ -6,6 +6,7 @@ import pytest
 from django.test import TestCase
 from pytest_django.asserts import assertQuerysetEqual
 
+from archivematica.archivematicaCommon.version import get_full_version
 from archivematica.dashboard.main.models import Agent
 from archivematica.dashboard.main.models import Directory
 from archivematica.dashboard.main.models import Event
@@ -140,8 +141,9 @@ def is_uuid(uuid_):
 
 def verify_event_details(event):
     assert (
-        'prohibited characters removed: program="change_names"; version="1.10.'
-    ) in event.event_detail
+        event.event_detail
+        == f'prohibited characters removed: program="change_names"; version="{get_full_version()}"'
+    )
     assertQuerysetEqual(
         event.agents.all(),
         [


### PR DESCRIPTION
The version information has been embedded for a while. This commit removes the git ident attribute because it seems redundant.