### PR TITLE
Add hidden and batch modes to purge transient data script

### DIFF
--- a/src/archivematica/dashboard/main/management/commands/purge_transient_processing_data.py
+++ b/src/archivematica/dashboard/main/management/commands/purge_transient_processing_data.py
@@ -17,6 +17,14 @@ from being purged.
 An optional parameter ``--keep-searches`` may be passed to retain search
 documents.
 
+An optional parameter ``--hidden-transfers-only`` may be passed to only purge
+packages hidden in the dashboard. In this mode, SIPs are filtered by
+``SIP.hidden=True`` and transfers are selected when either
+``Transfer.hidden=True`` or they are linked to a hidden SIP.
+
+An optional parameter ``--batch-size`` may be passed to cap how many SIPs and
+how many transfers are purged per run. ``--batch-size=0`` means no cap.
+
 By default, this command only purges packages of a certain age. It uses
 ``--age='0 06:00:00'``, meaning that no packages will be removed if they have
 not completed processing more than six hours ago. Optionally, users can pass
@@ -87,8 +95,27 @@ class Command(DashboardCommand):
                 'Default value is "0 06:00:00", i.e. "6 hours".'
             ),
         )
+        parser.add_argument(
+            "--hidden-transfers-only",
+            action="store_true",
+            help="Only purge packages tied to hidden SIPs.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=0,
+            help=(
+                "Process package deletions in batches. "
+                "Lower values can reduce lock duration at the expense of runtime. "
+                "Use 0 to process all matching packages at once. "
+                "Default is 0."
+            ),
+        )
 
     def handle(self, *args, **options):
+        if options["batch_size"] < 0:
+            raise CommandError("--batch-size must be greater than or equal to 0.")
+
         search_service = None
         if (
             not options["keep_searches"]
@@ -114,8 +141,40 @@ class Command(DashboardCommand):
                 raise CommandError("Age could not be parsed.")
             kwargs["completed_before"] = timezone.now() - duration
 
+        selected_transfer_ids = None
+        if options["hidden_transfers_only"]:
+            hidden_sips = models.SIP.objects.done(**kwargs).filter(hidden=True)
+            hidden_transfer_ids = list(
+                models.Transfer.objects.done(**kwargs)
+                .filter(hidden=True)
+                .order_by("pk")
+                .values_list("pk", flat=True)
+            )
+            linked_transfer_ids = list(
+                models.Transfer.objects.done(**kwargs)
+                .filter(file__sip_id__in=hidden_sips.values("pk"))
+                .order_by("pk")
+                .distinct()
+                .values_list("pk", flat=True)
+            )
+            batch_limit = options["batch_size"] or None
+            selected_transfer_ids = hidden_transfer_ids
+            selected_transfer_ids.extend(
+                transfer_id
+                for transfer_id in linked_transfer_ids
+                if transfer_id not in selected_transfer_ids
+            )
+            if batch_limit is not None:
+                selected_transfer_ids = selected_transfer_ids[:batch_limit]
+
         self.info("Purging SIPs...")
         sips = models.SIP.objects.done(**kwargs)
+        if options["hidden_transfers_only"]:
+            sips = sips.filter(hidden=True)
+        sips = sips.order_by("pk")
+        batch_limit = options["batch_size"] or None
+        if batch_limit is not None:
+            sips = sips[:batch_limit]
         for sip in sips:
             package_id = sip.pk
             if not options["quiet"]:
@@ -155,7 +214,14 @@ class Command(DashboardCommand):
                 self.stdout.write(traceback.print_exc())
 
         self.info("Purging transfers...")
-        transfers = models.Transfer.objects.done(**kwargs)
+        if selected_transfer_ids is not None:
+            transfers = models.Transfer.objects.filter(pk__in=selected_transfer_ids)
+            transfers = transfers.order_by("pk")
+        else:
+            transfers = models.Transfer.objects.done(**kwargs).order_by("pk")
+            batch_limit = options["batch_size"] or None
+            if batch_limit is not None:
+                transfers = transfers[:batch_limit]
         for transfer in transfers:
             package_id = transfer.pk
             if not options["quiet"]:

--- a/src/archivematica/dashboard/main/management/commands/purge_transient_processing_data.py
+++ b/src/archivematica/dashboard/main/management/commands/purge_transient_processing_data.py
@@ -148,8 +148,8 @@ class Command(DashboardCommand):
                 ):
                     if not options["quiet"]:
                         self.info("  Purging search documents...")
-                    search_service.delete_aip(package_id)
-                    search_service.delete_aip_files(package_id)
+                    search_service.delete_aip(str(package_id))
+                    search_service.delete_aip_files(str(package_id))
             except Exception as err:
                 self.error(f"  Error: {err}")
                 self.stdout.write(traceback.print_exc())

--- a/tests/dashboard/main/test_command_purge_transient_processing_data.py
+++ b/tests/dashboard/main/test_command_purge_transient_processing_data.py
@@ -141,6 +141,67 @@ def test_purge_command_skips_active_packages(
 
 
 @pytest.mark.django_db
+def test_purge_command_hidden_transfers_only_removes_hidden_sips_and_linked_transfers(
+    search_disabled, old_transfer, old_sip
+):
+    old_sip.hidden = True
+    old_sip.save(update_fields=["hidden"])
+    models.File.objects.filter(transfer=old_transfer).update(sip=old_sip)
+
+    hidden_transfer = models.Transfer.objects.create(
+        uuid=uuid.uuid4(),
+        currentlocation=r"%transferDirectory%",
+        status=models.PACKAGE_STATUS_DONE,
+        hidden=True,
+        completed_at=timezone.now() - parse_duration("0 12:00:00"),
+    )
+
+    visible_transfer = models.Transfer.objects.create(
+        uuid=uuid.uuid4(),
+        currentlocation=r"%transferDirectory%",
+        status=models.PACKAGE_STATUS_DONE,
+        completed_at=timezone.now() - parse_duration("0 12:00:00"),
+    )
+
+    call_command("purge_transient_processing_data", "--hidden-transfers-only")
+
+    assert models.SIP.objects.filter(pk=old_sip.pk).count() == 0
+    assert models.Transfer.objects.filter(pk=old_transfer.pk).count() == 0
+    assert models.Transfer.objects.filter(pk=hidden_transfer.pk).count() == 0
+    assert models.Transfer.objects.filter(pk=visible_transfer.pk).count() == 1
+
+
+@pytest.mark.django_db
+def test_purge_command_batch_size_limits_each_package_type(
+    search_disabled, old_transfer, old_sip
+):
+    models.Transfer.objects.create(
+        uuid=uuid.uuid4(),
+        currentlocation=r"%transferDirectory%",
+        status=models.PACKAGE_STATUS_DONE,
+        completed_at=timezone.now() - parse_duration("0 12:00:00"),
+    )
+    models.SIP.objects.create(
+        uuid=uuid.uuid4(),
+        status=models.PACKAGE_STATUS_DONE,
+        completed_at=timezone.now() - parse_duration("0 12:00:00"),
+    )
+
+    call_command("purge_transient_processing_data", "--batch-size", "1")
+
+    assert models.Transfer.objects.count() == 1
+    assert models.SIP.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_purge_command_rejects_negative_batch_size(search_disabled):
+    with pytest.raises(
+        Exception, match="--batch-size must be greater than or equal to 0."
+    ):
+        call_command("purge_transient_processing_data", "--batch-size", "-1")
+
+
+@pytest.mark.django_db
 def test_purge_command_output(search_disabled, old_transfer, old_sip, capsys):
     call_command("purge_transient_processing_data")
     captured = capsys.readouterr()

--- a/tests/dashboard/main/test_command_purge_transient_processing_data.py
+++ b/tests/dashboard/main/test_command_purge_transient_processing_data.py
@@ -107,8 +107,8 @@ def test_purge_command_removes_search_documents(
 ):
     call_command("purge_transient_processing_data")
 
-    mock_search_service.delete_aip.assert_called_once_with(old_sip.pk)
-    mock_search_service.delete_aip_files.assert_called_once_with(old_sip.pk)
+    mock_search_service.delete_aip.assert_called_once_with(str(old_sip.pk))
+    mock_search_service.delete_aip_files.assert_called_once_with(str(old_sip.pk))
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR updates purge_transient_processing_data with two new modes:

- `--hidden-transfers-only` limits the purge to hidden SIPs and to transfers that are either hidden themselves or linked to hidden SIPs.
- `--batch-size` limits how many SIPs and how many transfers are purged in a  single run.

It also fixes search document cleanup during purge runs when `--keep-searches`  is not used. The command was passing UUID primary key objects to the search  service, which raised `TypeError: 'UUID' object is not iterable` while deleting  AIP search documents. The command now passes string package IDs instead.

Connects to https://github.com/archivematica/Issues/issues/1530
