### PR TITLE
Use dynamic OS codename and architecture in Dockerfile

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -164,8 +164,10 @@ ARG MEDIAAREA_VERSION
 ARG JHOVE_VERSION
 
 RUN set -ex \
+	&& UBUNTU_CODENAME=$(grep -Po '(?<=^VERSION_CODENAME=).+' /etc/os-release) \
+	&& UBUNTU_ARCH=$(dpkg --print-architecture)  \
 	&& curl --retry 3 -fsSL https://packages.archivematica.org/1.19.x/key.asc | gpg --dearmor -o /etc/apt/keyrings/archivematica-1.19.x.gpg \
-	&& echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/archivematica-1.19.x.gpg] http://packages.archivematica.org/1.19.x/ubuntu-externals jammy main" > /etc/apt/sources.list.d/archivematica-external.list \
+	&& echo "deb [arch=${UBUNTU_ARCH} signed-by=/etc/apt/keyrings/archivematica-1.19.x.gpg] http://packages.archivematica.org/1.19.x/ubuntu-externals ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/archivematica-external.list \
 	&& curl --retry 3 -so /tmp/repo-mediaarea.deb -L https://mediaarea.net/repo/deb/repo-mediaarea_${MEDIAAREA_VERSION}_all.deb \
 	&& dpkg -i /tmp/repo-mediaarea.deb \
 	&& rm /tmp/repo-mediaarea.deb

--- a/hack/README.md
+++ b/hack/README.md
@@ -42,7 +42,11 @@ the [documentation][audience-compose-reference].
 
 Artefactual developers use Docker Compose on Linux heavily so it's important
 that you're familiar with it, and some choices in the configuration of this
-environment break in other operative systems.
+environment break in other operative systems. This setup is actively tested on
+Linux hosts running both `linux/amd64` and `linux/arm64` architectures. We rely
+exclusively on container images and packages that provide support for both
+architectures. However, our production-ready deployments are currently validated
+only on `linux/amd64`.
 
 [audience-compose-reference]: https://docs.docker.com/reference/cli/docker/compose/
 


### PR DESCRIPTION
This ensures compatibility across different `arm64` and `amd64` Ubuntu builds.