### PR TITLE
Prevent UID/GID clashes more robustly in Docker builds

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -18,13 +18,6 @@ ARG PYENV_DIR=/pyenv
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 
-# Ubuntu 24.04 and later Docker images include a default user with UID (1000)
-# and GID (1000). Remove this user to prevent conflicts with the USER_ID and
-# GROUP_ID build arguments.
-RUN set -ex \
-	&& id -u ubuntu >/dev/null 2>&1 \
-	&& userdel --remove ubuntu || true
-
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 	--mount=type=cache,target=/var/lib/apt,sharing=locked \
 	set -ex \
@@ -131,8 +124,8 @@ RUN set ex \
 
 FROM node:${NODE_VERSION} AS archivematica-dashboard-testing
 
-ARG USER_ID=1000
-ARG GROUP_ID=1000
+ARG USER_ID
+ARG GROUP_ID
 ARG SELENIUM_DIR=/selenium
 ENV PATH=${SELENIUM_DIR}/bin:$PATH
 
@@ -164,8 +157,8 @@ ENTRYPOINT ["npm", "run", "test-single-run"]
 
 FROM base-builder AS base
 
-ARG USER_ID=1000
-ARG GROUP_ID=1000
+ARG USER_ID
+ARG GROUP_ID
 ARG PYENV_DIR=/pyenv
 ARG MEDIAAREA_VERSION
 ARG JHOVE_VERSION
@@ -223,7 +216,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 		unrar-free \
 		uuid
 
+# Ensure the requested UID/GID do not clash with defaults in the Ubuntu base
+# image. We look up any existing user/group that already uses such identifiers
+# and remove them to avoid conflicts before creating the archivematica account.
 RUN set -ex \
+	&& { \
+		grp=$(getent group "${GROUP_ID}" | cut -d: -f1 || true); \
+		if [ -n "${grp}" ]; then groupdel --force "${grp}"; fi; \
+		usr=$(getent passwd "${USER_ID}" | cut -d: -f1 || true); \
+		if [ -n "${usr}" ]; then userdel --remove "${usr}"; fi; \
+	} \
 	&& groupadd --gid ${GROUP_ID} --system archivematica \
 	&& useradd --uid ${USER_ID} --gid ${GROUP_ID} --home-dir /var/archivematica --system archivematica \
 	&& mkdir -p /var/archivematica/sharedDirectory \
@@ -259,8 +261,8 @@ ENTRYPOINT ["pyenv", "exec", "python3", "-m", "archivematica.MCPServer.archivema
 
 FROM base AS archivematica-dashboard
 
-ARG USER_ID=1000
-ARG GROUP_ID=1000
+ARG USER_ID
+ARG GROUP_ID
 ARG PYTHON_VERSION=3.9
 
 USER root


### PR DESCRIPTION
The previous method for preventing UID/GID clashes in the Docker build process was limited to removing a specific "ubuntu" user with default IDs. This approach was insufficient in environments where different default UIDs/GIDs are used, or when user IDs on the host system (such as common macOS UIDs like 501 or GIDs like 20 for "staff") clash with IDs that might be present in the container. This change dynamically checks for and remove any existing user/group that occupies the requester `USER_ID` or `GROUP_ID`, ensuring that the "archivematica" user can be created with the specified IDs without conflict.