### PR TITLE
Add macOS support to dev environment

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -18,13 +18,6 @@ ARG PYENV_DIR=/pyenv
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 
-# Ubuntu 24.04 and later Docker images include a default user with UID (1000)
-# and GID (1000). Remove this user to prevent conflicts with the USER_ID and
-# GROUP_ID build arguments.
-RUN set -ex \
-	&& id -u ubuntu >/dev/null 2>&1 \
-	&& userdel --remove ubuntu || true
-
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 	--mount=type=cache,target=/var/lib/apt,sharing=locked \
 	set -ex \
@@ -131,8 +124,8 @@ RUN set ex \
 
 FROM node:${NODE_VERSION} AS archivematica-dashboard-testing
 
-ARG USER_ID=1000
-ARG GROUP_ID=1000
+ARG USER_ID
+ARG GROUP_ID
 ARG SELENIUM_DIR=/selenium
 ENV PATH=${SELENIUM_DIR}/bin:$PATH
 
@@ -164,8 +157,8 @@ ENTRYPOINT ["npm", "run", "test-single-run"]
 
 FROM base-builder AS base
 
-ARG USER_ID=1000
-ARG GROUP_ID=1000
+ARG USER_ID
+ARG GROUP_ID
 ARG PYENV_DIR=/pyenv
 ARG MEDIAAREA_VERSION
 ARG JHOVE_VERSION
@@ -224,8 +217,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 		uuid
 
 RUN set -ex \
-	&& groupadd --gid ${GROUP_ID} --system archivematica \
-	&& useradd --uid ${USER_ID} --gid ${GROUP_ID} --home-dir /var/archivematica --system archivematica \
+	&& { \
+		grp=$(getent group "${GROUP_ID}" | cut -d: -f1 || true); \
+		if [ -n "${grp}" ]; then groupdel --force "${grp}"; fi; \
+		usr=$(getent passwd "${USER_ID}" | cut -d: -f1 || true); \
+		if [ -n "${usr}" ]; then userdel --remove "${usr}"; fi; \
+	} \
+	&& groupadd --gid "${GROUP_ID}" --system archivematica \
+	&& useradd  --uid "${USER_ID}" --gid "${GROUP_ID}" --home-dir /var/archivematica --system archivematica \
 	&& mkdir -p /var/archivematica/sharedDirectory \
 	&& chown -R archivematica:archivematica /var/archivematica
 
@@ -259,8 +258,8 @@ ENTRYPOINT ["pyenv", "exec", "python3", "-m", "archivematica.MCPServer.archivema
 
 FROM base AS archivematica-dashboard
 
-ARG USER_ID=1000
-ARG GROUP_ID=1000
+ARG USER_ID
+ARG GROUP_ID
 ARG PYTHON_VERSION=3.9
 
 USER root

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -284,7 +284,7 @@ ENV FORWARDED_ALLOW_IPS=*
 
 RUN set -ex \
 	&& python3 -m archivematica.dashboard.manage collectstatic --noinput --clear \
-	&& python3 -m archivematica.dashboard.manage compilemessages
+	&& python3 -m archivematica.dashboard.manage compilemessages -l en
 
 ENV DJANGO_SETTINGS_MODULE=archivematica.dashboard.settings.production
 

--- a/hack/TODO
+++ b/hack/TODO
@@ -1,0 +1,3 @@
+READ THIS
+
+https://github.com/rancher-sandbox/rancher-desktop/issues/8606#issuecomment-2979109414

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -7,7 +7,6 @@ volumes:
   # These are not accessible outside of the docker host and are maintained by
   # Docker.
   mysql_data:
-  elasticsearch_data:
   archivematica_storage_service_staging_data:
 
   # External named volumes.
@@ -41,33 +40,6 @@ services:
       - "127.0.0.1:62001:3306"
     cap_add:
       - "SYS_NICE"
-
-  elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.23"
-    environment:
-      - "cluster.name=am-cluster"
-      - "node.name=am-node"
-      - "network.host=0.0.0.0"
-      - "bootstrap.memory_lock=true"
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - "cluster.routing.allocation.disk.threshold_enabled=${ELASTICSEARCH_DISK_THRESHOLD_ENABLED:-true}"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    healthcheck:
-      test: [
-        "CMD-SHELL",
-        "curl -fsSL http://localhost:9200/_cat/health?h=status | sed -r 's/^[[:space:]]+|[[:space:]]+$//g' | grep -q -E 'green|yellow'",
-      ]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
-    volumes:
-      - "elasticsearch_data:/usr/share/elasticsearch/data"
-    ports:
-      - "127.0.0.1:62002:9200"
 
   gearmand:
     image: "artefactual/gearmand:1.1.21.5-alpine"
@@ -117,7 +89,7 @@ services:
       ARCHIVEMATICA_MCPSERVER_CLIENT_HOST: "mysql"
       ARCHIVEMATICA_MCPSERVER_CLIENT_DATABASE: "MCP"
       ARCHIVEMATICA_MCPSERVER_MCPSERVER_MCPARCHIVEMATICASERVER: "gearmand:4730"
-      ARCHIVEMATICA_MCPSERVER_SEARCH_ENABLED: "${AM_SEARCH_ENABLED:-true}"
+      ARCHIVEMATICA_MCPSERVER_SEARCH_ENABLED: "${AM_SEARCH_ENABLED:-false}"
       ARCHIVEMATICA_MCPSERVER_MCPSERVER_PROMETHEUS_BIND_PORT: "7999"
       ARCHIVEMATICA_MCPSERVER_MCPSERVER_PROMETHEUS_BIND_ADDRESS: "0.0.0.0"
     volumes:
@@ -144,9 +116,8 @@ services:
       ARCHIVEMATICA_MCPCLIENT_CLIENT_PASSWORD: "demo"
       ARCHIVEMATICA_MCPCLIENT_CLIENT_HOST: "mysql"
       ARCHIVEMATICA_MCPCLIENT_CLIENT_DATABASE: "MCP"
-      ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_ELASTICSEARCHSERVER: "elasticsearch:9200"
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_MCPARCHIVEMATICASERVER: "gearmand:4730"
-      ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_SEARCH_ENABLED: "${AM_SEARCH_ENABLED:-true}"
+      ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_SEARCH_ENABLED: "${AM_SEARCH_ENABLED:-false}"
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CAPTURE_CLIENT_SCRIPT_OUTPUT: "${AM_CAPTURE_CLIENT_SCRIPT_OUTPUT:-true}"
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_SERVER: "clamavd:3310"
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_MAX_FILE_SIZE: "42"
@@ -164,7 +135,6 @@ services:
       - "clamavd"
       - "mysql"
       - "gearmand"
-      - "elasticsearch"
       - "archivematica-storage-service"
 
   archivematica-dashboard:
@@ -184,24 +154,18 @@ services:
       AM_GUNICORN_RELOAD_ENGINE: "auto"
       DJANGO_SETTINGS_MODULE: "archivematica.dashboard.settings.local"
       ARCHIVEMATICA_DASHBOARD_DASHBOARD_GEARMAN_SERVER: "gearmand:4730"
-      ARCHIVEMATICA_DASHBOARD_DASHBOARD_ELASTICSEARCH_SERVER: "elasticsearch:9200"
       ARCHIVEMATICA_DASHBOARD_DASHBOARD_PROMETHEUS_ENABLED: "1"
       ARCHIVEMATICA_DASHBOARD_CLIENT_USER: "archivematica"
       ARCHIVEMATICA_DASHBOARD_CLIENT_PASSWORD: "demo"
       ARCHIVEMATICA_DASHBOARD_CLIENT_HOST: "mysql"
       ARCHIVEMATICA_DASHBOARD_CLIENT_DATABASE: "MCP"
-      ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED: "${AM_SEARCH_ENABLED:-true}"
+      ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED: "${AM_SEARCH_ENABLED:-false}"
     volumes:
       - "../:/src"
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"
-    depends_on:
-      elasticsearch:
-        condition: service_healthy
-        restart: true
     links:
       - "mysql"
       - "gearmand"
-      - "elasticsearch"
       - "archivematica-storage-service"
 
   archivematica-storage-service:

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -26,7 +26,7 @@ volumes:
 services:
 
   mysql:
-    image: "percona:8.0"
+    image: "percona/percona-server:8.0"
     command: "--character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci"
     environment:
       MYSQL_ROOT_PASSWORD: "12345"
@@ -62,7 +62,7 @@ services:
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:ro"
 
   nginx:
-    image: "nginx:stable-alpine"
+    image: "nginx:stable"
     volumes:
       - "./etc/nginx/nginx.conf:/etc/nginx/nginx.conf:ro"
       - "./etc/nginx/conf.d/archivematica.conf:/etc/nginx/conf.d/archivematica.conf:ro"
@@ -72,6 +72,7 @@ services:
       - "62081:8000"
 
   archivematica-mcp-server:
+    platform: linux/amd64
     build:
       context: "../"
       dockerfile: "hack/Dockerfile"
@@ -100,6 +101,7 @@ services:
       - "gearmand"
 
   archivematica-mcp-client:
+    platform: linux/amd64
     build:
       context: "../"
       dockerfile: "hack/Dockerfile"
@@ -124,6 +126,7 @@ services:
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_MAX_SCAN_SIZE: "42"
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_MAX_STREAM_LENGTH: "100"
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_BACKEND: "clamdscanner" # Option: clamdscanner or clamscan;
+      ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_PASS_BY_STREAM: "false"
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_PROMETHEUS_BIND_PORT: "7999"
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_PROMETHEUS_BIND_ADDRESS: "0.0.0.0"
       ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_METADATA_XML_VALIDATION_ENABLED: "true"
@@ -138,6 +141,7 @@ services:
       - "archivematica-storage-service"
 
   archivematica-dashboard:
+    platform: linux/amd64
     build:
       context: "../"
       dockerfile: "hack/Dockerfile"

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -150,7 +150,7 @@ services:
     environment:
       FORWARDED_ALLOW_IPS: "*"
       AM_GUNICORN_ACCESSLOG: "/dev/null"
-      AM_GUNICORN_RELOAD: "true"
+      AM_GUNICORN_RELOAD: "false"
       AM_GUNICORN_RELOAD_ENGINE: "auto"
       DJANGO_SETTINGS_MODULE: "archivematica.dashboard.settings.local"
       ARCHIVEMATICA_DASHBOARD_DASHBOARD_GEARMAN_SERVER: "gearmand:4730"
@@ -180,7 +180,7 @@ services:
     environment:
       FORWARDED_ALLOW_IPS: "*"
       SS_GUNICORN_ACCESSLOG: "/dev/null"
-      SS_GUNICORN_RELOAD: "true"
+      SS_GUNICORN_RELOAD: "false"
       SS_GUNICORN_RELOAD_ENGINE: "auto"
       DJANGO_SETTINGS_MODULE: "archivematica.storage_service.storage_service.settings.local"
       SS_DB_URL: "mysql://archivematica:demo@mysql/SS"


### PR DESCRIPTION
> [!WARNING]  
> This PR has been replaced. I'll be submitting smaller PRs to address individual issues.

Already merged:

- [x] Use `clamav/clamav-debian:1.4.3-45` (published with ARM builds)
- [x] Use ES 8.x ARM builds (for now, search funcionality is removed)
- [x] Use percona and nginx images with ARM builds (https://github.com/artefactual/archivematica/pull/2102)
- [x] Update user management strategy to free macOS default uid/gid (to be discussed)
- [ ] Publish arm64 builds of tools in packages.archivematica.org