### PR TITLE
Prune Docker cache in AMAUATS workflow

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -55,6 +55,11 @@ jobs:
       - name: "Restart services"
         run: |
           make -C hack/ restart-am-services
+      - name: "Prune Docker"
+        run: |
+          docker builder prune --all --force
+          docker image prune --all --force
+        working-directory: ./hack
       - name: "Run AMAUAT tag"
         id: "amauat-run"
         run: |


### PR DESCRIPTION
This prevents the GitHub test runner from running out of disk space.