### PR TITLE
Fix AS matcher JSON serialization in dashboard views

### DIFF
--- a/src/archivematica/dashboard/components/ingest/pair_matcher.py
+++ b/src/archivematica/dashboard/components/ingest/pair_matcher.py
@@ -247,7 +247,7 @@ def review_matches(client, request, template, uuid, matches=None):
     if matches is None:
         matches = []
     object_paths = {
-        file_.uuid: remove_review_matches_prefixes(file_.currentlocation.decode())
+        str(file_.uuid): remove_review_matches_prefixes(file_.currentlocation.decode())
         for file_ in models.File.objects.filter(sip=uuid)
     }
     for match in matches:

--- a/src/archivematica/dashboard/components/ingest/views_as.py
+++ b/src/archivematica/dashboard/components/ingest/views_as.py
@@ -168,7 +168,7 @@ def ingest_upload_as_resource_component(client, request, uuid, resource_componen
 def _format_pair(client, resourceid, fileuuid):
     return {
         "resource_id": resourceid,
-        "file_uuid": fileuuid,
+        "file_uuid": str(fileuuid),
         # Returns verbose details about the resource/component, required
         # in order to populate the pair matching UI.
         "resource": client.get_resource_component_children(resourceid),

--- a/tests/dashboard/test_ingest.py
+++ b/tests/dashboard/test_ingest.py
@@ -275,3 +275,120 @@ def test_ingest_upload_atk_get_dip_object_paths_uuid_strings(tmp_path, settings)
         {"uuid": str(file_alpha.uuid), "path": "alpha.txt"},
         {"uuid": str(file_beta.uuid), "path": "beta.txt"},
     ]
+
+
+AS_RESOURCE_ID = "/repositories/2/resources/1"
+AS_COMPONENT_ID = "/repositories/2/archival_objects/61"
+
+
+@pytest.fixture
+def as_pair_record():
+    dip_uuid = uuid.uuid4()
+    file_uuid = uuid.uuid4()
+    ArchivesSpaceDIPObjectResourcePairing.objects.create(
+        dipuuid=dip_uuid,
+        fileuuid=file_uuid,
+        resourceid=AS_COMPONENT_ID,
+    )
+    return dip_uuid, file_uuid
+
+
+@pytest.fixture
+def dummy_as_client():
+    class DummyASClient:
+        RESOURCE = "resource"
+
+        def find_parent_id_for_component(self, _resource_component_id):
+            return self.RESOURCE, AS_RESOURCE_ID
+
+        def get_resource_component_children(self, resource_id):
+            return {"uri": resource_id, "children": []}
+
+        def get_resource_component_and_children(self, resource_id):
+            return {"uri": resource_id, "children": []}
+
+    return DummyASClient()
+
+
+@mock.patch(
+    "archivematica.dashboard.components.ingest.pair_matcher.ingest_upload_atk_get_dip_object_paths",
+    return_value=[],
+)
+@mock.patch("archivematica.dashboard.components.ingest.views_as.get_as_system_client")
+def test_ingest_upload_as_match_resource_component_serializes_existing_pair_file_uuid(
+    get_as_system_client_mock,
+    _,
+    admin_client,
+    dashboard_uuid,
+    as_pair_record,
+    dummy_as_client,
+):
+    dip_uuid, file_uuid = as_pair_record
+    get_as_system_client_mock.return_value = dummy_as_client
+
+    response = admin_client.get(
+        reverse(
+            "ingest:ingest_upload_as_match_dip_objects_to_resource_component_levels",
+            kwargs={
+                "uuid": dip_uuid,
+                "resource_component_id": AS_COMPONENT_ID,
+            },
+        )
+    )
+
+    assert response.status_code == 200
+    matches = json.loads(response.context["matches_json"])
+    assert matches[0]["file_uuid"] == str(file_uuid)
+
+
+@mock.patch(
+    "archivematica.dashboard.components.ingest.pair_matcher.ingest_upload_atk_get_dip_object_paths",
+    return_value=[],
+)
+@mock.patch("archivematica.dashboard.components.ingest.views_as.get_as_system_client")
+def test_ingest_upload_as_match_resource_serializes_existing_pair_file_uuid(
+    get_as_system_client_mock,
+    _,
+    admin_client,
+    dashboard_uuid,
+    as_pair_record,
+    dummy_as_client,
+):
+    dip_uuid, file_uuid = as_pair_record
+    get_as_system_client_mock.return_value = dummy_as_client
+
+    response = admin_client.get(
+        reverse(
+            "ingest:ingest_upload_as_match_dip_objects_to_resource_levels",
+            kwargs={
+                "uuid": dip_uuid,
+                "resource_id": AS_RESOURCE_ID,
+            },
+        )
+    )
+
+    assert response.status_code == 200
+    matches = json.loads(response.context["matches_json"])
+    assert matches[0]["file_uuid"] == str(file_uuid)
+
+
+@mock.patch("archivematica.dashboard.components.ingest.views_as.get_as_system_client")
+def test_ingest_upload_as_review_matches_serializes_existing_pair_file_uuid(
+    get_as_system_client_mock,
+    admin_client,
+    dashboard_uuid,
+    as_pair_record,
+    dummy_as_client,
+):
+    dip_uuid, file_uuid = as_pair_record
+    get_as_system_client_mock.return_value = dummy_as_client
+
+    response = admin_client.get(
+        reverse(
+            "ingest:ingest_upload_as_review_matches",
+            kwargs={"uuid": dip_uuid},
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.context["matches"][0]["file_uuid"] == str(file_uuid)


### PR DESCRIPTION
Follow-up to 45865b1245cc15982cc3cf0fab57d0ee838a2176, which covered UUID stringification in pair_matcher DIP object paths and MCPClient AS upload pairs.

This change covers the remaining Dashboard ArchivesSpace match/review view paths that consume persisted DIP-object/resource pairings:

- Match DIP objects to resource component levels.
- Match DIP objects to resource levels.
- Review current DIP-object-to-resource matches.