### PR TITLE
Fix monitor job status row styling

### DIFF
--- a/src/archivematica/dashboard/frontend/lib/monitor/components/ProcessMonitor.spec.ts
+++ b/src/archivematica/dashboard/frontend/lib/monitor/components/ProcessMonitor.spec.ts
@@ -287,6 +287,51 @@ describe('ProcessMonitor', () => {
     wrapper.unmount()
   })
 
+  it('keeps completed failed-transfer report jobs styled as successful', async () => {
+    const config: MonitorConfig = {
+      ...defaultConfig,
+      job_statuses: {
+        2: 'Completed successfully',
+      },
+    }
+
+    vi.mocked(getTransferStatuses).mockResolvedValueOnce({
+      objects: [{
+        uuid: 't-1',
+        directory: 'test-virus',
+        timestamp: 1,
+        jobs: [{
+          uuid: 'j-email-fail-report',
+          type: 'Email fail report',
+          microservicegroup: 'Failed transfer',
+          currentstep: 2,
+          timestamp: 1,
+          produces_tasks: true,
+        }],
+      }],
+      mcp: true,
+    })
+
+    const wrapper = mount(ProcessMonitor, {
+      props: { unitType: 'Transfer', config },
+      global: {
+        plugins: [i18n],
+      },
+    })
+
+    await flushPromises()
+    await wrapper.find('.microservice-group').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const job = wrapper.find('.job')
+    expect(job.exists()).toBe(true)
+    expect(job.text()).toContain('Email fail report')
+    expect(job.text()).toContain('Completed successfully')
+    expect(job.classes()).toContain('job-status-success')
+    expect(job.classes()).not.toContain('job-status-failed')
+    wrapper.unmount()
+  })
+
   it('sorts units and jobs by timestamp descending', async () => {
     vi.mocked(getTransferStatuses).mockResolvedValueOnce({
       objects: [

--- a/src/archivematica/dashboard/frontend/lib/shared/workflow.ts
+++ b/src/archivematica/dashboard/frontend/lib/shared/workflow.ts
@@ -169,9 +169,9 @@ const getStatusColorForCode = (statusCode: number): string =>
   STATUS_COLOR_BY_CODE[statusCode as MonitorStatusCode]
   ?? STATUS_COLOR_BY_CODE[STATUS_CODE_BY_NAME.STATUS_UNKNOWN]
 
-// Resolves a job-row background color from a job probe.
+// Resolves a job-row background color from the job's own status.
 const getStatusColorForJob = (probe: StatusProbe): string =>
-  getStatusColorForCode(resolveEffectiveStatus(probe))
+  getStatusColorForCode(probe.currentstep)
 
 // Resolves an icon filename from a raw status code.
 const getStatusIconForCode = (statusCode: number): StatusIconName =>


### PR DESCRIPTION
This renders job row colors from each job's own status instead of applying failed/rejected group overrides, preserving unit-level override behavior.