### PR TITLE
Move db access logic out of the elasticSearchFunction module

### DIFF
--- a/src/archivematica/MCPClient/clientScripts/index_aip.py
+++ b/src/archivematica/MCPClient/clientScripts/index_aip.py
@@ -12,6 +12,7 @@ from archivematica.archivematicaCommon import identifier_functions
 from archivematica.archivematicaCommon import storageService as storage_service
 from archivematica.archivematicaCommon.archivematicaFunctions import get_dashboard_uuid
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
+from archivematica.archivematicaCommon.databaseFunctions import get_sip_identifiers
 from archivematica.dashboard.main.models import UnitVariable
 
 django.setup()
@@ -61,7 +62,7 @@ def index_aip(job):
     job.pyprint("AIP info:", aip_info)
     aip_info = aip_info[0]
     mets_staging_path = os.path.join(sip_staging_path, f"METS.{sip_uuid}.xml")
-    identifiers = get_identifiers(job, sip_staging_path)
+    identifiers = get_identifiers(job, sip_staging_path) + get_sip_identifiers(sip_uuid)
     # If this is an AIC, find the number of AIP stored in it and index that
     aips_in_aic = None
     if sip_type == "AIC":

--- a/src/archivematica/MCPClient/clientScripts/index_aip.py
+++ b/src/archivematica/MCPClient/clientScripts/index_aip.py
@@ -10,6 +10,7 @@ from django.core.exceptions import ValidationError
 from archivematica.archivematicaCommon import elasticSearchFunctions
 from archivematica.archivematicaCommon import identifier_functions
 from archivematica.archivematicaCommon import storageService as storage_service
+from archivematica.archivematicaCommon.archivematicaFunctions import get_dashboard_uuid
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 from archivematica.dashboard.main.models import UnitVariable
 
@@ -96,6 +97,7 @@ def index_aip(job):
         encrypted=aip_info["encrypted"],
         location=location_description,
         printfn=job.pyprint,
+        dashboard_uuid=get_dashboard_uuid() or "",
     )
     if ret == 1:
         job.pyprint("Error indexing AIP and AIP files", file=sys.stderr)

--- a/src/archivematica/MCPClient/clientScripts/move_to_backlog.py
+++ b/src/archivematica/MCPClient/clientScripts/move_to_backlog.py
@@ -27,6 +27,7 @@ from django.db.models import Q
 import archivematica.archivematicaCommon.storageService as storage_service
 from archivematica.archivematicaCommon import elasticSearchFunctions
 from archivematica.archivematicaCommon.archivematicaFunctions import get_bag_size
+from archivematica.archivematicaCommon.archivematicaFunctions import get_dashboard_uuid
 from archivematica.archivematicaCommon.archivematicaFunctions import get_setting
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 from archivematica.archivematicaCommon.databaseFunctions import insertIntoEvents
@@ -79,7 +80,12 @@ def _index_transfer(job, transfer_id, transfer_path, size):
     elasticSearchFunctions.setup_reading_from_conf(mcpclient_settings)
     client = elasticSearchFunctions.get_client()
     elasticSearchFunctions.index_transfer_and_files(
-        client, transfer_id, transfer_path, size, printfn=job.pyprint
+        client,
+        transfer_id,
+        transfer_path,
+        size,
+        printfn=job.pyprint,
+        dashboard_uuid=get_dashboard_uuid() or "",
     )
 
 

--- a/src/archivematica/MCPClient/clientScripts/move_to_backlog.py
+++ b/src/archivematica/MCPClient/clientScripts/move_to_backlog.py
@@ -30,6 +30,7 @@ from archivematica.archivematicaCommon.archivematicaFunctions import get_bag_siz
 from archivematica.archivematicaCommon.archivematicaFunctions import get_dashboard_uuid
 from archivematica.archivematicaCommon.archivematicaFunctions import get_setting
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
+from archivematica.archivematicaCommon.databaseFunctions import get_transfer_details
 from archivematica.archivematicaCommon.databaseFunctions import insertIntoEvents
 from archivematica.dashboard.main.models import Agent
 from archivematica.dashboard.main.models import File
@@ -77,6 +78,7 @@ def _index_transfer(job, transfer_id, transfer_path, size):
     if "transfers" not in mcpclient_settings.SEARCH_ENABLED:
         logger.info("Skipping indexing: Transfers indexing is currently disabled.")
         return
+    transfer_name, accession_id, ingest_date = get_transfer_details(transfer_id)
     elasticSearchFunctions.setup_reading_from_conf(mcpclient_settings)
     client = elasticSearchFunctions.get_client()
     elasticSearchFunctions.index_transfer_and_files(
@@ -86,6 +88,9 @@ def _index_transfer(job, transfer_id, transfer_path, size):
         size,
         printfn=job.pyprint,
         dashboard_uuid=get_dashboard_uuid() or "",
+        transfer_name=transfer_name,
+        accession_id=accession_id,
+        ingest_date=ingest_date,
     )
 
 

--- a/src/archivematica/archivematicaCommon/aip_mets_parser.py
+++ b/src/archivematica/archivematicaCommon/aip_mets_parser.py
@@ -1,0 +1,444 @@
+import calendar
+import copy
+import os
+import re
+import time
+from collections.abc import Generator
+from typing import Any
+from typing import Optional
+
+from lxml import etree
+
+from archivematica.archivematicaCommon import namespaces as ns
+from archivematica.archivematicaCommon.externals import xmltodict
+from archivematica.dashboard.main.models import Identifier
+
+
+class AIPMETSParser:
+    def __init__(self, mets_path: str) -> None:
+        self.mets_path = mets_path
+        self.mets = self.parse()
+        self.dublincore: Optional[etree._Element] = ns.xml_find_premis(
+            self.mets, "mets:dmdSec/mets:mdWrap/mets:xmlData/dcterms:dublincore"
+        )
+        self.aic_identifier: Optional[str] = None
+        self.is_part_of: Optional[str] = None
+        if self.dublincore is not None:
+            aip_type = ns.xml_findtext_premis(
+                self.dublincore, "dc:type"
+            ) or ns.xml_findtext_premis(self.dublincore, "dcterms:type")
+            if aip_type == "Archival Information Collection":
+                self.aic_identifier = ns.xml_findtext_premis(
+                    self.dublincore, "dc:identifier"
+                ) or ns.xml_findtext_premis(self.dublincore, "dcterms:identifier")
+            elif aip_type == "Archival Information Package":
+                self.is_part_of = ns.xml_findtext_premis(
+                    self.dublincore, "dcterms:isPartOf"
+                )
+        self.created: int = self.get_create_date()
+        self.aip_metadata: list[dict[str, Any]] = self._get_aip_metadata()
+        self.file_count: int = 0
+
+    def get_create_date(self) -> int:
+        result = int(time.time())
+        # Pull the create time from the METS header.
+        # Old METS did not use `metsHdr`.
+        mets_hdr = ns.xml_find_premis(self.mets, "mets:metsHdr")
+        if mets_hdr is not None:
+            mets_created_attr = mets_hdr.get("CREATEDATE")
+            if mets_created_attr:
+                try:
+                    result = calendar.timegm(
+                        time.strptime(mets_created_attr, "%Y-%m-%dT%H:%M:%S")
+                    )
+                except ValueError:
+                    # Failed to parse METS CREATEDATE
+                    pass
+        return result
+
+    def parse(self) -> etree._Element:
+        tree = etree.parse(self.mets_path)
+        root = tree.getroot()
+        self._remove_tool_output_from_mets(root)
+        return root
+
+    def _remove_tool_output_from_mets(self, root: etree._Element) -> None:
+        """Remove tool output from a METS ElementTree.
+
+        Given an ElementTree object, removes all objectsCharacteristicsExtensions
+        elements. This modifies the existing document in-place; it does not return
+        a new document. This helps index METS files, which might otherwise get too
+        large to be usable.
+        """
+        # Remove tool output nodes
+        toolNodes = ns.xml_findall_premis(
+            root,
+            "mets:amdSec/mets:techMD/mets:mdWrap/mets:xmlData/premis:object/premis:objectCharacteristics/premis:objectCharacteristicsExtension",
+        )
+
+        for parent in toolNodes:
+            parent.clear()
+
+        print("Removed FITS output from METS.")
+
+    def _get_aip_metadata(self) -> list[dict[str, Any]]:
+        """Get metadata about the directories in the AIP.
+
+        Given a doc representing a METS file, look for Directory entries
+        that have descriptive or administrative metadata in the physical
+        structMap and return dictionaries with metadata attributes for
+        each directory.
+        """
+        result: list[dict[str, Any]] = []
+        physical_struct_map = ns.xml_find_premis(
+            self.mets, 'mets:structMap[@TYPE="physical"]'
+        )
+        if physical_struct_map is not None:
+            for directory in self._get_directories_with_metadata(physical_struct_map):
+                directory_metadata = self._get_directory_metadata(directory)
+                if directory_metadata:
+                    result.append(directory_metadata)
+        return result
+
+    def _get_directories_with_metadata(
+        self, container: etree._Element
+    ) -> list[etree._Element]:
+        """Return Directory entries with metadata sections.
+
+        Check if the entry references dmdSec (descriptive) or amdSec
+        (administrative) metadata sections.
+        """
+        result = ns.xml_xpath_premis(
+            container, './/mets:div[@TYPE="Directory"][@DMDID or @ADMID]'
+        )
+        return result if isinstance(result, list) else []
+
+    def _get_directory_metadata(self, directory: etree._Element) -> dict[str, Any]:
+        """Get descriptive or administrive metadata for a directory.
+
+        There are three types of metadata elements extracted:
+
+        1. Dublin core, set through the metadata/metadata.csv file or the
+        transfer/ingest metadata form in the dashboard
+        2. Custom (non dublin core), set through the metadata/metadata.csv
+        file
+        3. Bag/disk image metadata, set through the bag-info.txt file or
+        the disk image metadata form in the dashboard
+        4. Custom XML metadata, set through the source-metadata.csv files
+        and related XML files
+
+        These types are parsed and combined into a single dictionary of
+        metadata attributes. A marker element with the label of the
+        Directory entry is added to the result.
+        """
+        result = {}
+        elements_with_metadata = []
+        dmd_id = directory.attrib.get("DMDID")
+        if dmd_id:
+            for dmd_sec in self._get_latest_dmd_secs(dmd_id):
+                elements_with_metadata += self._get_descriptive_section_metadata(
+                    dmd_sec
+                )
+        for ADMID in directory.attrib.get("ADMID", "").split():
+            amd_sec = ns.xml_find_premis(self.mets, f'mets:amdSec[@ID="{ADMID}"]')
+            if amd_sec is not None:
+                # look for bag/disk image metadata
+                elements_with_metadata += ns.xml_findall_premis(
+                    amd_sec, "mets:sourceMD/mets:mdWrap/mets:xmlData/transfer_metadata"
+                )
+        if elements_with_metadata:
+            # add an attribute with the relative path of the Directory entry
+            elements_with_metadata.append(self._get_relative_path_element(directory))
+            result = self._combine_elements(elements_with_metadata)
+        return self._normalize_dict(result)
+
+    def _get_relative_path_element(self, directory: etree._Element) -> etree._Element:
+        """Build an element with the relative path of the directory."""
+        TAG = "__DIRECTORY_LABEL__"
+        result = etree.Element("container")
+        path = etree.SubElement(result, TAG)
+        path.text = directory.attrib.get("LABEL", "")
+        return result
+
+    def files(self) -> Generator[tuple[dict[str, Any], set[str]], None, None]:
+        # Index all files in a fileGrup with USE='original' or USE='metadata'.
+        original_files = ns.xml_findall_premis(
+            self.mets, "mets:fileSec/mets:fileGrp[@USE='original']/mets:file"
+        )
+        metadata_files = ns.xml_findall_premis(
+            self.mets, "mets:fileSec/mets:fileGrp[@USE='metadata']/mets:file"
+        )
+        files = original_files + metadata_files
+        self.file_count = len(files)
+        for file in files:
+            yield self.get_aip_file_index_data(file)
+
+    def get_aip_file_index_data(
+        self, file_: etree._Element
+    ) -> tuple[dict[str, Any], set[str]]:
+        # Establish the structure to be indexed for each file item.
+        indexData: dict[str, Any] = {
+            "FILEUUID": "",
+            "filePath": "",
+            "fileExtension": "",
+            "METS": {"dmdSec": {}, "amdSec": {}},
+            "accessionid": "",
+        }
+
+        accession_ids: set[str] = set()
+
+        # Get file UUID. If an ADMID exists, look in the amdSec for the UUID,
+        # otherwise parse it out of the file ID.
+        # 'Original' files have ADMIDs, 'Metadata' files do not.
+        admID = file_.attrib.get("ADMID", None)
+        fileUUID: Optional[str] = None
+        if admID is None:
+            # Parse UUID from the file ID.
+            uuix_regex = r"\w{8}-?\w{4}-?\w{4}-?\w{4}-?\w{12}"
+            uuids = re.findall(uuix_regex, file_.attrib["ID"])
+            # Multiple UUIDs may be returned - if they are all identical,
+            # use that UUID, otherwise use None.
+            # To determine all UUIDs are identical, use the size of the set.
+            if len(set(uuids)) == 1:
+                fileUUID = uuids[0]
+        else:
+            amdSec = self._get_amdSec(admID)
+            fileUUID = self._get_file_uuid(amdSec)
+            accession_id = self._get_accession_number(amdSec)
+            if accession_id is not None:
+                indexData["accessionid"] = accession_id
+                accession_ids.add(accession_id)
+
+            # Index amdSec information.
+            if amdSec is not None:
+                xml = etree.tostring(amdSec, encoding="utf8")
+                indexData["METS"]["amdSec"] = self._normalize_dict(xmltodict.parse(xml))
+
+        indexData["FILEUUID"] = fileUUID
+
+        file_metadata: list[dict[str, Any]] = []
+
+        # Get the parent division for the file pointer by searching the
+        # physical structural map section (structMap).
+        file_id = file_.attrib.get("ID", None)
+        file_pointer_division = ns.xml_find_premis(
+            self.mets,
+            f"mets:structMap[@TYPE='physical']//mets:fptr[@FILEID='{file_id}']/..",
+        )
+        if file_pointer_division is not None:
+            descriptive_metadata = self._get_file_metadata(file_pointer_division)
+            if descriptive_metadata:
+                file_metadata.append(descriptive_metadata)
+            # If the parent division has a DMDID attribute then index
+            # its data from the descriptive metadata section (dmdSec).
+            dmd_section_id = file_pointer_division.attrib.get("DMDID", None)
+            if dmd_section_id is not None:
+                # dmd_section_id can contain one id (e.g., "dmdSec_2") or
+                # more than one (e.g., "dmdSec_2 dmdSec_3", when a file
+                # has both DC and non-DC metadata).
+                # Attempt to index only the DC dmdSec if available.
+                for dmd_section_id_item in dmd_section_id.split():
+                    dmd_section_info = ns.xml_find_premis(
+                        self.mets,
+                        f"mets:dmdSec[@ID='{dmd_section_id_item}']/mets:mdWrap[@MDTYPE='DC']/mets:xmlData",
+                    )
+                    if dmd_section_info is not None:
+                        xml = etree.tostring(dmd_section_info, encoding="utf8")
+                        data = self._normalize_dict(xmltodict.parse(xml))
+                        indexData["METS"]["dmdSec"] = data
+                        break
+
+        indexData["transferMetadata"] = file_metadata
+
+        # Get file path from FLocat and extension.
+        flocat = ns.xml_find_premis(file_, "mets:FLocat")
+        if flocat is not None:
+            filePath = flocat.attrib["{http://www.w3.org/1999/xlink}href"]
+            indexData["filePath"] = filePath
+            _, fileExtension = os.path.splitext(filePath)
+            if fileExtension:
+                indexData["fileExtension"] = fileExtension[1:].lower()
+
+        indexData["identifiers"] = self._get_file_identifiers(fileUUID)
+
+        return indexData, accession_ids
+
+    def _get_amdSec(self, admID: str) -> Optional[etree._Element]:
+        """Get amdSec with given admID.
+
+        :param admID: admID.
+        :param doc: ElementTree object.
+        :return: amdSec.
+        """
+        return ns.xml_find_premis(self.mets, f"mets:amdSec[@ID='{admID}']")
+
+    def _get_file_uuid(self, amdSec: Optional[etree._Element]) -> Optional[str]:
+        """Get UUID of a file from amdSec.
+
+        :param amdSec: amdSec.
+        :return: File UUID.
+        """
+        uuid = ns.xml_findtext_premis(
+            amdSec,
+            "mets:techMD/mets:mdWrap/mets:xmlData/premis:object/premis:objectIdentifier/premis:objectIdentifierValue",
+        )
+        return uuid if isinstance(uuid, str) else None
+
+    def _get_accession_number(self, amdSec: Optional[etree._Element]) -> Optional[str]:
+        """Get accession number associated with a file from amdSec.
+
+        Look for a <premis:event> entry within file's amdSec that has a
+        <premis:eventType> of "registration". Return the text value (with leading
+        "accession#" stripped out) from the <premis:eventOutcomeDetailNote>.
+
+        If no matching <premis:event> entry is found, return None.
+
+        :param amdSec: amdSec.
+        :return: Accession number or None.
+        """
+        registration_detail_notes = ns.xml_xpath_premis(
+            amdSec,
+            ".//premis:event[premis:eventType='registration']/premis:eventOutcomeInformation/premis:eventOutcomeDetail/premis:eventOutcomeDetailNote",
+        )
+        if not registration_detail_notes or not isinstance(
+            registration_detail_notes, list
+        ):
+            return None
+        if not registration_detail_notes:
+            return None
+        element = registration_detail_notes[0]
+        if not hasattr(element, "text"):
+            return None
+        detail_text = element.text
+        if not isinstance(detail_text, str):
+            return None
+        ACCESSION_PREFIX = "accession#"
+        return detail_text[len(ACCESSION_PREFIX) :]
+
+    def _get_file_metadata(
+        self, file_pointer_division: etree._Element
+    ) -> dict[str, Any]:
+        """Get descriptive metadata for a file pointer.
+
+        There are various types of metadata elements extracted: dublin core
+        and custom (non dublin core), both set through the metadata/metadata.csv
+        file; and metadata added through the source-metadata.csv files and
+        related XML files.
+
+        These types are parsed and combined into a single dictionary of
+        metadata attributes.
+        """
+        result: dict[str, Any] = {}
+        elements_with_metadata: list[etree._Element] = []
+        dmd_id = file_pointer_division.attrib.get("DMDID")
+        if not dmd_id:
+            return result
+        for dmd_sec in self._get_latest_dmd_secs(dmd_id):
+            elements_with_metadata += self._get_descriptive_section_metadata(dmd_sec)
+        if elements_with_metadata:
+            result = self._combine_elements(elements_with_metadata)
+        return self._normalize_dict(result)
+
+    def _get_latest_dmd_secs(self, dmd_id: str) -> list[etree._Element]:
+        # Build a mapping of dmdSec by metadata type.
+        dmd_secs: dict[str, list[etree._Element]] = {}
+        for id in dmd_id.split():
+            dmd_sec = ns.xml_find_premis(self.mets, f'mets:dmdSec[@ID="{id}"]')
+            if not dmd_sec:
+                continue
+            # Use mdWrap MDTYPE and OTHERMDTYPE to generate a unique key.
+            md_wrap = ns.xml_find_premis(dmd_sec, "mets:mdWrap")
+            if not md_wrap:
+                continue
+            mdtype_key = md_wrap.attrib.get("MDTYPE")
+            # Ignore PREMIS:OBJECT.
+            if mdtype_key == "PREMIS:OBJECT":
+                continue
+            if mdtype_key is None:
+                continue
+            other_mdtype = md_wrap.attrib.get("OTHERMDTYPE")
+            if other_mdtype:
+                mdtype_key += "_" + other_mdtype
+            if mdtype_key not in dmd_secs:
+                dmd_secs[mdtype_key] = []
+            dmd_secs[mdtype_key].append(dmd_sec)
+        # Get only the latest dmdSec by type.
+        final_dmd_secs: list[etree._Element] = []
+        for _, secs in dmd_secs.items():
+            latest_date = ""
+            latest_sec: Optional[etree._Element] = None
+            for sec in secs:
+                date = sec.attrib.get("CREATED", "")
+                if not latest_date or date > latest_date:
+                    latest_date = date
+                    latest_sec = sec
+            # Do not add latest dmdSec if it's deleted.
+            if latest_sec and latest_sec.attrib.get("STATUS", "") != "deleted":
+                final_dmd_secs.append(latest_sec)
+        return final_dmd_secs
+
+    def _get_descriptive_section_metadata(
+        self, dmdSec: etree._Element
+    ) -> list[etree._Element]:
+        """Get dublin core and custom descriptive metadata."""
+        result: list[etree._Element] = []
+        # look for dublincore terms in the dmdSec
+        result += ns.xml_findall_premis(
+            dmdSec, 'mets:mdWrap[@MDTYPE="DC"]/mets:xmlData/dcterms:dublincore'
+        )
+        # look for non dublincore (custom) metadata
+        result += ns.xml_findall_premis(
+            dmdSec, 'mets:mdWrap[@MDTYPE="OTHER"]/mets:xmlData'
+        )
+        return result
+
+    def _combine_elements(self, elements: list[etree._Element]) -> dict[str, Any]:
+        """Serialize all the elements as a JSON compatible string.
+
+        Combine the elements contents into a single container and parse it
+        with xmltodict.
+        """
+        # wrap the data from all metadata elements in a container
+        container = etree.Element("container")
+        for element in elements:
+            for child in element:
+                # add a copy to not modify the METS file in place
+                container.append(copy.deepcopy(child))
+        # parse the container with xmltodict ignoring element attributes
+        return (
+            xmltodict.parse(
+                etree.tostring(container, encoding="utf8"), xml_attribs=False
+            ).get("container")
+            or {}
+        )
+
+    def _normalize_dict(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Normalize dictionary from xmltodict for ES indexing.
+
+        Because an XML element may contain text value or other elements, conversion
+        to a dict can result in different value types for the same key. This causes
+        problems in the Elasticsearch index as it expects consistent types. This
+        function recurses a dict and appends "_dict" to the keys with a dict value.
+        """
+        new: dict[str, Any] = {}
+        for key, value in data.items():
+            dict_key = key + "_dict"
+            if isinstance(value, dict):
+                new[dict_key] = self._normalize_dict(value)
+            elif isinstance(value, list):
+                for item in value:
+                    new_key = key
+                    if isinstance(item, dict):
+                        new_key = dict_key
+                        item = self._normalize_dict(item)
+                    if new_key not in new:
+                        new[new_key] = []
+                    new[new_key].append(item)
+            else:
+                new[key] = value
+        return new
+
+    def _get_file_identifiers(self, uuid: Optional[str]) -> list[str]:
+        return list(
+            Identifier.objects.filter(file=uuid).values_list("value", flat=True)
+        )

--- a/src/archivematica/archivematicaCommon/databaseFunctions.py
+++ b/src/archivematica/archivematicaCommon/databaseFunctions.py
@@ -20,6 +20,7 @@ import sys
 import uuid
 
 from django.db.models import Min
+from django.db.models import Q
 from django.utils import timezone
 
 from archivematica.dashboard.main.models import SIP
@@ -28,6 +29,7 @@ from archivematica.dashboard.main.models import Derivation
 from archivematica.dashboard.main.models import Event
 from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import FPCommandOutput
+from archivematica.dashboard.main.models import Identifier
 from archivematica.dashboard.main.models import Transfer
 
 LOGGER = logging.getLogger("archivematica.common")
@@ -295,3 +297,12 @@ def get_transfer_details(transfer_uuid):
             ingest_date = str(dt.date())
 
     return transfer_name, accession_id, ingest_date
+
+
+def get_sip_identifiers(uuid):
+    # Also index Directory identifiers so the AIP can be found through them
+    return list(
+        Identifier.objects.filter(Q(sip=uuid) | Q(directory__sip=uuid)).values_list(
+            "value", flat=True
+        )
+    )

--- a/src/archivematica/archivematicaCommon/databaseFunctions.py
+++ b/src/archivematica/archivematicaCommon/databaseFunctions.py
@@ -14,10 +14,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+import datetime
 import logging
 import sys
 import uuid
 
+from django.db.models import Min
 from django.utils import timezone
 
 from archivematica.dashboard.main.models import SIP
@@ -26,6 +28,7 @@ from archivematica.dashboard.main.models import Derivation
 from archivematica.dashboard.main.models import Event
 from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import FPCommandOutput
+from archivematica.dashboard.main.models import Transfer
 
 LOGGER = logging.getLogger("archivematica.common")
 
@@ -269,3 +272,26 @@ def deUnicode(unicode_string):
     if unicode_string is None:
         return None
     return str(unicode_string).encode("utf-8")
+
+
+def get_transfer_details(transfer_uuid):
+    transfer_name, accession_id, ingest_date = "", "", str(datetime.date.today())
+    try:
+        transfer = Transfer.objects.get(uuid=transfer_uuid)
+    except Transfer.DoesNotExist:
+        pass
+    else:
+        transfer_name = transfer.currentlocation.split("/")[-2]
+        if transfer.accessionid:
+            accession_id = transfer.accessionid
+        # It doesn't seem that Archivematica records the ingestion date
+        # associated with the Transfer but we can look at the earliest file
+        # entry instead - as long as there is a match which may not always be
+        # the case.
+        dt = File.objects.filter(transfer=transfer).aggregate(Min("enteredsystem"))[
+            "enteredsystem__min"
+        ]
+        if dt:
+            ingest_date = str(dt.date())
+
+    return transfer_name, accession_id, ingest_date

--- a/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
+++ b/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
@@ -32,7 +32,6 @@ from lxml import etree
 
 from archivematica.archivematicaCommon import namespaces as ns
 from archivematica.archivematicaCommon import version
-from archivematica.archivematicaCommon.archivematicaFunctions import get_dashboard_uuid
 from archivematica.archivematicaCommon.externals import xmltodict
 from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import Identifier
@@ -403,6 +402,7 @@ def index_aip_and_files(
     encrypted=False,
     location="",
     printfn=print,
+    dashboard_uuid="",
 ):
     """Index AIP and AIP files with UUID `uuid` at path `path`.
 
@@ -416,6 +416,7 @@ def index_aip_and_files(
     :param identifiers: optional additional identifiers (MODS, Islandora, etc.).
     :param encrypted: optional AIP encrypted boolean (defaults to `False`).
     :param printfn: optional print funtion.
+    :param dashboard_uuid: Pipeline UUID.
     :return: 0 is succeded, 1 otherwise.
     """
     # Stop if METS file is not at staging path.
@@ -476,6 +477,7 @@ def index_aip_and_files(
         name=name,
         identifiers=identifiers,
         aip_metadata=aip_metadata,
+        dashboard_uuid=dashboard_uuid,
     )
 
     printfn("Files indexed: " + str(files_indexed))
@@ -487,7 +489,7 @@ def index_aip_and_files(
         "filePath": aip_stored_path,
         ES_FIELD_SIZE: int(aip_size) / (1024 * 1024),
         ES_FIELD_FILECOUNT: files_indexed,
-        "origin": get_dashboard_uuid(),
+        "origin": dashboard_uuid,
         ES_FIELD_CREATED: created,
         ES_FIELD_AICID: aic_identifier,
         "isPartOf": is_part_of,
@@ -507,7 +509,9 @@ def index_aip_and_files(
     return 0
 
 
-def _index_aip_files(client, uuid, mets, name, identifiers=None, aip_metadata=None):
+def _index_aip_files(
+    client, uuid, mets, name, identifiers=None, aip_metadata=None, dashboard_uuid=""
+):
     """Index AIP files from AIP with UUID `uuid` and METS at path `mets_path`.
 
     :param client: The ElasticSearch client.
@@ -517,6 +521,7 @@ def _index_aip_files(client, uuid, mets, name, identifiers=None, aip_metadata=No
     :param identifiers: optional additional identifiers (MODS, Islandora, etc.).
     :param aip_metadata: list with the descriptive and administrative metadata
                          of each directory in the AIP
+    :param dashboard_uuid: Pipeline UUID.
     :return: number of files indexed, list of accession numbers
     """
 
@@ -559,7 +564,7 @@ def _index_aip_files(client, uuid, mets, name, identifiers=None, aip_metadata=No
         "isPartOf": is_part_of,
         ES_FIELD_AICID: aic_identifier,
         "METS": {"dmdSec": {}, "amdSec": {}},
-        "origin": get_dashboard_uuid(),
+        "origin": dashboard_uuid,
         "accessionid": "",
         ES_FIELD_STATUS: STATUS_UPLOADED,
     }
@@ -677,7 +682,7 @@ def _index_aip_files(client, uuid, mets, name, identifiers=None, aip_metadata=No
 
 
 def index_transfer_and_files(
-    client, uuid, path, size, pending_deletion=False, printfn=print
+    client, uuid, path, size, pending_deletion=False, printfn=print, dashboard_uuid=""
 ):
     """Indexes Transfer and Transfer files with UUID `uuid` at path `path`.
 
@@ -687,6 +692,7 @@ def index_transfer_and_files(
                  trailing / but not including objects/.
     :param size: size of transfer in bytes.
     :param printfn: optional print funtion.
+    :param dashboard_uuid: Pipeline UUID.
     :return: 0 is succeded, 1 otherwise.
     """
     # Stop if Transfer does not exist
@@ -730,6 +736,7 @@ def index_transfer_and_files(
         pending_deletion=pending_deletion,
         status=status,
         printfn=printfn,
+        dashboard_uuid=dashboard_uuid,
     )
 
     printfn("Files indexed: " + str(files_indexed))
@@ -763,6 +770,7 @@ def _index_transfer_files(
     status="",
     pending_deletion=False,
     printfn=print,
+    dashboard_uuid="",
 ):
     """Indexes files in the Transfer with UUID `uuid` at path `path`.
 
@@ -775,6 +783,7 @@ def _index_transfer_files(
     :param ingest_date: date Transfer was indexed
     :param status: optional Transfer status.
     :param printfn: optional print funtion.
+    :param dashboard_uuid: Pipeline UUID.
     :return: number of files indexed.
     """
     files_indexed = 0
@@ -782,9 +791,6 @@ def _index_transfer_files(
     # Some files should not be indexed.
     # This should match the basename of the file.
     ignore_files = ["processingMCP.xml"]
-
-    # Get dashboard UUID
-    dashboard_uuid = get_dashboard_uuid()
 
     for filepath in _list_files_in_dir(path):
         if os.path.isfile(filepath):

--- a/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
+++ b/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
@@ -466,6 +466,8 @@ def index_aip_and_files(
         identifiers=identifiers,
         aip_metadata=aip_metadata,
         dashboard_uuid=dashboard_uuid,
+        aic_identifier=aic_identifier,
+        is_part_of=is_part_of,
     )
 
     printfn("Files indexed: " + str(files_indexed))
@@ -498,7 +500,15 @@ def index_aip_and_files(
 
 
 def _index_aip_files(
-    client, uuid, mets, name, identifiers=None, aip_metadata=None, dashboard_uuid=""
+    client,
+    uuid,
+    mets,
+    name,
+    identifiers=None,
+    aip_metadata=None,
+    dashboard_uuid="",
+    aic_identifier=None,
+    is_part_of=None,
 ):
     """Index AIP files from AIP with UUID `uuid` and METS at path `mets_path`.
 
@@ -510,25 +520,10 @@ def _index_aip_files(
     :param aip_metadata: list with the descriptive and administrative metadata
                          of each directory in the AIP
     :param dashboard_uuid: Pipeline UUID.
+    :param aic_identifier: AIC identifier from DublinCore.
+    :param is_part_of: identifier for the AIC to which the AIP belongs.
     :return: number of files indexed, list of accession numbers
     """
-
-    # Extract isPartOf (for AIPs) or identifier (for AICs) from DublinCore.
-    dublincore = ns.xml_find_premis(
-        mets, "mets:dmdSec/mets:mdWrap/mets:xmlData/dcterms:dublincore"
-    )
-    aic_identifier = None
-    is_part_of = None
-    if dublincore is not None:
-        aip_type = ns.xml_findtext_premis(
-            dublincore, "dc:type"
-        ) or ns.xml_findtext_premis(dublincore, "dcterms:type")
-        if aip_type == "Archival Information Collection":
-            aic_identifier = ns.xml_findtext_premis(
-                dublincore, "dc:identifier"
-            ) or ns.xml_findtext_premis(dublincore, "dcterms:identifier")
-        elif aip_type == "Archival Information Package":
-            is_part_of = ns.xml_findtext_premis(dublincore, "dcterms:isPartOf")
 
     if identifiers is None:
         identifiers = []

--- a/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
+++ b/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
@@ -168,10 +168,6 @@ def _wait_for_cluster_yellow_status(client, wait_between_tries=10, max_tries=10)
             time.sleep(wait_between_tries)
 
 
-def _get_file_identifiers(uuid):
-    return list(Identifier.objects.filter(file=uuid).values_list("value", flat=True))
-
-
 # --------------
 # CREATE INDEXES
 # --------------
@@ -410,44 +406,10 @@ def index_aip_and_files(
         printfn(error_message, file=sys.stderr)
         return 1
 
-    tree = etree.parse(mets_staging_path)
-    _remove_tool_output_from_mets(tree)
-    root = tree.getroot()
-    # Extract AIC identifier, other specially-indexed information
-    aic_identifier = None
-    is_part_of = None
-    dublincore = ns.xml_find_premis(
-        root, "mets:dmdSec/mets:mdWrap/mets:xmlData/dcterms:dublincore"
-    )
-    if dublincore is not None:
-        aip_type = ns.xml_findtext_premis(
-            dublincore, "dc:type"
-        ) or ns.xml_findtext_premis(dublincore, "dcterms:type")
-        if aip_type == "Archival Information Collection":
-            aic_identifier = ns.xml_findtext_premis(
-                dublincore, "dc:identifier"
-            ) or ns.xml_findtext_premis(dublincore, "dcterms:identifier")
-        elif aip_type == "Archival Information Package":
-            is_part_of = ns.xml_findtext_premis(dublincore, "dcterms:isPartOf")
-
-    # Pull the create time from the METS header.
-    # Old METS did not use `metsHdr`.
-    created = time.time()
-    mets_hdr = ns.xml_find_premis(root, "mets:metsHdr")
-    if mets_hdr is not None:
-        mets_created_attr = mets_hdr.get("CREATEDATE")
-        if mets_created_attr:
-            try:
-                created = calendar.timegm(
-                    time.strptime(mets_created_attr, "%Y-%m-%dT%H:%M:%S")
-                )
-            except ValueError:
-                printfn("Failed to parse METS CREATEDATE: %s" % (mets_created_attr))
+    parser = AIPMETSParser(mets_staging_path)
 
     if identifiers is None:
         identifiers = []
-
-    aip_metadata = _get_aip_metadata(root)
 
     printfn("AIP UUID: " + uuid)
     printfn("Indexing AIP files ...")
@@ -455,13 +417,10 @@ def index_aip_and_files(
     (files_indexed, accession_ids) = _index_aip_files(
         client=client,
         uuid=uuid,
-        mets=root,
         name=name,
         identifiers=identifiers,
-        aip_metadata=aip_metadata,
         dashboard_uuid=dashboard_uuid,
-        aic_identifier=aic_identifier,
-        is_part_of=is_part_of,
+        parser=parser,
     )
 
     printfn("Files indexed: " + str(files_indexed))
@@ -474,12 +433,12 @@ def index_aip_and_files(
         ES_FIELD_SIZE: int(aip_size) / (1024 * 1024),
         ES_FIELD_FILECOUNT: files_indexed,
         "origin": dashboard_uuid,
-        ES_FIELD_CREATED: created,
-        ES_FIELD_AICID: aic_identifier,
-        "isPartOf": is_part_of,
+        ES_FIELD_CREATED: parser.created,
+        ES_FIELD_AICID: parser.aic_identifier,
+        "isPartOf": parser.is_part_of,
         ES_FIELD_AICCOUNT: aips_in_aic,
         "identifiers": identifiers,
-        "transferMetadata": aip_metadata,
+        "transferMetadata": parser.aip_metadata,
         ES_FIELD_ENCRYPTED: encrypted,
         ES_FIELD_ACCESSION_IDS: accession_ids,
         ES_FIELD_STATUS: STATUS_UPLOADED,
@@ -494,36 +453,21 @@ def index_aip_and_files(
 
 
 def _index_aip_files(
-    client,
-    uuid,
-    mets,
-    name,
-    identifiers=None,
-    aip_metadata=None,
-    dashboard_uuid="",
-    aic_identifier=None,
-    is_part_of=None,
+    client, uuid, name, identifiers=None, dashboard_uuid="", parser=None
 ):
     """Index AIP files from AIP with UUID `uuid` and METS at path `mets_path`.
 
     :param client: The ElasticSearch client.
     :param uuid: The UUID of the AIP we're indexing.
-    :param mets: root Element of the METS document.
     :param name: AIP name.
     :param identifiers: optional additional identifiers (MODS, Islandora, etc.).
-    :param aip_metadata: list with the descriptive and administrative metadata
-                         of each directory in the AIP
     :param dashboard_uuid: Pipeline UUID.
-    :param aic_identifier: AIC identifier from DublinCore.
-    :param is_part_of: identifier for the AIC to which the AIP belongs.
+    :param parser: AIPMETSParser instance.
     :return: number of files indexed, list of accession numbers
     """
 
     if identifiers is None:
         identifiers = []
-
-    if aip_metadata is None:
-        aip_metadata = []
 
     # Use a set to ensure accession numbers are unique without needing to
     # iterate through the list each time to check.
@@ -532,32 +476,24 @@ def _index_aip_files(
     am_version = version.get_version()
     indexed_at = time.time()
 
-    # Index all files in a fileGrup with USE='original' or USE='metadata'.
-    original_files = ns.xml_findall_premis(
-        mets, "mets:fileSec/mets:fileGrp[@USE='original']/mets:file"
-    )
-    metadata_files = ns.xml_findall_premis(
-        mets, "mets:fileSec/mets:fileGrp[@USE='metadata']/mets:file"
-    )
-    files = original_files + metadata_files
-
     def _generator():
         # Index AIC METS file if it exists.
-        for file_ in files:
-            file_data, file_accession_ids = get_aip_file_index_data(mets, file_)
+        for file_data, file_accession_ids in parser.files():
             file_data.update(
                 {
                     "archivematicaVersion": am_version,
                     "AIPUUID": uuid,
                     "sipName": name,
                     "indexedAt": indexed_at,
-                    "isPartOf": is_part_of,
-                    ES_FIELD_AICID: aic_identifier,
+                    "isPartOf": parser.is_part_of,
+                    ES_FIELD_AICID: parser.aic_identifier,
                     "origin": dashboard_uuid,
                     ES_FIELD_STATUS: STATUS_UPLOADED,
                 }
             )
-            file_data["transferMetadata"] = aip_metadata + file_data["transferMetadata"]
+            file_data["transferMetadata"] = (
+                parser.aip_metadata + file_data["transferMetadata"]
+            )
             file_data["identifiers"] = identifiers + file_data["identifiers"]
             accession_ids.update(file_accession_ids)
 
@@ -573,98 +509,10 @@ def _index_aip_files(
     # It should be revisited once we make documents smaller.
     bulk(client, _generator(), chunk_size=50)
 
-    file_count = len(files)
+    file_count = parser.file_count
     accession_ids_list = list(accession_ids)
 
     return (file_count, accession_ids_list)
-
-
-def get_aip_file_index_data(mets, file_):
-    # Establish the structure to be indexed for each file item.
-    indexData = {
-        "FILEUUID": "",
-        "filePath": "",
-        "fileExtension": "",
-        "METS": {"dmdSec": {}, "amdSec": {}},
-        "accessionid": "",
-    }
-
-    accession_ids = set()
-
-    # Get file UUID. If an ADMID exists, look in the amdSec for the UUID,
-    # otherwise parse it out of the file ID.
-    # 'Original' files have ADMIDs, 'Metadata' files do not.
-    admID = file_.attrib.get("ADMID", None)
-    if admID is None:
-        # Parse UUID from the file ID.
-        fileUUID = None
-        uuix_regex = r"\w{8}-?\w{4}-?\w{4}-?\w{4}-?\w{12}"
-        uuids = re.findall(uuix_regex, file_.attrib["ID"])
-        # Multiple UUIDs may be returned - if they are all identical,
-        # use that UUID, otherwise use None.
-        # To determine all UUIDs are identical, use the size of the set.
-        if len(set(uuids)) == 1:
-            fileUUID = uuids[0]
-    else:
-        amdSec = _get_amdSec(admID, mets)
-        fileUUID = _get_file_uuid(amdSec)
-        accession_id = _get_accession_number(amdSec)
-        if accession_id is not None:
-            indexData["accessionid"] = accession_id
-            accession_ids.add(accession_id)
-
-        # Index amdSec information.
-        xml = etree.tostring(amdSec, encoding="utf8")
-        indexData["METS"]["amdSec"] = _normalize_dict(xmltodict.parse(xml))
-
-    indexData["FILEUUID"] = fileUUID
-
-    file_metadata = []
-
-    # Get the parent division for the file pointer by searching the
-    # physical structural map section (structMap).
-    file_id = file_.attrib.get("ID", None)
-    file_pointer_division = ns.xml_find_premis(
-        mets,
-        f"mets:structMap[@TYPE='physical']//mets:fptr[@FILEID='{file_id}']/..",
-    )
-    if file_pointer_division is not None:
-        descriptive_metadata = _get_file_metadata(file_pointer_division, mets)
-        if descriptive_metadata:
-            file_metadata.append(descriptive_metadata)
-        # If the parent division has a DMDID attribute then index
-        # its data from the descriptive metadata section (dmdSec).
-        dmd_section_id = file_pointer_division.attrib.get("DMDID", None)
-        if dmd_section_id is not None:
-            # dmd_section_id can contain one id (e.g., "dmdSec_2") or
-            # more than one (e.g., "dmdSec_2 dmdSec_3", when a file
-            # has both DC and non-DC metadata).
-            # Attempt to index only the DC dmdSec if available.
-            for dmd_section_id_item in dmd_section_id.split():
-                dmd_section_info = ns.xml_find_premis(
-                    mets,
-                    f"mets:dmdSec[@ID='{dmd_section_id_item}']/mets:mdWrap[@MDTYPE='DC']/mets:xmlData",
-                )
-                if dmd_section_info is not None:
-                    xml = etree.tostring(dmd_section_info, encoding="utf8")
-                    data = _normalize_dict(xmltodict.parse(xml))
-                    indexData["METS"]["dmdSec"] = data
-                    break
-
-    indexData["transferMetadata"] = file_metadata
-
-    # Get file path from FLocat and extension.
-    filePath = ns.xml_find_premis(file_, "mets:FLocat").attrib[
-        "{http://www.w3.org/1999/xlink}href"
-    ]
-    indexData["filePath"] = filePath
-    _, fileExtension = os.path.splitext(filePath)
-    if fileExtension:
-        indexData["fileExtension"] = fileExtension[1:].lower()
-
-    indexData["identifiers"] = _get_file_identifiers(fileUUID)
-
-    return indexData, accession_ids
 
 
 def index_transfer_and_files(
@@ -876,224 +724,6 @@ def _try_to_index(
 # ----------------
 
 
-def _remove_tool_output_from_mets(doc):
-    """Remove tool output from a METS ElementTree.
-
-    Given an ElementTree object, removes all objectsCharacteristicsExtensions
-    elements. This modifies the existing document in-place; it does not return
-    a new document. This helps index METS files, which might otherwise get too
-    large to be usable.
-    """
-    root = doc.getroot()
-
-    # Remove tool output nodes
-    toolNodes = ns.xml_findall_premis(
-        root,
-        "mets:amdSec/mets:techMD/mets:mdWrap/mets:xmlData/premis:object/premis:objectCharacteristics/premis:objectCharacteristicsExtension",
-    )
-
-    for parent in toolNodes:
-        parent.clear()
-
-    print("Removed FITS output from METS.")
-
-
-def _get_directories_with_metadata(container):
-    """Return Directory entries with metadata sections.
-
-    Check if the entry references dmdSec (descriptive) or amdSec
-    (administrative) metadata sections.
-    """
-    return ns.xml_xpath_premis(
-        container, './/mets:div[@TYPE="Directory"][@DMDID or @ADMID]'
-    )
-
-
-def _get_descriptive_section_metadata(dmdSec):
-    """Get dublin core and custom descriptive metadata."""
-    result = []
-    # look for dublincore terms in the dmdSec
-    result += ns.xml_findall_premis(
-        dmdSec, 'mets:mdWrap[@MDTYPE="DC"]/mets:xmlData/dcterms:dublincore'
-    )
-    # look for non dublincore (custom) metadata
-    result += ns.xml_findall_premis(dmdSec, 'mets:mdWrap[@MDTYPE="OTHER"]/mets:xmlData')
-    return result
-
-
-def _combine_elements(elements):
-    """Serialize all the elements as a JSON compatible string.
-
-    Combine the elements contents into a single container and parse it
-    with xmltodict.
-    """
-    # wrap the data from all metadata elements in a container
-    container = etree.Element("container")
-    for element in elements:
-        for child in element:
-            # add a copy to not modify the METS file in place
-            container.append(copy.deepcopy(child))
-    # parse the container with xmltodict ignoring element attributes
-    return (
-        xmltodict.parse(
-            etree.tostring(container, encoding="utf8"), xml_attribs=False
-        ).get("container")
-        or {}
-    )
-
-
-def _get_relative_path_element(directory):
-    """Build an element with the relative path of the directory."""
-    TAG = "__DIRECTORY_LABEL__"
-    result = etree.Element("container")
-    path = etree.SubElement(result, TAG)
-    path.text = directory.attrib.get("LABEL", "")
-    return result
-
-
-def _get_latest_dmd_secs(dmd_id, doc):
-    # Build a mapping of dmdSec by metadata type.
-    dmd_secs = {}
-    for id in dmd_id.split():
-        dmd_sec = ns.xml_find_premis(doc, f'mets:dmdSec[@ID="{id}"]')
-        if not dmd_sec:
-            continue
-        # Use mdWrap MDTYPE and OTHERMDTYPE to generate a unique key.
-        md_wrap = ns.xml_find_premis(dmd_sec, "mets:mdWrap")
-        if not md_wrap:
-            continue
-        mdtype_key = md_wrap.attrib.get("MDTYPE")
-        # Ignore PREMIS:OBJECT.
-        if mdtype_key == "PREMIS:OBJECT":
-            continue
-        other_mdtype = md_wrap.attrib.get("OTHERMDTYPE")
-        if other_mdtype:
-            mdtype_key += "_" + other_mdtype
-        if mdtype_key not in dmd_secs:
-            dmd_secs[mdtype_key] = []
-        dmd_secs[mdtype_key].append(dmd_sec)
-    # Get only the latest dmdSec by type.
-    final_dmd_secs = []
-    for _, secs in dmd_secs.items():
-        latest_date = ""
-        latest_sec = None
-        for sec in secs:
-            date = sec.attrib.get("CREATED", "")
-            if not latest_date or date > latest_date:
-                latest_date = date
-                latest_sec = sec
-        # Do not add latest dmdSec if it's deleted.
-        if latest_sec and latest_sec.attrib.get("STATUS", "") != "deleted":
-            final_dmd_secs.append(latest_sec)
-    return final_dmd_secs
-
-
-def _get_file_metadata(file_pointer_division, doc):
-    """Get descriptive metadata for a file pointer.
-
-    There are various types of metadata elements extracted: dublin core
-    and custom (non dublin core), both set through the metadata/metadata.csv
-    file; and metadata added through the source-metadata.csv files and
-    related XML files.
-
-    These types are parsed and combined into a single dictionary of
-    metadata attributes.
-    """
-    result = {}
-    elements_with_metadata = []
-    dmd_id = file_pointer_division.attrib.get("DMDID")
-    if not dmd_id:
-        return result
-    for dmd_sec in _get_latest_dmd_secs(dmd_id, doc):
-        elements_with_metadata += _get_descriptive_section_metadata(dmd_sec)
-    if elements_with_metadata:
-        result = _combine_elements(elements_with_metadata)
-    return _normalize_dict(result)
-
-
-def _get_directory_metadata(directory, doc):
-    """Get descriptive or administrive metadata for a directory.
-
-    There are three types of metadata elements extracted:
-
-    1. Dublin core, set through the metadata/metadata.csv file or the
-       transfer/ingest metadata form in the dashboard
-    2. Custom (non dublin core), set through the metadata/metadata.csv
-       file
-    3. Bag/disk image metadata, set through the bag-info.txt file or
-       the disk image metadata form in the dashboard
-    4. Custom XML metadata, set through the source-metadata.csv files
-       and related XML files
-
-    These types are parsed and combined into a single dictionary of
-    metadata attributes. A marker element with the label of the
-    Directory entry is added to the result.
-    """
-    result = {}
-    elements_with_metadata = []
-    dmd_id = directory.attrib.get("DMDID")
-    if dmd_id:
-        for dmd_sec in _get_latest_dmd_secs(dmd_id, doc):
-            elements_with_metadata += _get_descriptive_section_metadata(dmd_sec)
-    for ADMID in directory.attrib.get("ADMID", "").split():
-        amd_sec = ns.xml_find_premis(doc, f'mets:amdSec[@ID="{ADMID}"]')
-        if amd_sec is not None:
-            # look for bag/disk image metadata
-            elements_with_metadata += ns.xml_findall_premis(
-                amd_sec, "mets:sourceMD/mets:mdWrap/mets:xmlData/transfer_metadata"
-            )
-    if elements_with_metadata:
-        # add an attribute with the relative path of the Directory entry
-        elements_with_metadata.append(_get_relative_path_element(directory))
-        result = _combine_elements(elements_with_metadata)
-    return _normalize_dict(result)
-
-
-def _get_aip_metadata(doc):
-    """Get metadata about the directories in the AIP.
-
-    Given a doc representing a METS file, look for Directory entries
-    that have descriptive or administrative metadata in the physical
-    structMap and return dictionaries with metadata attributes for
-    each directory.
-    """
-    result = []
-    physical_struct_map = ns.xml_find_premis(doc, 'mets:structMap[@TYPE="physical"]')
-    if physical_struct_map is not None:
-        for directory in _get_directories_with_metadata(physical_struct_map):
-            directory_metadata = _get_directory_metadata(directory, doc)
-            if directory_metadata:
-                result.append(directory_metadata)
-    return result
-
-
-def _normalize_dict(data):
-    """Normalize dictionary from xmltodict for ES indexing.
-
-    Because an XML element may contain text value or other elements, conversion
-    to a dict can result in different value types for the same key. This causes
-    problems in the Elasticsearch index as it expects consistent types. This
-    function recurses a dict and appends "_dict" to the keys with a dict value.
-    """
-    new = {}
-    for key, value in data.items():
-        dict_key = key + "_dict"
-        if isinstance(value, dict):
-            new[dict_key] = _normalize_dict(value)
-        elif isinstance(value, list):
-            for item in value:
-                new_key = key
-                if isinstance(item, dict):
-                    new_key = dict_key
-                    item = _normalize_dict(item)
-                if new_key not in new:
-                    new[new_key] = []
-                new[new_key].append(item)
-        else:
-            new[key] = value
-    return new
-
-
 def _get_file_formats(f):
     formats = []
     fields = [
@@ -1136,51 +766,6 @@ def _list_files_in_dir(path, filepaths=None):
 
     # Return fully traversed data
     return filepaths
-
-
-def _get_amdSec(admID, doc):
-    """Get amdSec with given admID.
-
-    :param admID: admID.
-    :param doc: ElementTree object.
-    :return: amdSec.
-    """
-    return ns.xml_find_premis(doc, f"mets:amdSec[@ID='{admID}']")
-
-
-def _get_file_uuid(amdSec):
-    """Get UUID of a file from amdSec.
-
-    :param amdSec: amdSec.
-    :return: File UUID.
-    """
-    return ns.xml_findtext_premis(
-        amdSec,
-        "mets:techMD/mets:mdWrap/mets:xmlData/premis:object/premis:objectIdentifier/premis:objectIdentifierValue",
-    )
-
-
-def _get_accession_number(amdSec):
-    """Get accession number associated with a file from amdSec.
-
-    Look for a <premis:event> entry within file's amdSec that has a
-    <premis:eventType> of "registration". Return the text value (with leading
-    "accession#" stripped out) from the <premis:eventOutcomeDetailNote>.
-
-    If no matching <premis:event> entry is found, return None.
-
-    :param amdSec: amdSec.
-    :return: Accession number or None.
-    """
-    registration_detail_notes = ns.xml_xpath_premis(
-        amdSec,
-        ".//premis:event[premis:eventType='registration']/premis:eventOutcomeInformation/premis:eventOutcomeDetail/premis:eventOutcomeDetailNote",
-    )
-    if not registration_detail_notes:
-        return None
-    detail_text = registration_detail_notes[0].text
-    ACCESSION_PREFIX = "accession#"
-    return detail_text[len(ACCESSION_PREFIX) :]
 
 
 # -------

--- a/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
+++ b/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
@@ -796,68 +796,98 @@ def _index_transfer_files(
 
     for filepath in _list_files_in_dir(path):
         if os.path.isfile(filepath):
-            # We need to account for the possibility of dealing with a BagIt
-            # transfer package - the new default in Archivematica.
-            # The BagIt is created when the package is sent to backlog hence
-            # the locations in the database do not reflect the BagIt paths.
-            # Strip the "data/" part when looking up the file entry.
-            stripped_path = re.sub(r"^data/", "", os.path.relpath(filepath, path))
-            currentlocation = "%transferDirectory%" + stripped_path
-            try:
-                f = File.objects.get(
-                    currentlocation=currentlocation.encode(), transfer_id=uuid
-                )
-                file_uuid = str(f.uuid)
-                formats = _get_file_formats(f)
-                bulk_extractor_reports = _list_bulk_extractor_reports(path, file_uuid)
-                if f.modificationtime is not None:
-                    modification_date = f.modificationtime.strftime("%Y-%m-%d")
-                else:
-                    modification_date = ""
-            except File.DoesNotExist:
-                file_uuid, modification_date = "", ""
-                formats = []
-                bulk_extractor_reports = []
-
             # Get file path info
             stripped_path = filepath.replace(path, transfer_name + "/")
-            file_extension = os.path.splitext(filepath)[1][1:].lower()
             filename = os.path.basename(filepath)
-            # Size in megabytes
-            size = os.path.getsize(filepath) / (1024 * 1024)
-            create_time = os.stat(filepath).st_ctime
 
-            if filename not in ignore_files:
-                printfn(f"Indexing {stripped_path} (UUID: {file_uuid})")
-
-                # TODO: Index Backlog Location UUID?
-                indexData = {
-                    "filename": filename,
-                    "relative_path": stripped_path,
-                    "fileuuid": file_uuid,
-                    "sipuuid": uuid,
-                    "accessionid": accession_id,
-                    ES_FIELD_STATUS: status,
-                    "origin": dashboard_uuid,
-                    "ingestdate": ingest_date,
-                    ES_FIELD_CREATED: create_time,
-                    "modification_date": modification_date,
-                    ES_FIELD_SIZE: size,
-                    "tags": [],
-                    "file_extension": file_extension,
-                    "bulk_extractor_reports": bulk_extractor_reports,
-                    "format": formats,
-                    "pending_deletion": pending_deletion,
-                }
-
-                _wait_for_cluster_yellow_status(client)
-                _try_to_index(client, indexData, TRANSFER_FILES_INDEX, printfn=printfn)
-
-                files_indexed = files_indexed + 1
-            else:
+            if filename in ignore_files:
                 printfn(f"Skipping indexing {stripped_path}")
+                continue
+
+            indexData = get_transfer_file_index_data(
+                filepath,
+                filename,
+                stripped_path,
+                path,
+                uuid,
+                accession_id,
+                status,
+                ingest_date,
+                pending_deletion,
+                dashboard_uuid,
+                printfn,
+            )
+
+            _wait_for_cluster_yellow_status(client)
+            _try_to_index(client, indexData, TRANSFER_FILES_INDEX, printfn=printfn)
+
+            files_indexed = files_indexed + 1
 
     return files_indexed
+
+
+def get_transfer_file_index_data(
+    filepath,
+    filename,
+    stripped_path,
+    transfer_path,
+    uuid,
+    accession_id,
+    status,
+    ingest_date,
+    pending_deletion,
+    dashboard_uuid,
+    printfn,
+):
+    # We need to account for the possibility of dealing with a BagIt
+    # transfer package - the new default in Archivematica.
+    # The BagIt is created when the package is sent to backlog hence
+    # the locations in the database do not reflect the BagIt paths.
+    # Strip the "data/" part when looking up the file entry.
+    currentlocation = "%transferDirectory%" + os.path.relpath(
+        filepath, transfer_path
+    ).removeprefix("data/")
+    try:
+        f = File.objects.get(currentlocation=currentlocation.encode(), transfer_id=uuid)
+        file_uuid = str(f.uuid)
+        formats = _get_file_formats(f)
+        bulk_extractor_reports = _list_bulk_extractor_reports(transfer_path, file_uuid)
+        if f.modificationtime is not None:
+            modification_date = f.modificationtime.strftime("%Y-%m-%d")
+        else:
+            modification_date = ""
+    except File.DoesNotExist:
+        file_uuid, modification_date = "", ""
+        formats = []
+        bulk_extractor_reports = []
+
+    file_extension = os.path.splitext(filepath)[1][1:].lower()
+
+    # Size in megabytes
+    size = os.path.getsize(filepath) / (1024 * 1024)
+    create_time = os.stat(filepath).st_ctime
+
+    printfn(f"Indexing {stripped_path} (UUID: {file_uuid})")
+
+    # TODO: Index Backlog Location UUID?
+    return {
+        "filename": filename,
+        "relative_path": stripped_path,
+        "fileuuid": file_uuid,
+        "sipuuid": uuid,
+        "accessionid": accession_id,
+        ES_FIELD_STATUS: status,
+        "origin": dashboard_uuid,
+        "ingestdate": ingest_date,
+        ES_FIELD_CREATED: create_time,
+        "modification_date": modification_date,
+        ES_FIELD_SIZE: size,
+        "tags": [],
+        "file_extension": file_extension,
+        "bulk_extractor_reports": bulk_extractor_reports,
+        "format": formats,
+        "pending_deletion": pending_deletion,
+    }
 
 
 def _try_to_index(

--- a/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
+++ b/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
@@ -433,7 +433,8 @@ def index_aip_and_files(
             aic_identifier = ns.xml_findtext_premis(
                 dublincore, "dc:identifier"
             ) or ns.xml_findtext_premis(dublincore, "dcterms:identifier")
-        is_part_of = ns.xml_findtext_premis(dublincore, "dcterms:isPartOf")
+        elif aip_type == "Archival Information Package":
+            is_part_of = ns.xml_findtext_premis(dublincore, "dcterms:isPartOf")
 
     # Pull the create time from the METS header.
     # Old METS did not use `metsHdr`.

--- a/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
+++ b/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
@@ -16,14 +16,12 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 import calendar
 import copy
-import datetime
 import logging
 import os
 import re
 import sys
 import time
 
-from django.db.models import Min
 from django.db.models import Q
 from elasticsearch import Elasticsearch
 from elasticsearch import ImproperlyConfigured
@@ -35,7 +33,6 @@ from archivematica.archivematicaCommon import version
 from archivematica.archivematicaCommon.externals import xmltodict
 from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import Identifier
-from archivematica.dashboard.main.models import Transfer
 
 logger = logging.getLogger("archivematica.common")
 
@@ -682,7 +679,16 @@ def _index_aip_files(
 
 
 def index_transfer_and_files(
-    client, uuid, path, size, pending_deletion=False, printfn=print, dashboard_uuid=""
+    client,
+    uuid,
+    path,
+    size,
+    pending_deletion=False,
+    printfn=print,
+    dashboard_uuid="",
+    transfer_name="",
+    accession_id="",
+    ingest_date="",
 ):
     """Indexes Transfer and Transfer files with UUID `uuid` at path `path`.
 
@@ -693,6 +699,9 @@ def index_transfer_and_files(
     :param size: size of transfer in bytes.
     :param printfn: optional print funtion.
     :param dashboard_uuid: Pipeline UUID.
+    :param transfer_name: name of Transfer
+    :param accession_id: optional accession ID
+    :param ingest_date: date Transfer was indexed
     :return: 0 is succeded, 1 otherwise.
     """
     # Stop if Transfer does not exist
@@ -704,25 +713,6 @@ def index_transfer_and_files(
 
     # Default status of a transfer file document in the index.
     status = "backlog"
-
-    transfer_name, accession_id, ingest_date = "", "", str(datetime.date.today())
-    try:
-        transfer = Transfer.objects.get(uuid=uuid)
-    except Transfer.DoesNotExist:
-        pass
-    else:
-        transfer_name = transfer.currentlocation.split("/")[-2]
-        if transfer.accessionid:
-            accession_id = transfer.accessionid
-        # It doesn't seem that Archivematica records the ingestion date
-        # associated with the Transfer but we can look at the earliest file
-        # entry instead - as long as there is a match which may not always be
-        # the case.
-        dt = File.objects.filter(transfer=transfer).aggregate(Min("enteredsystem"))[
-            "enteredsystem__min"
-        ]
-        if dt:
-            ingest_date = str(dt.date())
 
     printfn("Transfer UUID: " + uuid)
     printfn("Indexing Transfer files ...")

--- a/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
+++ b/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
@@ -174,15 +174,6 @@ def _wait_for_cluster_yellow_status(client, wait_between_tries=10, max_tries=10)
             time.sleep(wait_between_tries)
 
 
-def _get_sip_identifiers(uuid):
-    # Also index Directory identifiers so the AIP can be found through them
-    return list(
-        Identifier.objects.filter(Q(sip=uuid) | Q(directory__sip=uuid)).values_list(
-            "value", flat=True
-        )
-    )
-
-
 def _get_file_identifiers(uuid):
     return list(Identifier.objects.filter(file=uuid).values_list("value", flat=True))
 
@@ -460,7 +451,6 @@ def index_aip_and_files(
 
     if identifiers is None:
         identifiers = []
-    identifiers += _get_sip_identifiers(uuid)
 
     aip_metadata = _get_aip_metadata(root)
 

--- a/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
+++ b/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
@@ -550,20 +550,23 @@ def _index_aip_files(
     def _generator():
         # Index AIC METS file if it exists.
         for file_ in files:
-            file_data, file_accession_ids = get_aip_file_index_data(
-                mets,
-                file_,
-                uuid,
-                name,
-                aip_metadata,
-                identifiers,
-                aic_identifier,
-                is_part_of,
-                dashboard_uuid,
-                am_version,
-                indexed_at,
+            file_data, file_accession_ids = get_aip_file_index_data(mets, file_)
+            file_data.update(
+                {
+                    "archivematicaVersion": am_version,
+                    "AIPUUID": uuid,
+                    "sipName": name,
+                    "indexedAt": indexed_at,
+                    "isPartOf": is_part_of,
+                    ES_FIELD_AICID: aic_identifier,
+                    "origin": dashboard_uuid,
+                    ES_FIELD_STATUS: STATUS_UPLOADED,
+                }
             )
+            file_data["transferMetadata"] = aip_metadata + file_data["transferMetadata"]
+            file_data["identifiers"] = identifiers + file_data["identifiers"]
             accession_ids.update(file_accession_ids)
+
             yield {
                 "_op_type": "index",
                 "_index": AIP_FILES_INDEX,
@@ -582,34 +585,14 @@ def _index_aip_files(
     return (file_count, accession_ids_list)
 
 
-def get_aip_file_index_data(
-    mets,
-    file_,
-    uuid,
-    name,
-    aip_metadata,
-    identifiers,
-    aic_identifier,
-    is_part_of,
-    dashboard_uuid,
-    am_version,
-    indexed_at,
-):
+def get_aip_file_index_data(mets, file_):
     # Establish the structure to be indexed for each file item.
     indexData = {
-        "archivematicaVersion": am_version,
-        "AIPUUID": uuid,
-        "sipName": name,
         "FILEUUID": "",
-        "indexedAt": indexed_at,
         "filePath": "",
         "fileExtension": "",
-        "isPartOf": is_part_of,
-        ES_FIELD_AICID: aic_identifier,
         "METS": {"dmdSec": {}, "amdSec": {}},
-        "origin": dashboard_uuid,
         "accessionid": "",
-        ES_FIELD_STATUS: STATUS_UPLOADED,
     }
 
     accession_ids = set()
@@ -674,7 +657,7 @@ def get_aip_file_index_data(
                     indexData["METS"]["dmdSec"] = data
                     break
 
-    indexData["transferMetadata"] = aip_metadata + file_metadata
+    indexData["transferMetadata"] = file_metadata
 
     # Get file path from FLocat and extension.
     filePath = ns.xml_find_premis(file_, "mets:FLocat").attrib[
@@ -685,7 +668,7 @@ def get_aip_file_index_data(
     if fileExtension:
         indexData["fileExtension"] = fileExtension[1:].lower()
 
-    indexData["identifiers"] = identifiers + _get_file_identifiers(fileUUID)
+    indexData["identifiers"] = _get_file_identifiers(fileUUID)
 
     return indexData, accession_ids
 
@@ -804,18 +787,23 @@ def _index_transfer_files(
                 printfn(f"Skipping indexing {stripped_path}")
                 continue
 
-            indexData = get_transfer_file_index_data(
-                filepath,
-                filename,
-                stripped_path,
-                path,
-                uuid,
-                accession_id,
-                status,
-                ingest_date,
-                pending_deletion,
-                dashboard_uuid,
-                printfn,
+            indexData = get_transfer_file_index_data(filepath, path, uuid)
+            indexData.update(
+                {
+                    "filename": filename,
+                    "relative_path": stripped_path,
+                    "sipuuid": uuid,
+                    "accessionid": accession_id,
+                    ES_FIELD_STATUS: status,
+                    "origin": dashboard_uuid,
+                    "ingestdate": ingest_date,
+                    "tags": [],
+                    "pending_deletion": pending_deletion,
+                }
+            )
+
+            printfn(
+                f"Indexing {indexData['relative_path']} (UUID: {indexData['fileuuid']})"
             )
 
             _wait_for_cluster_yellow_status(client)
@@ -826,19 +814,7 @@ def _index_transfer_files(
     return files_indexed
 
 
-def get_transfer_file_index_data(
-    filepath,
-    filename,
-    stripped_path,
-    transfer_path,
-    uuid,
-    accession_id,
-    status,
-    ingest_date,
-    pending_deletion,
-    dashboard_uuid,
-    printfn,
-):
+def get_transfer_file_index_data(filepath, transfer_path, uuid):
     # We need to account for the possibility of dealing with a BagIt
     # transfer package - the new default in Archivematica.
     # The BagIt is created when the package is sent to backlog hence
@@ -867,26 +843,15 @@ def get_transfer_file_index_data(
     size = os.path.getsize(filepath) / (1024 * 1024)
     create_time = os.stat(filepath).st_ctime
 
-    printfn(f"Indexing {stripped_path} (UUID: {file_uuid})")
-
     # TODO: Index Backlog Location UUID?
     return {
-        "filename": filename,
-        "relative_path": stripped_path,
         "fileuuid": file_uuid,
-        "sipuuid": uuid,
-        "accessionid": accession_id,
-        ES_FIELD_STATUS: status,
-        "origin": dashboard_uuid,
-        "ingestdate": ingest_date,
         ES_FIELD_CREATED: create_time,
         "modification_date": modification_date,
         ES_FIELD_SIZE: size,
-        "tags": [],
         "file_extension": file_extension,
         "bulk_extractor_reports": bulk_extractor_reports,
         "format": formats,
-        "pending_deletion": pending_deletion,
     }
 
 

--- a/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
+++ b/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
@@ -14,11 +14,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
-import calendar
-import copy
 import logging
 import os
-import re
 import sys
 import time
 
@@ -26,13 +23,10 @@ from django.db.models import Q
 from elasticsearch import Elasticsearch
 from elasticsearch import ImproperlyConfigured
 from elasticsearch.helpers import bulk
-from lxml import etree
 
-from archivematica.archivematicaCommon import namespaces as ns
 from archivematica.archivematicaCommon import version
-from archivematica.archivematicaCommon.externals import xmltodict
+from archivematica.archivematicaCommon.aip_mets_parser import AIPMETSParser
 from archivematica.dashboard.main.models import File
-from archivematica.dashboard.main.models import Identifier
 
 logger = logging.getLogger("archivematica.common")
 

--- a/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
+++ b/src/archivematica/archivematicaCommon/elasticSearchFunctions.py
@@ -535,22 +535,8 @@ def _index_aip_files(
     # iterate through the list each time to check.
     accession_ids = set()
 
-    # Establish the structure to be indexed for each file item.
-    fileData = {
-        "archivematicaVersion": version.get_version(),
-        "AIPUUID": uuid,
-        "sipName": name,
-        "FILEUUID": "",
-        "indexedAt": time.time(),
-        "filePath": "",
-        "fileExtension": "",
-        "isPartOf": is_part_of,
-        ES_FIELD_AICID: aic_identifier,
-        "METS": {"dmdSec": {}, "amdSec": {}},
-        "origin": dashboard_uuid,
-        "accessionid": "",
-        ES_FIELD_STATUS: STATUS_UPLOADED,
-    }
+    am_version = version.get_version()
+    indexed_at = time.time()
 
     # Index all files in a fileGrup with USE='original' or USE='metadata'.
     original_files = ns.xml_findall_premis(
@@ -564,94 +550,26 @@ def _index_aip_files(
     def _generator():
         # Index AIC METS file if it exists.
         for file_ in files:
-            # Make a deep copy of dict, not a copy of dict contents.
-            indexData = fileData.copy()
-
-            # Get file UUID. If an ADMID exists, look in the amdSec for the UUID,
-            # otherwise parse it out of the file ID.
-            # 'Original' files have ADMIDs, 'Metadata' files do not.
-            admID = file_.attrib.get("ADMID", None)
-            if admID is None:
-                # Parse UUID from the file ID.
-                fileUUID = None
-                uuix_regex = r"\w{8}-?\w{4}-?\w{4}-?\w{4}-?\w{12}"
-                uuids = re.findall(uuix_regex, file_.attrib["ID"])
-                # Multiple UUIDs may be returned - if they are all identical,
-                # use that UUID, otherwise use None.
-                # To determine all UUIDs are identical, use the size of the set.
-                if len(set(uuids)) == 1:
-                    fileUUID = uuids[0]
-            else:
-                amdSec = _get_amdSec(admID, mets)
-                fileUUID = _get_file_uuid(amdSec)
-                accession_id = _get_accession_number(amdSec)
-                if accession_id is not None:
-                    indexData["accessionid"] = accession_id
-                    accession_ids.add(accession_id)
-
-                # Index amdSec information.
-                xml = etree.tostring(amdSec, encoding="utf8")
-                indexData["METS"]["amdSec"] = _normalize_dict(xmltodict.parse(xml))
-
-            indexData["FILEUUID"] = fileUUID
-
-            file_metadata = []
-
-            # Get the parent division for the file pointer by searching the
-            # physical structural map section (structMap).
-            file_id = file_.attrib.get("ID", None)
-            file_pointer_division = ns.xml_find_premis(
+            file_data, file_accession_ids = get_aip_file_index_data(
                 mets,
-                f"mets:structMap[@TYPE='physical']//mets:fptr[@FILEID='{file_id}']/..",
+                file_,
+                uuid,
+                name,
+                aip_metadata,
+                identifiers,
+                aic_identifier,
+                is_part_of,
+                dashboard_uuid,
+                am_version,
+                indexed_at,
             )
-            if file_pointer_division is not None:
-                descriptive_metadata = _get_file_metadata(file_pointer_division, mets)
-                if descriptive_metadata:
-                    file_metadata.append(descriptive_metadata)
-                # If the parent division has a DMDID attribute then index
-                # its data from the descriptive metadata section (dmdSec).
-                dmd_section_id = file_pointer_division.attrib.get("DMDID", None)
-                if dmd_section_id is not None:
-                    # dmd_section_id can contain one id (e.g., "dmdSec_2") or
-                    # more than one (e.g., "dmdSec_2 dmdSec_3", when a file
-                    # has both DC and non-DC metadata).
-                    # Attempt to index only the DC dmdSec if available.
-                    for dmd_section_id_item in dmd_section_id.split():
-                        dmd_section_info = ns.xml_find_premis(
-                            mets,
-                            f"mets:dmdSec[@ID='{dmd_section_id_item}']/mets:mdWrap[@MDTYPE='DC']/mets:xmlData",
-                        )
-                        if dmd_section_info is not None:
-                            xml = etree.tostring(dmd_section_info, encoding="utf8")
-                            data = _normalize_dict(xmltodict.parse(xml))
-                            indexData["METS"]["dmdSec"] = data
-                            break
-
-            indexData["transferMetadata"] = aip_metadata + file_metadata
-
-            # Get file path from FLocat and extension.
-            filePath = ns.xml_find_premis(file_, "mets:FLocat").attrib[
-                "{http://www.w3.org/1999/xlink}href"
-            ]
-            indexData["filePath"] = filePath
-            _, fileExtension = os.path.splitext(filePath)
-            if fileExtension:
-                indexData["fileExtension"] = fileExtension[1:].lower()
-
-            indexData["identifiers"] = identifiers + _get_file_identifiers(fileUUID)
-
+            accession_ids.update(file_accession_ids)
             yield {
                 "_op_type": "index",
                 "_index": AIP_FILES_INDEX,
                 "_type": DOC_TYPE,
-                "_source": indexData,
+                "_source": file_data,
             }
-
-            # Reset fileData['METS']['amdSec'] and fileData['METS']['dmdSec'],
-            # since they are updated in the loop above.
-            # See http://stackoverflow.com/a/3975388 for explanation.
-            fileData["METS"]["amdSec"] = {}
-            fileData["METS"]["dmdSec"] = {}
 
     # Number of docs (chunk_size) defaults to 500 which is probably too big as
     # we're potentially dealing with large documents (full amdSec embedded).
@@ -662,6 +580,114 @@ def _index_aip_files(
     accession_ids_list = list(accession_ids)
 
     return (file_count, accession_ids_list)
+
+
+def get_aip_file_index_data(
+    mets,
+    file_,
+    uuid,
+    name,
+    aip_metadata,
+    identifiers,
+    aic_identifier,
+    is_part_of,
+    dashboard_uuid,
+    am_version,
+    indexed_at,
+):
+    # Establish the structure to be indexed for each file item.
+    indexData = {
+        "archivematicaVersion": am_version,
+        "AIPUUID": uuid,
+        "sipName": name,
+        "FILEUUID": "",
+        "indexedAt": indexed_at,
+        "filePath": "",
+        "fileExtension": "",
+        "isPartOf": is_part_of,
+        ES_FIELD_AICID: aic_identifier,
+        "METS": {"dmdSec": {}, "amdSec": {}},
+        "origin": dashboard_uuid,
+        "accessionid": "",
+        ES_FIELD_STATUS: STATUS_UPLOADED,
+    }
+
+    accession_ids = set()
+
+    # Get file UUID. If an ADMID exists, look in the amdSec for the UUID,
+    # otherwise parse it out of the file ID.
+    # 'Original' files have ADMIDs, 'Metadata' files do not.
+    admID = file_.attrib.get("ADMID", None)
+    if admID is None:
+        # Parse UUID from the file ID.
+        fileUUID = None
+        uuix_regex = r"\w{8}-?\w{4}-?\w{4}-?\w{4}-?\w{12}"
+        uuids = re.findall(uuix_regex, file_.attrib["ID"])
+        # Multiple UUIDs may be returned - if they are all identical,
+        # use that UUID, otherwise use None.
+        # To determine all UUIDs are identical, use the size of the set.
+        if len(set(uuids)) == 1:
+            fileUUID = uuids[0]
+    else:
+        amdSec = _get_amdSec(admID, mets)
+        fileUUID = _get_file_uuid(amdSec)
+        accession_id = _get_accession_number(amdSec)
+        if accession_id is not None:
+            indexData["accessionid"] = accession_id
+            accession_ids.add(accession_id)
+
+        # Index amdSec information.
+        xml = etree.tostring(amdSec, encoding="utf8")
+        indexData["METS"]["amdSec"] = _normalize_dict(xmltodict.parse(xml))
+
+    indexData["FILEUUID"] = fileUUID
+
+    file_metadata = []
+
+    # Get the parent division for the file pointer by searching the
+    # physical structural map section (structMap).
+    file_id = file_.attrib.get("ID", None)
+    file_pointer_division = ns.xml_find_premis(
+        mets,
+        f"mets:structMap[@TYPE='physical']//mets:fptr[@FILEID='{file_id}']/..",
+    )
+    if file_pointer_division is not None:
+        descriptive_metadata = _get_file_metadata(file_pointer_division, mets)
+        if descriptive_metadata:
+            file_metadata.append(descriptive_metadata)
+        # If the parent division has a DMDID attribute then index
+        # its data from the descriptive metadata section (dmdSec).
+        dmd_section_id = file_pointer_division.attrib.get("DMDID", None)
+        if dmd_section_id is not None:
+            # dmd_section_id can contain one id (e.g., "dmdSec_2") or
+            # more than one (e.g., "dmdSec_2 dmdSec_3", when a file
+            # has both DC and non-DC metadata).
+            # Attempt to index only the DC dmdSec if available.
+            for dmd_section_id_item in dmd_section_id.split():
+                dmd_section_info = ns.xml_find_premis(
+                    mets,
+                    f"mets:dmdSec[@ID='{dmd_section_id_item}']/mets:mdWrap[@MDTYPE='DC']/mets:xmlData",
+                )
+                if dmd_section_info is not None:
+                    xml = etree.tostring(dmd_section_info, encoding="utf8")
+                    data = _normalize_dict(xmltodict.parse(xml))
+                    indexData["METS"]["dmdSec"] = data
+                    break
+
+    indexData["transferMetadata"] = aip_metadata + file_metadata
+
+    # Get file path from FLocat and extension.
+    filePath = ns.xml_find_premis(file_, "mets:FLocat").attrib[
+        "{http://www.w3.org/1999/xlink}href"
+    ]
+    indexData["filePath"] = filePath
+    _, fileExtension = os.path.splitext(filePath)
+    if fileExtension:
+        indexData["fileExtension"] = fileExtension[1:].lower()
+
+    indexData["identifiers"] = identifiers + _get_file_identifiers(fileUUID)
+
+    return indexData, accession_ids
 
 
 def index_transfer_and_files(

--- a/src/archivematica/dashboard/main/management/commands/rebuild_aip_index_from_storage_service.py
+++ b/src/archivematica/dashboard/main/management/commands/rebuild_aip_index_from_storage_service.py
@@ -83,6 +83,10 @@ def get_aips_in_aic(mets_root, temp_dir, uuid):
 class Command(DashboardCommand):
     help = __doc__
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dashboard_uuid = am.get_dashboard_uuid() or ""
+
     def add_arguments(self, parser):
         """Entry point to add custom arguments."""
         parser.add_argument(
@@ -107,7 +111,7 @@ class Command(DashboardCommand):
         parser.add_argument(
             "--pipeline",
             help="Pipeline UUID to use when filtering packages",
-            default=am.get_dashboard_uuid(),
+            default=self.dashboard_uuid,
         )
 
     def handle(self, *args, **options):
@@ -247,6 +251,7 @@ class Command(DashboardCommand):
                 aips_in_aic=aips_in_aic,
                 encrypted=package_info.get("encrypted", False),
                 location=location_description,
+                dashboard_uuid=self.dashboard_uuid,
             )
             self.info(f"Successfully indexed package {uuid}")
             os.remove(mets_download_path)

--- a/src/archivematica/dashboard/main/management/commands/rebuild_aip_index_from_storage_service.py
+++ b/src/archivematica/dashboard/main/management/commands/rebuild_aip_index_from_storage_service.py
@@ -45,6 +45,7 @@ from lxml import etree
 from archivematica.archivematicaCommon import archivematicaFunctions as am
 from archivematica.archivematicaCommon import elasticSearchFunctions as es
 from archivematica.archivematicaCommon import storageService
+from archivematica.archivematicaCommon.databaseFunctions import get_sip_identifiers
 from archivematica.dashboard.main.management.commands import DashboardCommand
 from archivematica.dashboard.main.management.commands import setup_es_for_aip_reindexing
 
@@ -249,6 +250,7 @@ class Command(DashboardCommand):
                 name=package_name,
                 aip_size=package_info["size"],
                 aips_in_aic=aips_in_aic,
+                identifiers=get_sip_identifiers(uuid),
                 encrypted=package_info.get("encrypted", False),
                 location=location_description,
                 dashboard_uuid=self.dashboard_uuid,

--- a/src/archivematica/dashboard/main/management/commands/rebuild_elasticsearch_aip_index_from_files.py
+++ b/src/archivematica/dashboard/main/management/commands/rebuild_elasticsearch_aip_index_from_files.py
@@ -47,6 +47,7 @@ from archivematica.archivematicaCommon import archivematicaFunctions as am
 from archivematica.archivematicaCommon import elasticSearchFunctions
 from archivematica.archivematicaCommon import namespaces as ns
 from archivematica.archivematicaCommon import storageService as storage_service
+from archivematica.archivematicaCommon.databaseFunctions import get_sip_identifiers
 from archivematica.dashboard.main.management.commands import DashboardCommand
 from archivematica.dashboard.main.management.commands import setup_es_for_aip_reindexing
 
@@ -168,7 +169,7 @@ def processAIPThenDeleteMETSFile(path, temp_dir, es_client, delete_existing_data
         name=aip_name,
         aip_size=aip_info[0]["size"],
         aips_in_aic=aips_in_aic,
-        identifiers=[],  # TODO get these
+        identifiers=get_sip_identifiers(aip_uuid),
         location=location_description,
     )
 

--- a/src/archivematica/dashboard/main/management/commands/rebuild_transfer_backlog.py
+++ b/src/archivematica/dashboard/main/management/commands/rebuild_transfer_backlog.py
@@ -86,6 +86,10 @@ class Command(DashboardCommand):
     CHECKSUM_TYPE = "sha256"
     CHECKSUM_UTIL = "sha256sum"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dashboard_uuid = am.get_dashboard_uuid() or ""
+
     def add_arguments(self, parser):
         """Entry point to add custom arguments."""
         parser.add_argument(
@@ -100,7 +104,7 @@ class Command(DashboardCommand):
         parser.add_argument(
             "--pipeline",
             help="Pipeline UUID to use when filtering packages from Storage Service",
-            default=am.get_dashboard_uuid(),
+            default=self.dashboard_uuid,
         )
         parser.add_argument(
             "--delete-all",
@@ -555,6 +559,7 @@ def _import_self_describing_transfer(
         str(transfer_dir) + "/",
         size,
         printfn=_elasticsearch_noop_printfn,
+        dashboard_uuid=cmd.dashboard_uuid,
     )
 
 
@@ -578,6 +583,7 @@ def _import_pipeline_dependant_transfer(
         str(transfer_dir) + "/",
         size,
         printfn=_elasticsearch_noop_printfn,
+        dashboard_uuid=cmd.dashboard_uuid,
     )
     try:
         storageService.reindex_file(transfer_uuid)

--- a/src/archivematica/dashboard/main/management/commands/rebuild_transfer_backlog.py
+++ b/src/archivematica/dashboard/main/management/commands/rebuild_transfer_backlog.py
@@ -56,6 +56,7 @@ from django.core.management.base import CommandError
 from archivematica.archivematicaCommon import archivematicaFunctions as am
 from archivematica.archivematicaCommon import elasticSearchFunctions as es
 from archivematica.archivematicaCommon import storageService
+from archivematica.archivematicaCommon.databaseFunctions import get_transfer_details
 from archivematica.archivematicaCommon.fileOperations import addFileToTransfer
 from archivematica.archivematicaCommon.fileOperations import extract_package
 from archivematica.dashboard.components.rights.load import load_rights
@@ -553,6 +554,7 @@ def _import_self_describing_transfer(
                 if django_settings.DEBUG:
                     traceback.print_exc()
 
+    transfer_name, accession_id, ingest_date = get_transfer_details(transfer_uuid)
     es.index_transfer_and_files(
         es_client,
         transfer_uuid,
@@ -560,6 +562,9 @@ def _import_self_describing_transfer(
         size,
         printfn=_elasticsearch_noop_printfn,
         dashboard_uuid=cmd.dashboard_uuid,
+        transfer_name=transfer_name,
+        accession_id=accession_id,
+        ingest_date=ingest_date,
     )
 
 
@@ -577,6 +582,7 @@ def _import_pipeline_dependant_transfer(
     except (Transfer.DoesNotExist, ValidationError):
         cmd.warning(f"Skipping transfer {transfer_uuid} - not found in the database!")
         return
+    transfer_name, accession_id, ingest_date = get_transfer_details(transfer_uuid)
     es.index_transfer_and_files(
         es_client,
         transfer_uuid,
@@ -584,6 +590,9 @@ def _import_pipeline_dependant_transfer(
         size,
         printfn=_elasticsearch_noop_printfn,
         dashboard_uuid=cmd.dashboard_uuid,
+        transfer_name=transfer_name,
+        accession_id=accession_id,
+        ingest_date=ingest_date,
     )
     try:
         storageService.reindex_file(transfer_uuid)

--- a/tests/archivematicaCommon/test_database_functions.py
+++ b/tests/archivematicaCommon/test_database_functions.py
@@ -5,8 +5,11 @@ import pytest
 from django.test import TestCase
 
 from archivematica.archivematicaCommon import databaseFunctions
+from archivematica.dashboard.main.models import SIP
+from archivematica.dashboard.main.models import Directory
 from archivematica.dashboard.main.models import Event
 from archivematica.dashboard.main.models import File
+from archivematica.dashboard.main.models import Identifier
 
 AGENTS_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "agents.json"
 TEST_DATABASE_FUNCTIONS_FIXTURE = (
@@ -153,3 +156,26 @@ class TestDatabaseFunctions(TestCase):
         ).agents
         assert agents.get(id=2)
         assert agents.get(id=5)
+
+
+@pytest.fixture
+def sip(db):
+    sip = SIP.objects.create(uuid="f663fd87-5ce4-4114-886e-4856371cf0d6")
+    sip.identifiers.add(Identifier.objects.create(value="sip_identifier"))
+    return sip
+
+
+@pytest.fixture
+def directories(db, sip):
+    # Two directories are created but only one is associated with the SIP
+    dir1 = Directory.objects.create(
+        uuid="49fe38a0-c50a-4fdf-9353-04d61057220d", sip=sip
+    )
+    dir1.identifiers.add(Identifier.objects.create(value="dir1"))
+    dir2 = Directory.objects.create(uuid="58eaa39c-2a0b-47fd-9d81-52fbaa108abc")
+    dir2.identifiers.add(Identifier.objects.create(value="dir2"))
+
+
+def test_get_sip_identifiers_returns_sip_and_directory_identifiers(sip, directories):
+    result = databaseFunctions.get_sip_identifiers(sip.uuid)
+    assert sorted(result) == ["dir1", "sip_identifier"]

--- a/tests/archivematicaCommon/test_elasticsearch_functions.py
+++ b/tests/archivematicaCommon/test_elasticsearch_functions.py
@@ -9,6 +9,7 @@ from django.utils.timezone import make_aware
 from lxml import etree
 
 from archivematica.archivematicaCommon import elasticSearchFunctions
+from archivematica.archivematicaCommon.databaseFunctions import get_transfer_details
 from archivematica.dashboard.main.models import SIP
 from archivematica.dashboard.main.models import Directory
 from archivematica.dashboard.main.models import File
@@ -1068,6 +1069,7 @@ def test_index_transfer_and_files(
     expected_date = "2024-01-01"
     expected_status = "backlog"
 
+    transfer_name, accession_id, ingest_date = get_transfer_details(transfer.uuid)
     result = elasticSearchFunctions.index_transfer_and_files(
         es_client,
         str(transfer.uuid),
@@ -1075,6 +1077,9 @@ def test_index_transfer_and_files(
         1024,
         printfn=printfn,
         dashboard_uuid=str(dashboard_uuid),
+        transfer_name=transfer_name,
+        accession_id=accession_id,
+        ingest_date=ingest_date,
     )
     assert result == 0
 

--- a/tests/archivematicaCommon/test_elasticsearch_functions.py
+++ b/tests/archivematicaCommon/test_elasticsearch_functions.py
@@ -361,6 +361,7 @@ def test_index_mets_file_metadata(bulk, dashboard_uuid, es_client):
         mets=etree.parse(mets_file_path).getroot(),
         name=sipName,
         identifiers=identifiers,
+        dashboard_uuid=str(dashboard_uuid),
     )
 
     assert bulk.call_count == 1
@@ -434,7 +435,7 @@ def test_index_mets_file_metadata(bulk, dashboard_uuid, es_client):
 
 @pytest.mark.django_db
 @mock.patch("archivematica.archivematicaCommon.elasticSearchFunctions.bulk")
-def test_index_mets_file_metadata_with_utf8(bulk, es_client):
+def test_index_mets_file_metadata_with_utf8(bulk, es_client, dashboard_uuid):
     def _bulk(client, actions, stats_only=False, *args, **kwargs):
         pass
 
@@ -448,6 +449,7 @@ def test_index_mets_file_metadata_with_utf8(bulk, es_client):
         mets=etree.parse(mets_file_path).getroot(),
         name="",
         identifiers=[],
+        dashboard_uuid=str(dashboard_uuid),
     )
 
 
@@ -600,6 +602,7 @@ def test_index_aipfile_fileuuid(
         mets=etree.parse(os.path.join(THIS_DIR, "fixtures", metsfile)).getroot(),
         name=f"{aipname}-{aipuuid}",
         identifiers=[],
+        dashboard_uuid=str(dashboard_uuid),
     )
 
     for file_uuid in fileuuid_dict:
@@ -657,6 +660,7 @@ def test_index_aipfile_dmdsec(bulk, dashboard_uuid, metsfile, dmdsec_dict):
         mets=etree.parse(os.path.join(THIS_DIR, "fixtures", metsfile)).getroot(),
         name="{}-{}".format("DUMMYNAME", "DUMMYUUID"),
         identifiers=[],
+        dashboard_uuid=str(dashboard_uuid),
     )
 
     for key, value in dmdsec_dict["dublincore_dict"].items():
@@ -950,6 +954,7 @@ def test_index_aip_and_files(
         aip_name,
         1024 * 1024 * 10,
         printfn=printfn,
+        dashboard_uuid=str(dashboard_uuid),
     )
     assert result == 0
 
@@ -992,7 +997,7 @@ def test_index_aip_and_files(
 
 
 def test_index_transfer_and_files_logs_error_if_transfer_path_does_not_exist(
-    es_client, tmp_path, caplog
+    es_client, tmp_path, caplog, dashboard_uuid
 ):
     printfn = mock.Mock()
     transfer_uuid = uuid.uuid4()
@@ -1005,6 +1010,7 @@ def test_index_transfer_and_files_logs_error_if_transfer_path_does_not_exist(
         str(transfer_path),
         1024,
         printfn=printfn,
+        dashboard_uuid=str(dashboard_uuid),
     )
     assert result == 1
 
@@ -1068,6 +1074,7 @@ def test_index_transfer_and_files(
         str(transfer.currentlocation),
         1024,
         printfn=printfn,
+        dashboard_uuid=str(dashboard_uuid),
     )
     assert result == 0
 

--- a/tests/archivematicaCommon/test_elasticsearch_functions.py
+++ b/tests/archivematicaCommon/test_elasticsearch_functions.py
@@ -10,10 +10,7 @@ from lxml import etree
 
 from archivematica.archivematicaCommon import elasticSearchFunctions
 from archivematica.archivematicaCommon.databaseFunctions import get_transfer_details
-from archivematica.dashboard.main.models import SIP
-from archivematica.dashboard.main.models import Directory
 from archivematica.dashboard.main.models import File
-from archivematica.dashboard.main.models import Identifier
 from archivematica.dashboard.main.models import Transfer
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -666,29 +663,6 @@ def test_index_aipfile_dmdsec(bulk, dashboard_uuid, metsfile, dmdsec_dict):
 
     for key, value in dmdsec_dict["dublincore_dict"].items():
         assert indexed_data[dmdsec_dict["filePath"]][key] == value
-
-
-@pytest.fixture
-def sip(db):
-    sip = SIP.objects.create(uuid="f663fd87-5ce4-4114-886e-4856371cf0d6")
-    sip.identifiers.add(Identifier.objects.create(value="sip_identifier"))
-    return sip
-
-
-@pytest.fixture
-def directories(db, sip):
-    # Two directories are created but only one is associated with the SIP
-    dir1 = Directory.objects.create(
-        uuid="49fe38a0-c50a-4fdf-9353-04d61057220d", sip=sip
-    )
-    dir1.identifiers.add(Identifier.objects.create(value="dir1"))
-    dir2 = Directory.objects.create(uuid="58eaa39c-2a0b-47fd-9d81-52fbaa108abc")
-    dir2.identifiers.add(Identifier.objects.create(value="dir2"))
-
-
-def test_get_sip_identifiers_returns_sip_and_directory_identifiers(sip, directories):
-    result = elasticSearchFunctions._get_sip_identifiers(sip.uuid)
-    assert sorted(result) == ["dir1", "sip_identifier"]
 
 
 PHYSICAL_STRUCT_MAP = """<mets:structMap ID="structMap_1" LABEL="Archivematica default" TYPE="physical" xmlns:mets="http://www.loc.gov/METS/">

--- a/tests/archivematicaCommon/test_elasticsearch_functions.py
+++ b/tests/archivematicaCommon/test_elasticsearch_functions.py
@@ -1453,3 +1453,17 @@ def test_try_to_index_raises_exception_after_retries(client):
         mock.call("ERROR: error trying to index."),
         mock.call(error),
     ]
+
+
+def test_mets_parser_with_no_dublincore_data(tmp_path: pathlib.Path) -> None:
+    mets_path = tmp_path / "mets.xml"
+    mets_path.write_text(METS)
+    default_created_date = 1749572903
+
+    with mock.patch("time.time", return_value=default_created_date):
+        parser = elasticSearchFunctions.AIPMETSParser(str(mets_path))
+
+    assert not parser.aic_identifier
+    assert not parser.is_part_of
+    assert parser.created == default_created_date
+    assert not parser.aip_metadata

--- a/tests/archivematicaCommon/test_elasticsearch_functions.py
+++ b/tests/archivematicaCommon/test_elasticsearch_functions.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import pytest
 from django.utils.timezone import make_aware
-from lxml import etree
 
 from archivematica.archivematicaCommon import elasticSearchFunctions
 from archivematica.archivematicaCommon.databaseFunctions import get_transfer_details
@@ -356,10 +355,10 @@ def test_index_mets_file_metadata(bulk, dashboard_uuid, es_client):
     elasticSearchFunctions._index_aip_files(
         client=es_client,
         uuid=aip_uuid,
-        mets=etree.parse(mets_file_path).getroot(),
         name=sipName,
         identifiers=identifiers,
         dashboard_uuid=str(dashboard_uuid),
+        parser=elasticSearchFunctions.AIPMETSParser(mets_file_path),
     )
 
     assert bulk.call_count == 1
@@ -444,10 +443,10 @@ def test_index_mets_file_metadata_with_utf8(bulk, es_client, dashboard_uuid):
     elasticSearchFunctions._index_aip_files(
         client=es_client,
         uuid="",
-        mets=etree.parse(mets_file_path).getroot(),
         name="",
         identifiers=[],
         dashboard_uuid=str(dashboard_uuid),
+        parser=elasticSearchFunctions.AIPMETSParser(mets_file_path),
     )
 
 
@@ -597,10 +596,12 @@ def test_index_aipfile_fileuuid(
     elasticSearchFunctions._index_aip_files(
         client=None,
         uuid=aipuuid,
-        mets=etree.parse(os.path.join(THIS_DIR, "fixtures", metsfile)).getroot(),
         name=f"{aipname}-{aipuuid}",
         identifiers=[],
         dashboard_uuid=str(dashboard_uuid),
+        parser=elasticSearchFunctions.AIPMETSParser(
+            os.path.join(THIS_DIR, "fixtures", metsfile)
+        ),
     )
 
     for file_uuid in fileuuid_dict:
@@ -655,47 +656,16 @@ def test_index_aipfile_dmdsec(bulk, dashboard_uuid, metsfile, dmdsec_dict):
     elasticSearchFunctions._index_aip_files(
         client=None,
         uuid="DUMMYUUID",
-        mets=etree.parse(os.path.join(THIS_DIR, "fixtures", metsfile)).getroot(),
         name="{}-{}".format("DUMMYNAME", "DUMMYUUID"),
         identifiers=[],
         dashboard_uuid=str(dashboard_uuid),
+        parser=elasticSearchFunctions.AIPMETSParser(
+            os.path.join(THIS_DIR, "fixtures", metsfile)
+        ),
     )
 
     for key, value in dmdsec_dict["dublincore_dict"].items():
         assert indexed_data[dmdsec_dict["filePath"]][key] == value
-
-
-PHYSICAL_STRUCT_MAP = """<mets:structMap ID="structMap_1" LABEL="Archivematica default" TYPE="physical" xmlns:mets="http://www.loc.gov/METS/">
-  <mets:div LABEL="Demo-166e916c-0676-4324-8045-bfc628bebcea" TYPE="Directory" DMDID="dmdSec_1">
-    <mets:div LABEL="objects" TYPE="Directory" DMDID="dmdSec_2 dmdSec_3">
-      <mets:div LABEL="View_from_lookout_over_Queenstown_towards_the_Remarkables_in_spring-49ad492e-7f1f-4f76-a394-17fa9c9a392d.tif" TYPE="Item">
-        <mets:fptr FILEID="file-49ad492e-7f1f-4f76-a394-17fa9c9a392d"/>
-      </mets:div>
-      <mets:div LABEL="View_from_lookout_over_Queenstown_towards_the_Remarkables_in_spring.jpg" TYPE="Item" ADMID="amdSec_1">
-        <mets:fptr FILEID="file-e36a4785-f271-405d-ac75-e54cfdbf74e4"/>
-      </mets:div>
-      <mets:div LABEL="artwork" TYPE="Directory" ADMID="amdSec_2">
-        <mets:div LABEL="MARBLES-9077d660-cc89-4ea3-a61c-f932328985ef.tif" TYPE="Item">
-          <mets:fptr FILEID="file-9077d660-cc89-4ea3-a61c-f932328985ef"/>
-        </mets:div>
-      </mets:div>
-      <mets:div LABEL="empty" TYPE="Directory">
-      </mets:div>
-    </mets:div>
-  </mets:div>
-</mets:structMap>
-"""
-
-
-@pytest.fixture
-def physical_struct_map():
-    return etree.fromstring(PHYSICAL_STRUCT_MAP)
-
-
-def test_get_directories_with_metadata(physical_struct_map):
-    result = elasticSearchFunctions._get_directories_with_metadata(physical_struct_map)
-    labels = sorted(directory.attrib["LABEL"] for directory in result)
-    assert labels == ["Demo-166e916c-0676-4324-8045-bfc628bebcea", "artwork", "objects"]
 
 
 METS = """<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -786,94 +756,6 @@ METS = """<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xsi="http://www
   </mets:amdSec>
 </mets:mets>
 """
-
-
-@pytest.fixture
-def mets():
-    return etree.fromstring(METS)
-
-
-@pytest.fixture
-def directory():
-    result = etree.Element("directory")
-    result.set("LABEL", "some/path/to/directory")
-    result.set("DMDID", "dmdSec_1 dmdSec_2 dmdSec_3 dmdSec_4 dmdSec_5 dmdSec_6")
-    result.set("ADMID", "amdSec_1")
-    return result
-
-
-@pytest.fixture
-def directory_with_no_metadata():
-    result = etree.Element("directory")
-    return result
-
-
-@pytest.fixture
-def file_pointer():
-    result = etree.Element("file")
-    result.set("DMDID", "dmdSec_1 dmdSec_2 dmdSec_3 dmdSec_4 dmdSec_5 dmdSec_6")
-    return result
-
-
-@pytest.fixture
-def file_pointer_with_no_metadata():
-    result = etree.Element("file")
-    return result
-
-
-expected_file_metadata = {
-    "custom_field": ["updated custom field part 1", "updated custom field part 2"],
-    "custom_field2": "updated custom field 2",
-    "dc:creator": "AM",
-    "dc:subject": [None, None, None],
-    "dc:title": "Some title",
-    "record_dict": {
-        "idfield": "idfield",
-        "controlfield": [
-            "controlfield 1",
-            "controlfield 2",
-        ],
-        "datafield_dict": [
-            {
-                "subfield": [
-                    "subfield 1",
-                    "subfield 2",
-                ]
-            },
-            {
-                "subfield": "subfield 3",
-            },
-        ],
-    },
-}
-
-
-expected_directory_metadata = {
-    "__DIRECTORY_LABEL__": "some/path/to/directory",
-    "FIELD_CONTACT_NAME": ["A.", "R.", "Chivist"],
-    "Payload-Oxum": "63140.2",
-    **expected_file_metadata,
-}
-
-
-@pytest.mark.parametrize(
-    "element_fixture_name, method_name, expected_metadata",
-    [
-        ("directory", "_get_directory_metadata", expected_directory_metadata),
-        ("directory_with_no_metadata", "_get_directory_metadata", {}),
-        ("file_pointer", "_get_file_metadata", expected_file_metadata),
-        ("file_pointer_with_no_metadata", "_get_file_metadata", {}),
-    ],
-)
-def test_get_metadata(
-    request, mets, element_fixture_name, method_name, expected_metadata
-):
-    assert (
-        getattr(elasticSearchFunctions, method_name)(
-            request.getfixturevalue(element_fixture_name), mets
-        )
-        == expected_metadata
-    )
 
 
 def test_index_aip_and_files_logs_error_if_mets_does_not_exist(


### PR DESCRIPTION
This updates the `index_aip_and_files` and `index_transfer_and_files` functions in the `archivematica.archivematicaCommon.elasticSearchFunction` module to receive the pipeline UUID, transfer details, and SIP identifiers as parameters, eliminating the need for direct database access to retrieve this information.

It also introduces a separate class to encapsulate the logic for parsing the AIP METS to extract AIP metadata such as creation date, AIC identifier or `isPartOf` attribute, which is used when indexing the AIP and its files.

Connected to https://github.com/archivematica/Issues/issues/1752