### PR TITLE
Fix UUID JSON encoding in AS DIP upload

### DIFF
--- a/src/archivematica/MCPClient/clientScripts/upload_archivesspace.py
+++ b/src/archivematica/MCPClient/clientScripts/upload_archivesspace.py
@@ -51,7 +51,7 @@ def get_files_from_dip(dip_location):
 
 def get_pairs(dip_uuid):
     return {
-        pair.fileuuid: pair.resourceid
+        str(pair.fileuuid): pair.resourceid
         for pair in ArchivesSpaceDIPObjectResourcePairing.objects.filter(
             dipuuid=dip_uuid
         )

--- a/src/archivematica/dashboard/components/ingest/pair_matcher.py
+++ b/src/archivematica/dashboard/components/ingest/pair_matcher.py
@@ -290,7 +290,7 @@ def ingest_upload_atk_get_dip_object_paths(uuid):
             )
             object_path = remove_objects_prefix(object_path)
             paths.append(object_path)
-            path_uuids[object_path] = file.uuid
+            path_uuids[object_path] = str(file.uuid)
     paths.sort()
     for path in paths:
         files.append({"uuid": path_uuids[path], "path": path})

--- a/tests/MCPClient/test_upload_archivesspace.py
+++ b/tests/MCPClient/test_upload_archivesspace.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 
+from archivematica.dashboard.main.models import ArchivesSpaceDIPObjectResourcePairing
 from archivematica.MCPClient.clientScripts import upload_archivesspace
 
 
@@ -35,18 +36,35 @@ def test_get_files_from_dip_with_empty_dip_location(logger, tmpdir):
     logger.error.assert_called_once_with(f"no files in {str(dip)}/objects")
 
 
-@mock.patch(
-    "archivematica.MCPClient.clientScripts.upload_archivesspace.ArchivesSpaceDIPObjectResourcePairing.objects.filter",
-    return_value=[
-        mock.Mock(fileuuid="1", resourceid="myresource"),
-        mock.Mock(fileuuid="2", resourceid="myresource"),
-    ],
-)
-def test_get_pairs(filter_mock):
-    dip_uuid = "somedipuuid"
+@pytest.mark.django_db
+def test_get_pairs():
+    dip_uuid = uuid.uuid4()
+    file_uuid_1 = uuid.uuid4()
+    file_uuid_2 = uuid.uuid4()
+    ArchivesSpaceDIPObjectResourcePairing.objects.bulk_create(
+        [
+            ArchivesSpaceDIPObjectResourcePairing(
+                dipuuid=dip_uuid,
+                fileuuid=file_uuid_1,
+                resourceid="myresource",
+            ),
+            ArchivesSpaceDIPObjectResourcePairing(
+                dipuuid=dip_uuid,
+                fileuuid=file_uuid_2,
+                resourceid="myresource",
+            ),
+            ArchivesSpaceDIPObjectResourcePairing(
+                dipuuid=uuid.uuid4(),
+                fileuuid=uuid.uuid4(),
+                resourceid="otherresource",
+            ),
+        ]
+    )
     result = upload_archivesspace.get_pairs(dip_uuid)
-    assert result == {"1": "myresource", "2": "myresource"}
-    filter_mock.assert_called_once_with(dipuuid=dip_uuid)
+    assert result == {
+        str(file_uuid_1): "myresource",
+        str(file_uuid_2): "myresource",
+    }
 
 
 @mock.patch(

--- a/tests/dashboard/test_ingest.py
+++ b/tests/dashboard/test_ingest.py
@@ -12,6 +12,9 @@ from django.test.client import Client
 from django.urls import reverse
 
 from archivematica.archivematicaCommon.archivematicaFunctions import b64decode_string
+from archivematica.dashboard.components.ingest.pair_matcher import (
+    ingest_upload_atk_get_dip_object_paths,
+)
 from archivematica.dashboard.components.ingest.views import (
     _adjust_directories_draggability,
 )
@@ -19,6 +22,7 @@ from archivematica.dashboard.components.ingest.views import (
     _es_results_to_appraisal_tab_format,
 )
 from archivematica.dashboard.components.ingest.views_as import get_as_system_client
+from archivematica.dashboard.main import models
 from archivematica.dashboard.main.models import Access
 from archivematica.dashboard.main.models import ArchivesSpaceDIPObjectResourcePairing
 from archivematica.dashboard.main.models import DashboardSetting
@@ -402,3 +406,55 @@ def test_ingest_upload_as_match_shows_deleted_rows(
 
     log_record = caplog.records[0]
     assert log_record.message == f"Resource {resource_id} File {file_uuid} matches 1"
+
+
+@pytest.mark.django_db
+def test_ingest_upload_atk_get_dip_object_paths_uuid_strings(tmp_path, settings):
+    settings.WATCH_DIRECTORY = str(tmp_path)
+    sip_uuid = uuid.uuid4()
+    sip_uuid_str = str(sip_uuid)
+    dip_dir_name = f"dip-{sip_uuid}"
+    dip_upload_dir = tmp_path / "uploadDIP" / dip_dir_name
+    dip_upload_dir.mkdir(parents=True)
+
+    object_paths = ["objects/beta.txt", "objects/alpha.txt"]
+    mets_path = dip_upload_dir / f"METS.{sip_uuid}.xml"
+    mets_path.write_text(
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <mets:fileSec>
+    <mets:fileGrp USE="original">
+      <mets:file ID="file1">
+        <mets:FLocat xlink:href="{object_paths[0]}" />
+      </mets:file>
+      <mets:file ID="file2">
+        <mets:FLocat xlink:href="{object_paths[1]}" />
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+</mets:mets>
+""",
+        encoding="utf-8",
+    )
+
+    sip = models.SIP.objects.create(
+        uuid=sip_uuid,
+        currentpath=f"{settings.WATCH_DIRECTORY}/uploadDIP/{dip_dir_name}/",
+    )
+    file_beta = models.File.objects.create(
+        sip=sip,
+        originallocation=b"origin-beta",
+        currentlocation=f"%SIPDirectory%{object_paths[0]}".encode(),
+    )
+    file_alpha = models.File.objects.create(
+        sip=sip,
+        originallocation=b"origin-alpha",
+        currentlocation=f"%SIPDirectory%{object_paths[1]}".encode(),
+    )
+
+    result = ingest_upload_atk_get_dip_object_paths(sip_uuid_str)
+
+    assert result == [
+        {"uuid": str(file_alpha.uuid), "path": "alpha.txt"},
+        {"uuid": str(file_beta.uuid), "path": "beta.txt"},
+    ]


### PR DESCRIPTION
These changes correct how UUIDs are JSON-encoded when building the
ArchivesSpace DIP upload payloads in the pair matcher helper used in
the Dashboard user interface and in the client script when it
communicates with AS.
