### PR TITLE
Remove wiki references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ See the [LICENSE] file for details.
 
 * [Website] for the user and administrator documentation
 * [Presentations repo] and [YouTube channel] for previous trainings and talks
-* [Case studies repo] for a collection of resources about working on and with Archivematica
+* [Case studies repo] for a collection of resources about working on and with
+Archivematica
 * [User Group] is a forum/mailing list for user questions (both
 technical and end-user)
 * [Paid support] is for paid support, hosting, training, consulting
@@ -38,7 +39,7 @@ analysis and community resources
 * [Issues] is the Git repository used for tracking Archivematica issues
 and feature/enhancement ideas
 * The [Archivematica roadmap] contains current release information and potential
- future works
+future works
 
 ## Contributing
 
@@ -46,17 +47,17 @@ Thank you for your interest in Archivematica!
 
 For more details, see the [contributing guidelines].
 
-Read about our guidelines for making [pull requests], including [contribution 
-standards], and make any [documentation updates] reflecting the changes 
+Read about our guidelines for making [pull requests], including [contribution
+standards], and make any [documentation updates] reflecting the changes
 introduced by your contribution.
 
-Our [Contributors Portal] contains useful background information and 
+Our [Contributors Portal] contains useful background information and
 instructions on translations in Archivematica.
 
 You might have questions about the history of development decisions: find
 answers in the [Architectural Decisions Record].
 
-Our current release notes are available on GitHub. Release notes from version 
+Our current release notes are available on GitHub. Release notes from version
 0.6 to 1.17.1 are available in [RELEASENOTES file].
 
 ## Reporting an issue

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ instructions on translations in Archivematica.
 You might have questions about the history of development decisions: find
 answers in the [Architectural Decisions Record].
 
-Our current release notes are available on GitHub. Release notes from version
-0.6 to 1.17.1 are available in [RELEASENOTES file].
+Our current release notes are available on GitHub. Release notes since version
+0.6 are available in the [RELEASENOTES file].
 
 ## Reporting an issue
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ and software development contracts from Artefactual
 analysis and community resources
 * [Issues] is the Git repository used for tracking Archivematica issues
 and feature/enhancement ideas
-* The [Archivematica roadmap] contains current release information and potential future works
+* The [Archivematica roadmap] contains current release information and potential
+ future works
 
 ## Contributing
 
@@ -45,14 +46,18 @@ Thank you for your interest in Archivematica!
 
 For more details, see the [contributing guidelines].
 
-Read about our guidelines for making [pull requests], including [contribution standards], and make any [documentation updates] reflecting the changes introduced by your contribution.
+Read about our guidelines for making [pull requests], including [contribution 
+standards], and make any [documentation updates] reflecting the changes 
+introduced by your contribution.
 
-Our [Contributors Portal] contains useful background information and instructions on translations in Archivematica.
+Our [Contributors Portal] contains useful background information and 
+instructions on translations in Archivematica.
 
 You might have questions about the history of development decisions: find
 answers in the [Architectural Decisions Record].
 
-Our current release notes are available on GitHub. Release notes from version 0.6 to 1.17.1 are available in [RELEASENOTES file].
+Our current release notes are available on GitHub. Release notes from version 
+0.6 to 1.17.1 are available in [RELEASENOTES file].
 
 ## Reporting an issue
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Archivematica consists of several projects working together, including:
   the Format Policy Registry (FPR) server that displays and updates FPR
   rules and commands
 
-For more projects in the Archivematica ecosystem,
-see the [getting started] page.
+For more projects in the Archivematica ecosystem, see the list on the
+[dependencies] page of the [Contributors Portal].
 
 [Architectural Decisions Record]: https://adr.archivematica.org/
 [Archivematica API documentation]: https://archivematica.org/docs/latest/dev-manual/api/api-reference-archivematica/#api-reference-archivematica
@@ -101,11 +101,11 @@ see the [getting started] page.
 [contributing guidelines]: https://github.com/artefactual/archivematica/blob/qa/1.x/CONTRIBUTING.md
 [contribution standards]: https://github.com/artefactual/archivematica/blob/qa/1.x/CONTRIBUTING.md#contribution-standards
 [Contributors Portal]: https://contributors.artefactual.com/
+[dependencies]: https://contributors.artefactual.com/dependencies.html#archivematica
 [Developer guide]: https://github.com/artefactual/archivematica/blob/qa/1.x/hack/README.md
 [Development installation]: https://github.com/artefactual/archivematica/tree/qa/1.x/hack
 [documentation updates]: https://github.com/artefactual/archivematica-docs/wiki
 [Format Policy Registry]: https://github.com/artefactual/archivematica/tree/qa/1.x/src/archivematica/dashboard/fpr
-[getting started]: https://www.archivematica.org/en/docs/latest/getting-started/
 [GitHub CI]: https://github.com/artefactual/archivematica/actions/workflows/test.yml/badge.svg
 [issue reporting]: https://github.com/archivematica/Issues/blob/main/CONTRIBUTING.md
 [Issues]: https://github.com/archivematica/Issues

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See the [LICENSE] file for details.
 
 * [Website] for the user and administrator documentation
 * [Presentations repo] and [YouTube channel] for previous trainings and talks
+* [Case studies repo] for a collection of resources about working on and with Archivematica
 * [User Group] is a forum/mailing list for user questions (both
 technical and end-user)
 * [Paid support] is for paid support, hosting, training, consulting
@@ -36,6 +37,7 @@ and software development contracts from Artefactual
 analysis and community resources
 * [Issues] is the Git repository used for tracking Archivematica issues
 and feature/enhancement ideas
+* The [Archivematica roadmap] contains current release information and potential future works
 
 ## Contributing
 
@@ -43,20 +45,21 @@ Thank you for your interest in Archivematica!
 
 For more details, see the [contributing guidelines].
 
-Read about our [merging process], including branch naming conventions, and
-make any [documentation update] reflecting the changes introduced by your
-contribution.
+Read about our guidelines for making [pull requests], including [contribution standards], and make any [documentation updates] reflecting the changes introduced by your contribution.
 
-You might have questions about the history of developement decisions: find
+Our [Contributors Portal] contains useful background information and instructions on translations in Archivematica.
+
+You might have questions about the history of development decisions: find
 answers in the [Architectural Decisions Record].
 
-The [Wiki] currently holds the release notes and previous developer facing
-documentation.
+Our current release notes are available on GitHub. Release notes from version 0.6 to 1.17.1 are available in [RELEASENOTES file].
 
 ## Reporting an issue
 
 Issues related to Archivematica, the Storage Service, or any related
 repository can be filed in the [Issues] repository.
+
+Read our guide about [issue reporting].
 
 ### Security
 
@@ -85,25 +88,30 @@ see the [getting started] page.
 [Archivematica Codecov]: https://codecov.io/gh/artefactual/archivematica
 [Archivematica GitHub]: https://github.com/artefactual/archivematica
 [Archivematica]: https://www.archivematica.org/
+[Archivematica roadmap]: https://github.com/archivematica/Issues/wiki/Archivematica-Roadmap
 [Artefactual]: https://www.artefactual.com/
+[Case studies repo]: https://github.com/archivematica/archivematica-case-studies
 [codecov]: https://codecov.io/gh/artefactual/archivematica/branch/qa/1.x/graph/badge.svg?token=tKlfjhmrlC
 [contributing guidelines]: https://github.com/artefactual/archivematica/blob/qa/1.x/CONTRIBUTING.md
+[contribution standards]: https://github.com/artefactual/archivematica/blob/qa/1.x/CONTRIBUTING.md#contribution-standards
+[Contributors Portal]: https://contributors.artefactual.com/
 [Developer guide]: https://github.com/artefactual/archivematica/blob/qa/1.x/hack/README.md
 [Development installation]: https://github.com/artefactual/archivematica/tree/qa/1.x/hack
-[documentation update]: https://github.com/artefactual/archivematica-docs/wiki
+[documentation updates]: https://github.com/artefactual/archivematica-docs/wiki
 [Format Policy Registry]: https://github.com/artefactual/archivematica/tree/qa/1.x/src/archivematica/dashboard/fpr
-[getting started]: https://wiki.archivematica.org/Getting_started#Projects
+[getting started]: https://www.archivematica.org/en/docs/latest/getting-started/
 [GitHub CI]: https://github.com/artefactual/archivematica/actions/workflows/test.yml/badge.svg
+[issue reporting]: https://github.com/archivematica/Issues/blob/main/CONTRIBUTING.md
 [Issues]: https://github.com/archivematica/Issues
 [LICENSE]: LICENSE
-[merging process]: https://wiki.archivematica.org/Merging
 [Paid support]: https://www.artefactual.com/services/
 [Production installation]: https://www.archivematica.org/docs/latest/admin-manual/installation-setup/installation/installation/
+[pull requests]: https://github.com/artefactual/archivematica/blob/qa/1.x/CONTRIBUTING.md#getting-started
+[RELEASENOTES file]: RELEASENOTES.md
 [SECURITY file]: SECURITY.md
 [Presentations repo]: https://slideshare.net/Archivematica/presentations
 [Storage Service]: https://github.com/artefactual/archivematica-storage-service
 [Test workflow]: https://github.com/artefactual/archivematica/actions/workflows/test.yml
 [User Group]: https://groups.google.com/forum/#!forum/archivematica
 [Website]: https://www.archivematica.org/
-[Wiki]: https://wiki.archivematica.org/Development
 [YouTube channel]: https://www.youtube.com/@ArtefactualSystems


### PR DESCRIPTION
Updating references and wording in the README.md to remove any references to the Archivematica wiki and instead point to current resources such as the Archivematica documentation or contributing guidelines.