### PR TITLE
Update Docker images in dev services

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "docker-compose"
+    directory: "/hack"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+    groups:
+      docker-compose-dev:
+        patterns:
+          - "*"
+  - package-ecosystem: "docker-compose"
+    directory: "/tests/integration"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+    groups:
+      docker-compose-tests:
+        patterns:
+          - "*"

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -27,7 +27,7 @@ volumes:
 services:
 
   mysql:
-    image: "percona:8.0"
+    image: "percona/percona-server:8.0.43-34"
     command: "--character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci"
     environment:
       MYSQL_ROOT_PASSWORD: "12345"
@@ -73,14 +73,14 @@ services:
       - "127.0.0.1:62002:9200"
 
   gearmand:
-    image: "artefactual/gearmand:1.1.21.5-alpine"
+    image: "artefactual/gearmand:1.1.22-alpine"
     command: "--queue-type=builtin"
     user: "gearman"
     ports:
       - "127.0.0.1:62004:4730"
 
   clamavd:
-    image: "clamav/clamav-debian:1.4.3-45"
+    image: "clamav/clamav-debian:1.4.3-56"
     user: "clamav"
     entrypoint: "/init-unprivileged"
     environment:
@@ -93,7 +93,7 @@ services:
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:ro"
 
   nginx:
-    image: "nginx:stable-alpine"
+    image: "nginx:1.28.0"
     volumes:
       - "./etc/nginx/nginx.conf:/etc/nginx/nginx.conf:ro"
       - "./etc/nginx/conf.d/archivematica.conf:/etc/nginx/conf.d/archivematica.conf:ro"

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -4,7 +4,7 @@ name: am-integration
 services:
 
   mysql:
-    image: "percona:8.0"
+    image: "percona/percona-server:8.0.43-34"
     command: "--character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci"
     environment:
       MYSQL_ROOT_PASSWORD: "root"
@@ -97,7 +97,7 @@ services:
       - "keycloak"
 
   keycloak:
-    image: "quay.io/keycloak/keycloak:latest"
+    image: "quay.io/keycloak/keycloak:26.3.3-0"
     command: ["start-dev", "--import-realm"]
     restart: "unless-stopped"
     environment:


### PR DESCRIPTION
This commit updates several Docker images while ensuring backward compatibility. The Percona and Nginx images used support ARM64 builds.

Pinning images in Docker Compose requires updating them regularly, but Dependabot can handle that. At Artefactual, we've generally adopted this practice because it provides reproducibility without the risk of falling behind on updates, and the same approach could make sense here.

Relates to https://github.com/artefactual/archivematica/pull/2076.