### PR TITLE
Dashboard: add OIDC auto-create-user toggle

### DIFF
--- a/src/archivematica/dashboard/install/README.md
+++ b/src/archivematica/dashboard/install/README.md
@@ -288,6 +288,13 @@ variables or in the gunicorn configuration file.
   - **Type:** `boolean`
   - **Default:** `false`
 
+- **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_OIDC_AUTO_CREATE_USER`**:
+  - **Description:** enables automatic local user creation for successful OIDC
+    logins when no matching Dashboard user already exists.
+  - **Config file example:** `Dashboard.oidc_auto_create_user`
+  - **Type:** `boolean`
+  - **Default:** `true`
+
 - **`ARCHIVEMATICA_DASHBOARD_DASHBOARD_STORAGE_SERVICE_CLIENT_TIMEOUT`**:
   - **Description:** configures the Storage Service client to stop waiting for a
     response after a given number of seconds.
@@ -748,6 +755,9 @@ These variables specify the behaviour of CAS authentication. Only applicable if
 These variables specify the behaviour of OpenID Connect (OIDC) authentication.
 Only applicable if `ARCHIVEMATICA_DASHBOARD_DASHBOARD_OIDC_AUTHENTICATION` is
 set.
+
+Automatic local user creation for OIDC logins is controlled by
+`ARCHIVEMATICA_DASHBOARD_DASHBOARD_OIDC_AUTO_CREATE_USER`.
 
 - **`OIDC_RP_CLIENT_ID`**:
   - **Description:** OIDC client ID

--- a/src/archivematica/dashboard/settings/base.py
+++ b/src/archivematica/dashboard/settings/base.py
@@ -133,6 +133,11 @@ CONFIG_MAPPING = {
         "option": "oidc_allow_local_authentication",
         "type": "boolean",
     },
+    "oidc_auto_create_user": {
+        "section": "Dashboard",
+        "option": "oidc_auto_create_user",
+        "type": "boolean",
+    },
     "storage_service_client_timeout": {
         "section": "Dashboard",
         "option": "storage_service_client_timeout",
@@ -242,6 +247,7 @@ csrf_trusted_origins =
 use_x_forwarded_host = False
 oidc_authentication = False
 oidc_allow_local_authentication = True
+oidc_auto_create_user = True
 storage_service_client_timeout = 86400
 storage_service_client_quick_timeout = 5
 agentarchives_client_timeout = 300
@@ -689,6 +695,7 @@ if CAS_AUTHENTICATION:
 OIDC_AUTHENTICATION = config.get("oidc_authentication")
 if OIDC_AUTHENTICATION:
     OIDC_ALLOW_LOCAL_AUTHENTICATION = config.get("oidc_allow_local_authentication")
+    OIDC_CREATE_USER = config.get("oidc_auto_create_user")
 
     INSTALLED_APPS += ["mozilla_django_oidc"]
     ALLOW_USER_EDITS = False

--- a/tests/dashboard/test_oidc.py
+++ b/tests/dashboard/test_oidc.py
@@ -344,3 +344,4 @@ def test_get_or_create_user_returns_existing_user_when_creation_disabled(
     )
 
     assert user == existing_user
+    assert User.objects.count() == 1

--- a/tests/dashboard/test_oidc.py
+++ b/tests/dashboard/test_oidc.py
@@ -300,8 +300,7 @@ def test_get_userinfo(settings: pytest_django.Settings) -> None:
 
 @pytest.mark.django_db
 def test_get_or_create_user_does_not_create_user_when_disabled(
-    settings: pytest_django.fixtures.SettingsWrapper,
-    monkeypatch: pytest.MonkeyPatch,
+    settings: pytest_django.Settings, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     settings.OIDC_CREATE_USER = False
     backend = CustomOIDCBackend()
@@ -323,8 +322,7 @@ def test_get_or_create_user_does_not_create_user_when_disabled(
 
 @pytest.mark.django_db
 def test_get_or_create_user_returns_existing_user_when_creation_disabled(
-    settings: pytest_django.fixtures.SettingsWrapper,
-    monkeypatch: pytest.MonkeyPatch,
+    settings: pytest_django.Settings, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     settings.OIDC_CREATE_USER = False
     existing_user = User.objects.create_user(

--- a/tests/dashboard/test_oidc.py
+++ b/tests/dashboard/test_oidc.py
@@ -1,5 +1,6 @@
 import pytest
 import pytest_django
+from django.contrib.auth.models import User
 
 from archivematica.dashboard.components.accounts.backends import CustomOIDCBackend
 
@@ -20,6 +21,7 @@ def settings(settings: pytest_django.Settings) -> pytest_django.Settings:
         "family_name": "last_name",
     }
     settings.OIDC_OP_SET_ROLES_FROM_CLAIMS = False
+    settings.OIDC_CREATE_USER = True
     settings.OIDC_OP_ROLE_CLAIM_PATH = "realm_access.roles"
     settings.OIDC_ID_ATTRIBUTE_MAP = {"email": "email"}
     settings.OIDC_USERNAME_ALGO = lambda email: email
@@ -294,3 +296,51 @@ def test_get_userinfo(settings: pytest_django.Settings) -> None:
     assert info["email"] == "test@example.com"
     assert info["first_name"] == "Test"
     assert info["last_name"] == "User"
+
+
+@pytest.mark.django_db
+def test_get_or_create_user_does_not_create_user_when_disabled(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings.OIDC_CREATE_USER = False
+    backend = CustomOIDCBackend()
+    monkeypatch.setattr(
+        backend,
+        "get_userinfo",
+        lambda access_token, id_token, payload: {"email": "new@example.com"},
+    )
+
+    user = backend.get_or_create_user(
+        access_token="access-token",
+        id_token="id-token",
+        payload={"sub": "test"},
+    )
+
+    assert user is None
+    assert User.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_get_or_create_user_returns_existing_user_when_creation_disabled(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings.OIDC_CREATE_USER = False
+    existing_user = User.objects.create_user(
+        username="existing@example.com", email="existing@example.com"
+    )
+    backend = CustomOIDCBackend()
+    monkeypatch.setattr(
+        backend,
+        "get_userinfo",
+        lambda access_token, id_token, payload: {"email": "existing@example.com"},
+    )
+
+    user = backend.get_or_create_user(
+        access_token="access-token",
+        id_token="id-token",
+        payload={"sub": "test"},
+    )
+
+    assert user == existing_user

--- a/typings/mozilla_django_oidc/auth.pyi
+++ b/typings/mozilla_django_oidc/auth.pyi
@@ -39,6 +39,12 @@ class OIDCAuthenticationBackend(ModelBackend):
         id_token: str,
         payload: _OIDCClaims | None,
     ) -> dict[str, object]: ...
+    def get_or_create_user(
+        self,
+        access_token: str,
+        id_token: str,
+        payload: _OIDCClaims | None,
+    ) -> User | None: ...
     def authenticate(
         self,
         request: HttpRequest | None,


### PR DESCRIPTION
Add a Dashboard config option to control whether OIDC logins can automatically create a local user when no matching Dashboard account exists.

This keeps the current default behavior enabled and exposes it through the new application variable
`ARCHIVEMATICA_DASHBOARD_DASHBOARD_OIDC_AUTO_CREATE_USER`.

Connects to https://github.com/archivematica/Issues/issues/1783