### PR TITLE
Fix Log out link

### DIFF
--- a/src/archivematica/dashboard/components/accounts/views.py
+++ b/src/archivematica/dashboard/components/accounts/views.py
@@ -269,7 +269,7 @@ class CustomOIDCLogoutView(OIDCLogoutView):
     Provide OpenID Logout capability
     """
 
-    def get(self, request):
+    def post(self, request):
         self.request = request
 
         if "oidc_id_token" in request.session:

--- a/src/archivematica/dashboard/media/css/style.css
+++ b/src/archivematica/dashboard/media/css/style.css
@@ -71,13 +71,27 @@ body {
   font-size: 13px;
 }
 
-.topbar div > ul .dropdown-menu > li > a {
+.topbar div > ul .dropdown-menu > li > a,
+.topbar div > ul .dropdown-menu > li > form > button {
   color: #999;
 }
 
-.topbar div > ul .dropdown-menu > li > a:hover {
+.topbar div > ul .dropdown-menu > li > a:hover,
+.topbar div > ul .dropdown-menu > li > form > button:hover {
   color: #fff;
   background-color: #191919;
+}
+
+.topbar div > ul .dropdown-menu > li > form > button {
+  background: none;
+  border: 0;
+  padding: 3px 20px;
+  width: 100%;
+  text-align: left;
+}
+
+.topbar div > ul .dropdown-menu > li > form {
+  margin: 0;
 }
 
 .topbar div > ul .dropdown-menu > .divider {

--- a/src/archivematica/dashboard/templates/layout.html
+++ b/src/archivematica/dashboard/templates/layout.html
@@ -1,6 +1,7 @@
 {% load active i18n static lang user %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
+{% logout_link as logout_url %}
 <!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
   <head>
@@ -76,7 +77,12 @@
                   <ul class="dropdown-menu" aria-labelledby="dropdownUser">
                     <li><a href="{% url 'accounts:profile' %}">{% trans "Your profile" %}</a></li>
                     <li class="divider"></li>
-                    <li><a href="{% logout_link %}">{% trans "Log out" %}</a></li>
+                    <li>
+                      <form method="post" action="{{ logout_url }}">
+                        {% csrf_token %}
+                        <button type="submit">{% trans "Log out" %}</button>
+                      </form>
+                    </li>
                   </ul>
                 </li>
               {% endif %}

--- a/tests/dashboard/components/accounts/test_views.py
+++ b/tests/dashboard/components/accounts/test_views.py
@@ -526,3 +526,18 @@ def test_admin_fails_to_change_another_users_password_with_incorrect_admin_passw
     # Verify admin password is unchanged
     admin_user.refresh_from_db()
     assert admin_user.check_password(admin_password)
+
+
+@pytest.mark.xfail(reason="Django 5.2 requires logout requests to be POST not GET.")
+@pytest.mark.django_db
+def test_logout_view_logs_out_user(
+    dashboard_uuid: uuid.UUID,
+    non_administrative_user: User,
+    client: Client,
+) -> None:
+    client.force_login(non_administrative_user)
+
+    response = client.get(reverse("accounts:logout"), follow=True)
+    assert response.status_code == 200
+
+    assert response.request["PATH_INFO"] == reverse("accounts:login")

--- a/tests/dashboard/components/accounts/test_views.py
+++ b/tests/dashboard/components/accounts/test_views.py
@@ -528,7 +528,6 @@ def test_admin_fails_to_change_another_users_password_with_incorrect_admin_passw
     assert admin_user.check_password(admin_password)
 
 
-@pytest.mark.xfail(reason="Django 5.2 requires logout requests to be POST not GET.")
 @pytest.mark.django_db
 def test_logout_view_logs_out_user(
     dashboard_uuid: uuid.UUID,
@@ -537,7 +536,7 @@ def test_logout_view_logs_out_user(
 ) -> None:
     client.force_login(non_administrative_user)
 
-    response = client.get(reverse("accounts:logout"), follow=True)
+    response = client.post(reverse("accounts:logout"), follow=True)
     assert response.status_code == 200
 
     assert response.request["PATH_INFO"] == reverse("accounts:login")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+from django.contrib.auth.models import AbstractUser
+
+
+@pytest.fixture
+def user(django_user_model: type[AbstractUser]) -> AbstractUser:
+    user = django_user_model.objects.create(
+        username="foobar",
+        email="foobar@example.com",
+        first_name="Foo",
+        last_name="Bar",
+    )
+    user.set_password("foobar1A,")
+    user.save()
+
+    return user

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,0 +1,31 @@
+import os
+import uuid
+
+import pytest
+from django.contrib.auth.models import AbstractUser
+from django.urls import reverse
+from playwright.sync_api import Page
+from pytest_django.live_server_helper import LiveServer
+
+if "RUN_INTEGRATION_TESTS" not in os.environ:
+    pytest.skip("Skipping integration tests", allow_module_level=True)
+
+
+@pytest.mark.xfail(reason="Django 5.2 requires logout requests to be POST not GET.")
+@pytest.mark.django_db
+def test_logout_link_logs_out_user(
+    page: Page, live_server: LiveServer, dashboard_uuid: uuid.UUID, user: AbstractUser
+) -> None:
+    page.goto(live_server.url)
+    assert page.url == f"{live_server.url}{reverse('accounts:login')}"
+
+    page.get_by_label("Username").fill("foobar")
+    page.get_by_label("Password").fill("foobar1A,")
+    page.get_by_text("Log in", exact=True).click()
+
+    assert page.url == f"{live_server.url}/transfer/"
+
+    page.get_by_text("foobar").click()
+    page.get_by_role("link", name="Log out").click()
+
+    assert page.url == f"{live_server.url}{reverse('accounts:login')}"

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -11,7 +11,6 @@ if "RUN_INTEGRATION_TESTS" not in os.environ:
     pytest.skip("Skipping integration tests", allow_module_level=True)
 
 
-@pytest.mark.xfail(reason="Django 5.2 requires logout requests to be POST not GET.")
 @pytest.mark.django_db
 def test_logout_link_logs_out_user(
     page: Page, live_server: LiveServer, dashboard_uuid: uuid.UUID, user: AbstractUser
@@ -26,6 +25,6 @@ def test_logout_link_logs_out_user(
     assert page.url == f"{live_server.url}/transfer/"
 
     page.get_by_text("foobar").click()
-    page.get_by_role("link", name="Log out").click()
+    page.get_by_role("button", name="Log out").click()
 
     assert page.url == f"{live_server.url}{reverse('accounts:login')}"

--- a/tests/integration/test_oidc_auth.py
+++ b/tests/integration/test_oidc_auth.py
@@ -212,7 +212,7 @@ def test_logging_out_logs_out_user_from_secondary_provider_admin_role(
 
     # Logging out redirects the user to the login url.
     page.get_by_text("supportadmin@example.com").click()
-    page.get_by_role("link", name="Log out").click()
+    page.get_by_role("button", name="Log out").click()
     assert page.url == f"{live_server.url}{reverse('accounts:login')}"
 
     # Logging in through the OIDC provider requires to authenticate again.
@@ -245,7 +245,7 @@ def test_logging_out_logs_out_user_from_secondary_provider_default_role(
 
     # Logging out redirects the user to the login url.
     page.get_by_text("supportdefault@example.com").click()
-    page.get_by_role("link", name="Log out").click()
+    page.get_by_role("button", name="Log out").click()
     assert page.url == f"{live_server.url}{reverse('accounts:login')}"
 
     # Logging in through the OIDC provider requires to authenticate again.

--- a/tests/integration/test_oidc_auth.py
+++ b/tests/integration/test_oidc_auth.py
@@ -12,20 +12,6 @@ if "RUN_INTEGRATION_TESTS" not in os.environ:
     pytest.skip("Skipping integration tests", allow_module_level=True)
 
 
-@pytest.fixture
-def user(django_user_model: type[User]) -> User:
-    user = django_user_model.objects.create(
-        username="foobar",
-        email="foobar@example.com",
-        first_name="Foo",
-        last_name="Bar",
-    )
-    user.set_password("foobar1A,")
-    user.save()
-
-    return user
-
-
 @pytest.mark.django_db
 def test_oidc_backend_creates_local_user(
     page: Page,


### PR DESCRIPTION
[Django 5.0](https://docs.djangoproject.com/en/5.2/releases/5.0/#features-removed-in-5-0) requires the logout requests to be POST not GET:

> Support for logging out via `GET` requests in the `django.contrib.auth.views.LogoutView` and `django.contrib.auth.views.logout_then_login()` is removed.

This replaces the `Log out` link in the navigation bar with a form and submit button.

Connected to https://github.com/archivematica/Issues/issues/1773