### PR TITLE
Remove dead rights-holder model/field

### DIFF
--- a/src/archivematica/MCPClient/clientScripts/trim_create_rights_entries.py
+++ b/src/archivematica/MCPClient/clientScripts/trim_create_rights_entries.py
@@ -163,7 +163,6 @@ def call(jobs):
                             metadataappliestoidentifier=fileUUID,
                             rightsstatementidentifiertype="UUID",
                             rightsstatementidentifiervalue=str(uuid.uuid4()),
-                            rightsholder=1,
                             rightsbasis="Other",
                         )
 

--- a/src/archivematica/dashboard/components/rights/forms.py
+++ b/src/archivematica/dashboard/components/rights/forms.py
@@ -25,7 +25,6 @@ class RightsForm(forms.ModelForm):
     class Meta:
         model = models.RightsStatement
         fields = ("rightsbasis",)
-        widgets = {"rightsholder": forms.widgets.TextInput(attrs=settings.INPUT_ATTRS)}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/archivematica/dashboard/components/rights/views.py
+++ b/src/archivematica/dashboard/components/rights/views.py
@@ -15,10 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 import logging
-import re
 
 from django.forms.models import inlineformset_factory
-from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.shortcuts import render
 from django.urls import reverse
@@ -90,25 +88,6 @@ def ingest_rights_grants_edit(request, uuid, id):
     return rights_grants_edit(request, uuid, id, "ingest")
 
 
-def rights_parse_agent_id(input):
-    return 0
-    if input == "":
-        agentId = 0
-    else:
-        agentRaw = input
-        try:
-            int(agentRaw)
-            agentId = int(agentRaw)
-        except ValueError:
-            agentRe = re.compile(r"(.*)\[(\d*)\]")
-            match = agentRe.match(agentRaw)
-            if match:
-                agentId = match.group(2)
-            else:
-                agentId = 0
-    return agentId
-
-
 def rights_edit(request, uuid, id=None, section="ingest"):
     jobs = models.Job.objects.filter(sipuuid=uuid)
     name = jobs.get_directory_name()
@@ -120,19 +99,8 @@ def rights_edit(request, uuid, id=None, section="ingest"):
 
     if id:
         viewRights = models.RightsStatement.objects.get(pk=id)
-        agentId = None
         if request.method == "POST":
             postData = request.POST.copy()
-            """
-            agentId = rights_parse_agent_id(postData.get('rightsholder'))
-            if agentId == 0 and postData.get('rightsholder') != '0' and postData.get('rightsholder') != '':
-                agent = models.RightsStatementLinkingAgentIdentifier()
-                agent.rightsstatement = viewRights
-                agent.linkingagentidentifiervalue = postData.get('rightsholder')
-                agent.save()
-                agentId = agent.id
-            postData.__setitem__('rightsholder', agentId)
-            """
             form = forms.RightsForm(postData, instance=viewRights)
             form.cleaned_data = postData
             viewRights = form.save()
@@ -168,10 +136,7 @@ def rights_edit(request, uuid, id=None, section="ingest"):
         )
     else:
         if request.method == "POST":
-            postData = request.POST.copy()
-            agentId = rights_parse_agent_id(postData.get("rightsholder"))
-            postData.__setitem__("rightsholder", agentId)
-            form = forms.RightsForm(postData)
+            form = forms.RightsForm(request.POST)
         else:
             form = forms.RightsForm()
             viewRights = models.RightsStatement()
@@ -746,30 +711,6 @@ def rights_delete(request, uuid, id, section):
 def rights_grant_delete(request, uuid, id, section):
     models.RightsStatementRightsGranted.objects.get(pk=id).delete()
     return redirect("rights_%s:index" % section, uuid)
-
-
-def rights_holders_lookup(request, id):
-    try:
-        agent = models.RightsStatementLinkingAgentIdentifier.objects.get(pk=id)
-        result = agent.linkingagentidentifiervalue + " [" + str(agent.id) + "]"
-    except Exception:
-        result = ""
-    return HttpResponse(result)
-
-
-def rights_holders_autocomplete(request):
-    search_text = request.GET.get("text", "")
-
-    response = {}
-
-    agents = models.RightsStatementLinkingAgentIdentifier.objects.filter(
-        linkingagentidentifiervalue__icontains=search_text
-    )
-    for agent in agents:
-        value = agent.linkingagentidentifiervalue + " [" + str(agent.id) + "]"
-        response[value] = value
-
-    return helpers.json_response(response)
 
 
 def rights_list(request, uuid, section):

--- a/src/archivematica/dashboard/main/migrations/0087_remove_dead_rights_holder_code.py
+++ b/src/archivematica/dashboard/main/migrations/0087_remove_dead_rights_holder_code.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("main", "0086_remove_appraisal"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="rightsstatement",
+            name="rightsholder",
+        ),
+        migrations.DeleteModel(
+            name="RightsStatementLinkingAgentIdentifier",
+        ),
+    ]

--- a/src/archivematica/dashboard/main/models.py
+++ b/src/archivematica/dashboard/main/models.py
@@ -1063,9 +1063,6 @@ class RightsStatement(models.Model):
     rightsstatementidentifiervalue = models.TextField(
         db_column="rightsStatementIdentifierValue", blank=True, verbose_name=_("Value")
     )
-    rightsholder = models.IntegerField(
-        db_column="fkAgent", default=0, verbose_name=_("Rights holder")
-    )
     RIGHTS_BASIS_CHOICES = (
         ("Copyright", _("Copyright")),
         ("Statute", _("Statute")),
@@ -1504,27 +1501,6 @@ class RightsStatementOtherRightsInformationNote(models.Model):
     class Meta:
         db_table = "RightsStatementOtherRightsNote"
         verbose_name = _("Rights: Other: Note")
-
-
-class RightsStatementLinkingAgentIdentifier(models.Model):
-    id = models.AutoField(primary_key=True, db_column="pk")
-    rightsstatement = models.ForeignKey(
-        RightsStatement, db_column="fkRightsStatement", on_delete=models.CASCADE
-    )
-    linkingagentidentifiertype = models.TextField(
-        db_column="linkingAgentIdentifierType",
-        verbose_name=_("Linking Agent"),
-        blank=True,
-    )
-    linkingagentidentifiervalue = models.TextField(
-        db_column="linkingAgentIdentifierValue",
-        verbose_name=_("Linking Agent Value"),
-        blank=True,
-    )
-
-    class Meta:
-        db_table = "RightsStatementLinkingAgentIdentifier"
-        verbose_name = _("Rights: Agent")
 
 
 class UnitVariableManager(models.Manager):

--- a/src/archivematica/dashboard/media/js/repeating-ajax-data.js
+++ b/src/archivematica/dashboard/media/js/repeating-ajax-data.js
@@ -131,14 +131,8 @@ Type will default to textarea.
 var RepeatingDataView = Backbone.View.extend({
 
   initialize: function() {
-    this.items = [];
-
     if (this.options.schema) {
       this.schema = this.options.schema;
-    }
-
-    if (this.options.description) {
-      this.description = this.options.description;
     }
 
     if (this.options.parentId) {
@@ -148,85 +142,6 @@ var RepeatingDataView = Backbone.View.extend({
     if (this.options.url) {
       this.url = this.options.url;
     }
-
-    if (this.options.noCreation != undefined) {
-      this.noCreation = this.options.noCreation;
-    }
-
-    if (this.options.canDelete != undefined) {
-      this.canDelete = this.options.canDelete;
-    }
-
-    this.waitingForInput = false;
-  },
-
-  newLinkEl: function() {
-    var $linkEl = $('<div class="btn btn-default">New ' + this.description + '</div>')
-      , self = this;
-
-    // allow suppression of button for creating new records
-    if (this.noCreation) {
-      return;
-    }
-
-    $linkEl.click(function() {
-      $(this).attr('disabled', 'true');
-      if (!self.waitingForInput) {
-      self.waitingForInput = true;
-      var field = new RepeatingDataRecordView(
-          0,
-          self.schema
-        )
-        , fieldEl = field.render().el;
-
-      var $input = $(fieldEl)
-        , $div = $('<div/>');
-
-      $div.append($input);
-      $(self.el).append($div);
-      $input.on('change', function() {
-        $.ajax({
-          url: self.url,
-          type: 'POST',
-          data: field.getValues(),
-          headers: {'X-CSRFToken': getCookie('csrftoken')},
-          success: function(result) {
-            $(self).attr('disabled', 'false');
-            self.waitingForInput = false;
-            $input.hide();
-            $input.fadeIn(function() {
-              self.render();
-            });
-          }
-        });
-      });
-
-      }
-    });
-
-    return $linkEl;
-  },
-
-  appendDelHandlerToRecord: function(fieldEl, id) {
-    var $delHandle = $('<span>' + gettext('Delete') + '</span>')
-      , self = this;
-
-    $(fieldEl).append($delHandle);
-
-    $delHandle.click(function() {
-      var deleteConfirm = gettext('Are you sure?');
-      if (confirm(deleteConfirm)) {
-        $.ajax({
-          url: self.url + '/' + id,
-          type: 'DELETE',
-          data: {'id': id},
-          headers: {'X-CSRFToken': getCookie('csrftoken')},
-          success: function(result) {
-            self.render();
-          }
-        });
-      }
-    });
   },
 
   render: function(cb) {
@@ -237,8 +152,7 @@ var RepeatingDataView = Backbone.View.extend({
         type: 'GET',
         success: function(result) {
           $(self.el)
-            .empty()
-            .append(self.newLinkEl());
+            .empty();
 
           // cycle through each result
           for(var index in result.results) {
@@ -268,10 +182,6 @@ var RepeatingDataView = Backbone.View.extend({
                 self.url
               )
               , fieldEl = field.render().el;
-
-            if (self.canDelete) {
-              self.appendDelHandlerToRecord(fieldEl, fieldData.id);
-            }
 
             $(self.el).append(fieldEl);
 

--- a/src/archivematica/dashboard/media/js/rights_edit.js
+++ b/src/archivematica/dashboard/media/js/rights_edit.js
@@ -46,7 +46,7 @@ function repeatingNotesRecordsSchema(dataType) {
 
 function setUpRepeatingCopyrightNotesRecords(parentId) {
   var schema = repeatingNotesRecordsSchema('copyright');
-  setUpRepeatingField('copyrightnotes_', parentId, gettext('Copyright Note'), schema, '/formdata/copyrightnote/' + parentId + '/', true);
+  setUpRepeatingField('copyrightnotes_', parentId, gettext('Copyright Note'), schema, '/formdata/copyrightnote/' + parentId + '/');
 }
 
 function setUpCopyrightDocumentationIdentifierAttributes() {
@@ -59,7 +59,7 @@ function setUpCopyrightDocumentationIdentifierAttributes() {
 
 function setUpRepeatingCopyrightDocumentationIdentifierRecords(parentId) {
   var schema = repeatingDocumentationIdentifierRecordsSchema('copyright');
-  setUpRepeatingField('copyrightdocidfields_', parentId, gettext('Copyright Documentation Identifier'), schema, '/formdata/copyrightdocumentationidentifier/' + parentId + '/', true, setUpCopyrightDocumentationIdentifierAttributes);
+  setUpRepeatingField('copyrightdocidfields_', parentId, gettext('Copyright Documentation Identifier'), schema, '/formdata/copyrightdocumentationidentifier/' + parentId + '/', setUpCopyrightDocumentationIdentifierAttributes);
   setUpCopyrightDocumentationIdentifierAttributes();
 }
 
@@ -71,7 +71,7 @@ function setUpStatuteDocumentationIdentifierAttributes() {
 
 function setUpRepeatingStatuteDocumentationIdentifierRecords(parentId) {
   var schema = repeatingDocumentationIdentifierRecordsSchema('statute');
-  setUpRepeatingField('statutedocidfields_', parentId, gettext('Statute Documentation Identifier'), schema, '/formdata/statutedocumentationidentifier/' + parentId + '/', true, setUpStatuteDocumentationIdentifierAttributes);
+  setUpRepeatingField('statutedocidfields_', parentId, gettext('Statute Documentation Identifier'), schema, '/formdata/statutedocumentationidentifier/' + parentId + '/', setUpStatuteDocumentationIdentifierAttributes);
   setUpStatuteDocumentationIdentifierAttributes();
 }
 
@@ -83,7 +83,7 @@ function setUpStatuteNoteAttributes() {
 
 function setUpRepeatingStatuteNotesRecords(parentId) {
   var schema = repeatingNotesRecordsSchema('statute');
-  setUpRepeatingField('statutenotes_', parentId, gettext('Statute Note'), schema, '/formdata/statutenote/' + parentId + '/', true, setUpStatuteNoteAttributes);
+  setUpRepeatingField('statutenotes_', parentId, gettext('Statute Note'), schema, '/formdata/statutenote/' + parentId + '/', setUpStatuteNoteAttributes);
   setUpStatuteNoteAttributes();
 }
 
@@ -93,20 +93,20 @@ function setUpLicenseDocumentationIdentifierAttributes() {
 
 function setUpRepeatingLicenseDocumentationIdentifierRecords(parentId) {
   var schema = repeatingDocumentationIdentifierRecordsSchema('license');
-  setUpRepeatingField('licensedocidfields_', parentId, gettext('License Documentation Identifier'), schema, '/formdata/licensedocumentationidentifier/' + parentId + '/', true, setUpLicenseDocumentationIdentifierAttributes);
+  setUpRepeatingField('licensedocidfields_', parentId, gettext('License Documentation Identifier'), schema, '/formdata/licensedocumentationidentifier/' + parentId + '/', setUpLicenseDocumentationIdentifierAttributes);
   setUpLicenseDocumentationIdentifierAttributes();
 }
 
 function setUpRepeatingOtherRightsDocumentationIdentifierRecords(parentId) {
   var schema = repeatingDocumentationIdentifierRecordsSchema('otherrights');
-  setUpRepeatingField('otherrightsdocidfields_', parentId, gettext('Other Rights Documentation Identifier'), schema, '/formdata/otherrightsdocumentationidentifier/' + parentId + '/', true);
+  setUpRepeatingField('otherrightsdocidfields_', parentId, gettext('Other Rights Documentation Identifier'), schema, '/formdata/otherrightsdocumentationidentifier/' + parentId + '/');
 }
 
 function setUpRepeatingOtherRightsNotesRecords(parentId) {
   var schema = {
     'otherrightsnote': {},
   };
-  setUpRepeatingField('otherrightsnotes_', parentId, gettext('Other Rights Note'), schema, '/formdata/otherrightsnote/' + parentId + '/', true);
+  setUpRepeatingField('otherrightsnotes_', parentId, gettext('Other Rights Note'), schema, '/formdata/otherrightsnote/' + parentId + '/');
 }
 
 function setUpLicenseNoteAttributes() {
@@ -119,7 +119,7 @@ function setUpRepeatingLicenseNotesRecords(parentId) {
   var schema = {
     'licensenote': {},
   };
-  setUpRepeatingField('licensenotes_', parentId, gettext('License Note'), schema, '/formdata/licensenote/' + parentId + '/', true, setUpLicenseNoteAttributes);
+  setUpRepeatingField('licensenotes_', parentId, gettext('License Note'), schema, '/formdata/licensenote/' + parentId + '/', setUpLicenseNoteAttributes);
   setUpLicenseNoteAttributes();
 }
 
@@ -141,7 +141,7 @@ function setUpRepeatingRightsGrantedRestrictionRecords(parentId) {
       }
     }
   };
-  setUpRepeatingField('rightsrestrictions_', parentId, gettext('Restriction'), schema, '/formdata/rightsrestriction/' + parentId + '/', true, setUpRepeatingRightsGrantedRestrictionAttributes);
+  setUpRepeatingField('rightsrestrictions_', parentId, gettext('Restriction'), schema, '/formdata/rightsrestriction/' + parentId + '/', setUpRepeatingRightsGrantedRestrictionAttributes);
   setUpRepeatingRightsGrantedRestrictionAttributes();
 }
 
@@ -149,42 +149,19 @@ function setUpRepeatingRightsGrantedNotesRecords(parentId) {
   var schema = {
     'rightsgrantednote': {},
   };
-  setUpRepeatingField('rightsfields_', parentId, gettext('Rights Granted Note'), schema, '/formdata/rightsnote/' + parentId + '/', true);
+  setUpRepeatingField('rightsfields_', parentId, gettext('Rights Granted Note'), schema, '/formdata/rightsnote/' + parentId + '/');
 }
 
 // repeating child field to a formset bound to existing data
-function setUpRepeatingField(idPrefix, parentId, description, schema, url, noCreation, cb) {
+function setUpRepeatingField(idPrefix, parentId, description, schema, url, cb) {
   var rights = new RepeatingDataView({
     el: $('#' + idPrefix + parentId),
     description: description,
     parentId: parentId,
     schema: schema,
-    url: url,
-    noCreation: noCreation
+    url: url
   });
   rights.render(cb);
-
-  if (parentId == '' || parentId == 'None') {
-    var instructionDescription = description.toLowerCase()
-      , instructions;
-
-    // make other rights fields instructions generic as they are used with
-    // a number of types of basises
-    if (instructionDescription == 'other rights documentation identifier') {
-      instructionDescription = 'documentation identifier';
-    }
-
-    if (instructionDescription == 'other rights note') {
-      instructionDescription = 'note';
-    }
-
-    if (noCreation == undefined || !noCreation) {
-      instructions = interpolate(gettext('You\'ll be able to create a %s record once the above section is completed.'), [instructionDescription]);
-      $('#' + idPrefix + parentId).append(
-        '<span class="help-block">' + instructions + '</span>'
-      );
-    }
-  }
 }
 
 // logic to hide forms to create new data if data already exists:
@@ -314,35 +291,4 @@ $(document).ready(function() {
   $('.rights-grant-restrictions').each(function() {
     $($(this).parent().children().first().next().next()).after($(this));
   });
-
-  // establish rightsholder autocomplete
-  if ($('#id_rightsholder').length > 0) {
-    // lookup rightsholder
-    $.get('lookup/rightsholder/' + $('#id_rightsholder').val(), function(data) {
-      $('#id_rightsholder').val(data);
-    });
-
-    // attach autocomplete
-    $("#id_rightsholder").autocomplete({  
-
-      // define callback to format results  
-      source: function(req, add){  
- 
-        // pass request to server  
-        $.getJSON("autocomplete/rightsholders", {'text': req.term}, function(data) {  
- 
-          // create array for response objects  
-          var suggestions = [];  
-  
-          // process response  
-          $.each(data, function(i, val){  
-            suggestions.push(val);  
-          });  
-
-          // pass array to callback  
-          add(suggestions);  
-        });
-      }
-    });
-  }
 });

--- a/tests/MCPClient/fixtures/rights.json
+++ b/tests/MCPClient/fixtures/rights.json
@@ -6,7 +6,6 @@
         "status": "ORIGINAL",
         "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
         "metadataappliestoidentifier": "a4a5480c-9f51-4119-8dcb-d3f12e647c14",
-        "rightsholder": 0,
         "rightsstatementidentifiervalue": "",
         "rightsbasis": "Copyright",
         "rightsstatementidentifiertype": ""
@@ -19,7 +18,6 @@
         "status": "ORIGINAL",
         "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
         "metadataappliestoidentifier": "a4a5480c-9f51-4119-8dcb-d3f12e647c14",
-        "rightsholder": 0,
         "rightsstatementidentifiervalue": "",
         "rightsbasis": "Statute",
         "rightsstatementidentifiertype": ""
@@ -32,7 +30,6 @@
         "status": "ORIGINAL",
         "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
         "metadataappliestoidentifier": "a4a5480c-9f51-4119-8dcb-d3f12e647c14",
-        "rightsholder": 0,
         "rightsstatementidentifiervalue": "",
         "rightsbasis": "License",
         "rightsstatementidentifiertype": ""
@@ -45,7 +42,6 @@
         "status": "ORIGINAL",
         "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
         "metadataappliestoidentifier": "a4a5480c-9f51-4119-8dcb-d3f12e647c14",
-        "rightsholder": 0,
         "rightsstatementidentifiervalue": "",
         "rightsbasis": "Donor",
         "rightsstatementidentifiertype": ""
@@ -58,7 +54,6 @@
         "status": "REINGEST",
         "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
         "metadataappliestoidentifier": "10d57d98-29e5-4b2c-9f9f-d163e632eb31",
-        "rightsholder": 0,
         "rightsstatementidentifiervalue": "",
         "rightsbasis": "Copyright",
         "rightsstatementidentifiertype": ""
@@ -71,7 +66,6 @@
         "status": "UPDATED",
         "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
         "metadataappliestoidentifier": "2941f14c-bd57-4f4a-a514-a3bf6ac5adf0",
-        "rightsholder": 0,
         "rightsstatementidentifiervalue": "",
         "rightsbasis": "Statute",
         "rightsstatementidentifiertype": ""
@@ -84,7 +78,6 @@
         "status": "REINGEST",
         "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
         "metadataappliestoidentifier": "2941f14c-bd57-4f4a-a514-a3bf6ac5adf0",
-        "rightsholder": 0,
         "rightsstatementidentifiervalue": "",
         "rightsbasis": "Copyright",
         "rightsstatementidentifiertype": ""
@@ -97,7 +90,6 @@
         "status": "REINGEST",
         "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
         "metadataappliestoidentifier": "2941f14c-bd57-4f4a-a514-a3bf6ac5adf0",
-        "rightsholder": 0,
         "rightsstatementidentifiervalue": "",
         "rightsbasis": "License",
         "rightsstatementidentifiertype": ""
@@ -110,7 +102,6 @@
         "status": "REINGEST",
         "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
         "metadataappliestoidentifier": "2941f14c-bd57-4f4a-a514-a3bf6ac5adf0",
-        "rightsholder": 0,
         "rightsstatementidentifiervalue": "",
         "rightsbasis": "Donor",
         "rightsstatementidentifiertype": ""
@@ -123,7 +114,6 @@
         "status": "REINGEST",
         "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
         "metadataappliestoidentifier": "2941f14c-bd57-4f4a-a514-a3bf6ac5adf0",
-        "rightsholder": 0,
         "rightsstatementidentifiervalue": "",
         "rightsbasis": "Policy",
         "rightsstatementidentifiertype": ""

--- a/tests/MCPClient/test_parse_mets_to_db.py
+++ b/tests/MCPClient/test_parse_mets_to_db.py
@@ -184,7 +184,6 @@ class TestParsePremisRights(TestCase):
         )
         assert rights.rightsstatementidentifiertype == ""
         assert rights.rightsstatementidentifiervalue == ""
-        assert rights.rightsholder == 0
         assert rights.rightsbasis == "Copyright"
         assert rights.status == "REINGEST"
         cr = models.RightsStatementCopyright.objects.get(rightsstatement=rights)
@@ -240,7 +239,6 @@ class TestParsePremisRights(TestCase):
         )
         assert rights.rightsstatementidentifiertype == ""
         assert rights.rightsstatementidentifiervalue == ""
-        assert rights.rightsholder == 0
         assert rights.rightsbasis == "License"
         assert rights.status == "REINGEST"
         li = models.RightsStatementLicense.objects.get(rightsstatement=rights)
@@ -279,7 +277,6 @@ class TestParsePremisRights(TestCase):
         )
         assert rights.rightsstatementidentifiertype == ""
         assert rights.rightsstatementidentifiervalue == ""
-        assert rights.rightsholder == 0
         assert rights.rightsbasis == "Statute"
         assert rights.status == "REINGEST"
         st = models.RightsStatementStatuteInformation.objects.get(
@@ -325,7 +322,6 @@ class TestParsePremisRights(TestCase):
         )
         assert rights.rightsstatementidentifiertype == ""
         assert rights.rightsstatementidentifiervalue == ""
-        assert rights.rightsholder == 0
         assert rights.rightsbasis == "Policy"
         assert rights.status == "REINGEST"
         other = models.RightsStatementOtherRightsInformation.objects.get(
@@ -369,7 +365,6 @@ class TestParsePremisRights(TestCase):
         )
         assert rights.rightsstatementidentifiertype == ""
         assert rights.rightsstatementidentifiervalue == ""
-        assert rights.rightsholder == 0
         assert rights.rightsbasis == "Donor"
         assert rights.status == "REINGEST"
         other = models.RightsStatementOtherRightsInformation.objects.get(
@@ -414,7 +409,6 @@ class TestParsePremisRights(TestCase):
         )
         assert rights.rightsstatementidentifiertype == ""
         assert rights.rightsstatementidentifiervalue == ""
-        assert rights.rightsholder == 0
         assert rights.rightsbasis == "Statute"
         assert rights.status == "REINGEST"
         st = models.RightsStatementStatuteInformation.objects.get(

--- a/tests/dashboard/fixtures/rights.json
+++ b/tests/dashboard/fixtures/rights.json
@@ -4,7 +4,6 @@
         "status": "ORIGINAL",
         "metadataappliestotype": "3e48343d-e2d2-4956-aaa3-b54d26eb9761",
         "metadataappliestoidentifier": "d64b0f43-f6d3-42ac-9821-c559dca13786",
-        "rightsholder": 0,
         "rightsstatementidentifiervalue": "",
         "rightsbasis": "Copyright",
         "rightsstatementidentifiertype": ""


### PR DESCRIPTION
This change removes the legacy rightsholder linkage (fkAgent) and the unused RightsStatementLinkingAgentIdentifier table because they were no longer part of active rights capture, display, import, or export workflows.