### PR TITLE
Use clamav/clamav-debian image

### DIFF
--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -79,9 +79,9 @@ services:
   clamavd:
     image: "clamav/clamav-debian:1.4.3-45"
     environment:
-      CLAMD_CONF_MaxFileSize: "42"
-      CLAMD_CONF_MaxScanSize: "42"
-      CLAMD_CONF_StreamMaxLength: "100"
+      CLAMD_CONF_MaxFileSize: "42M"
+      CLAMD_CONF_MaxScanSize: "42M"
+      CLAMD_CONF_StreamMaxLength: "100M"
     ports:
       - "127.0.0.1:62006:3310"
     volumes:

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -77,11 +77,11 @@ services:
       - "127.0.0.1:62004:4730"
 
   clamavd:
-    image: "artefactual/clamav:latest"
+    image: "clamav/clamav-debian:1.4.3-45"
     environment:
-      CLAMAV_MAX_FILE_SIZE: "42"
-      CLAMAV_MAX_SCAN_SIZE: "42"
-      CLAMAV_MAX_STREAM_LENGTH: "100"
+      CLAMD_CONF_MaxFileSize: "42"
+      CLAMD_CONF_MaxScanSize: "42"
+      CLAMD_CONF_StreamMaxLength: "100"
     ports:
       - "127.0.0.1:62006:3310"
     volumes:

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -78,6 +78,8 @@ services:
 
   clamavd:
     image: "clamav/clamav-debian:1.4.3-45"
+    user: "clamav"
+    entrypoint: "/init-unprivileged"
     environment:
       CLAMD_CONF_MaxFileSize: "42M"
       CLAMD_CONF_MaxScanSize: "42M"


### PR DESCRIPTION
I've been checking the status of the [official ClamAV images](https://github.com/Cisco-Talos/clamav-docker), and it looks like it's now possible to inject config values via environment variables. Because of this, I don't think there's any point in using https://github.com/artefactual-labs/docker-clamavd anymore. `clamav/clamav-debian` also happens to be a multi-arch image. See the [full documentation](https://github.com/Cisco-Talos/clamav-docker/blob/main/clamav/README-debian.md).

Also, the `artefactual/clamav` image hasn't been updated since Jan 10, 2018 (so it's 7 years old). Trivy reports 309 vulnerabilities (29 criticals), while the official ClamAV image seems to have a decent track record of being updated frequently. See the [full report](https://gist.github.com/sevein/2a4c245cf725468954ea139ae9ed18a4).

> [!WARNING]
> I'm currently unsure what action, if any, we need to take regarding this change: [9a38e47c]. We updated the ClamAV UID and GID to 333 to match Archivematica's default, but I'm unsure whether this is strictly necessary, e.g. our dev envs use 1000:1000 for the Archivematica user and AFAIK we haven't seen any problems.

[9a38e47c]: https://github.com/artefactual-labs/docker-clamavd/commit/9a38e47cd89cbd126474db76f78753aa969bf9c2