### PR TITLE
Preserve existing XML catalogs when adding local one

### DIFF
--- a/src/archivematica/MCPClient/client/mcp.py
+++ b/src/archivematica/MCPClient/client/mcp.py
@@ -19,11 +19,15 @@ def main() -> None:
     metrics.start_prometheus_server()
 
     # Use local XML schemas for validation.
-    os.environ["XML_CATALOG_FILES"] = str(
+    existing_catalogs = os.environ.get("XML_CATALOG_FILES", "")
+    catalog = str(
         importlib.resources.files("archivematica.MCPClient")
         / "assets"
         / "catalog"
         / "catalog.xml"
+    )
+    os.environ["XML_CATALOG_FILES"] = (
+        f"{catalog} {existing_catalogs}" if existing_catalogs else catalog
     )
 
     pool = WorkerPool()


### PR DESCRIPTION
This avoids overwriting the XML_CATALOG_FILES environment variable by prepending the local MCPClient catalog to any existing value.

This maintains compatibility with other catalogs already set in the environment and allows AMAUATs to define their own as needed.

This is preparatory work for upgrading to `lxml` `6.0.0`, which [disables HTTP access for XML parsing](https://lxml.de/6.0/changes-6.0.0.html):

> Binary wheels use the library versions libxml2 2.14.4 and libxslt 1.1.43. Note that this disables direct HTTP and FTP support for parsing from URLs. Use Python URL request tools instead (which usually also support HTTPS). To test the availability, use "http" in etree.LIBXML_FEATURES.

Once this is merged, an additional catalog can be configured to allow the `metadata-xml` AMAUAT to pass.

Connected to https://github.com/archivematica/Issues/issues/1720