### PR TITLE
Add .zip path lookup for extracted Dataverse bundle files

### DIFF
--- a/src/archivematica/MCPClient/clientScripts/parse_dataverse_mets.py
+++ b/src/archivematica/MCPClient/clientScripts/parse_dataverse_mets.py
@@ -104,9 +104,7 @@ def get_db_objects(job, mets, transfer_uuid):
                         file_entry.originallocation,
                     )
                 except (File.DoesNotExist, ValidationError):
-                    logger.debug(
-                        "Could not find file using .zip path: %s", zip_path
-                    )
+                    logger.debug("Could not find file using .zip path: %s", zip_path)
                 except File.MultipleObjectsReturned as err:
                     logger.info(
                         "Multiple entries for `%s` found. Exception: %s",

--- a/src/archivematica/MCPClient/clientScripts/parse_dataverse_mets.py
+++ b/src/archivematica/MCPClient/clientScripts/parse_dataverse_mets.py
@@ -85,6 +85,45 @@ def get_db_objects(job, mets, transfer_uuid):
             logger.info(
                 "Multiple entries for `%s` found. Exception: %s", entry.path, err
             )
+        # After extraction, bundle files are recorded in the database
+        # under the .zip package path instead of the directory path in
+        # METS. Try looking up the file using the .zip-based path.
+        if file_entry is None:
+            parts = entry.path.split("/", 1)
+            if len(parts) == 2:
+                zip_path = os.path.join(
+                    transfer_objects_directory, parts[0] + ".zip", parts[1]
+                )
+                try:
+                    file_entry = File.objects.get(
+                        originallocation=zip_path.encode(),
+                        transfer_id=transfer_uuid,
+                    )
+                    logger.info(
+                        "Found file via .zip path: %s",
+                        file_entry.originallocation,
+                    )
+                except (File.DoesNotExist, ValidationError):
+                    logger.debug(
+                        "Could not find file using .zip path: %s", zip_path
+                    )
+                except File.MultipleObjectsReturned as err:
+                    logger.info(
+                        "Multiple entries for `%s` found. Exception: %s",
+                        zip_path,
+                        err,
+                    )
+            if file_entry is not None and (
+                file_entry.currentlocation is None
+                and file_entry.removedtime is not None
+            ):
+                logger.info(
+                    "File: %s has been removed from the transfer, see "
+                    "previous microservice job outputs for details, e.g. "
+                    "Extract packages",
+                    file_entry.originallocation,
+                )
+                continue
         try:
             # Attempt to find the original location through just its filename
             # as it may be sitting in the root item/objects directory of the

--- a/tests/MCPClient/test_parse_dataverse.py
+++ b/tests/MCPClient/test_parse_dataverse.py
@@ -298,3 +298,24 @@ class TestParseDataverse(TestCase):
         # Processing should continue on the objects mapping that remains.
         assert mapping is not None
         assert len(mapping) == 1
+
+    def test_zip_path_lookup(self):
+        """When a bundle has been extracted, the file's originallocation in the
+        database uses the .zip package path. Verify that get_db_objects can
+        still find the file when the METS path uses the directory form.
+        """
+        # Change Weather_data.sav's originallocation from the directory path
+        # to the .zip path that extract_contents.py would produce.
+        sav_file = models.File.objects.get(pk="e2834eed-4178-469a-9a4e-c8f1490bb804")
+        sav_file.originallocation = (
+            b"%transferDirectory%objects/Weather_data.zip/Weather_data.sav"
+        )
+        sav_file.save()
+
+        mapping = parse_dataverse.get_db_objects(self.job, self.mets, self.uuid)
+        mets_sav = self.mets.get_file(
+            file_uuid="fb3b1250-5e45-499f-b0b1-0f6a20d77366"
+        )
+        assert mapping is not None
+        assert len(mapping) == 7
+        assert mapping[mets_sav] == sav_file

--- a/tests/MCPClient/test_parse_dataverse.py
+++ b/tests/MCPClient/test_parse_dataverse.py
@@ -313,9 +313,7 @@ class TestParseDataverse(TestCase):
         sav_file.save()
 
         mapping = parse_dataverse.get_db_objects(self.job, self.mets, self.uuid)
-        mets_sav = self.mets.get_file(
-            file_uuid="fb3b1250-5e45-499f-b0b1-0f6a20d77366"
-        )
+        mets_sav = self.mets.get_file(file_uuid="fb3b1250-5e45-499f-b0b1-0f6a20d77366")
         assert mapping is not None
         assert len(mapping) == 7
         assert mapping[mets_sav] == sav_file


### PR DESCRIPTION
Related issue: https://github.com/archivematica/Issues/issues/1745

Hi there! This is is the second part of the fix for Dataverse file type identification issues. The first part is in PR #2250 

When a Dataverse bundle file (like a `.zip` package) is extracted by `extract_contents.py`, the extracted files retain the `.zip` package name in their database paths. For example, `Weather_data.sav` gets stored as `objects/Weather_data.zip/Weather_data.sav.` However the `get_db_objects` function in `parse_dataverse_mets.py` looks up files using the path recorded in the METS file, which in this case would be `objects/Weather_data/Weather_data.sav`. Because the database path includes `.zip` while the METS path does not, the lookup fails to find a match which causes the entire transfer to fail.

I added an extra lookup step in `get_db_objects`: it takes the directory name from the METS path, appends a `.zip` extension, and reconstructs the path to query the database. So now the lookup order is:
1. Try the full METS path (existing behavior)
2. Try the METS path with `.zip` appended to the directory name (new)
3. Fall back to matching by filename only (existing behavior)

Thanks! Let me know if you have any questions or concerns.