### PR TITLE
Optimize dashboard queries in status endpoints

### DIFF
--- a/tests/MCPServer/test_rpc_server.py
+++ b/tests/MCPServer/test_rpc_server.py
@@ -1,3 +1,4 @@
+import importlib.resources
 import threading
 import uuid
 from unittest import mock
@@ -7,6 +8,7 @@ from django.utils import timezone
 
 from archivematica.dashboard.main import models
 from archivematica.MCPServer.server import rpc_server
+from archivematica.MCPServer.server import workflow
 from archivematica.MCPServer.server.jobs.chain import get_job_class_for_link
 
 TASK_PRODUCING_LINK_ID = "002716a1-ae29-4f36-98ab-0d97192669c4"
@@ -57,3 +59,185 @@ def test_units_statuses_handler_sets_produces_tasks_from_job_class(wf):
     assert len(response) == 1
     assert len(response[0]["jobs"]) == 1
     assert response[0]["jobs"][0]["produces_tasks"] is True
+
+
+@pytest.mark.django_db
+def test_units_statuses_handler_returns_transfers():
+    transfer_uuid = str(uuid.uuid4())
+    transfer = models.Transfer.objects.create(uuid=transfer_uuid)
+    models.Job.objects.create(
+        sipuuid=transfer.pk,
+        unittype="unitTransfer",
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_COMPLETED_SUCCESSFULLY,
+        microservicechainlink="7d728c39-395f-4892-8193-92f086c0546f",
+    )
+    package_queue = mock.MagicMock()
+    package_queue.jobs_awaiting_decisions.return_value = {}
+    with open(
+        importlib.resources.files("archivematica.MCPServer")
+        / "assets"
+        / "workflow.json"
+    ) as fp:
+        wf = workflow.load(fp)
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    server = rpc_server.RPCServer(wf, shutdown_event, package_queue, None)
+    result = server._units_statuses_handler(
+        None, wf, {"type": "Transfer", "lang": "en"}
+    )
+
+    assert len(result) == 1
+    assert result[0]["uuid"] == transfer_uuid
+
+
+@pytest.mark.django_db
+def test_units_statuses_handler_returns_sips():
+    sip_uuid = str(uuid.uuid4())
+    sip = models.SIP.objects.create(uuid=sip_uuid)
+    models.Job.objects.create(
+        sipuuid=sip.pk,
+        unittype="unitSIP",
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_COMPLETED_SUCCESSFULLY,
+        microservicechainlink="7d728c39-395f-4892-8193-92f086c0546f",
+    )
+    package_queue = mock.MagicMock()
+    package_queue.jobs_awaiting_decisions.return_value = {}
+    with open(
+        importlib.resources.files("archivematica.MCPServer")
+        / "assets"
+        / "workflow.json"
+    ) as fp:
+        wf = workflow.load(fp)
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    server = rpc_server.RPCServer(wf, shutdown_event, package_queue, None)
+    result = server._units_statuses_handler(None, wf, {"type": "SIP", "lang": "en"})
+
+    assert len(result) == 1
+    assert result[0]["uuid"] == sip_uuid
+
+
+@pytest.mark.django_db
+def test_units_statuses_handler_excludes_hidden_transfers():
+    visible_transfer_uuid = str(uuid.uuid4())
+    hidden_transfer_uuid = str(uuid.uuid4())
+    visible_transfer = models.Transfer.objects.create(
+        uuid=visible_transfer_uuid, hidden=False
+    )
+    hidden_transfer = models.Transfer.objects.create(
+        uuid=hidden_transfer_uuid, hidden=True
+    )
+    models.Job.objects.create(
+        sipuuid=visible_transfer.pk,
+        unittype="unitTransfer",
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_COMPLETED_SUCCESSFULLY,
+        microservicechainlink="7d728c39-395f-4892-8193-92f086c0546f",
+    )
+    models.Job.objects.create(
+        sipuuid=hidden_transfer.pk,
+        unittype="unitTransfer",
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_COMPLETED_SUCCESSFULLY,
+        microservicechainlink="7d728c39-395f-4892-8193-92f086c0546f",
+    )
+    package_queue = mock.MagicMock()
+    package_queue.jobs_awaiting_decisions.return_value = {}
+    with open(
+        importlib.resources.files("archivematica.MCPServer")
+        / "assets"
+        / "workflow.json"
+    ) as fp:
+        wf = workflow.load(fp)
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    server = rpc_server.RPCServer(wf, shutdown_event, package_queue, None)
+    result = server._units_statuses_handler(
+        None, wf, {"type": "Transfer", "lang": "en"}
+    )
+
+    assert len(result) == 1
+    assert result[0]["uuid"] == visible_transfer_uuid
+
+
+@pytest.mark.django_db
+def test_units_statuses_handler_excludes_hidden_sips():
+    visible_sip_uuid = str(uuid.uuid4())
+    hidden_sip_uuid = str(uuid.uuid4())
+    visible_sip = models.SIP.objects.create(uuid=visible_sip_uuid, hidden=False)
+    hidden_sip = models.SIP.objects.create(uuid=hidden_sip_uuid, hidden=True)
+    models.Job.objects.create(
+        sipuuid=visible_sip.pk,
+        unittype="unitSIP",
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_COMPLETED_SUCCESSFULLY,
+        microservicechainlink="7d728c39-395f-4892-8193-92f086c0546f",
+    )
+    models.Job.objects.create(
+        sipuuid=hidden_sip.pk,
+        unittype="unitSIP",
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_COMPLETED_SUCCESSFULLY,
+        microservicechainlink="7d728c39-395f-4892-8193-92f086c0546f",
+    )
+    package_queue = mock.MagicMock()
+    package_queue.jobs_awaiting_decisions.return_value = {}
+    with open(
+        importlib.resources.files("archivematica.MCPServer")
+        / "assets"
+        / "workflow.json"
+    ) as fp:
+        wf = workflow.load(fp)
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    server = rpc_server.RPCServer(wf, shutdown_event, package_queue, None)
+    result = server._units_statuses_handler(None, wf, {"type": "SIP", "lang": "en"})
+
+    assert len(result) == 1
+    assert result[0]["uuid"] == visible_sip_uuid
+
+
+@pytest.mark.django_db
+def test_units_statuses_handler_raises_error_when_type_missing():
+    package_queue = mock.MagicMock()
+    with open(
+        importlib.resources.files("archivematica.MCPServer")
+        / "assets"
+        / "workflow.json"
+    ) as fp:
+        wf = workflow.load(fp)
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    server = rpc_server.RPCServer(wf, shutdown_event, package_queue, None)
+
+    with pytest.raises(
+        rpc_server.UnexpectedPayloadError, match="Missing parameter: 'type'"
+    ):
+        server._units_statuses_handler(None, wf, {"lang": "en"})
+
+
+@pytest.mark.django_db
+def test_units_statuses_handler_raises_error_when_lang_missing():
+    package_queue = mock.MagicMock()
+    with open(
+        importlib.resources.files("archivematica.MCPServer")
+        / "assets"
+        / "workflow.json"
+    ) as fp:
+        wf = workflow.load(fp)
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    server = rpc_server.RPCServer(wf, shutdown_event, package_queue, None)
+
+    with pytest.raises(
+        rpc_server.UnexpectedPayloadError, match="Missing parameter: 'lang'"
+    ):
+        server._units_statuses_handler(None, wf, {"type": "SIP"})


### PR DESCRIPTION
Currently, the queries used to retrieve items for the Transfer and Ingest tabs on the dashboard first retrieve all possible items, then go through them  one by one and weed out the ones that are supposed to be hidden. This commit updates the transfer and ingest status endpoints to ignore hidden items on the first pass instead. In cases where there are many hidden items, this avoids numerous unnecessary database calls and speeds up the transfer/status and ingest/status endpoints significantly. The commit also adds tests for the RPCServer's _units_statuses_handler.