### PR TITLE
Fix metadata-only reingest to reprocess updated metadata.csv

### DIFF
--- a/src/archivematica/MCPClient/clientScripts/archivematicaCreateMETSReingest.py
+++ b/src/archivematica/MCPClient/clientScripts/archivematicaCreateMETSReingest.py
@@ -447,10 +447,8 @@ def add_new_files(job, mets, sip_uuid, sip_dir):
 
     If a new file is a metadata.csv, parse it to create dmdSecs.
     """
-    # Find new files
-    # How tell new file from old with same name? Check hash?
-    # QUESTION should the metadata.csv be parsed and only updated if different
-    # even if one already existed?
+    # Find new files and detect metadata.csv changes even when METS already
+    # contains the path.
     new_files = []
     old_mets_rel_path = _get_old_mets_rel_path(sip_uuid)
     metadata_csv = None

--- a/src/archivematica/MCPClient/clientScripts/archivematicaCreateMETSReingest.py
+++ b/src/archivematica/MCPClient/clientScripts/archivematicaCreateMETSReingest.py
@@ -454,6 +454,7 @@ def add_new_files(job, mets, sip_uuid, sip_dir):
     new_files = []
     old_mets_rel_path = _get_old_mets_rel_path(sip_uuid)
     metadata_csv = None
+    metadata_csv_path = "objects/metadata/metadata.csv"
     objects_dir = os.path.join(sip_dir, "objects")
     for dirpath, _, filenames in os.walk(objects_dir):
         for filename in filenames:
@@ -473,12 +474,23 @@ def add_new_files(job, mets, sip_uuid, sip_dir):
                         currentlocation=current_loc.encode(), sip_id=str(sip_uuid)
                     )
                     new_files.append(f)
-                    if rel_path == "objects/metadata/metadata.csv":
+                    if rel_path == metadata_csv_path:
                         metadata_csv = f
             else:
+                if rel_path == metadata_csv_path:
+                    file_obj = models.File.objects.filter(
+                        currentlocation=current_loc.encode(), sip_id=str(sip_uuid)
+                    ).first()
+                    if file_obj and _metadata_csv_changed(fsentry, file_obj, sip_dir):
+                        metadata_csv = file_obj
+                        job.pyprint(
+                            rel_path,
+                            "found in METS with changed content, will reprocess",
+                        )
+                        continue
                 job.pyprint(rel_path, "found in METS, no further work needed")
 
-    if not new_files:
+    if not new_files and metadata_csv is None:
         return mets
 
     # Set global counters so getAMDSec will work

--- a/src/archivematica/MCPClient/clientScripts/archivematicaCreateMETSReingest.py
+++ b/src/archivematica/MCPClient/clientScripts/archivematicaCreateMETSReingest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import copy
+import hashlib
 import os
 
 import metsrw
@@ -402,6 +403,40 @@ def add_events(job, mets, sip_uuid):
             fsentry.add_premis_agent(createmets2.createAgent(agent))
 
     return mets
+
+
+def _compute_checksum(path, algorithm="SHA-256"):
+    """Return the hex digest of a file on disk using the given algorithm."""
+    algo = (algorithm or "SHA-256").lower().replace("-", "")
+    hasher = hashlib.new(algo)
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _get_fsentry_fixity(fsentry):
+    """Extract the stored fixity (algorithm, digest) from a METS fsentry."""
+    for amdsec in getattr(fsentry, "amdsecs", []):
+        doc = amdsec.serialize()
+        algo_el = doc.find(".//premis:messageDigestAlgorithm", namespaces=ns.NSMAP)
+        digest_el = doc.find(".//premis:messageDigest", namespaces=ns.NSMAP)
+        if digest_el is not None:
+            algo = algo_el.text if algo_el is not None else None
+            return algo, digest_el.text
+    return None, None
+
+
+def _metadata_csv_changed(fsentry, file_obj, sip_dir):
+    """Return True if on-disk metadata.csv differs from what METS records."""
+    algo, stored_digest = _get_fsentry_fixity(fsentry)
+    current_path = file_obj.currentlocation.decode().replace(
+        "%SIPDirectory%", sip_dir, 1
+    )
+    current_digest = _compute_checksum(current_path, algorithm=algo)
+    if stored_digest is None:
+        return True
+    return current_digest != stored_digest
 
 
 def add_new_files(job, mets, sip_uuid, sip_dir):

--- a/tests/MCPClient/fixtures/mets_metadata_csv_existing.xml
+++ b/tests/MCPClient/fixtures/mets_metadata_csv_existing.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:premis="info:lc/xmlns/premis-v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="test-mets">
+  <mets:amdSec ID="amdSec_1">
+    <mets:techMD ID="techMD_1">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file" version="3.0">
+            <premis:objectIdentifier>
+              <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+              <premis:objectIdentifierValue>3140ebe1-995c-490g-a34a-83955p7c844e</premis:objectIdentifierValue>
+            </premis:objectIdentifier>
+            <premis:objectCharacteristics>
+              <premis:compositionLevel>0</premis:compositionLevel>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm>SHA-256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>old-digest-value</premis:messageDigest>
+              </premis:fixity>
+            </premis:objectCharacteristics>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:fileSec>
+    <mets:fileGrp USE="original">
+      <mets:file ID="file-1111" ADMID="amdSec_1">
+        <mets:FLocat LOCTYPE="OTHER" OTHERLOCTYPE="SYSTEM" xlink:href="objects/metadata/metadata.csv"/>
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap TYPE="physical">
+    <mets:div TYPE="Directory" LABEL="objects">
+      <mets:div TYPE="Directory" LABEL="metadata">
+        <mets:div TYPE="Item" LABEL="metadata.csv" ADMID="amdSec_1">
+          <mets:fptr FILEID="file-1111"/>
+        </mets:div>
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+</mets:mets>

--- a/tests/MCPClient/test_reingest_mets.py
+++ b/tests/MCPClient/test_reingest_mets.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import metsrw
 from django.core.management import call_command
@@ -2114,3 +2115,40 @@ class TestUpdateMetadataCSV(TestCase):
             nondc_dmdsecs[0].findtext(".//custom_field", namespaces=NSMAP)
             == "A custom field"
         )
+
+
+class TestAddNewFilesMetadataCSV(TestCase):
+    """Ensure add_new_files reprocesses metadata.csv when contents change."""
+
+    def setUp(self):
+        self.sip_uuid = "5b5b0c0c-4bde-4ce0-9da3-4e278ee2bfad"
+        self.sip_dir = os.path.join(FIXTURES_DIR, "metadata_csv_directories", "")
+        self.sip = models.SIP.objects.create(uuid=self.sip_uuid, currentpath="")
+        self.metadata_file = models.File.objects.create(
+            uuid="b6c17471-0f3c-4f34-9b26-8738b614c9d9",
+            sip=self.sip,
+            originallocation=b"%SIPDirectory%objects/metadata/metadata.csv",
+            currentlocation=b"%SIPDirectory%objects/metadata/metadata.csv",
+            filegrpuse="metadata",
+            checksum="old-digest-value",
+            checksumtype="SHA-256",
+        )
+
+    @mock.patch(
+        "archivematica.MCPClient.clientScripts.archivematicaCreateMETSReingest.update_metadata_csv"
+    )
+    def test_metadata_csv_with_new_content_is_reprocessed(self, mock_update):
+        mets = metsrw.METSDocument.fromfile(
+            os.path.join(FIXTURES_DIR, "mets_metadata_csv_existing.xml")
+        )
+        mock_update.return_value = mets
+
+        result = archivematicaCreateMETSReingest.add_new_files(
+            mcp_job, mets, self.sip_uuid, self.sip_dir
+        )
+
+        mock_update.assert_called_once()
+        args = mock_update.call_args[0]
+        assert args[0] is mcp_job
+        assert str(args[2].uuid) == str(self.metadata_file.uuid)
+        assert result is mets


### PR DESCRIPTION
Related issue: https://github.com/archivematica/Issues/issues/1771

### Overview

- Problem: `add_new_files` only considers files “new” if they are absent from METS; on second reingest, `metadata.csv` already exists in METS so it is skipped even when content changes.
- Root cause: metadata.csv is persisted at `metadata.csv` after first reingest, so subsequent reingests reuse the same METS path and are ignored by the “new file” check.
- Fix: compare the on-disk checksum of metadata.csv with the METS PREMIS fixity; when the content differs, reprocess `metadata.csv` even if the file already exists in METS.
- Implementation: add checksum/fixity helpers and trigger `update_metadata_csv` on content change without forcing a full “new file” path.
- Tests: add a regression test that simulates a METS with existing `metadata.csv` and verifies it is reprocessed when content changes.

Obs: I've just sent in the signed contributor's agreement