### PR TITLE
Improve Docker build performance with caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,13 @@ jobs:
       - name: "Create external volumes"
         run: |
           make -C hack/ create-volumes
+      - name: "Restore .tox cache"
+        uses: "actions/cache@v4"
+        with:
+          path: ./.tox
+          key: tox-${{ matrix.python-version }}-${{ steps.cache_key.outputs.requirements_hash }}
+          restore-keys: |
+            tox-${{ matrix.python-version }}-
       - name: "Run make rule"
         run: |
           docker buildx install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,44 @@ on:
       - "qa/**"
       - "stable/**"
 jobs:
+  cache-pyenv-builder:
+    name: "Cache layers of the pyenv-builder stage"
+    runs-on: "ubuntu-24.04"
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        ubuntu-version: ["24.04"]
+    steps:
+      - name: "Check out repository"
+        uses: "actions/checkout@v4"
+      - name: "Set up Docker Buildx"
+        uses: "docker/setup-buildx-action@v3"
+        with:
+          driver-opts: |
+            network=host
+      - name: "Generate cache key from requirements"
+        id: cache_key
+        run: |
+          echo "requirements_hash=${{ hashFiles('requirements*.txt', 'requirements*.in', 'pyproject.toml') }}" >> $GITHUB_OUTPUT
+      - name: "Build base layers"
+        uses: "docker/build-push-action@v6"
+        with:
+          context: .
+          file: ./hack/Dockerfile
+          target: pyenv-builder
+          build-args: |
+            UBUNTU_VERSION=${{ matrix.ubuntu-version }}
+            PYTHON_VERSION=${{ matrix.python-version }}
+            BUILDKIT_INLINE_CACHE=1
+          push: false
+          cache-from: |
+            type=gha,scope=archivematica-tests-base-${{ matrix.ubuntu-version }}-${{ matrix.python-version }}
+            type=gha,scope=archivematica-tests-${{ matrix.ubuntu-version }}-${{ matrix.python-version }}-${{ steps.cache_key.outputs.requirements_hash }}
+          cache-to: |
+            type=gha,scope=archivematica-tests-base-${{ matrix.ubuntu-version }}-${{ matrix.python-version }},mode=max
+            type=gha,scope=archivematica-tests-${{ matrix.ubuntu-version }}-${{ matrix.python-version }}-${{ steps.cache_key.outputs.requirements_hash }},mode=max
   test:
+    needs: [cache-pyenv-builder]
     name: "Test ${{ matrix.rule }} on ${{ matrix.python-version }}"
     runs-on: "ubuntu-24.04"
     strategy:
@@ -47,8 +84,15 @@ jobs:
         id: group_id
         run: |
           echo "group_id=$(id -g)" >> $GITHUB_OUTPUT
+      - name: "Generate cache key from requirements"
+        id: cache_key
+        run: |
+          echo "requirements_hash=${{ hashFiles('requirements*.txt', 'requirements*.in', 'pyproject.toml') }}" >> $GITHUB_OUTPUT
       - name: "Set up buildx"
         uses: "docker/setup-buildx-action@v3"
+        with:
+          driver-opts: |
+            network=host
       - name: "Build archivematica-tests image"
         uses: "docker/build-push-action@v6"
         with:
@@ -60,11 +104,18 @@ jobs:
             GROUP_ID=${{ steps.group_id.outputs.group_id }}
             UBUNTU_VERSION=${{ matrix.ubuntu-version }}
             PYTHON_VERSION=${{ matrix.python-version }}
+            BUILDKIT_INLINE_CACHE=1
           tags: archivematica-tests:latest
           push: false
           load: true
-          cache-from: "type=gha,scope=archivematica-tests-${{ matrix.ubuntu-version }}-${{ matrix.python-version }}-${{ matrix.rule }}"
-          cache-to: "type=gha,scope=archivematica-tests-${{ matrix.ubuntu-version }}-${{ matrix.python-version }}-${{ matrix.rule }},mode=max"
+          cache-from: |
+            type=gha,scope=archivematica-tests-base-${{ matrix.ubuntu-version }}-${{ matrix.python-version }}
+            type=gha,scope=archivematica-tests-${{ matrix.ubuntu-version }}-${{ matrix.python-version }}-${{ matrix.rule }}
+            type=gha,scope=archivematica-tests-${{ matrix.ubuntu-version }}-${{ matrix.python-version }}-${{ steps.cache_key.outputs.requirements_hash }}
+          cache-to: |
+            type=gha,scope=archivematica-tests-base-${{ matrix.ubuntu-version }}-${{ matrix.python-version }},mode=max
+            type=gha,scope=archivematica-tests-${{ matrix.ubuntu-version }}-${{ matrix.python-version }}-${{ matrix.rule }},mode=max
+            type=gha,scope=archivematica-tests-${{ matrix.ubuntu-version }}-${{ matrix.python-version }}-${{ steps.cache_key.outputs.requirements_hash }},mode=max
       - name: "Create external volumes"
         run: |
           make -C hack/ create-volumes

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -25,7 +25,9 @@ RUN set -ex \
 	&& id -u ubuntu >/dev/null 2>&1 \
 	&& userdel --remove ubuntu || true
 
-RUN set -ex \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+	--mount=type=cache,target=/var/lib/apt,sharing=locked \
+	set -ex \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		ca-certificates \
@@ -39,8 +41,7 @@ RUN set -ex \
 		locales \
 		make \
 		pkg-config \
-		tzdata \
-	&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+		tzdata
 
 RUN locale-gen en_US.UTF-8
 ENV LANG=en_US.UTF-8
@@ -56,7 +57,9 @@ FROM base-builder AS pyenv-builder
 
 ARG PYTHON_VERSION=3.9
 
-RUN set -ex \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+	--mount=type=cache,target=/var/lib/apt,sharing=locked \
+	set -ex \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		build-essential \
@@ -71,8 +74,7 @@ RUN set -ex \
 		libxmlsec1-dev \
 		tk-dev \
 		xz-utils \
-		zlib1g-dev \
-	&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+		zlib1g-dev
 
 RUN set -ex \
 	&& curl --retry 3 -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
@@ -81,7 +83,8 @@ RUN set -ex \
 
 COPY --link requirements-dev.txt /src/requirements-dev.txt
 
-RUN set -ex \
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+	set -ex \
 	&& pyenv exec python3 -m pip install --upgrade pip setuptools \
 	&& pyenv exec python3 -m pip install --requirement /src/requirements-dev.txt \
 	&& pyenv rehash
@@ -92,11 +95,12 @@ FROM base-builder AS browsers-builder
 
 ARG SELENIUM_DIR=/selenium
 
-RUN set -ex \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+	--mount=type=cache,target=/var/lib/apt,sharing=locked \
+	set -ex \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
-		jq \
-	&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+		jq
 
 RUN set -ex \
 	&& SELENIUM_CACHE=${SELENIUM_DIR}/cache \
@@ -132,7 +136,9 @@ ARG GROUP_ID=1000
 ARG SELENIUM_DIR=/selenium
 ENV PATH=${SELENIUM_DIR}/bin:$PATH
 
-RUN set -ex \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+	--mount=type=cache,target=/var/lib/apt,sharing=locked \
+	set -ex \
 	&& apt-get update \
 	&& apt-get -y --no-install-recommends install \
 		libasound2 \
@@ -144,8 +150,7 @@ RUN set -ex \
 		libnss3 \
 		libx11-xcb1 \
 		libxcb1 \
-		libxtst6 \
-	&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+		libxtst6
 
 COPY --chown=${USER_ID}:${GROUP_ID} --from=browsers-builder --link ${SELENIUM_DIR} ${SELENIUM_DIR}
 COPY --chown=${USER_ID}:${GROUP_ID} --from=archivematica-dashboard-frontend-builder --link /src/src/archivematica/dashboard/frontend/node_modules /src/src/archivematica/dashboard/frontend/node_modules
@@ -170,7 +175,11 @@ RUN set -ex \
 	&& echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/archivematica-1.18.x.gpg] http://packages.archivematica.org/1.18.x/ubuntu-externals jammy main" > /etc/apt/sources.list.d/archivematica-external.list \
 	&& curl --retry 3 -so /tmp/repo-mediaarea.deb -L https://mediaarea.net/repo/deb/repo-mediaarea_${MEDIAAREA_VERSION}_all.deb \
 	&& dpkg -i /tmp/repo-mediaarea.deb \
-	&& rm /tmp/repo-mediaarea.deb \
+	&& rm /tmp/repo-mediaarea.deb
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+	--mount=type=cache,target=/var/lib/apt,sharing=locked \
+	set -ex \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		atool \
@@ -212,8 +221,7 @@ RUN set -ex \
 		tree \
 		unar \
 		unrar-free \
-		uuid \
-	&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+		uuid
 
 RUN set -ex \
 	&& groupadd --gid ${GROUP_ID} --system archivematica \
@@ -294,7 +302,9 @@ FROM base AS archivematica-dashboard-integration-tests
 
 USER root
 
-RUN set -ex \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+	--mount=type=cache,target=/var/lib/apt,sharing=locked \
+	set -ex \
 	&& python3 -m playwright install-deps firefox
 
 USER archivematica

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -282,13 +282,15 @@ flush-test-dbs: start-mysql
 	$(foreach test_db,$(__TEST_DBS),$(call drop_db,$(test_db));)
 
 test-build:  ## Build archivematica-tests image.
-	docker build \
-		-t archivematica-tests \
-		-f $(CURDIR)/Dockerfile \
-		--build-arg TARGET=archivematica-tests \
-		--build-arg UBUNTU_VERSION \
-		--build-arg PYTHON_VERSION \
-			../
+	@if [ "$$GITHUB_ACTIONS" != "true" ]; then \
+		docker build \
+			-t archivematica-tests \
+			-f $(CURDIR)/Dockerfile \
+			--build-arg TARGET=archivematica-tests \
+			--build-arg UBUNTU_VERSION \
+			--build-arg PYTHON_VERSION \
+			../; \
+	fi
 
 __TOXENVS_MCPSERVER := mcp-server
 test-mcp-server: start-mysql  ## Run MCPServer tests.


### PR DESCRIPTION
This optimizes Docker build performance by:

- Using BuildKit cache mounts for apt and pip in the `hack/Dockerfile` and removing manual cache cleanup steps.
- Adding a separate job in the `test.yml` GitHub workflow to pre-build and cache the `pyenv-builder` stage layers and using cache keys based on requirements file changes and build contexts.