### PR TITLE
Migrate directives in CSP settings file

### DIFF
--- a/src/archivematica/dashboard/settings/base.py
+++ b/src/archivematica/dashboard/settings/base.py
@@ -732,6 +732,7 @@ if OIDC_AUTHENTICATION:
 
 CSP_ENABLED = config.get("csp_enabled")
 if CSP_ENABLED:
+    INSTALLED_APPS.append("csp")
     MIDDLEWARE.insert(0, "csp.middleware.CSPMiddleware")
 
     from archivematica.dashboard.settings.components.csp import *

--- a/src/archivematica/dashboard/settings/components/csp.py
+++ b/src/archivematica/dashboard/settings/components/csp.py
@@ -1,11 +1,18 @@
-CSP_DEFAULT_SRC = ["'none'"]
-CSP_SCRIPT_SRC = ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
-CSP_STYLE_SRC = ["'self'", "'unsafe-inline'"]
-CSP_IMG_SRC = ["'self'", "data:"]
-CSP_FONT_SRC = ["'self'", "data:"]
+from csp.constants import NONE
+from csp.constants import SELF
+from csp.constants import UNSAFE_EVAL
+from csp.constants import UNSAFE_INLINE
 
-# for preview file pane in the appraisal tab
-CSP_FRAME_SRC = ["'self'"]
-
-# for /status
-CSP_CONNECT_SRC = ["'self'"]
+CONTENT_SECURITY_POLICY = {
+    "DIRECTIVES": {
+        "default-src": [NONE],
+        "script-src": [SELF, UNSAFE_INLINE, UNSAFE_EVAL],
+        "style-src": [SELF, UNSAFE_INLINE],
+        "img-src": [SELF, "data:"],
+        "font-src": [SELF, "data:"],
+        # for preview file pane in the appraisal tab
+        "frame-src": [SELF],
+        # for /status
+        "connect-src": [SELF],
+    }
+}


### PR DESCRIPTION
This follows the `django-csp` [4.0 migration guide](https://django-csp.readthedocs.io/en/latest/migration-guide.html) to update the directives in the CSP settings file.