### PR TITLE
Fix cleanup job after SIP arrangement

### DIFF
--- a/src/archivematica/MCPClient/clientScripts/post_store_aip_hook.py
+++ b/src/archivematica/MCPClient/clientScripts/post_store_aip_hook.py
@@ -162,9 +162,9 @@ def post_store_hook(job, sip_uuid):
     for transfer_uuid in transfer_uuids:
         job.pyprint("Checking if transfer", transfer_uuid, "is fully stored...")
         arranged_uuids = set(
-            models.SIPArrange.objects.filter(transfer_uuid=transfer_uuid)
-            .filter(aip_created=True)
-            .values_list("file_uuid", flat=True)
+            models.SIPArrange.objects.filter(
+                transfer_uuid=transfer_uuid, aip_created=True
+            ).values_list("file_uuid", flat=True)
         )
         backlog_uuids = set(
             models.File.objects.filter(transfer=transfer_uuid).values_list(
@@ -180,7 +180,7 @@ def post_store_hook(job, sip_uuid):
             )
             # Submit delete req to SS (not actually delete), remove from ES
             storage_service.request_file_deletion(
-                uuid=transfer_uuid,
+                uuid=str(transfer_uuid),
                 user_id=0,
                 user_email="archivematica system",
                 reason_for_deletion="All files in Transfer are now in AIPs.",
@@ -192,7 +192,7 @@ def post_store_hook(job, sip_uuid):
     dspace_handle_to_archivesspace(job, sip_uuid)
 
     # POST-STORE CALLBACK
-    storage_service.post_store_aip_callback(sip_uuid)
+    storage_service.post_store_aip_callback(str(sip_uuid))
 
     # When not using SIP arrangement, we perform best-effort deletion of the
     # original transfer directory under currentlyProcessing.


### PR DESCRIPTION
The `Clean up after storing AIP` job currently fails to contact the Storage Service after arranging a SIP, resulting in the backlog transfer not being deleted and the post-store callback not being triggered for the stored AIP.

<img width="972" height="162" alt="imagen" src="https://github.com/user-attachments/assets/15a344eb-23c2-4055-8ebe-149b89b1c349" />

<img width="1511" height="794" alt="Captura desde 2025-08-08 12-13-23" src="https://github.com/user-attachments/assets/74a793e1-762f-45dc-b383-149f732d1b95" />

Connected to https://github.com/archivematica/Issues/issues/1720