### PR TITLE
Use originalFileName to set original file paths for Dataverse tabu

### DIFF
--- a/src/archivematica/MCPClient/clientScripts/convert_dataverse_structure.py
+++ b/src/archivematica/MCPClient/clientScripts/convert_dataverse_structure.py
@@ -227,20 +227,23 @@ def create_bundle(job, tabfile_json):
     bundle = metsrw.FSEntry(path=base_name, type="Directory")
     # Find the original file and add it to the METS FS Entries.
     tabfile_datafile = tabfile_json.get("dataFile")
-    fname = None
-    ext = EXTENSION_MAPPING.get(
-        tabfile_datafile.get("originalFormatLabel", ""), "UNKNOWN"
-    )
-    logger.info("Retrieved extension mapping value: %s", ext)
-    logger.info(
-        "Original file format listed as %s",
-        tabfile_datafile.get("originalFileFormat", "None"),
-    )
-    if ext == "UNKNOWN":
-        fname = tabfile_datafile.get("filename")
-        logger.info("Original Format Label is UNKNOWN, using filename: %s", fname)
-    if fname is None:
-        fname = f"{base_name}{ext}"
+    fname = tabfile_datafile.get("originalFileName")
+    if fname:
+        logger.info("Using original file name from dataset.json: %s", fname)
+    else:
+        ext = EXTENSION_MAPPING.get(
+            tabfile_datafile.get("originalFormatLabel", ""), "UNKNOWN"
+        )
+        logger.info("Retrieved extension mapping value: %s", ext)
+        logger.info(
+            "Original file format listed as %s",
+            tabfile_datafile.get("originalFileFormat", "None"),
+        )
+        if ext == "UNKNOWN":
+            fname = tabfile_datafile.get("filename")
+            logger.info("Original Format Label is UNKNOWN, using filename: %s", fname)
+        if fname is None:
+            fname = f"{base_name}{ext}"
     checksum_value = tabfile_datafile.get("md5")
     if checksum_value is None:
         return None

--- a/tests/MCPClient/test_create_dataverse_mets.py
+++ b/tests/MCPClient/test_create_dataverse_mets.py
@@ -329,3 +329,59 @@ class TestDataverseExample:
             )
         assert len(authors) == fixture.author_count
         assert auth_list == fixture.author_list
+
+
+@pytest.mark.parametrize(
+    "original_format_label, tabfile_name, original_file_name",
+    [
+        ("SPSS Binary", "example.tab", "example.sav"),
+        (
+            "MS Excel Spreadsheet",
+            "originalFormatXlsx-2.tab",
+            "originalFormatXlsx-2.xlsx",
+        ),
+        ("Stata 14 Binary", "stata14.tab", "stata14.dta"),
+    ],
+)
+def test_create_bundle_prefers_original_file_name(
+    original_format_label, tabfile_name, original_file_name
+):
+    job = Job("stub", "stub", ["", ""])
+    file_json = {
+        "label": tabfile_name,
+        "dataFile": {
+            "filename": tabfile_name,
+            "originalFileName": original_file_name,
+            "originalFormatLabel": original_format_label,
+            "md5": "80f0cfe73c4d0b55b3dd9a71e8be0ef2",
+        },
+    }
+
+    bundle = convert_dataverse_structure.create_bundle(job, file_json)
+
+    assert bundle is not None
+    paths = {child.path: child for child in bundle.children}
+    base_name = tabfile_name[:-4]
+    original_path = f"{base_name}/{original_file_name}"
+    tab_path = f"{base_name}/{tabfile_name}"
+
+    assert original_path in paths
+    assert paths[original_path].use == "original"
+    assert tab_path in paths
+    assert paths[tab_path].use == "derivative"
+
+
+def test_create_bundle_falls_back_without_original_file_name():
+    job = Job("stub", "stub", ["", ""])
+    file_json = {
+        "label": "example.tab",
+        "dataFile": {
+            "filename": "example.tab",
+            "originalFormatLabel": "Comma Separated Values",
+            "md5": "80f0cfe73c4d0b55b3dd9a71e8be0ef2",
+        },
+    }
+    bundle = convert_dataverse_structure.create_bundle(job, file_json)
+    assert bundle is not None
+    paths = {child.path for child in bundle.children}
+    assert "example/example.csv" in paths


### PR DESCRIPTION
Issue related: https://github.com/archivematica/Issues/issues/1744

Hi there, it's me again! I submitted two pull requests ([#1](https://github.com/artefactual/archivematica/pull/2046), [#2](https://github.com/artefactual/archivematica/pull/2048)) last year but missed the follow-up messages because I left the position for a while. I'm back now and noticed the issue still seems to be around, so I created a new pull request linked to the same issue.

This PR addresses the same problem as before: some tabular data files in Dataverse have an `originalFormatLabel` that isn't in the `EXTENSION_MAPPING` dictionary, which causes the original file path to be generated incorrectly and leads to checksum validation failures. For example, an SPSS file might have its `originalFormatLabel` listed as "SPSS Binary" in `dataset.json`, but `EXTENSION_MAPPING` only has "SPSS SAV" and "SPSS Portable". When no match is found it falls back to using the .tab filename (e.g., depress.tab), but the actual file on disk is depress.sav — the path mismatch causes the checksum validation to fail.

The fix prioritizes using the `originalFileName` field from `dataset.json` to get the accurate filename, and only falls back to the existing extension mapping logic when that field isn't available.
Thank you! I know I've probably missed a lot, so please let me know if there are any concerns (or if this has already been fixed).