### PR TITLE
Use artefactual/gearmand:1.1.21.5-alpine

### DIFF
--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - "127.0.0.1:62002:9200"
 
   gearmand:
-    image: "artefactual/gearmand:1.1.18-alpine"
+    image: "artefactual/gearmand:1.1.21.5-alpine"
     command: "--queue-type=builtin"
     user: "gearman"
     ports:


### PR DESCRIPTION
Trivy reports ~30 vulnerabilities in `artefactual/gearmand:1.1.18-alpine` (see [report]) and zero vulnerabilities in `artefactual/gearmand:1.1.21.5-alpine`.

```
Report Summary

┌──────────────────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                        Target                        │  Type  │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ artefactual/gearmand:1.1.21.5-alpine (alpine 3.22.0) │ alpine │        0        │    -    │
└──────────────────────────────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```

[report]: https://gist.github.com/sevein/be12c21c21844979de30feb571231b04

CHANGELOG: https://github.com/gearman/gearmand/releases