### PR TITLE
Remove warnings about autocreated index fields

### DIFF
--- a/src/archivematica/dashboard/settings/base.py
+++ b/src/archivematica/dashboard/settings/base.py
@@ -753,3 +753,6 @@ if PROMETHEUS_ENABLED:
 
 # Apply email settings
 globals().update(email_settings.get_settings(config))
+
+# Remove models.W042 warning
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/src/archivematica/dashboard/settings/base.py
+++ b/src/archivematica/dashboard/settings/base.py
@@ -753,6 +753,3 @@ if PROMETHEUS_ENABLED:
 
 # Apply email settings
 globals().update(email_settings.get_settings(config))
-
-# Remove models.W042 warning
-DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/src/archivematica/dashboard/settings/production.py
+++ b/src/archivematica/dashboard/settings/production.py
@@ -22,3 +22,6 @@ from archivematica.dashboard.settings.base import config
 ALLOWED_HOSTS = config.get("allowed_hosts").split(",")
 
 SECRET_KEY = config.get("secret_key")
+
+# Remove warning about autocreated primary keys.
+SILENCED_SYSTEM_CHECKS = ["models.W042"]


### PR DESCRIPTION
Removes models.W042 warning when running manage.py commands

Connected to https://github.com/archivematica/Issues/issues/1759