### PR TITLE
Delete unused filename fragment from template

### DIFF
--- a/src/archivematica/dashboard/media/css/style.css
+++ b/src/archivematica/dashboard/media/css/style.css
@@ -373,10 +373,6 @@ li.user > a {
   font-size: 11px;
 }
 
-.task-dialog > table {
-  width: 100%;
-}
-
 .task-dialog a {
   color: Blue;
   text-decoration: none;

--- a/src/archivematica/dashboard/media/js/jobs.js
+++ b/src/archivematica/dashboard/media/js/jobs.js
@@ -505,39 +505,6 @@ var BaseJobView = Backbone.View.extend({
       this.model.view = this;
     },
 
-  taskDialog: function(data, options)
-    {
-      var dialog = $('<div class="task-dialog"><a name="tasks-dialog-top"></a></div>');
-
-      if (options == undefined) {
-        options = {};
-      }
-
-      if (options.width == undefined) {
-        options.width = 640;
-      }
-
-      if (options.height == undefined) {
-        options.height = 640;
-      }
-
-      var table = $('<table class="table"></table>');
-      table.append(data);
-      dialog.append(table)
-
-      return dialog.dialog({
-          title: interpolate(gettext('%(directory) &raquo; %(type) &raquo; Tasks'), {'directory': this.model.sip.get('directory'), 'type': this.model.get('type')}, true),
-          width: options.width,
-          height: options.height,
-          modal: true,
-          buttons: [
-            {
-              text: gettext('Close'),
-              click: function() { $(this).dialog('close'); }
-            }]
-        });
-    },
-
   showTasks: function(event)
     {
       event.preventDefault();

--- a/src/archivematica/dashboard/templates/ingest/grid.html
+++ b/src/archivematica/dashboard/templates/ingest/grid.html
@@ -91,10 +91,7 @@
   <script type="text/template" id="job-template">
     <div class="job-detail-microservice">
       <span class="job-type-label">{% trans "Job" %}</span>
-      <span title="<%= uuid %>">
-        <%= type %>
-        <% if (obj.filename) { %> (file: <i><%= filename %></i>)<% } %>
-      </span>
+      <span title="<%= uuid %>"><%= type %></span>
       <% tmp = window.microservices_help[type]; %>
       <% if (tmp !== undefined) { %>
         [<a href="#" title="<%= tmp %>">?</a>]

--- a/src/archivematica/dashboard/templates/ingest/normalization_report.html
+++ b/src/archivematica/dashboard/templates/ingest/normalization_report.html
@@ -3,7 +3,6 @@
 {% load static %}
 
 {% block js %}
-<script type="text/javascript" src="{% static 'js/jobs.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/ingest/normalization_report.js' %}"></script>
 {% endblock %}
 


### PR DESCRIPTION
This commit updates the legacy ingest job-row template fragment by removing the conditional (file: <filename>) rendering, since the current ingest status payload does not include a job filename field. The change is a cleanup of unreachable template logic and is not expected to alter runtime behavior.

Related: https://github.com/artefactual/archivematica-history/commit/a7b8878318e9e7d4891dd0deb79c56feb6b81f05