### PR TITLE
Fix nav-count alignment in collapsed mobile navbar

### DIFF
--- a/src/archivematica/dashboard/vue/lib/topbar/components/NavCounts.vue
+++ b/src/archivematica/dashboard/vue/lib/topbar/components/NavCounts.vue
@@ -41,11 +41,13 @@ onMounted(() => {
   </Teleport>
 </template>
 
-<style scoped>
-.nav-count {
-  position: absolute;
-  top: 2px;
-  right: -6px;
+<style>
+.topbar a.nav-transfer,
+.topbar a.nav-ingest {
+  position: relative;
+}
+
+.topbar .nav-count {
   border-radius: 999px;
   background-color: red;
   color: white;
@@ -59,5 +61,18 @@ onMounted(() => {
   justify-content: center;
   line-height: 1;
   z-index: 10;
+  position: static;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+@media (min-width: 768px) {
+  .topbar .nav-count {
+    position: absolute;
+    top: 2px;
+    right: -6px;
+    margin-left: 0;
+    vertical-align: baseline;
+  }
 }
 </style>


### PR DESCRIPTION
#### Before

<img width="486" height="339" alt="image" src="https://github.com/user-attachments/assets/5b95ccd0-fc12-4ed3-8dc2-cdc562c9c937" />

#### After

<img width="487" height="339" alt="image" src="https://github.com/user-attachments/assets/f7cfdf7f-b533-420f-8205-992a31ea2c22" />
