### PR TITLE
Add current password validation to user edit form

### DIFF
--- a/src/archivematica/dashboard/components/accounts/views.py
+++ b/src/archivematica/dashboard/components/accounts/views.py
@@ -133,7 +133,7 @@ def edit(request, id=None, return_view=None):
 
     # Form
     if request.method == "POST":
-        form = UserChangeForm(request.POST, instance=user)
+        form = UserChangeForm(request.POST, instance=user, requesting_user=request.user)
         userprofileform = UserProfileForm(request.POST, instance=user_profile)
         if form.is_valid() and userprofileform.is_valid():
             user = form.save(commit=False)
@@ -173,7 +173,9 @@ def edit(request, id=None, return_view=None):
         if request.user.is_superuser:
             suppress_administrator_toggle = False
         form = UserChangeForm(
-            instance=user, suppress_administrator_toggle=suppress_administrator_toggle
+            instance=user,
+            suppress_administrator_toggle=suppress_administrator_toggle,
+            requesting_user=request.user,
         )
         userprofileform = UserProfileForm(instance=user_profile)
 

--- a/tests/dashboard/components/accounts/test_forms.py
+++ b/tests/dashboard/components/accounts/test_forms.py
@@ -1,0 +1,87 @@
+import pytest
+from django.contrib.auth.models import User
+
+from archivematica.dashboard.components.accounts.forms import UserChangeForm
+
+
+@pytest.mark.django_db
+def test_current_password_is_not_required_when_not_changing_password(
+    admin_user: User,
+) -> None:
+    # Create a user to edit.
+    user_to_edit = User.objects.create_user(username="testuser", password="oldpass")
+
+    # Form data without passwords.
+    form_data = {
+        "username": "testuser",
+        "first_name": "Test",
+        "last_name": "User",
+        "email": "test@example.com",
+        "is_active": True,
+        "is_superuser": False,
+    }
+
+    form = UserChangeForm(
+        data=form_data, instance=user_to_edit, requesting_user=admin_user
+    )
+
+    # Form should be valid even if current_password is not provided.
+    assert form.is_valid()
+
+
+@pytest.mark.django_db
+def test_current_password_is_required_when_changing_password(admin_user: User) -> None:
+    # Create a user to edit.
+    user_to_edit = User.objects.create_user(username="testuser", password="oldpass")
+
+    # Form data with password change request but missing current_password.
+    form_data = {
+        "username": "testuser",
+        "first_name": "Test",
+        "last_name": "User",
+        "email": "test@example.com",
+        "is_active": True,
+        "is_superuser": False,
+        "password": "newpass123",
+        "password_confirmation": "newpass123",
+    }
+
+    form = UserChangeForm(
+        data=form_data, instance=user_to_edit, requesting_user=admin_user
+    )
+
+    # Form should be invalid due to missing current_password.
+    assert not form.is_valid()
+    assert form.errors["current_password"] == [
+        "Your current password is required when setting a new password."
+    ]
+
+
+@pytest.mark.django_db
+def test_current_password_is_required_when_only_password_confirmation_provided(
+    admin_user: User,
+) -> None:
+    # Create a user to edit.
+    user_to_edit = User.objects.create_user(username="testuser", password="oldpass")
+
+    # Form data with only password_confirmation but missing current_password.
+    form_data = {
+        "username": "testuser",
+        "first_name": "Test",
+        "last_name": "User",
+        "email": "test@example.com",
+        "is_active": True,
+        "is_superuser": False,
+        "password": "",  # Empty password
+        "password_confirmation": "newpass123",
+    }
+
+    form = UserChangeForm(
+        data=form_data, instance=user_to_edit, requesting_user=admin_user
+    )
+
+    # Form should be invalid due to missing current_password.
+    assert not form.is_valid()
+    assert form.errors["current_password"] == [
+        "Your current password is required when setting a new password."
+    ]


### PR DESCRIPTION
This updates the user edit form to require the current password from the user setting a new password. It also improves the form field ordering and labels to enhance the user experience. Tests have been added to cover all scenarios handled by the view and the form.

Connected to https://github.com/archivematica/Issues/issues/1757