### PR TITLE
Hide non-tasked jobs

### DIFF
--- a/src/archivematica/MCPServer/server/jobs/base.py
+++ b/src/archivematica/MCPServer/server/jobs/base.py
@@ -32,6 +32,9 @@ class Job(metaclass=abc.ABCMeta):
     STATUS_EXECUTING_COMMANDS = models.Job.STATUS_EXECUTING_COMMANDS
     STATUS_FAILED = models.Job.STATUS_FAILED
 
+    # Whether this job type writes rows in the Tasks table.
+    produces_tasks = False
+
     def __init__(self, job_chain, link, package):
         self.uuid = uuid.uuid4()
         self.job_chain = job_chain

--- a/src/archivematica/MCPServer/server/jobs/client.py
+++ b/src/archivematica/MCPServer/server/jobs/client.py
@@ -35,6 +35,8 @@ class ClientScriptJob(Job, metaclass=abc.ABCMeta):
     For task details, see the `Task` and `GearmanTaskBackend` classes.
     """
 
+    produces_tasks = True
+
     # The number of files we'll pack into each MCP Client job.  Chosen somewhat
     # arbitrarily, but benchmarking with larger values (like 512) didn't make much
     # difference to throughput.

--- a/src/archivematica/MCPServer/server/rpc_server.py
+++ b/src/archivematica/MCPServer/server/rpc_server.py
@@ -28,6 +28,7 @@ from archivematica.archivematicaCommon.gearman_encoder import JSONDataEncoder
 from archivematica.dashboard.main.models import SIP
 from archivematica.dashboard.main.models import Job
 from archivematica.dashboard.main.models import Transfer
+from archivematica.MCPServer.server.jobs.chain import get_job_class_for_link
 from archivematica.MCPServer.server.packages import create_package
 from archivematica.MCPServer.server.packages import get_approve_transfer_chain_id
 from archivematica.MCPServer.server.processing_config import get_processing_fields
@@ -404,6 +405,12 @@ class RPCServer(GearmanWorker):
                 )
                 new_job["microservicegroup"] = link.get_label("group", lang)
                 new_job["type"] = link.get_label("description", lang)
+                try:
+                    new_job["produces_tasks"] = get_job_class_for_link(
+                        link
+                    ).produces_tasks
+                except ValueError:
+                    new_job["produces_tasks"] = False
                 try:
                     new_job["choices"] = _pull_choices(
                         str(job_.jobuuid), lang, jobs_awaiting_for_approval

--- a/src/archivematica/dashboard/templates/ingest/grid.html
+++ b/src/archivematica/dashboard/templates/ingest/grid.html
@@ -101,7 +101,9 @@
       <span title="<%= new Date(timestamp * 1000).getArchivematicaDateTime() %> / <%= timestamp %>"><%= currentstep_label %></span>
     </div>
     <div class="job-detail-actions">
-      <a class="btn_show_tasks" href="#" title="{% trans 'Tasks' %}"><span>{% trans "Tasks" %}</span></a>
+      <% if (produces_tasks === true) { %>
+        <a class="btn_show_tasks" href="#" title="{% trans 'Tasks' %}"><span>{% trans "Tasks" %}</span></a>
+      <% } %>
     </div>
   </script>
 

--- a/src/archivematica/dashboard/templates/transfer/grid.html
+++ b/src/archivematica/dashboard/templates/transfer/grid.html
@@ -112,7 +112,9 @@
       <span title="<%= new Date(timestamp * 1000).getArchivematicaDateTime() %> / <%= timestamp %>"><%= currentstep_label %></span>
     </div>
     <div class="job-detail-actions">
-      <a class="btn_show_tasks" href="#" title="{% trans 'Tasks' %}"><span>{% trans "Tasks" %}</span></a>
+      <% if (produces_tasks === true) { %>
+        <a class="btn_show_tasks" href="#" title="{% trans 'Tasks' %}"><span>{% trans "Tasks" %}</span></a>
+      <% } %>
     </div>
   </script>
 

--- a/tests/MCPServer/conftest.py
+++ b/tests/MCPServer/conftest.py
@@ -1,0 +1,15 @@
+import importlib.resources
+
+import pytest
+
+from archivematica.MCPServer.server import workflow as workflow_module
+
+
+@pytest.fixture
+def wf():
+    with open(
+        importlib.resources.files("archivematica.MCPServer")
+        / "assets"
+        / "workflow.json"
+    ) as fp:
+        return workflow_module.load(fp)

--- a/tests/MCPServer/test_rpc_server.py
+++ b/tests/MCPServer/test_rpc_server.py
@@ -1,4 +1,3 @@
-import importlib.resources
 import threading
 import uuid
 from unittest import mock
@@ -8,11 +7,13 @@ from django.utils import timezone
 
 from archivematica.dashboard.main import models
 from archivematica.MCPServer.server import rpc_server
-from archivematica.MCPServer.server import workflow
+from archivematica.MCPServer.server.jobs.chain import get_job_class_for_link
+
+TASK_PRODUCING_LINK_ID = "002716a1-ae29-4f36-98ab-0d97192669c4"
 
 
 @pytest.mark.django_db
-def test_approve_partial_reingest_handler():
+def test_approve_partial_reingest_handler(wf):
     sip = models.SIP.objects.create(uuid=str(uuid.uuid4()))
     models.Job.objects.create(
         sipuuid=sip.pk,
@@ -21,12 +22,6 @@ def test_approve_partial_reingest_handler():
         currentstep=models.Job.STATUS_AWAITING_DECISION,
     )
     package_queue = mock.MagicMock()
-    with open(
-        importlib.resources.files("archivematica.MCPServer")
-        / "assets"
-        / "workflow.json"
-    ) as fp:
-        wf = workflow.load(fp)
     shutdown_event = threading.Event()
     shutdown_event.set()
 
@@ -34,3 +29,31 @@ def test_approve_partial_reingest_handler():
     server._approve_partial_reingest_handler(None, wf, {"sip_uuid": sip.pk})
 
     package_queue.decide.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_units_statuses_handler_sets_produces_tasks_from_job_class(wf):
+    task_producing_link = wf.get_link(TASK_PRODUCING_LINK_ID)
+    assert get_job_class_for_link(task_producing_link).produces_tasks is True
+
+    sip = models.SIP.objects.create(uuid=str(uuid.uuid4()))
+    models.Job.objects.create(
+        sipuuid=sip.pk,
+        unittype="unitSIP",
+        microservicegroup="Test group",
+        microservicechainlink=task_producing_link.id,
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_EXECUTING_COMMANDS,
+    )
+
+    package_queue = mock.MagicMock()
+    package_queue.jobs_awaiting_decisions.return_value = {}
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    server = rpc_server.RPCServer(wf, shutdown_event, package_queue, None)
+    response = server._units_statuses_handler(None, None, {"type": "SIP", "lang": "en"})
+
+    assert len(response) == 1
+    assert len(response[0]["jobs"]) == 1
+    assert response[0]["jobs"][0]["produces_tasks"] is True

--- a/tests/MCPServer/test_workflow.py
+++ b/tests/MCPServer/test_workflow.py
@@ -98,9 +98,7 @@ def test_load_valid_document(path):
     assert first_link.get_label("foobar") is None
 
 
-def test_link_browse_methods():
-    with open(ASSETS_DIR / "workflow.json") as fp:
-        wf = workflow.load(fp)
+def test_link_browse_methods(wf):
     ln = wf.get_link("1ba589db-88d1-48cf-bb1a-a5f9d2b17378")
     assert ln.get_next_link(code="0").id == "087d27be-c719-47d8-9bbb-9a7d8b609c44"
     assert ln.get_status_id(code="0") == workflow._STATUSES["Completed successfully"]


### PR DESCRIPTION
This pull request updates MCPServer to include an additional field in the job listing that indicates when a job does not produce tasks. The dashboard uses this field to hide the Tasks button for those jobs, so users are not redirected to an empty tasks page.

<img width="866" height="546" alt="image" src="https://github.com/user-attachments/assets/f73a2043-c669-43d9-b7b5-e035bffe6768" />