### PR TITLE
Fix MCPClient worker recycling and metrics state growth

### DIFF
--- a/src/archivematica/MCPClient/client/__init__.py
+++ b/src/archivematica/MCPClient/client/__init__.py
@@ -1,44 +1,27 @@
-import atexit
 import os
-import shutil
-import tempfile
 
 
-def configure_prometheus_multiproc_dir() -> str:
-    """Create the Prometheus multi-process directory.
+def configure_prometheus_client() -> None:
+    """Keep MCPClient metrics in the parent-owned scrape contract.
 
-    Ensure that the multi-process directory exists. Use a temporary directory
-    instead when the user did not provide one via the environment string.
-    The environment string is always set for the library to be set up properly.
+    Some client script imports can load prometheus_client before this package is
+    imported. Resetting ValueClass after clearing the environment keeps later
+    MCPClient collectors in normal in-process mode even in that import order.
+    Created-series export is also disabled so normal collectors do not add
+    time series that the previous MultiProcessCollector scrape did not expose.
     """
-    try:
-        prometheus_tmp_dir = os.environ["PROMETHEUS_MULTIPROC_DIR"]
-    except KeyError:
-        pass
-    else:
-        os.makedirs(prometheus_tmp_dir, mode=0o770, exist_ok=True)
-        return prometheus_tmp_dir
+    os.environ.pop("PROMETHEUS_MULTIPROC_DIR", None)
+    os.environ.pop("prometheus_multiproc_dir", None)
+    os.environ["PROMETHEUS_DISABLE_CREATED_SERIES"] = "true"
+    from prometheus_client import disable_created_metrics
+    from prometheus_client import values
 
-    prometheus_tmp_dir = tempfile.mkdtemp(prefix="prometheus-stats")
-    os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_tmp_dir
-
-    return prometheus_tmp_dir
+    disable_created_metrics()
+    values.ValueClass = values.get_value_class()
 
 
-def delete_prometheus_multiproc_dir(prometheus_tmp_dir: str) -> None:
-    """The multi-process directory must be wiped between runs."""
-    shutil.rmtree(prometheus_tmp_dir)
-
-
-# Set up the temporary directory that the Prometheus client library will use to
-# store metrics of MCPClient and its child processes.
-#
-# Setting the environment string "prometheus_multiproc_dir" is the only
-# mechanism we have to ensure that the Prometheus client library is in
-# multi-process mode. "prometheus_client.values.ValueClass" will be an instance
-# of "MultiProcessValue".
-#
-# This needs to happen before we import client.metrics. The temporary directory
-# is removed before the application exits.
-prometheus_tmp_dir = configure_prometheus_multiproc_dir()
-atexit.register(delete_prometheus_multiproc_dir, prometheus_tmp_dir)
+# MCPClient owns Prometheus metrics in the parent process. Workers send metric
+# events to the parent over a multiprocessing queue instead of using
+# prometheus_client multiprocess mode, which stores per-worker mmap files that
+# grow without bound when workers are recycled frequently.
+configure_prometheus_client()

--- a/src/archivematica/MCPClient/client/gearman.py
+++ b/src/archivematica/MCPClient/client/gearman.py
@@ -175,7 +175,7 @@ class MCPGearmanWorker(gearman.GearmanWorker):
             task_name,
         )
 
-        with metrics.task_execution_time_histogram.labels(script_name=task_name).time():
+        with metrics.time_task_execution(task_name):
             jobs = self._prepare_jobs(task_name, gearman_job)
             # run task will update jobs in place, by reference
             run_task(task_name, job_module, jobs)

--- a/src/archivematica/MCPClient/client/gearman.py
+++ b/src/archivematica/MCPClient/client/gearman.py
@@ -4,6 +4,7 @@ import multiprocessing
 from datetime import datetime
 from multiprocessing.synchronize import Event
 from types import TracebackType
+from typing import Callable
 from typing import Optional
 from typing import Union
 
@@ -53,6 +54,14 @@ logger = logging.getLogger("archivematica.mcp.client.gearman")
 
 
 class MCPGearmanWorker(gearman.GearmanWorker):
+    """Gearman worker used by MCPClient child processes.
+
+    Task registration in python-gearman is mostly local until ``work()`` opens
+    a server connection and flushes the initial client ID and CAN_DO commands.
+    The optional readiness callback lets the process pool observe that stronger
+    boundary instead of treating object construction as worker readiness.
+    """
+
     data_encoder = JSONDataEncoder
 
     def __init__(
@@ -61,6 +70,7 @@ class MCPGearmanWorker(gearman.GearmanWorker):
         client_scripts: list[str],
         shutdown_event: Optional[Event] = None,
         max_jobs_to_process: Optional[int] = None,
+        readiness_callback: Optional[Callable[[], None]] = None,
     ) -> None:
         super().__init__(hosts)
 
@@ -69,6 +79,8 @@ class MCPGearmanWorker(gearman.GearmanWorker):
         self.jobs_processed_count = 0
         self.max_jobs_to_process = max_jobs_to_process
         self.shutdown_event = shutdown_event
+        self.readiness_callback = readiness_callback
+        self.ready_reported = False
 
         self.set_client_id(self.client_id.encode("ascii"))
 
@@ -77,6 +89,32 @@ class MCPGearmanWorker(gearman.GearmanWorker):
             self.register_task(client_script.encode(), task_handler)
 
         logger.debug("Worker %s registered tasks: %s", self.client_id, client_scripts)
+
+    def _report_ready_if_connections_flushed(self) -> None:
+        """Report readiness after Gearman startup commands have been flushed.
+
+        ``register_task`` records abilities locally when no server connection
+        exists. During ``work()``, python-gearman establishes connections,
+        writes SET_CLIENT_ID, RESET_ABILITIES, CAN_DO, and PRE_SLEEP commands,
+        and then polls until the outgoing buffers are empty. Only then do we
+        tell the parent that this process is ready for its worker slot.
+        """
+        if self.ready_reported or self.readiness_callback is None:
+            return
+
+        connected = [
+            connection
+            for connection in getattr(self, "connection_list", [])
+            if connection.connected
+        ]
+        if not connected:
+            return
+
+        if any(connection.writable() for connection in connected):
+            return
+
+        self.ready_reported = True
+        self.readiness_callback()
 
     @staticmethod
     def _format_job_results(jobs: list[Job]) -> JobResults:
@@ -160,10 +198,11 @@ class MCPGearmanWorker(gearman.GearmanWorker):
         return bool(super().on_job_exception(current_job, exc_info))
 
     def after_poll(self, any_activity: bool) -> bool:
-        """Hook for worker exit after a poll.
+        """Hook for worker readiness and exit after a poll.
 
         We exit if the shutdown event has been set, or if `max_jobs_to_process`
-        jobs have been completed.
+        jobs have been completed. Readiness is reported only after those exit
+        checks, so a worker that is about to stop is not marked ready.
         """
         if self.shutdown_event and self.shutdown_event.is_set():
             logger.info("Gearman Worker exited due to shutdown")
@@ -178,5 +217,7 @@ class MCPGearmanWorker(gearman.GearmanWorker):
                 self.jobs_processed_count,
             )
             return False
+
+        self._report_ready_if_connections_flushed()
 
         return True

--- a/src/archivematica/MCPClient/client/metrics.py
+++ b/src/archivematica/MCPClient/client/metrics.py
@@ -1,14 +1,33 @@
-"""
-Exposes various metrics via Prometheus.
+"""Expose MCPClient metrics via Prometheus.
+
+MCPClient supervises short-lived worker processes. Using prometheus_client
+multiprocess mode for those workers creates per-PID mmap files under
+``/tmp/prometheus-stats*``; counters and histograms from dead workers remain
+there by design and become expensive to merge as workers are recycled.
+
+Instead, MCPClient owns a single Prometheus registry in the long-lived parent
+process. Worker processes send compact :class:`MetricEvent` messages over a
+multiprocessing queue, and the parent applies those events to ``REGISTRY``.
+This keeps metric state in one process while preserving the public MCPClient
+metric names.
 """
 
 import configparser
 import datetime
 import functools
+import logging
+import queue
 import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
 from typing import Callable
+from typing import NamedTuple
 from typing import Optional
+from typing import Protocol
 from typing import TypeVar
+from typing import cast
 from wsgiref.simple_server import WSGIServer
 
 import django
@@ -22,9 +41,9 @@ from prometheus_client import CollectorRegistry
 from prometheus_client import Counter
 from prometheus_client import Gauge
 from prometheus_client import Histogram
-from prometheus_client import multiprocess
 from prometheus_client import start_http_server
 
+from archivematica.archivematicaCommon import common_metrics
 from archivematica.archivematicaCommon.common_metrics import PACKAGE_FILE_COUNT_BUCKETS
 from archivematica.archivematicaCommon.common_metrics import PACKAGE_SIZE_BUCKETS
 from archivematica.archivematicaCommon.common_metrics import PROCESSING_TIME_BUCKETS
@@ -34,27 +53,65 @@ from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import FileFormatVersion
 from archivematica.dashboard.main.models import Transfer
 
+logger = logging.getLogger("archivematica.mcp.client.metrics")
+
+
+class MetricQueue(Protocol):
+    """Small protocol shared by multiprocessing and test queues.
+
+    Workers only need non-blocking writes. The parent listener uses blocking
+    reads while running and non-blocking reads during shutdown drain.
+    """
+
+    def get(self, block: bool = True, timeout: Optional[float] = None) -> Any: ...
+    def get_nowait(self) -> Any: ...
+    def put_nowait(self, item: Any) -> None: ...
+
+
+class MetricEvent(NamedTuple):
+    """A metric mutation sent from a worker to the parent process.
+
+    ``collector`` is a key in ``_COLLECTORS`` rather than a metric name. The
+    event represents an operation to replay on the parent-owned collector, not
+    a Prometheus sample.
+    """
+
+    collector: str
+    action: str
+    labels: tuple[tuple[str, str], ...] = ()
+    value: float = 1.0
+
+
+# Dedicated registry served by MCPClient's /metrics endpoint. It intentionally
+# excludes prometheus_client's default runtime/process collectors.
+REGISTRY = CollectorRegistry()
+_EVENT_QUEUE: Optional[MetricQueue] = None
+_EVENT_QUEUE_LOCK = threading.RLock()
+
+
 job_counter = Counter(
     "mcpclient_job_total",
     "Number of jobs processed, labeled by script",
     ["script_name"],
+    registry=REGISTRY,
 )
 job_processed_timestamp = Gauge(
     "mcpclient_job_success_timestamp",
     "Timestamp of most recent job processed, labeled by script",
     ["script_name"],
-    multiprocess_mode="livesum",
+    registry=REGISTRY,
 )
 job_error_counter = Counter(
     "mcpclient_job_error_total",
     "Number of failures processing jobs, labeled by script",
     ["script_name"],
+    registry=REGISTRY,
 )
 job_error_timestamp = Gauge(
     "mcpclient_job_error_timestamp",
     "Timestamp of most recent job failure, labeled by script",
     ["script_name"],
-    multiprocess_mode="livesum",
+    registry=REGISTRY,
 )
 
 task_execution_time_histogram = Histogram(
@@ -62,113 +119,138 @@ task_execution_time_histogram = Histogram(
     "Histogram of worker task execution times in seconds, labeled by script",
     ["script_name"],
     buckets=TASK_DURATION_BUCKETS,
+    registry=REGISTRY,
 )
 
 transfer_started_counter = Counter(
     "mcpclient_transfer_started_total",
     "Number of Transfers started, by transfer type",
     ["transfer_type"],
+    registry=REGISTRY,
 )
 transfer_started_timestamp = Gauge(
     "mcpclient_transfer_started_timestamp",
     "Timestamp of most recent transfer started, by transfer type",
     ["transfer_type"],
-    multiprocess_mode="livesum",
+    registry=REGISTRY,
 )
 transfer_completed_counter = Counter(
     "mcpclient_transfer_completed_total",
     "Number of Transfers completed, by transfer type",
     ["transfer_type"],
+    registry=REGISTRY,
 )
 transfer_completed_timestamp = Gauge(
     "mcpclient_transfer_completed_timestamp",
     "Timestamp of most recent transfer completed, by transfer type",
     ["transfer_type"],
-    multiprocess_mode="livesum",
+    registry=REGISTRY,
 )
 transfer_error_counter = Counter(
     "mcpclient_transfer_error_total",
     "Number of transfer failures, by transfer type, error type",
     ["transfer_type", "failure_type"],
+    registry=REGISTRY,
 )
 transfer_error_timestamp = Gauge(
     "mcpclient_transfer_error_timestamp",
     "Timestamp of most recent transfer failure, by transfer type, error type",
     ["transfer_type", "failure_type"],
-    multiprocess_mode="livesum",
+    registry=REGISTRY,
 )
 transfer_files_histogram = Histogram(
     "mcpclient_transfer_files",
     "Histogram of number of files included in transfers, by transfer type",
     ["transfer_type"],
     buckets=PACKAGE_FILE_COUNT_BUCKETS,
+    registry=REGISTRY,
 )
 transfer_size_histogram = Histogram(
     "mcpclient_transfer_size_bytes",
     "Histogram of number bytes in transfers, by transfer type",
     ["transfer_type"],
     buckets=PACKAGE_SIZE_BUCKETS,
+    registry=REGISTRY,
 )
 
-sip_started_counter = Counter("mcpclient_sip_started_total", "Number of SIPs started")
+sip_started_counter = Counter(
+    "mcpclient_sip_started_total",
+    "Number of SIPs started",
+    registry=REGISTRY,
+)
 sip_started_timestamp = Gauge(
     "mcpclient_sip_started_timestamp",
     "Timestamp of most recent SIP started",
-    multiprocess_mode="livesum",
+    registry=REGISTRY,
 )
 sip_error_counter = Counter(
     "mcpclient_sip_error_total",
     "Number of SIP failures, by error type",
     ["failure_type"],
+    registry=REGISTRY,
 )
 sip_error_timestamp = Gauge(
     "mcpclient_sip_error_timestamp",
     "Timestamp of most recent SIP failure, by error type",
     ["failure_type"],
-    multiprocess_mode="livesum",
+    registry=REGISTRY,
 )
 
-aips_stored_counter = Counter("mcpclient_aips_stored_total", "Number of AIPs stored")
-dips_stored_counter = Counter("mcpclient_dips_stored_total", "Number of DIPs stored")
+aips_stored_counter = Counter(
+    "mcpclient_aips_stored_total",
+    "Number of AIPs stored",
+    registry=REGISTRY,
+)
+dips_stored_counter = Counter(
+    "mcpclient_dips_stored_total",
+    "Number of DIPs stored",
+    registry=REGISTRY,
+)
 aips_stored_timestamp = Gauge(
     "mcpclient_aips_stored_timestamp",
     "Timestamp of most recent AIP stored",
-    multiprocess_mode="livesum",
+    registry=REGISTRY,
 )
 dips_stored_timestamp = Gauge(
     "mcpclient_dips_stored_timestamp",
     "Timestamp of most recent DIP stored",
-    multiprocess_mode="livesum",
+    registry=REGISTRY,
 )
 aip_processing_time_histogram = Histogram(
     "mcpclient_aip_processing_seconds",
     "Histogram of AIP processing time, from first file recorded in DB to storage in SS",
     buckets=PROCESSING_TIME_BUCKETS,
+    registry=REGISTRY,
 )
 dip_processing_time_histogram = Histogram(
     "mcpclient_dip_processing_seconds",
     "Histogram of DIP processing time, from first file recorded in DB to storage in SS",
     buckets=PROCESSING_TIME_BUCKETS,
+    registry=REGISTRY,
 )
 aip_files_stored_histogram = Histogram(
     "mcpclient_aip_files_stored",
     "Histogram of number of files stored in AIPs. Note, this includes metadata, derivatives, etc.",
     buckets=PACKAGE_FILE_COUNT_BUCKETS,
+    registry=REGISTRY,
 )
 dip_files_stored_histogram = Histogram(
     "mcpclient_dip_files_stored",
     "Histogram of number of files stored in DIPs.",
     buckets=PACKAGE_FILE_COUNT_BUCKETS,
+    registry=REGISTRY,
 )
 aip_size_histogram = Histogram(
     "mcpclient_aip_size_bytes",
     "Histogram of number of bytes stored in AIPs. Note, this includes metadata, derivatives, etc.",
     buckets=PACKAGE_SIZE_BUCKETS,
+    registry=REGISTRY,
 )
 dip_size_histogram = Histogram(
     "mcpclient_dip_size_bytes",
     "Histogram of number of bytes stored in DIPs. Note, this includes metadata, derivatives, etc.",
     buckets=PACKAGE_SIZE_BUCKETS,
+    registry=REGISTRY,
 )
 
 # As we track over 1000 formats, the cardinality here is around 3000 and
@@ -178,6 +260,7 @@ aip_files_stored_by_file_group_and_format_counter = Counter(
     "mcpclient_aip_files_stored_by_file_group_and_format_total",
     "Number of original files stored in AIPs labeled by file group, format name.",
     ["file_group", "format_name"],
+    registry=REGISTRY,
 )
 aip_original_file_timestamps_histogram = Histogram(
     "mcpclient_aip_original_file_timestamps",
@@ -185,6 +268,16 @@ aip_original_file_timestamps_histogram = Histogram(
     buckets=[1970, 1980, 1990, 2005, 2010]
     + list(range(2015, datetime.date.today().year + 2))
     + [float("inf")],
+    registry=REGISTRY,
+)
+ss_api_time_counter = Counter(
+    "common_ss_api_request_duration_seconds",
+    (
+        "Total time waiting on the Storage Service API in seconds, labeled by "
+        "function name"
+    ),
+    ["function"],
+    registry=REGISTRY,
 )
 
 
@@ -192,6 +285,43 @@ aip_original_file_timestamps_histogram = Histogram(
 FILE_GROUPS = ("original", "derivative", "metadata")
 PACKAGE_FAILURE_TYPES = ("fail", "reject")
 TRANSFER_TYPES = ("Standard", "Dataverse", "Dspace", "TRIM", "Maildir", "Unknown")
+
+# Map stable event names to parent-owned collectors. Worker code must use these
+# keys so event payloads remain small and independent of collector instances.
+_COLLECTORS = {
+    "job_counter": job_counter,
+    "job_processed_timestamp": job_processed_timestamp,
+    "job_error_counter": job_error_counter,
+    "job_error_timestamp": job_error_timestamp,
+    "task_execution_time_histogram": task_execution_time_histogram,
+    "transfer_started_counter": transfer_started_counter,
+    "transfer_started_timestamp": transfer_started_timestamp,
+    "transfer_completed_counter": transfer_completed_counter,
+    "transfer_completed_timestamp": transfer_completed_timestamp,
+    "transfer_error_counter": transfer_error_counter,
+    "transfer_error_timestamp": transfer_error_timestamp,
+    "transfer_files_histogram": transfer_files_histogram,
+    "transfer_size_histogram": transfer_size_histogram,
+    "sip_started_counter": sip_started_counter,
+    "sip_started_timestamp": sip_started_timestamp,
+    "sip_error_counter": sip_error_counter,
+    "sip_error_timestamp": sip_error_timestamp,
+    "aips_stored_counter": aips_stored_counter,
+    "dips_stored_counter": dips_stored_counter,
+    "aips_stored_timestamp": aips_stored_timestamp,
+    "dips_stored_timestamp": dips_stored_timestamp,
+    "aip_processing_time_histogram": aip_processing_time_histogram,
+    "dip_processing_time_histogram": dip_processing_time_histogram,
+    "aip_files_stored_histogram": aip_files_stored_histogram,
+    "dip_files_stored_histogram": dip_files_stored_histogram,
+    "aip_size_histogram": aip_size_histogram,
+    "dip_size_histogram": dip_size_histogram,
+    "aip_files_stored_by_file_group_and_format_counter": (
+        aip_files_stored_by_file_group_and_format_counter
+    ),
+    "aip_original_file_timestamps_histogram": (aip_original_file_timestamps_histogram),
+    "ss_api_time_counter": ss_api_time_counter,
+}
 
 
 T = TypeVar("T")
@@ -207,6 +337,194 @@ def skip_if_prometheus_disabled(
         return None
 
     return wrapper
+
+
+def configure_event_queue(event_queue: Optional[MetricQueue]) -> None:
+    """Route metric updates through a queue.
+
+    MCPClient workers call this with the parent-owned queue before processing
+    Gearman jobs. The parent keeps the default ``None`` value and applies
+    metrics directly.
+    """
+    global _EVENT_QUEUE
+    with _EVENT_QUEUE_LOCK:
+        _EVENT_QUEUE = event_queue
+
+
+def apply_event(event: MetricEvent) -> None:
+    """Apply one worker metric event to the parent registry."""
+    collector = _COLLECTORS[event.collector]
+    metric = collector.labels(**dict(event.labels)) if event.labels else collector
+
+    if event.action == "inc":
+        cast(Counter, metric).inc(event.value)
+    elif event.action == "set":
+        cast(Gauge, metric).set(event.value)
+    elif event.action == "set_max":
+        current = cast(Any, metric)._value.get()
+        if event.value > current:
+            cast(Gauge, metric).set(event.value)
+    elif event.action == "observe":
+        cast(Histogram, metric).observe(event.value)
+    else:
+        raise ValueError(f"Unknown metric event action: {event.action}")
+
+
+class EventListener:
+    """Drain worker metric events and apply them in the parent process."""
+
+    def __init__(self, event_queue: MetricQueue) -> None:
+        self.event_queue = event_queue
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        self._thread = threading.Thread(
+            target=self._listen,
+            name="mcpclient-metrics-listener",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join()
+        self._drain()
+
+    def _listen(self) -> None:
+        while not self._stop.is_set():
+            try:
+                event = self.event_queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            self._apply(event)
+
+    def _drain(self) -> None:
+        while True:
+            try:
+                event = self.event_queue.get_nowait()
+            except queue.Empty:
+                return
+            self._apply(event)
+
+    @staticmethod
+    def _apply(event: Any) -> None:
+        if isinstance(event, MetricEvent):
+            try:
+                apply_event(event)
+            except Exception:
+                logger.exception("Failed to apply MCPClient metric event: %r", event)
+
+
+def _record_event(
+    collector: str,
+    action: str,
+    labels: Optional[dict[str, str]] = None,
+    value: float = 1.0,
+) -> None:
+    event = MetricEvent(
+        collector=collector,
+        action=action,
+        labels=tuple(sorted((labels or {}).items())),
+        value=value,
+    )
+    with _EVENT_QUEUE_LOCK:
+        event_queue = _EVENT_QUEUE
+
+    if event_queue is None:
+        apply_event(event)
+        return
+
+    try:
+        event_queue.put_nowait(event)
+    except Exception:
+        # Metrics must not affect task execution.
+        pass
+
+
+def _inc(
+    collector: str,
+    labels: Optional[dict[str, str]] = None,
+    amount: float = 1.0,
+) -> None:
+    _record_event(collector, "inc", labels, amount)
+
+
+def _set(
+    collector: str,
+    labels: Optional[dict[str, str]] = None,
+    value: float = 0.0,
+) -> None:
+    _record_event(collector, "set", labels, value)
+
+
+def _set_max(
+    collector: str,
+    labels: Optional[dict[str, str]] = None,
+    value: float = 0.0,
+) -> None:
+    _record_event(collector, "set_max", labels, value)
+
+
+def _set_to_current_time(
+    collector: str,
+    labels: Optional[dict[str, str]] = None,
+) -> None:
+    _set_max(collector, labels, time.time())
+
+
+def _observe(
+    collector: str,
+    labels: Optional[dict[str, str]] = None,
+    value: float = 0.0,
+) -> None:
+    _record_event(collector, "observe", labels, value)
+
+
+class _StorageServiceAPITimeCounterChild:
+    """Counter child compatible with common_metrics.ss_api_time_counter."""
+
+    def __init__(self, labels: dict[str, str]) -> None:
+        self.labels = labels
+
+    def inc(self, amount: float = 1.0) -> None:
+        _inc("ss_api_time_counter", self.labels, amount)
+
+
+class _StorageServiceAPITimeCounter:
+    """Bridge common Storage Service API timing into MCPClient metrics.
+
+    The shared ``storageService`` helpers call ``common_metrics.ss_api_timer``,
+    which increments ``common_metrics.ss_api_time_counter``. Replacing that
+    counter in MCPClient keeps ``common_ss_api_request_duration_seconds`` in
+    MCPClient scrapes without re-enabling prometheus_client multiprocess mode.
+    """
+
+    def labels(
+        self, *labelvalues: str, **labelkwargs: str
+    ) -> _StorageServiceAPITimeCounterChild:
+        labels = dict(labelkwargs)
+        if labelvalues:
+            labels["function"] = labelvalues[0]
+
+        return _StorageServiceAPITimeCounterChild(labels)
+
+
+cast(Any, common_metrics).ss_api_time_counter = _StorageServiceAPITimeCounter()
+
+
+@contextmanager
+def time_task_execution(script_name: str) -> Iterator[None]:
+    start = time.monotonic()
+    try:
+        yield
+    finally:
+        _observe(
+            "task_execution_time_histogram",
+            {"script_name": script_name},
+            time.monotonic() - start,
+        )
 
 
 def init_counter_labels() -> None:
@@ -251,35 +569,34 @@ def init_counter_labels() -> None:
 
 @skip_if_prometheus_disabled
 def worker_exit(process_id: Optional[int]) -> None:
-    multiprocess.mark_process_dead(process_id)
+    return None
 
 
 @skip_if_prometheus_disabled
 def start_prometheus_server() -> tuple[WSGIServer, threading.Thread]:
-    registry = CollectorRegistry()
-    multiprocess.MultiProcessCollector(registry)
-
     init_counter_labels()
 
     result: tuple[WSGIServer, threading.Thread] = start_http_server(
         settings.PROMETHEUS_BIND_PORT,
         addr=settings.PROMETHEUS_BIND_ADDRESS,
-        registry=registry,
+        registry=REGISTRY,
     )
     return result
 
 
 @skip_if_prometheus_disabled
 def job_completed(script_name: str) -> None:
-    job_counter.labels(script_name=script_name).inc()
-    job_processed_timestamp.labels(script_name=script_name).set_to_current_time()
+    labels = {"script_name": script_name}
+    _inc("job_counter", labels)
+    _set_to_current_time("job_processed_timestamp", labels)
 
 
 @skip_if_prometheus_disabled
 def job_failed(script_name: str) -> None:
-    job_counter.labels(script_name=script_name).inc()
-    job_error_counter.labels(script_name=script_name).inc()
-    job_error_timestamp.labels(script_name=script_name).set_to_current_time()
+    labels = {"script_name": script_name}
+    _inc("job_counter", labels)
+    _inc("job_error_counter", labels)
+    _set_to_current_time("job_error_timestamp", labels)
 
 
 def _get_file_group(raw_file_group_use: str) -> str:
@@ -305,9 +622,9 @@ def _get_file_group(raw_file_group_use: str) -> str:
 
 @skip_if_prometheus_disabled
 def aip_stored(sip_uuid: str, size: int) -> None:
-    aips_stored_counter.inc()
-    aips_stored_timestamp.set_to_current_time()
-    aip_size_histogram.observe(size)
+    _inc("aips_stored_counter")
+    _set_to_current_time("aips_stored_timestamp")
+    _observe("aip_size_histogram", value=size)
 
     try:
         earliest_file = File.objects.filter(sip_id=sip_uuid).earliest("enteredsystem")
@@ -315,11 +632,11 @@ def aip_stored(sip_uuid: str, size: int) -> None:
         pass
     else:
         duration = (timezone.now() - earliest_file.enteredsystem).total_seconds()
-        aip_processing_time_histogram.observe(duration)
+        _observe("aip_processing_time_histogram", value=duration)
 
     # We do two queries here, as we may not have format information for everything
     total_file_count = File.objects.filter(sip_id=sip_uuid).count()
-    aip_files_stored_histogram.observe(total_file_count)
+    _observe("aip_files_stored_histogram", value=total_file_count)
 
     if settings.PROMETHEUS_DETAILED_METRICS:
         # TODO: This could probably benefit from batching with prefetches. Using just
@@ -328,8 +645,9 @@ def aip_stored(sip_uuid: str, size: int) -> None:
             File.objects.filter(sip_id=sip_uuid).exclude(filegrpuse="aip").iterator()
         ):
             if file_obj.filegrpuse.lower() == "original" and file_obj.modificationtime:
-                aip_original_file_timestamps_histogram.observe(
-                    file_obj.modificationtime.year
+                _observe(
+                    "aip_original_file_timestamps_histogram",
+                    value=file_obj.modificationtime.year,
                 )
 
             file_group = _get_file_group(file_obj.filegrpuse)
@@ -349,16 +667,17 @@ def aip_stored(sip_uuid: str, size: int) -> None:
             ):
                 format_name = format_version_m2m.format_version.format.description
 
-            aip_files_stored_by_file_group_and_format_counter.labels(
-                file_group=file_group, format_name=format_name
-            ).inc()
+            _inc(
+                "aip_files_stored_by_file_group_and_format_counter",
+                {"file_group": file_group, "format_name": format_name},
+            )
 
 
 @skip_if_prometheus_disabled
 def dip_stored(sip_uuid: str, size: int) -> None:
-    dips_stored_counter.inc()
-    dips_stored_timestamp.set_to_current_time()
-    dip_size_histogram.observe(size)
+    _inc("dips_stored_counter")
+    _set_to_current_time("dips_stored_timestamp")
+    _observe("dip_size_histogram", value=size)
 
     try:
         earliest_file = File.objects.filter(sip_id=sip_uuid).earliest("enteredsystem")
@@ -366,18 +685,19 @@ def dip_stored(sip_uuid: str, size: int) -> None:
         pass
     else:
         duration = (timezone.now() - earliest_file.enteredsystem).total_seconds()
-        dip_processing_time_histogram.observe(duration)
+        _observe("dip_processing_time_histogram", value=duration)
 
     file_count = File.objects.filter(sip_id=sip_uuid).count()
-    dip_files_stored_histogram.observe(file_count)
+    _observe("dip_files_stored_histogram", value=file_count)
 
 
 @skip_if_prometheus_disabled
 def transfer_started(transfer_type: str) -> None:
     if not transfer_type:
         transfer_type = "Unknown"
-    transfer_started_counter.labels(transfer_type=transfer_type).inc()
-    transfer_started_timestamp.labels(transfer_type=transfer_type).set_to_current_time()
+    labels = {"transfer_type": transfer_type}
+    _inc("transfer_started_counter", labels)
+    _set_to_current_time("transfer_started_timestamp", labels)
 
 
 @skip_if_prometheus_disabled
@@ -389,19 +709,16 @@ def transfer_completed(transfer_uuid: str) -> None:
 
     transfer_type = transfer.type or "Unknown"
 
-    transfer_completed_counter.labels(transfer_type=transfer_type).inc()
-    transfer_completed_timestamp.labels(
-        transfer_type=transfer_type
-    ).set_to_current_time()
+    labels = {"transfer_type": transfer_type}
+    _inc("transfer_completed_counter", labels)
+    _set_to_current_time("transfer_completed_timestamp", labels)
 
     file_queryset = File.objects.filter(transfer=transfer)
     file_count = file_queryset.count()
-    transfer_files_histogram.labels(transfer_type=transfer_type).observe(file_count)
+    _observe("transfer_files_histogram", labels, file_count)
 
     transfer_size = file_queryset.aggregate(total_size=Sum("size"))
-    transfer_size_histogram.labels(transfer_type=transfer_type).observe(
-        transfer_size["total_size"]
-    )
+    _observe("transfer_size_histogram", labels, transfer_size["total_size"] or 0)
 
 
 @skip_if_prometheus_disabled
@@ -409,21 +726,19 @@ def transfer_failed(transfer_type: str, failure_type: str) -> None:
     if not transfer_type:
         transfer_type = "Unknown"
 
-    transfer_error_counter.labels(
-        transfer_type=transfer_type, failure_type=failure_type
-    ).inc()
-    transfer_error_timestamp.labels(
-        transfer_type=transfer_type, failure_type=failure_type
-    ).set_to_current_time()
+    labels = {"transfer_type": transfer_type, "failure_type": failure_type}
+    _inc("transfer_error_counter", labels)
+    _set_to_current_time("transfer_error_timestamp", labels)
 
 
 @skip_if_prometheus_disabled
 def sip_started() -> None:
-    sip_started_counter.inc()
-    sip_started_timestamp.set_to_current_time()
+    _inc("sip_started_counter")
+    _set_to_current_time("sip_started_timestamp")
 
 
 @skip_if_prometheus_disabled
 def sip_failed(failure_type: str) -> None:
-    sip_error_counter.labels(failure_type=failure_type).inc()
-    sip_error_timestamp.labels(failure_type=failure_type).set_to_current_time()
+    labels = {"failure_type": failure_type}
+    _inc("sip_error_counter", labels)
+    _set_to_current_time("sip_error_timestamp", labels)

--- a/src/archivematica/MCPClient/client/pool.py
+++ b/src/archivematica/MCPClient/client/pool.py
@@ -11,18 +11,31 @@ with ``max_tasks_per_child``, which is useful to free resources held.
 
 Workers log events into a shared queue while the pool runs a background thread
 (log listener) that listens to the queue and writes the events safely.
+
+The parent treats worker process liveness and Gearman readiness as separate
+states. A child can be alive but unusable if it has not reached the point where
+it has connected to Gearman and flushed its startup commands. The pool tracks
+that readiness explicitly so failed replacements are restarted instead of
+leaving a live-but-unregistered worker slot in place.
 """
 
+import faulthandler
 import logging
 import logging.handlers
 import multiprocessing
+import os
+import queue
+import signal
 import threading
 import time
+from enum import Enum
 from multiprocessing.synchronize import Event
 from types import ModuleType
+from typing import NamedTuple
 from typing import Optional
 from typing import Protocol
 from typing import TypeVar
+from typing import cast
 
 import django
 
@@ -39,11 +52,19 @@ T = TypeVar("T")
 
 
 class QueueLike(Protocol[T]):
-    def get(self) -> T: ...
+    def get(self, block: bool = True, timeout: Optional[float] = None) -> T: ...
+    def get_nowait(self) -> T: ...
     def put_nowait(self, item: T) -> None: ...
 
 
 LogQueue = QueueLike[logging.LogRecord]
+WorkerReadyQueue = QueueLike["WorkerReadyMessage"]
+
+# Use forkserver so workers are not forked directly from the long-lived parent.
+# The parent has threads for logging, metrics, and pool maintenance; forking a
+# process with active threads and inherited locks is fragile. Forkserver still
+# gives us process isolation while starting children from a simpler process.
+MP_CONTEXT = multiprocessing.get_context("forkserver")
 
 # This is how the return value of the `_get_worker_init_args` method looks
 # below:
@@ -58,6 +79,7 @@ LogQueue = QueueLike[logging.LogRecord]
 #                 "transcribefile_v0.0",
 #                 "characterizefile_v0.0",
 #             ],
+#             0,
 #         ),
 #         {
 #             "shutdown_event": "<multiprocessing.synchronize.Event object at 0x7609ba454340>"
@@ -65,49 +87,123 @@ LogQueue = QueueLike[logging.LogRecord]
 #     ),
 #     ...
 # ]
-WorkerInitArgs = list[tuple[tuple[LogQueue, list[str]], dict[str, Event]]]
+WorkerInitArgs = list[
+    tuple[tuple[LogQueue, WorkerReadyQueue, list[str], int], dict[str, Event]]
+]
 
 logger = logging.getLogger("archivematica.mcp.client.worker")
 
 
+class WorkerReadyMessage(NamedTuple):
+    """Readiness notification sent by a child worker to the parent.
+
+    This does not mean only "the process started". It means the child reached
+    MCPClient's readiness boundary and should be considered available for its
+    worker slot if the PID still matches the currently tracked process.
+    """
+
+    worker_index: int
+    process_id: int
+
+
+class WorkerState(str, Enum):
+    """Parent-observed state for one worker slot."""
+
+    STARTING = "starting"
+    READY = "ready"
+    EXITED = "exited"
+    UNREADY_TIMEOUT = "unready_timeout"
+
+
+def _register_traceback_dump_handler() -> None:
+    """Let the parent request a Python stack dump from a stuck child."""
+    if not hasattr(signal, "SIGUSR1"):
+        logger.debug("SIGUSR1 is not available; worker traceback dumps disabled")
+        return
+
+    try:
+        faulthandler.register(signal.SIGUSR1, all_threads=True, chain=False)
+    except (OSError, RuntimeError, ValueError) as err:
+        logger.warning("Could not register worker traceback dump handler: %s", err)
+
+
 def run_gearman_worker(
     log_queue: LogQueue,
+    readiness_queue: WorkerReadyQueue,
     client_scripts: list[str],
+    worker_index: int,
     shutdown_event: Optional[Event] = None,
 ) -> None:
-    """Target function executed by child processes in the pool."""
+    """Target function executed by child processes in the pool.
+
+    Each child configures queue-backed logging and metrics, closes inherited
+    database connections, builds its own Gearman worker, and reports readiness
+    only through the Gearman worker's readiness callback.
+    """
+    # Child processes should not inherit MCPClient parent signal handlers. Keep
+    # SIGTERM terminable by Process.terminate(), and let SIGINT use Python's
+    # normal KeyboardInterrupt behavior.
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    signal.signal(signal.SIGINT, signal.default_int_handler)
+    _register_traceback_dump_handler()
+
+    process_id = multiprocessing.current_process().pid
+    if process_id is None:
+        raise RuntimeError("Worker process has no PID")
+
+    max_jobs_to_process = settings.MAX_TASKS_PER_CHILD
+
     # Set up logging, as we're in a new process now.
     logger = logging.getLogger("archivematica.mcp.client")
     logger.setLevel(logging.DEBUG)
     queue_handler = logging.handlers.QueueHandler(log_queue)
     logger.addHandler(queue_handler)
 
-    process_id = multiprocessing.current_process().pid
     gearman_hosts = [settings.GEARMAN_SERVER]
-    max_jobs_to_process = settings.MAX_TASKS_PER_CHILD
 
     # Reject connections of the parent, this process will have its own.
     db.connections.close_all()
+
+    def report_ready() -> None:
+        readiness_queue.put_nowait(WorkerReadyMessage(worker_index, process_id))
 
     worker = MCPGearmanWorker(
         gearman_hosts,
         client_scripts,
         shutdown_event=shutdown_event,
         max_jobs_to_process=max_jobs_to_process,
+        readiness_callback=report_ready,
     )
     logger.debug("Worker process %s starting", process_id)
-    worker.work()
-    logger.debug("Worker process %s exiting", process_id)
+    try:
+        worker.work()
+    finally:
+        logger.debug("Worker process %s exiting", process_id)
 
 
 class WorkerPool:
     # Delay in the maintenance loop until workers are checked and restarted.
     WORKER_RESTART_DELAY = 1.0
+    # Workers normally register Gearman tasks quickly. A worker that remains
+    # alive but unready after this timeout is treated as a failed replacement.
+    WORKER_STARTUP_TIMEOUT = 30.0
+    # Time to wait after SIGTERM before killing an unready worker.
+    WORKER_TERMINATE_TIMEOUT = 5.0
+    WORKER_TRACEBACK_DUMP_DELAY = 0.5
 
     def __init__(self) -> None:
-        self.log_queue: LogQueue = multiprocessing.Queue()
-        self.shutdown_event = multiprocessing.Event()
+        self.log_queue: LogQueue = MP_CONTEXT.Queue()
+        self.worker_readiness_queue: WorkerReadyQueue = MP_CONTEXT.Queue()
+        self.shutdown_event = MP_CONTEXT.Event()
         self.workers: list[multiprocessing.Process] = []
+
+        # Slot state is owned by the parent. ``worker_ready`` maps slot -> PID
+        # so a delayed readiness message from an already-replaced child cannot
+        # mark the new process ready by accident.
+        self.worker_started_at: dict[int, float] = {}
+        self.worker_ready_at: dict[int, float] = {}
+        self.worker_ready: dict[int, int] = {}
+        self.worker_state: dict[int, WorkerState] = {}
         self.job_modules = loader.load_job_modules(settings.CLIENT_MODULES_FILE)
         self.worker_function = run_gearman_worker
 
@@ -186,20 +282,29 @@ class WorkerPool:
 
         return [
             (
-                (self.log_queue, worker_init_scripts),
+                (
+                    self.log_queue,
+                    self.worker_readiness_queue,
+                    worker_init_scripts,
+                    index,
+                ),
                 {
                     "shutdown_event": self.shutdown_event,
                 },
             )
-            for worker_init_scripts in init_scripts
+            for index, worker_init_scripts in enumerate(init_scripts)
         ]
 
     def _maintain_pool(self) -> None:
-        """Run as a loop in another thread; we check the pool size and spin up
-        new workers as required.
+        """Run the worker supervision loop in the parent process.
+
+        The loop drains readiness messages and replaces workers that have
+        exited or remained alive without reaching readiness.
         """
         while not self.shutdown_event.is_set():
+            self._collect_worker_readiness()
             self._restart_exited_workers()
+            self._restart_unready_workers()
             time.sleep(self.WORKER_RESTART_DELAY)
 
     def _restart_exited_workers(self) -> bool:
@@ -209,6 +314,15 @@ class WorkerPool:
         restarted = False
         for index, worker in enumerate(self.workers):
             if worker.exitcode is not None:
+                self.worker_state[index] = WorkerState.EXITED
+                self.worker_ready.pop(index, None)
+                self.worker_ready_at.pop(index, None)
+                logger.info(
+                    "Worker slot %s process %s exited with code %s; restarting",
+                    index,
+                    worker.pid,
+                    worker.exitcode,
+                )
                 metrics.worker_exit(worker.pid)
                 worker.join()
                 restarted = True
@@ -216,16 +330,157 @@ class WorkerPool:
 
         return restarted
 
+    def _collect_worker_readiness(self) -> None:
+        """Accept readiness messages from the current process in each slot.
+
+        Replacement can race with child startup. A stale child may report ready
+        after the parent has already put a new process in the same slot, so the
+        PID in the message must match the currently tracked worker PID.
+        """
+        while True:
+            try:
+                message = self.worker_readiness_queue.get_nowait()
+            except queue.Empty:
+                return
+
+            if message.worker_index >= len(self.workers):
+                logger.debug(
+                    "Ignoring readiness from unknown worker index %s (pid %s)",
+                    message.worker_index,
+                    message.process_id,
+                )
+                continue
+
+            current_worker = self.workers[message.worker_index]
+            if current_worker.pid != message.process_id:
+                logger.debug(
+                    "Ignoring stale readiness from worker index %s pid %s; current pid is %s",
+                    message.worker_index,
+                    message.process_id,
+                    current_worker.pid,
+                )
+                continue
+
+            now = time.monotonic()
+            started_at = self.worker_started_at.get(message.worker_index)
+            if started_at is not None:
+                logger.info(
+                    "Worker slot %s process %s reported ready after %.3f seconds",
+                    message.worker_index,
+                    message.process_id,
+                    now - started_at,
+                )
+            else:
+                logger.info(
+                    "Worker slot %s process %s reported ready",
+                    message.worker_index,
+                    message.process_id,
+                )
+            self.worker_ready[message.worker_index] = message.process_id
+            self.worker_ready_at[message.worker_index] = now
+            self.worker_state[message.worker_index] = WorkerState.READY
+
+    def _restart_unready_workers(self) -> bool:
+        """Restart workers that are alive but never reached readiness.
+
+        This handles the failure mode where process supervision alone is not
+        enough: the OS process exists, but the worker did not complete Gearman
+        initialization and therefore cannot take tasks.
+        """
+        restarted = False
+        now = time.monotonic()
+        for index, worker in enumerate(self.workers):
+            if worker.exitcode is not None:
+                continue
+
+            if self.worker_ready.get(index) == worker.pid:
+                continue
+
+            started_at = self.worker_started_at.get(index)
+            if started_at is None or now - started_at < self.WORKER_STARTUP_TIMEOUT:
+                continue
+
+            logger.warning(
+                "Worker slot %s process %s did not report ready within %.1f seconds; restarting",
+                index,
+                worker.pid,
+                self.WORKER_STARTUP_TIMEOUT,
+            )
+            self.worker_state[index] = WorkerState.UNREADY_TIMEOUT
+            self.worker_ready.pop(index, None)
+            self.worker_ready_at.pop(index, None)
+            self._dump_unready_worker_traceback(index, worker)
+            worker.terminate()
+            worker.join(self.WORKER_TERMINATE_TIMEOUT)
+            if worker.is_alive():
+                logger.error(
+                    "Worker slot %s process %s did not terminate; killing",
+                    index,
+                    worker.pid,
+                )
+                worker.kill()
+                worker.join()
+
+            metrics.worker_exit(worker.pid)
+            self.workers[index] = self._start_worker(index)
+            restarted = True
+
+        return restarted
+
+    def _dump_unready_worker_traceback(
+        self, index: int, worker: multiprocessing.Process
+    ) -> None:
+        """Request a diagnostic traceback before terminating an unready child."""
+        if worker.pid is None or not hasattr(signal, "SIGUSR1"):
+            return
+
+        logger.warning(
+            "Requesting traceback dump from unready worker slot %s process %s",
+            index,
+            worker.pid,
+        )
+        try:
+            os.kill(worker.pid, signal.SIGUSR1)
+        except ProcessLookupError:
+            logger.debug(
+                "Worker slot %s process %s exited before traceback dump request",
+                index,
+                worker.pid,
+            )
+            return
+        except OSError as err:
+            logger.warning(
+                "Could not request traceback dump from worker slot %s process %s: %s",
+                index,
+                worker.pid,
+                err,
+            )
+            return
+
+        time.sleep(self.WORKER_TRACEBACK_DUMP_DELAY)
+
     def _start_worker(self, index: int) -> multiprocessing.Process:
-        """Start the new worker in a separate process."""
+        """Start a worker process and reset parent readiness for its slot."""
         worker_args, worker_kwargs = self._worker_init_args[index]
-        worker = multiprocessing.Process(
-            name=f"MCPClientWorker-{index}",
-            target=self.worker_function,
-            args=worker_args,
-            kwargs=worker_kwargs,
+        worker = cast(
+            multiprocessing.Process,
+            MP_CONTEXT.Process(
+                name=f"MCPClientWorker-{index}",
+                target=self.worker_function,
+                args=worker_args,
+                kwargs=worker_kwargs,
+            ),
         )
         worker.daemon = False
         worker.start()
+        self.worker_started_at[index] = time.monotonic()
+        self.worker_ready_at.pop(index, None)
+        self.worker_ready.pop(index, None)
+        self.worker_state[index] = WorkerState.STARTING
+        logger.info(
+            "Worker slot %s started process %s; waiting for ready message",
+            index,
+            worker.pid,
+        )
 
         return worker

--- a/src/archivematica/MCPClient/client/pool.py
+++ b/src/archivematica/MCPClient/client/pool.py
@@ -59,6 +59,7 @@ class QueueLike(Protocol[T]):
 
 LogQueue = QueueLike[logging.LogRecord]
 WorkerReadyQueue = QueueLike["WorkerReadyMessage"]
+MetricQueue = QueueLike[metrics.MetricEvent]
 
 # Use forkserver so workers are not forked directly from the long-lived parent.
 # The parent has threads for logging, metrics, and pool maintenance; forking a
@@ -72,6 +73,8 @@ MP_CONTEXT = multiprocessing.get_context("forkserver")
 #     (
 #         (
 #             "<multiprocessing.queues.Queue object at 0x7609ba4badf0>",
+#             "<multiprocessing.queues.Queue object at 0x7609ba4baf00>",
+#             "<multiprocessing.queues.Queue object at 0x7609ba4bb010>",
 #             [
 #                 "archivematicaclamscan_v0.0",
 #                 "examinecontents_v0.0",
@@ -88,7 +91,10 @@ MP_CONTEXT = multiprocessing.get_context("forkserver")
 #     ...
 # ]
 WorkerInitArgs = list[
-    tuple[tuple[LogQueue, WorkerReadyQueue, list[str], int], dict[str, Event]]
+    tuple[
+        tuple[LogQueue, WorkerReadyQueue, MetricQueue, list[str], int],
+        dict[str, Event],
+    ]
 ]
 
 logger = logging.getLogger("archivematica.mcp.client.worker")
@@ -130,6 +136,7 @@ def _register_traceback_dump_handler() -> None:
 def run_gearman_worker(
     log_queue: LogQueue,
     readiness_queue: WorkerReadyQueue,
+    metrics_queue: MetricQueue,
     client_scripts: list[str],
     worker_index: int,
     shutdown_event: Optional[Event] = None,
@@ -158,6 +165,7 @@ def run_gearman_worker(
     logger.setLevel(logging.DEBUG)
     queue_handler = logging.handlers.QueueHandler(log_queue)
     logger.addHandler(queue_handler)
+    metrics.configure_event_queue(metrics_queue)
 
     gearman_hosts = [settings.GEARMAN_SERVER]
 
@@ -194,6 +202,7 @@ class WorkerPool:
     def __init__(self) -> None:
         self.log_queue: LogQueue = MP_CONTEXT.Queue()
         self.worker_readiness_queue: WorkerReadyQueue = MP_CONTEXT.Queue()
+        self.metrics_queue: MetricQueue = MP_CONTEXT.Queue()
         self.shutdown_event = MP_CONTEXT.Event()
         self.workers: list[multiprocessing.Process] = []
 
@@ -216,8 +225,12 @@ class WorkerPool:
 
         self.pool_maintainance_thread: Optional[threading.Thread] = None
         self.logging_listener: Optional[logging.handlers.QueueListener] = None
+        self.metrics_listener: Optional[metrics.EventListener] = None
 
     def start(self) -> None:
+        self.metrics_listener = metrics.EventListener(self.metrics_queue)
+        self.metrics_listener.start()
+
         self.logging_listener = logging.handlers.QueueListener(
             self.log_queue,
             *logger.handlers,
@@ -253,6 +266,9 @@ class WorkerPool:
         if self.logging_listener is not None:
             self.logging_listener.stop()
 
+        if self.metrics_listener is not None:
+            self.metrics_listener.stop()
+
     def _get_script_workers_required(
         self, job_modules: dict[str, Optional[ModuleType]]
     ) -> dict[str, int]:
@@ -285,6 +301,7 @@ class WorkerPool:
                 (
                     self.log_queue,
                     self.worker_readiness_queue,
+                    self.metrics_queue,
                     worker_init_scripts,
                     index,
                 ),

--- a/src/archivematica/MCPClient/clientScripts/bag_with_empty_directories.py
+++ b/src/archivematica/MCPClient/clientScripts/bag_with_empty_directories.py
@@ -77,6 +77,11 @@ def bag_with_empty_directories(job, destination, sip_directory, sip_uuid, algori
             shutil.copytree(item, dst)
     make_bag(
         destination,
+        # BagIt creates a multiprocessing pool when processes > 1. In
+        # MCPClient, workers may recycle immediately after this task; if a
+        # BagIt child exits during that handoff it can be adopted by the
+        # long-lived MCPClient parent and remain as a zombie. Zombies do not
+        # hold RSS, but enough of them can exhaust process-table/PID capacity.
         processes=multiprocessing.cpu_count(),
         bag_info={"External-Identifier": sip_uuid},
         checksums=[algorithm],

--- a/src/archivematica/MCPServer/server/mcp.py
+++ b/src/archivematica/MCPServer/server/mcp.py
@@ -27,6 +27,7 @@ import logging
 import os
 import signal
 import threading
+import time
 
 import django
 
@@ -34,6 +35,7 @@ django.setup()
 
 from django.conf import settings
 
+from archivematica.archivematicaCommon.dbconns import auto_close_old_connections
 from archivematica.MCPServer.server import metrics
 from archivematica.MCPServer.server import rpc_server
 from archivematica.MCPServer.server import shared_dirs
@@ -49,6 +51,47 @@ from archivematica.MCPServer.server.watch_dirs import watch_directories
 from archivematica.MCPServer.server.workflow import load_workflow
 
 logger = logging.getLogger("archivematica.mcp.server")
+
+# Transfer retrieval happens before the workflow starts and can spend a long
+# time waiting on Storage Service. Run one retrieval at a time so API bursts do
+# not start many expensive copies at once.
+TRANSFER_START_WORKER_THREADS = 1
+
+
+class TransferStartExecutor:
+    """Executor for pre-workflow transfer startup work.
+
+    This keeps long Storage Service retrievals out of the main workflow worker
+    pool while preserving the existing unbounded submission behavior.
+    """
+
+    def __init__(self, max_workers):
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+
+    def submit(self, fn, *args, **kwargs):
+        metrics.transfer_start_submitted()
+
+        def run():
+            with auto_close_old_connections():
+                metrics.transfer_start_running()
+                started = time.monotonic()
+                try:
+                    result = fn(*args, **kwargs)
+                except Exception:
+                    metrics.transfer_start_finished(
+                        "failed", time.monotonic() - started
+                    )
+                    raise
+                else:
+                    metrics.transfer_start_finished(
+                        "succeeded", time.monotonic() - started
+                    )
+                    return result
+
+        return self._executor.submit(run)
+
+    def shutdown(self, wait=True):
+        self._executor.shutdown(wait=wait)
 
 
 def watched_dir_handler(package_queue, path, watched_dir):
@@ -89,6 +132,9 @@ def main(shutdown_event=None):
         # default concurrent packages limit.
         max_workers=settings.WORKER_THREADS
     )
+    transfer_start_executor = TransferStartExecutor(
+        TRANSFER_START_WORKER_THREADS,
+    )
 
     def signal_handler(signal, frame):
         """Used to handle the stop/kill command signals (SIGINT, SIGKILL)"""
@@ -96,6 +142,7 @@ def main(shutdown_event=None):
 
         shutdown_event.set()
         executor.shutdown(wait=False)
+        transfer_start_executor.shutdown(wait=False)
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
@@ -111,6 +158,7 @@ def main(shutdown_event=None):
     logger.debug("Cleaned up old db entries.")
 
     metrics.init_labels(workflow)
+    metrics.configure_transfer_start_executor(TRANSFER_START_WORKER_THREADS)
     metrics.start_prometheus_server()
 
     package_queue = PackageQueue(executor, shutdown_event, debug=settings.DEBUG)
@@ -119,7 +167,7 @@ def main(shutdown_event=None):
     for x in range(settings.RPC_THREADS):
         rpc_thread = threading.Thread(
             target=rpc_server.start,
-            args=(workflow, shutdown_event, package_queue, executor),
+            args=(workflow, shutdown_event, package_queue, transfer_start_executor),
             name=f"RPCServer-{x}",
         )
         rpc_thread.start()
@@ -140,6 +188,7 @@ def main(shutdown_event=None):
     watch_dir_thread.join(1.0)
     for thread in rpc_threads:
         thread.join(0.1)
+    transfer_start_executor.shutdown(wait=False)
     logger.debug("RPC threads stopped.")
 
     logger.info("MCP server shut down complete.")

--- a/src/archivematica/MCPServer/server/metrics.py
+++ b/src/archivematica/MCPServer/server/metrics.py
@@ -63,6 +63,29 @@ job_queue_length_gauge = Gauge(
 package_queue_length_gauge = Gauge(
     "mcpserver_package_queue_length", "Number of queued packages", ["package_type"]
 )
+transfer_start_active_gauge = Gauge(
+    "mcpserver_transfer_start_active_tasks",
+    "Number of transfer start tasks currently retrieving content from transfer sources",
+)
+transfer_start_queued_gauge = Gauge(
+    "mcpserver_transfer_start_queued_tasks",
+    "Number of transfer start tasks queued before retrieving content from transfer sources",
+)
+transfer_start_max_workers_gauge = Gauge(
+    "mcpserver_transfer_start_max_workers",
+    "Maximum number of transfer start tasks that may run concurrently",
+)
+transfer_start_counter = Counter(
+    "mcpserver_transfer_start_total",
+    "Number of transfer start tasks, labeled by outcome",
+    ["status"],
+)
+transfer_start_duration_histogram = Histogram(
+    "mcpserver_transfer_start_duration_seconds",
+    "Duration of transfer start tasks in seconds, labeled by outcome",
+    ["status"],
+    buckets=TASK_DURATION_BUCKETS,
+)
 
 PACKAGE_TYPES = ("Transfer", "SIP", "DIP")
 
@@ -105,6 +128,36 @@ def start_prometheus_server():
     return start_http_server(
         settings.PROMETHEUS_BIND_PORT, addr=settings.PROMETHEUS_BIND_ADDRESS
     )
+
+
+@skip_if_prometheus_disabled
+def configure_transfer_start_executor(max_workers):
+    transfer_start_max_workers_gauge.set(max_workers)
+    transfer_start_active_gauge.set(0)
+    transfer_start_queued_gauge.set(0)
+    for status in ("submitted", "succeeded", "failed"):
+        transfer_start_counter.labels(status=status)
+    for status in ("succeeded", "failed"):
+        transfer_start_duration_histogram.labels(status=status)
+
+
+@skip_if_prometheus_disabled
+def transfer_start_submitted():
+    transfer_start_queued_gauge.inc()
+    transfer_start_counter.labels(status="submitted").inc()
+
+
+@skip_if_prometheus_disabled
+def transfer_start_running():
+    transfer_start_queued_gauge.dec()
+    transfer_start_active_gauge.inc()
+
+
+@skip_if_prometheus_disabled
+def transfer_start_finished(status, duration):
+    transfer_start_active_gauge.dec()
+    transfer_start_counter.labels(status=status).inc()
+    transfer_start_duration_histogram.labels(status=status).observe(duration)
 
 
 @skip_if_prometheus_disabled

--- a/src/archivematica/MCPServer/server/packages.py
+++ b/src/archivematica/MCPServer/server/packages.py
@@ -25,6 +25,13 @@ from archivematica.MCPServer.server.utils import uuid_from_path
 
 logger = logging.getLogger("archivematica.mcp.server.packages")
 
+TRANSFER_RETRIEVAL_JOB_TYPE = "Retrieve contents from transfer source"
+TRANSFER_RETRIEVAL_MICROSERVICE_GROUP = "Transfer retrieval"
+TRANSFER_RETRIEVAL_FAILED_GROUP = "Transfer retrieval failed"
+
+# Keep failure messages within Jobs.jobType's existing schema limit.
+JOB_TYPE_MAX_LENGTH = 250
+
 
 StartingPoint = collections.namedtuple("StartingPoint", "watched_dir chain link")
 
@@ -249,7 +256,9 @@ def _copy_from_transfer_sources(paths, relative_destination):
     message = []
     for item in files.values():
         reply, error = storage_service.copy_files(
-            item["location"], processing_location, item["files"]
+            item["location"],
+            processing_location,
+            item["files"],
         )
         if reply is None:
             message.append(str(error))
@@ -290,6 +299,56 @@ def _move_to_internal_shared_dir(filepath, dest, transfer):
             _get_setting("SHARED_DIRECTORY"), r"%sharedPath%", 1
         )
         transfer.save()
+
+
+@auto_close_old_connections()
+def _create_transfer_retrieval_job(transfer, directory):
+    return models.Job.objects.create(
+        createdtime=timezone.now(),
+        directory=directory,
+        sipuuid=transfer.pk,
+        unittype="unitTransfer",
+        currentstep=models.Job.STATUS_UNKNOWN,
+        microservicegroup=TRANSFER_RETRIEVAL_MICROSERVICE_GROUP,
+        jobtype=TRANSFER_RETRIEVAL_JOB_TYPE,
+        microservicechainlink=None,
+    )
+
+
+@auto_close_old_connections()
+def _mark_transfer_retrieval_started(transfer, retrieval_job_id, directory):
+    transfer.status = models.PACKAGE_STATUS_PROCESSING
+    transfer.save(update_fields=["status"])
+    models.Job.objects.filter(jobuuid=retrieval_job_id).update(
+        currentstep=models.Job.STATUS_EXECUTING_COMMANDS,
+        directory=directory,
+        microservicegroup=TRANSFER_RETRIEVAL_MICROSERVICE_GROUP,
+    )
+
+
+@auto_close_old_connections()
+def _mark_transfer_retrieval_completed(retrieval_job_id):
+    models.Job.objects.filter(jobuuid=retrieval_job_id).update(
+        currentstep=models.Job.STATUS_COMPLETED_SUCCESSFULLY,
+        microservicegroup=TRANSFER_RETRIEVAL_MICROSERVICE_GROUP,
+    )
+
+
+def _transfer_retrieval_failure_job_type(error):
+    job_type = f"{TRANSFER_RETRIEVAL_JOB_TYPE}: {error}"
+    return job_type[:JOB_TYPE_MAX_LENGTH]
+
+
+@auto_close_old_connections()
+def _mark_transfer_retrieval_failed(transfer, retrieval_job_id, error):
+    transfer.status = models.PACKAGE_STATUS_FAILED
+    transfer.completed_at = timezone.now()
+    transfer.save(update_fields=["status", "completed_at"])
+    models.Job.objects.filter(jobuuid=retrieval_job_id).update(
+        currentstep=models.Job.STATUS_FAILED,
+        microservicegroup=TRANSFER_RETRIEVAL_FAILED_GROUP,
+        jobtype=_transfer_retrieval_failure_job_type(error),
+    )
 
 
 @auto_close_old_connections()
@@ -342,6 +401,8 @@ def create_package(
         except (models.TransferMetadataSet.DoesNotExist, ValidationError):
             pass
     transfer = models.Transfer.objects.create(**kwargs)
+    transfer.status = models.PACKAGE_STATUS_PROCESSING
+    transfer.save(update_fields=["status"])
     if not processing_configuration_file_exists(processing_config):
         processing_config = "default"
     transfer.set_processing_configuration(processing_config)
@@ -354,12 +415,23 @@ def create_package(
     logger.debug(
         "Package %s: starting transfer (%s)", transfer.pk, (name, type_, path, tmpdir)
     )
-    params = (transfer, name, path, tmpdir, starting_point)
+    retrieval_job = _create_transfer_retrieval_job(transfer, path)
+    params = (transfer, name, path, tmpdir, starting_point, retrieval_job.pk)
     if auto_approve:
         params = params + (workflow, package_queue)
-        result = executor.submit(_start_package_transfer_with_auto_approval, *params)
+        try:
+            result = executor.submit(
+                _start_package_transfer_with_auto_approval, *params
+            )
+        except Exception as err:
+            _mark_transfer_retrieval_failed(transfer, retrieval_job.pk, err)
+            raise
     else:
-        result = executor.submit(_start_package_transfer, *params)
+        try:
+            result = executor.submit(_start_package_transfer, *params)
+        except Exception as err:
+            _mark_transfer_retrieval_failed(transfer, retrieval_job.pk, err)
+            raise
 
     result.add_done_callback(lambda f: os.chmod(tmpdir, 0o770))
 
@@ -379,6 +451,13 @@ def _capture_transfer_failure(fn):
                 raise
             else:
                 logger.exception("Exception occurred during transfer processing")
+                transfer = args[0] if args else None
+                retrieval_job_id = None
+                if len(args) >= 6:
+                    retrieval_job_id = args[5]
+                if isinstance(transfer, models.Transfer) and retrieval_job_id:
+                    _mark_transfer_retrieval_failed(transfer, retrieval_job_id, err)
+                raise
 
     return wrap
 
@@ -400,7 +479,14 @@ def _determine_transfer_paths(name, path, tmpdir):
 
 @_capture_transfer_failure
 def _start_package_transfer_with_auto_approval(
-    transfer, name, path, tmpdir, starting_point, workflow, package_queue
+    transfer,
+    name,
+    path,
+    tmpdir,
+    starting_point,
+    retrieval_job_id,
+    workflow,
+    package_queue,
 ):
     """Start a new transfer the new way.
 
@@ -409,6 +495,7 @@ def _start_package_transfer_with_auto_approval(
     the transfer because we go directly into the next chain link.
     """
     transfer_rel, filepath, path = _determine_transfer_paths(name, path, tmpdir)
+    _mark_transfer_retrieval_started(transfer, retrieval_job_id, filepath)
     logger.debug(
         "Package %s: determined vars transfer_rel=%s, filepath=%s, path=%s",
         transfer.pk,
@@ -429,6 +516,7 @@ def _start_package_transfer_with_auto_approval(
     _move_to_internal_shared_dir(
         filepath, _get_setting("PROCESSING_DIRECTORY"), transfer
     )
+    _mark_transfer_retrieval_completed(retrieval_job_id)
 
     logger.debug("Package %s: starting workflow processing", transfer.pk)
     unit = Transfer(path, transfer.pk)
@@ -442,7 +530,9 @@ def _start_package_transfer_with_auto_approval(
 
 
 @_capture_transfer_failure
-def _start_package_transfer(transfer, name, path, tmpdir, starting_point):
+def _start_package_transfer(
+    transfer, name, path, tmpdir, starting_point, retrieval_job_id
+):
     """Start a new transfer the old way.
 
     This means copying the transfer into one of the standard watched dirs.
@@ -451,6 +541,7 @@ def _start_package_transfer(transfer, name, path, tmpdir, starting_point):
     observer.
     """
     transfer_rel, filepath, path = _determine_transfer_paths(name, path, tmpdir)
+    _mark_transfer_retrieval_started(transfer, retrieval_job_id, filepath)
     logger.debug(
         "Package %s: determined vars transfer_rel=%s, filepath=%s, path=%s",
         transfer.pk,
@@ -474,6 +565,7 @@ def _start_package_transfer(transfer, name, path, tmpdir, starting_point):
         starting_point.watched_dir,
     )
     _move_to_internal_shared_dir(filepath, starting_point.watched_dir, transfer)
+    _mark_transfer_retrieval_completed(retrieval_job_id)
 
 
 class LocationPath:
@@ -552,7 +644,32 @@ class Package(metaclass=abc.ABCMeta):
         """
         completed_at = timezone.now()
         statuses = (models.PACKAGE_STATUS_UNKNOWN, models.PACKAGE_STATUS_PROCESSING)
-        models.Transfer.objects.filter(status__in=statuses).update(
+        stale_transfers = models.Transfer.objects.filter(status__in=statuses)
+        stale_transfer_retrieval_jobs = models.Job.objects.filter(
+            sipuuid__in=stale_transfers.values("uuid"),
+            unittype="unitTransfer",
+            microservicegroup=TRANSFER_RETRIEVAL_MICROSERVICE_GROUP,
+            jobtype=TRANSFER_RETRIEVAL_JOB_TYPE,
+        )
+        stale_transfer_retrieval_jobs.filter(
+            currentstep=models.Job.STATUS_UNKNOWN,
+        ).update(
+            currentstep=models.Job.STATUS_FAILED,
+            microservicegroup=TRANSFER_RETRIEVAL_FAILED_GROUP,
+            jobtype=_transfer_retrieval_failure_job_type(
+                "MCPServer restarted before transfer retrieval started"
+            ),
+        )
+        stale_transfer_retrieval_jobs.filter(
+            currentstep=models.Job.STATUS_EXECUTING_COMMANDS,
+        ).update(
+            currentstep=models.Job.STATUS_FAILED,
+            microservicegroup=TRANSFER_RETRIEVAL_FAILED_GROUP,
+            jobtype=_transfer_retrieval_failure_job_type(
+                "MCPServer restarted before transfer retrieval completed"
+            ),
+        )
+        stale_transfers.update(
             status=models.PACKAGE_STATUS_FAILED,
             completed_at=completed_at,
         )

--- a/src/archivematica/MCPServer/server/rpc_server.py
+++ b/src/archivematica/MCPServer/server/rpc_server.py
@@ -2,6 +2,12 @@
 
 We have plans to replace this server with gRPC.
 
+Most handlers serialize persisted database state directly. The
+`getUnitsStatuses` handler has one response-only compatibility shim for
+pre-workflow transfer retrieval: when retrieval has completed but no normal
+workflow job has been persisted yet, it presents the active transfer as still
+executing through the synthetic retrieval job.
+
 TODO(sevein): methods with `raise_exc` enabled should be updated so they don't
 need it, but it needs to be tested further. The main thing to check is whether
 the client is ready to handle application-level exceptions.
@@ -29,11 +35,62 @@ from archivematica.dashboard.main.models import SIP
 from archivematica.dashboard.main.models import Job
 from archivematica.dashboard.main.models import Transfer
 from archivematica.MCPServer.server.jobs.chain import get_job_class_for_link
+from archivematica.MCPServer.server.packages import TRANSFER_RETRIEVAL_FAILED_GROUP
+from archivematica.MCPServer.server.packages import TRANSFER_RETRIEVAL_JOB_TYPE
+from archivematica.MCPServer.server.packages import (
+    TRANSFER_RETRIEVAL_MICROSERVICE_GROUP,
+)
 from archivematica.MCPServer.server.packages import create_package
 from archivematica.MCPServer.server.packages import get_approve_transfer_chain_id
 from archivematica.MCPServer.server.processing_config import get_processing_fields
 
 logger = logging.getLogger("archivematica.mcp.server.rpc_server")
+
+TRANSFER_RETRIEVAL_MICROSERVICE_GROUPS = {
+    TRANSFER_RETRIEVAL_MICROSERVICE_GROUP,
+    TRANSFER_RETRIEVAL_FAILED_GROUP,
+}
+
+
+def _is_transfer_retrieval_job(job):
+    return (
+        job.unittype == "unitTransfer"
+        and job.microservicegroup in TRANSFER_RETRIEVAL_MICROSERVICE_GROUPS
+        and job.jobtype.startswith(TRANSFER_RETRIEVAL_JOB_TYPE)
+    )
+
+
+def _show_completed_retrieval_as_executing(unit, jobs, has_workflow_job):
+    """Present the pre-workflow handoff window as still in progress.
+
+    The retrieval job is persisted as completed once Storage Service retrieval
+    finishes. The first normal workflow job may then wait only in
+    `PackageQueue` memory until a `CONCURRENT_PACKAGES` slot is available; it
+    is persisted later, when `Job.run()` starts. Until that workflow job exists,
+    clients that derive unit progress from the newest visible job would
+    otherwise show an active transfer as complete.
+
+    Keep this response-only. The persisted retrieval job remains completed so
+    job history stays truthful, while the unit-level status signal remains
+    compatible with clients that already treat executing jobs as in progress.
+    """
+    if has_workflow_job or not unit.active or not jobs:
+        return
+
+    latest_job = jobs[0]
+    is_retrieval_job = (
+        latest_job["microservicegroup"] == TRANSFER_RETRIEVAL_MICROSERVICE_GROUP
+        and latest_job["type"] == TRANSFER_RETRIEVAL_JOB_TYPE
+    )
+    if (
+        latest_job["link_id"] is None
+        and latest_job["currentstep"] == Job.STATUS_COMPLETED_SUCCESSFULLY
+        and is_retrieval_job
+    ):
+        # Retrieval is done, but workflow has not started yet. Present the
+        # active transfer through the existing job status field without
+        # changing the persisted Job row.
+        latest_job["currentstep"] = Job.STATUS_EXECUTING_COMMANDS
 
 
 class RPCServerError(Exception):
@@ -391,8 +448,11 @@ class RPCServer(GearmanWorker):
                 "active": unit.active,
                 "jobs": [],
             }
-            jobs = Job.objects.filter(sipuuid=unit_id).order_by(
-                "-createdtime", "-jobuuid"
+            jobs = list(
+                Job.objects.filter(sipuuid=unit_id).order_by("-createdtime", "-jobuuid")
+            )
+            has_workflow_job = any(
+                job_.microservicechainlink is not None for job_ in jobs
             )
             if jobs:
                 item["directory"] = jobs[0].get_directory_name()
@@ -409,25 +469,36 @@ class RPCServer(GearmanWorker):
                     pass
             # Append jobs
             for job_ in jobs:
+                link = None
                 try:
                     link = self.workflow.get_link(job_.microservicechainlink)
                 except KeyError:
-                    continue
+                    if not _is_transfer_retrieval_job(job_):
+                        continue
                 new_job = {}
                 new_job["uuid"] = str(job_.jobuuid)
-                new_job["link_id"] = str(job_.microservicechainlink)
+                new_job["link_id"] = (
+                    str(job_.microservicechainlink)
+                    if job_.microservicechainlink is not None
+                    else None
+                )
                 new_job["currentstep"] = job_.currentstep
                 new_job["timestamp"] = (
                     f"{calendar.timegm(job_.createdtime.timetuple())}.{job_.createdtime.microsecond:06d}"
                 )
-                new_job["microservicegroup"] = link.get_label("group", lang)
-                new_job["type"] = link.get_label("description", lang)
-                try:
-                    new_job["produces_tasks"] = get_job_class_for_link(
-                        link
-                    ).produces_tasks
-                except ValueError:
+                if link is None:
+                    new_job["microservicegroup"] = job_.microservicegroup
+                    new_job["type"] = job_.jobtype
                     new_job["produces_tasks"] = False
+                else:
+                    new_job["microservicegroup"] = link.get_label("group", lang)
+                    new_job["type"] = link.get_label("description", lang)
+                    try:
+                        new_job["produces_tasks"] = get_job_class_for_link(
+                            link
+                        ).produces_tasks
+                    except ValueError:
+                        new_job["produces_tasks"] = False
                 try:
                     new_job["choices"] = _pull_choices(
                         str(job_.jobuuid), lang, jobs_awaiting_for_approval
@@ -435,6 +506,10 @@ class RPCServer(GearmanWorker):
                 except JobNotWaitingForApprovalError:
                     pass
                 item["jobs"].append(new_job)
+            if model is Transfer:
+                _show_completed_retrieval_as_executing(
+                    unit, item["jobs"], has_workflow_job
+                )
             objects.append(item)
         return objects
 
@@ -462,16 +537,30 @@ class RPCServer(GearmanWorker):
         )
         jobs = []
         for item in microservices:
+            link = None
+            job_obj = None
             try:
                 link = self.workflow.get_link(item.get("microservicechainlink"))
             except KeyError:
-                continue
+                job_obj = jobs_qs.get(jobuuid=item.get("jobuuid"))
+                if not _is_transfer_retrieval_job(job_obj):
+                    continue
+            if link is None:
+                if job_obj is None:
+                    job_obj = jobs_qs.get(jobuuid=item.get("jobuuid"))
+                if not _is_transfer_retrieval_job(job_obj):
+                    continue
+                description = job_obj.jobtype
+                group = job_obj.microservicegroup
+            else:
+                description = link.get_label("description", lang)
+                group = link.get_label("group", lang)
             jobs.append(
                 {
                     "id": item.get("jobuuid"),
-                    "description": link.get_label("description", lang),
+                    "description": description,
                     "status": item.get("currentstep"),
-                    "group": link.get_label("group", lang),
+                    "group": group,
                 }
             )
         return {"name": jobs_qs.get_directory_name(), "jobs": jobs}

--- a/tests/MCPClient/test_gearman.py
+++ b/tests/MCPClient/test_gearman.py
@@ -1,0 +1,65 @@
+from collections.abc import Callable
+
+from archivematica.MCPClient.client import gearman
+
+
+class FakeConnection:
+    def __init__(self, connected: bool, writable: bool) -> None:
+        self.connected = connected
+        self._writable = writable
+
+    def writable(self) -> bool:
+        return self._writable
+
+
+def make_worker(
+    connections: list[FakeConnection],
+    readiness_callback: Callable[[], None],
+) -> gearman.MCPGearmanWorker:
+    worker = gearman.MCPGearmanWorker.__new__(gearman.MCPGearmanWorker)
+    worker.connection_list = connections
+    worker.readiness_callback = readiness_callback
+    worker.ready_reported = False
+    worker.shutdown_event = None
+    worker.max_jobs_to_process = None
+    worker.jobs_processed_count = 0
+    return worker
+
+
+def test_after_poll_reports_ready_after_startup_commands_are_flushed() -> None:
+    readiness_reports = []
+    worker = make_worker(
+        [FakeConnection(connected=True, writable=False)],
+        lambda: readiness_reports.append(True),
+    )
+
+    assert worker.after_poll(any_activity=True) is True
+
+    assert readiness_reports == [True]
+    assert worker.ready_reported is True
+
+
+def test_after_poll_waits_until_connected_worker_is_not_writable() -> None:
+    readiness_reports = []
+    worker = make_worker(
+        [FakeConnection(connected=True, writable=True)],
+        lambda: readiness_reports.append(True),
+    )
+
+    assert worker.after_poll(any_activity=True) is True
+
+    assert readiness_reports == []
+    assert worker.ready_reported is False
+
+
+def test_after_poll_reports_ready_only_once() -> None:
+    readiness_reports = []
+    worker = make_worker(
+        [FakeConnection(connected=True, writable=False)],
+        lambda: readiness_reports.append(True),
+    )
+
+    assert worker.after_poll(any_activity=True) is True
+    assert worker.after_poll(any_activity=True) is True
+
+    assert readiness_reports == [True]

--- a/tests/MCPClient/test_metrics.py
+++ b/tests/MCPClient/test_metrics.py
@@ -1,0 +1,298 @@
+import logging
+import os
+import pathlib
+import queue
+import subprocess
+import sys
+import textwrap
+import time
+
+from prometheus_client import generate_latest
+
+from archivematica.archivematicaCommon import common_metrics
+from archivematica.MCPClient.client import metrics
+
+
+class FakeQueue:
+    def __init__(self) -> None:
+        self.items = []
+
+    def put_nowait(self, item: object) -> None:
+        self.items.append(item)
+
+
+def test_worker_metric_calls_are_queued(monkeypatch) -> None:
+    fake_queue = FakeQueue()
+    monkeypatch.setattr(metrics.settings, "PROMETHEUS_ENABLED", True)
+    monkeypatch.setattr(metrics.time, "time", lambda: 123.0)
+
+    metrics.configure_event_queue(fake_queue)
+    try:
+        metrics.job_completed("copy_v0.0")
+    finally:
+        metrics.configure_event_queue(None)
+
+    assert fake_queue.items == [
+        metrics.MetricEvent(
+            "job_counter",
+            "inc",
+            (("script_name", "copy_v0.0"),),
+            1.0,
+        ),
+        metrics.MetricEvent(
+            "job_processed_timestamp",
+            "set_max",
+            (("script_name", "copy_v0.0"),),
+            123.0,
+        ),
+    ]
+
+
+def test_metric_events_are_applied_to_parent_registry(monkeypatch) -> None:
+    monkeypatch.setattr(metrics.settings, "PROMETHEUS_ENABLED", True)
+
+    metrics.apply_event(
+        metrics.MetricEvent(
+            "job_counter",
+            "inc",
+            (("script_name", "event-test_v0.0"),),
+            3.0,
+        )
+    )
+
+    output = generate_latest(metrics.REGISTRY).decode()
+
+    assert 'mcpclient_job_total{script_name="event-test_v0.0"} 3.0' in output
+
+
+def test_timestamp_metric_events_keep_highest_timestamp() -> None:
+    labels = (("script_name", "out-of-order-timestamp_v0.0"),)
+    metrics.apply_event(
+        metrics.MetricEvent("job_processed_timestamp", "set_max", labels, 200.0)
+    )
+    metrics.apply_event(
+        metrics.MetricEvent("job_processed_timestamp", "set_max", labels, 100.0)
+    )
+
+    output = generate_latest(metrics.REGISTRY).decode()
+
+    assert (
+        'mcpclient_job_success_timestamp{script_name="out-of-order-timestamp_v0.0"} 200.0'
+        in output
+    )
+
+
+def test_metric_listener_logs_apply_failures_and_continues(monkeypatch, caplog) -> None:
+    event_queue = queue.Queue()
+    listener = metrics.EventListener(event_queue)
+    bad_event = metrics.MetricEvent("job_counter", "inc", (), 1.0)
+    good_event = metrics.MetricEvent(
+        "job_counter",
+        "inc",
+        (("script_name", "after-bad-event_v0.0"),),
+        1.0,
+    )
+    applied_events = []
+
+    def fake_apply_event(event: metrics.MetricEvent) -> None:
+        if event == bad_event:
+            raise ValueError("bad metric event")
+        applied_events.append(event)
+
+    monkeypatch.setattr(metrics, "apply_event", fake_apply_event)
+    caplog.set_level(logging.ERROR, logger=metrics.logger.name)
+
+    processed_by_listener = False
+    listener.start()
+    try:
+        event_queue.put_nowait(bad_event)
+        event_queue.put_nowait(good_event)
+
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            if good_event in applied_events:
+                processed_by_listener = True
+                break
+            time.sleep(0.01)
+    finally:
+        listener.stop()
+
+    assert processed_by_listener
+    assert "Failed to apply MCPClient metric event" in caplog.text
+
+
+def test_transfer_completed_records_zero_size_for_empty_transfer(monkeypatch) -> None:
+    class FakeTransfer:
+        type = "Standard"
+
+    class EmptyFileQuerySet:
+        def count(self) -> int:
+            return 0
+
+        def aggregate(self, **kwargs: object) -> dict[str, object]:
+            return {"total_size": None}
+
+    fake_queue = FakeQueue()
+    monkeypatch.setattr(metrics.settings, "PROMETHEUS_ENABLED", True)
+    monkeypatch.setattr(
+        metrics.Transfer.objects, "get", lambda **kwargs: FakeTransfer()
+    )
+    monkeypatch.setattr(
+        metrics.File.objects, "filter", lambda **kwargs: EmptyFileQuerySet()
+    )
+
+    metrics.configure_event_queue(fake_queue)
+    try:
+        metrics.transfer_completed("empty-transfer")
+    finally:
+        metrics.configure_event_queue(None)
+
+    assert (
+        metrics.MetricEvent(
+            "transfer_size_histogram",
+            "observe",
+            (("transfer_type", "Standard"),),
+            0,
+        )
+        in fake_queue.items
+    )
+
+
+def test_metrics_import_resets_prometheus_multiprocess_mode(
+    tmp_path: pathlib.Path,
+) -> None:
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    pythonpath = [
+        str(repo_root / "src"),
+        str(repo_root / "src" / "archivematica" / "MCPClient"),
+    ]
+
+    env = os.environ.copy()
+    if env.get("PYTHONPATH"):
+        pythonpath.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath)
+    env["DJANGO_SETTINGS_MODULE"] = "settings.test"
+    env["PROMETHEUS_MULTIPROC_DIR"] = str(tmp_path)
+
+    code = textwrap.dedent(
+        """
+        import os
+
+        from archivematica.archivematicaCommon import common_metrics
+        from prometheus_client import values
+
+        assert common_metrics.ss_api_time_counter
+        assert values.ValueClass._multiprocess
+
+        from archivematica.MCPClient.client import metrics
+
+        assert os.environ.get("PROMETHEUS_MULTIPROC_DIR") is None
+        assert not values.ValueClass._multiprocess
+        metrics.job_completed("copy_v0.0")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_storage_service_api_timer_events_are_queued(monkeypatch) -> None:
+    fake_queue = FakeQueue()
+    times = iter([100.0, 102.5])
+    monkeypatch.setattr(common_metrics.time, "time", lambda: next(times))
+
+    metrics.configure_event_queue(fake_queue)
+    try:
+        with common_metrics.ss_api_timer(function="get_file_info"):
+            pass
+    finally:
+        metrics.configure_event_queue(None)
+
+    assert fake_queue.items == [
+        metrics.MetricEvent(
+            "ss_api_time_counter",
+            "inc",
+            (("function", "get_file_info"),),
+            2.5,
+        )
+    ]
+
+
+def test_storage_service_api_timer_events_are_exposed_in_mcpclient_registry() -> None:
+    metrics.apply_event(
+        metrics.MetricEvent(
+            "ss_api_time_counter",
+            "inc",
+            (("function", "store_aip"),),
+            1.25,
+        )
+    )
+
+    output = generate_latest(metrics.REGISTRY).decode()
+
+    assert "# TYPE common_ss_api_request_duration_seconds_total counter" in output
+    assert (
+        'common_ss_api_request_duration_seconds_total{function="store_aip"} 1.25'
+        in output
+    )
+
+
+def test_registry_preserves_mcpclient_metric_contract(monkeypatch) -> None:
+    monkeypatch.setattr(metrics.settings, "PROMETHEUS_DETAILED_METRICS", False)
+
+    metrics.init_counter_labels()
+    output = generate_latest(metrics.REGISTRY).decode()
+
+    assert "python_info" not in output
+    assert "process_cpu_seconds_total" not in output
+    assert "_created" not in output
+
+    expected_types = {
+        "mcpclient_job_total": "counter",
+        "mcpclient_job_success_timestamp": "gauge",
+        "mcpclient_job_error_total": "counter",
+        "mcpclient_job_error_timestamp": "gauge",
+        "mcpclient_task_execution_time_seconds": "histogram",
+        "mcpclient_transfer_started_total": "counter",
+        "mcpclient_transfer_started_timestamp": "gauge",
+        "mcpclient_transfer_completed_total": "counter",
+        "mcpclient_transfer_completed_timestamp": "gauge",
+        "mcpclient_transfer_error_total": "counter",
+        "mcpclient_transfer_error_timestamp": "gauge",
+        "mcpclient_transfer_files": "histogram",
+        "mcpclient_transfer_size_bytes": "histogram",
+        "mcpclient_sip_started_total": "counter",
+        "mcpclient_sip_started_timestamp": "gauge",
+        "mcpclient_sip_error_total": "counter",
+        "mcpclient_sip_error_timestamp": "gauge",
+        "mcpclient_aips_stored_total": "counter",
+        "mcpclient_dips_stored_total": "counter",
+        "mcpclient_aips_stored_timestamp": "gauge",
+        "mcpclient_dips_stored_timestamp": "gauge",
+        "mcpclient_aip_processing_seconds": "histogram",
+        "mcpclient_dip_processing_seconds": "histogram",
+        "mcpclient_aip_files_stored": "histogram",
+        "mcpclient_dip_files_stored": "histogram",
+        "mcpclient_aip_size_bytes": "histogram",
+        "mcpclient_dip_size_bytes": "histogram",
+        "mcpclient_aip_original_file_timestamps": "histogram",
+        "common_ss_api_request_duration_seconds_total": "counter",
+    }
+
+    for metric_name, metric_type in expected_types.items():
+        assert f"# TYPE {metric_name} {metric_type}" in output
+
+    assert 'mcpclient_job_total{script_name="copy_v0.0"}' in output
+    assert 'mcpclient_transfer_started_total{transfer_type="Standard"}' in output
+    assert (
+        'mcpclient_transfer_error_total{failure_type="fail",transfer_type="Standard"}'
+    ) in output
+    assert (
+        'mcpclient_task_execution_time_seconds_bucket{le="2.0",script_name="copy_v0.0"}'
+    ) in output

--- a/tests/MCPClient/test_pool.py
+++ b/tests/MCPClient/test_pool.py
@@ -1,0 +1,165 @@
+import queue
+from typing import Any
+
+import pytest
+
+from archivematica.MCPClient.client import pool
+
+
+class FakeReadinessQueue:
+    def __init__(self, messages: list[pool.WorkerReadyMessage]) -> None:
+        self.messages = messages
+
+    def get_nowait(self) -> pool.WorkerReadyMessage:
+        try:
+            return self.messages.pop(0)
+        except IndexError:
+            raise queue.Empty
+
+
+class FakeWorker:
+    exitcode = None
+
+    def __init__(self, pid: int, alive: bool = True) -> None:
+        self.pid = pid
+        self.alive = alive
+        self.terminated = False
+        self.killed = False
+        self.join_calls: list[Any] = []
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.alive = False
+        self.exitcode = -15
+
+    def kill(self) -> None:
+        self.killed = True
+        self.alive = False
+        self.exitcode = -9
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_calls.append(timeout)
+
+
+def test_collect_worker_readiness_ignores_stale_worker_messages() -> None:
+    worker_pool = pool.WorkerPool.__new__(pool.WorkerPool)
+    worker_pool.workers = [FakeWorker(222)]
+    worker_pool.worker_ready = {}
+    worker_pool.worker_ready_at = {}
+    worker_pool.worker_started_at = {0: 10.0}
+    worker_pool.worker_state = {0: pool.WorkerState.STARTING}
+    worker_pool.worker_readiness_queue = FakeReadinessQueue(
+        [
+            pool.WorkerReadyMessage(worker_index=0, process_id=111),
+            pool.WorkerReadyMessage(worker_index=1, process_id=333),
+            pool.WorkerReadyMessage(worker_index=0, process_id=222),
+        ]
+    )
+
+    worker_pool._collect_worker_readiness()
+
+    assert worker_pool.worker_ready == {0: 222}
+    assert worker_pool.worker_state == {0: pool.WorkerState.READY}
+
+
+def test_collect_worker_readiness_records_ready_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worker_pool = pool.WorkerPool.__new__(pool.WorkerPool)
+    worker_pool.workers = [FakeWorker(222)]
+    worker_pool.worker_ready = {}
+    worker_pool.worker_ready_at = {}
+    worker_pool.worker_started_at = {0: 10.0}
+    worker_pool.worker_state = {0: pool.WorkerState.STARTING}
+    worker_pool.worker_readiness_queue = FakeReadinessQueue(
+        [pool.WorkerReadyMessage(worker_index=0, process_id=222)]
+    )
+    monkeypatch.setattr(pool.time, "monotonic", lambda: 12.5)
+
+    worker_pool._collect_worker_readiness()
+
+    assert worker_pool.worker_ready == {0: 222}
+    assert worker_pool.worker_ready_at == {0: 12.5}
+    assert worker_pool.worker_state == {0: pool.WorkerState.READY}
+
+
+def test_restart_unready_workers_replaces_alive_workers_after_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worker = FakeWorker(123)
+    replacement = FakeWorker(456)
+    worker_pool = pool.WorkerPool.__new__(pool.WorkerPool)
+    worker_pool.workers = [worker]
+    worker_pool.worker_ready = {}
+    worker_pool.worker_ready_at = {}
+    worker_pool.worker_started_at = {0: 0.0}
+    worker_pool.worker_state = {0: pool.WorkerState.STARTING}
+    worker_pool.WORKER_STARTUP_TIMEOUT = 30.0
+    worker_pool.WORKER_TERMINATE_TIMEOUT = 0.1
+    worker_pool._start_worker = lambda index: replacement
+    traceback_dump_requests = []
+    worker_pool._dump_unready_worker_traceback = lambda index, worker: (
+        traceback_dump_requests.append((index, worker.pid))
+    )
+    exited_worker_pids = []
+    monkeypatch.setattr(pool.time, "monotonic", lambda: 31.0)
+    monkeypatch.setattr(pool.metrics, "worker_exit", exited_worker_pids.append)
+
+    restarted = worker_pool._restart_unready_workers()
+
+    assert restarted is True
+    assert worker.terminated is True
+    assert worker.killed is False
+    assert worker.join_calls == [0.1]
+    assert worker_pool.workers == [replacement]
+    assert worker_pool.worker_state == {0: pool.WorkerState.UNREADY_TIMEOUT}
+    assert traceback_dump_requests == [(0, 123)]
+    assert exited_worker_pids == [123]
+
+
+def test_restart_exited_workers_records_exited_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worker = FakeWorker(123, alive=False)
+    worker.exitcode = 0
+    replacement = FakeWorker(456)
+    worker_pool = pool.WorkerPool.__new__(pool.WorkerPool)
+    worker_pool.workers = [worker]
+    worker_pool.worker_ready = {0: 123}
+    worker_pool.worker_ready_at = {0: 12.0}
+    worker_pool.worker_state = {0: pool.WorkerState.READY}
+    worker_pool._start_worker = lambda index: replacement
+    exited_worker_pids = []
+    monkeypatch.setattr(pool.metrics, "worker_exit", exited_worker_pids.append)
+
+    restarted = worker_pool._restart_exited_workers()
+
+    assert restarted is True
+    assert worker.join_calls == [None]
+    assert worker_pool.workers == [replacement]
+    assert worker_pool.worker_ready == {}
+    assert worker_pool.worker_ready_at == {}
+    assert worker_pool.worker_state == {0: pool.WorkerState.EXITED}
+    assert exited_worker_pids == [123]
+
+
+def test_dump_unready_worker_traceback_requests_child_stack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worker = FakeWorker(123)
+    worker_pool = pool.WorkerPool.__new__(pool.WorkerPool)
+    worker_pool.WORKER_TRACEBACK_DUMP_DELAY = 0.5
+    kill_requests = []
+    sleep_requests = []
+    monkeypatch.setattr(
+        pool.os, "kill", lambda pid, sig: kill_requests.append((pid, sig))
+    )
+    monkeypatch.setattr(pool.time, "sleep", sleep_requests.append)
+
+    worker_pool._dump_unready_worker_traceback(0, worker)
+
+    assert kill_requests == [(123, pool.signal.SIGUSR1)]
+    assert sleep_requests == [0.5]

--- a/tests/MCPServer/test_package.py
+++ b/tests/MCPServer/test_package.py
@@ -400,6 +400,43 @@ def test_package_statuses(tmp_path, package_class, model_class):
     assert model_class.objects.get(pk=package_id).status == models.PACKAGE_STATUS_FAILED
 
 
+@pytest.mark.parametrize(
+    "currentstep,error",
+    [
+        (
+            models.Job.STATUS_UNKNOWN,
+            "MCPServer restarted before transfer retrieval started",
+        ),
+        (
+            models.Job.STATUS_EXECUTING_COMMANDS,
+            "MCPServer restarted before transfer retrieval completed",
+        ),
+    ],
+)
+@pytest.mark.django_db(transaction=True)
+def test_cleanup_old_db_entries_fails_stale_transfer_retrieval_job(currentstep, error):
+    transfer = models.Transfer.objects.create(status=models.PACKAGE_STATUS_PROCESSING)
+    retrieval_job = models.Job.objects.create(
+        createdtime="2026-06-12T00:00:00Z",
+        sipuuid=transfer.pk,
+        unittype="unitTransfer",
+        currentstep=currentstep,
+        microservicegroup="Transfer retrieval",
+        jobtype="Retrieve contents from transfer source",
+        microservicechainlink=None,
+    )
+
+    Package.cleanup_old_db_entries()
+
+    transfer.refresh_from_db()
+    retrieval_job.refresh_from_db()
+    assert transfer.status == models.PACKAGE_STATUS_FAILED
+    assert transfer.completed_at is not None
+    assert retrieval_job.currentstep == models.Job.STATUS_FAILED
+    assert retrieval_job.microservicegroup == "Transfer retrieval failed"
+    assert retrieval_job.jobtype == (f"Retrieve contents from transfer source: {error}")
+
+
 @pytest.mark.django_db(transaction=True)
 def test_create_package(tmp_path, admin_user, settings):
     package_queue = mock.Mock(spec=PackageQueue)
@@ -431,6 +468,14 @@ def test_create_package(tmp_path, admin_user, settings):
 
     # Verify a transfer was added.
     assert models.Transfer.objects.count() == 1
+    transfer = models.Transfer.objects.get()
+    assert transfer.status == models.PACKAGE_STATUS_PROCESSING
+
+    retrieval_job = models.Job.objects.get(sipuuid=transfer.pk)
+    assert retrieval_job.unittype == "unitTransfer"
+    assert retrieval_job.currentstep == models.Job.STATUS_UNKNOWN
+    assert retrieval_job.microservicechainlink is None
+    assert retrieval_job.jobtype == "Retrieve contents from transfer source"
 
 
 def test_capture_transfer_failure_propagates_transfer_does_not_exist():
@@ -451,14 +496,44 @@ def test_capture_transfer_failure_propagates_validation_error():
         fn()
 
 
-def test_capture_transfer_failure_logs_other_exceptions():
+def test_capture_transfer_failure_logs_and_propagates_other_exceptions():
     @_capture_transfer_failure
     def fn():
         raise RuntimeError("something went wrong")
 
     with mock.patch("archivematica.MCPServer.server.packages.logger") as mock_logger:
-        fn()
+        with pytest.raises(RuntimeError):
+            fn()
 
     mock_logger.exception.assert_called_once_with(
         "Exception occurred during transfer processing"
     )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_capture_transfer_failure_marks_retrieval_job_and_transfer_failed():
+    transfer = models.Transfer.objects.create(status=models.PACKAGE_STATUS_PROCESSING)
+    job = models.Job.objects.create(
+        createdtime="2026-06-12T00:00:00Z",
+        sipuuid=transfer.pk,
+        unittype="unitTransfer",
+        currentstep=models.Job.STATUS_EXECUTING_COMMANDS,
+        microservicegroup="Transfer retrieval",
+        jobtype="Retrieve contents from transfer source",
+        microservicechainlink=None,
+    )
+
+    @_capture_transfer_failure
+    def fn(transfer, name, path, tmpdir, starting_point, retrieval_job_id):
+        raise RuntimeError("something went wrong")
+
+    with pytest.raises(RuntimeError):
+        fn(transfer, "name", "path", "tmpdir", None, job.pk)
+
+    transfer.refresh_from_db()
+    job.refresh_from_db()
+    assert transfer.status == models.PACKAGE_STATUS_FAILED
+    assert transfer.completed_at is not None
+    assert job.currentstep == models.Job.STATUS_FAILED
+    assert job.microservicegroup == "Transfer retrieval failed"
+    assert job.jobtype == "Retrieve contents from transfer source: something went wrong"

--- a/tests/MCPServer/test_rpc_server.py
+++ b/tests/MCPServer/test_rpc_server.py
@@ -1,5 +1,6 @@
 import threading
 import uuid
+from datetime import timedelta
 from unittest import mock
 
 import pytest
@@ -57,6 +58,173 @@ def test_units_statuses_handler_sets_produces_tasks_from_job_class(wf):
     assert len(response) == 1
     assert len(response[0]["jobs"]) == 1
     assert response[0]["jobs"][0]["produces_tasks"] is True
+
+
+@pytest.mark.django_db
+def test_units_statuses_handler_keeps_only_retrieval_jobs_without_workflow_links(wf):
+    transfer = models.Transfer.objects.create(uuid=str(uuid.uuid4()))
+    retrieval_job = models.Job.objects.create(
+        sipuuid=transfer.pk,
+        unittype="unitTransfer",
+        microservicegroup="Transfer retrieval",
+        jobtype="Retrieve contents from transfer source",
+        microservicechainlink=None,
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_UNKNOWN,
+    )
+    models.Job.objects.create(
+        sipuuid=transfer.pk,
+        unittype="unitTransfer",
+        microservicegroup="Orphaned workflow group",
+        jobtype="Orphaned workflow job",
+        microservicechainlink=None,
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_UNKNOWN,
+    )
+
+    package_queue = mock.MagicMock()
+    package_queue.jobs_awaiting_decisions.return_value = {}
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    server = rpc_server.RPCServer(wf, shutdown_event, package_queue, None)
+    response = server._units_statuses_handler(
+        None, None, {"type": "Transfer", "lang": "en"}
+    )
+
+    assert len(response) == 1
+    assert len(response[0]["jobs"]) == 1
+    job = response[0]["jobs"][0]
+    assert job["uuid"] == str(retrieval_job.jobuuid)
+    assert job["link_id"] is None
+    assert job["currentstep"] == models.Job.STATUS_UNKNOWN
+    assert job["microservicegroup"] == "Transfer retrieval"
+    assert job["type"] == "Retrieve contents from transfer source"
+    assert job["produces_tasks"] is False
+
+
+@pytest.mark.django_db
+def test_units_statuses_handler_shows_completed_retrieval_as_executing(wf):
+    """Present active transfers as processing during the workflow handoff.
+
+    This simulates retrieval having completed while the first workflow job has
+    not been persisted yet. That can happen while the job is waiting in
+    PackageQueue for a CONCURRENT_PACKAGES slot.
+    """
+    transfer = models.Transfer.objects.create(
+        uuid=str(uuid.uuid4()), status=models.PACKAGE_STATUS_PROCESSING
+    )
+    retrieval_job = models.Job.objects.create(
+        sipuuid=transfer.pk,
+        unittype="unitTransfer",
+        microservicegroup="Transfer retrieval",
+        jobtype="Retrieve contents from transfer source",
+        microservicechainlink=None,
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_COMPLETED_SUCCESSFULLY,
+    )
+
+    package_queue = mock.MagicMock()
+    package_queue.jobs_awaiting_decisions.return_value = {}
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    server = rpc_server.RPCServer(wf, shutdown_event, package_queue, None)
+    response = server._units_statuses_handler(
+        None, None, {"type": "Transfer", "lang": "en"}
+    )
+
+    assert len(response) == 1
+    assert response[0]["active"] is True
+    assert response[0]["jobs"][0]["uuid"] == str(retrieval_job.jobuuid)
+    assert response[0]["jobs"][0]["currentstep"] == (
+        models.Job.STATUS_EXECUTING_COMMANDS
+    )
+
+    retrieval_job.refresh_from_db()
+    # The workaround is response-only; job history remains truthful.
+    assert retrieval_job.currentstep == models.Job.STATUS_COMPLETED_SUCCESSFULLY
+
+
+@pytest.mark.django_db
+def test_units_statuses_handler_keeps_retrieval_done_after_workflow_starts(wf):
+    """Stop the presentation override once a workflow job is visible."""
+    created_time = timezone.now()
+    transfer = models.Transfer.objects.create(
+        uuid=str(uuid.uuid4()), status=models.PACKAGE_STATUS_PROCESSING
+    )
+    retrieval_job = models.Job.objects.create(
+        sipuuid=transfer.pk,
+        unittype="unitTransfer",
+        microservicegroup="Transfer retrieval",
+        jobtype="Retrieve contents from transfer source",
+        microservicechainlink=None,
+        createdtime=created_time,
+        currentstep=models.Job.STATUS_COMPLETED_SUCCESSFULLY,
+    )
+    models.Job.objects.create(
+        sipuuid=transfer.pk,
+        unittype="unitTransfer",
+        microservicechainlink=TASK_PRODUCING_LINK_ID,
+        createdtime=created_time + timedelta(seconds=1),
+        currentstep=models.Job.STATUS_EXECUTING_COMMANDS,
+    )
+
+    package_queue = mock.MagicMock()
+    package_queue.jobs_awaiting_decisions.return_value = {}
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    server = rpc_server.RPCServer(wf, shutdown_event, package_queue, None)
+    response = server._units_statuses_handler(
+        None, None, {"type": "Transfer", "lang": "en"}
+    )
+
+    jobs = {job["uuid"]: job for job in response[0]["jobs"]}
+    assert jobs[str(retrieval_job.jobuuid)]["currentstep"] == (
+        models.Job.STATUS_COMPLETED_SUCCESSFULLY
+    )
+
+
+@pytest.mark.django_db
+def test_unit_status_handler_keeps_only_retrieval_jobs_without_workflow_links(wf):
+    transfer = models.Transfer.objects.create(uuid=str(uuid.uuid4()))
+    retrieval_job = models.Job.objects.create(
+        sipuuid=transfer.pk,
+        unittype="unitTransfer",
+        microservicegroup="Transfer retrieval",
+        jobtype="Retrieve contents from transfer source",
+        microservicechainlink=None,
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_UNKNOWN,
+    )
+    models.Job.objects.create(
+        sipuuid=transfer.pk,
+        unittype="unitTransfer",
+        microservicegroup="Orphaned workflow group",
+        jobtype="Orphaned workflow job",
+        microservicechainlink=None,
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_UNKNOWN,
+    )
+
+    package_queue = mock.MagicMock()
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    server = rpc_server.RPCServer(wf, shutdown_event, package_queue, None)
+    response = server._unit_status_handler(
+        None, None, {"id": str(transfer.pk), "lang": "en"}
+    )
+
+    assert response["jobs"] == [
+        {
+            "id": retrieval_job.jobuuid,
+            "description": "Retrieve contents from transfer source",
+            "status": models.Job.STATUS_UNKNOWN,
+            "group": "Transfer retrieval",
+        }
+    ]
 
 
 @pytest.mark.django_db

--- a/tests/dashboard/test_api.py
+++ b/tests/dashboard/test_api.py
@@ -214,6 +214,50 @@ def test_get_unit_status_processing(jobs_processing, transfer):
 
 
 @pytest.mark.django_db
+def test_get_unit_status_failed_currentstep_without_failed_group_stays_processing(
+    transfer,
+):
+    Job.objects.create(
+        sipuuid=transfer.uuid,
+        unittype="unitTransfer",
+        currentstep=Job.STATUS_FAILED,
+        createdtime="2026-06-12T00:00:00Z",
+        microservicegroup="Create SIP from Transfer",
+        jobtype="Check transfer directory for objects",
+    )
+
+    status = views.get_unit_status(transfer.uuid, "unitTransfer")
+
+    assert status["status"] == "PROCESSING"
+
+    completed = helpers.completed_units_efficient(
+        unit_type="transfer", include_failed=True
+    )
+    assert completed == []
+
+
+@pytest.mark.django_db
+def test_get_unit_status_retrieval_failure_job_reports_failed(transfer):
+    Job.objects.create(
+        sipuuid=transfer.uuid,
+        unittype="unitTransfer",
+        currentstep=Job.STATUS_FAILED,
+        createdtime="2026-06-12T00:00:00Z",
+        microservicegroup="Transfer retrieval failed",
+        jobtype="Retrieve contents from transfer source: something went wrong",
+    )
+
+    status = views.get_unit_status(transfer.uuid, "unitTransfer")
+
+    assert status["status"] == "FAILED"
+
+    completed = helpers.completed_units_efficient(
+        unit_type="transfer", include_failed=True
+    )
+    assert completed == [str(transfer.uuid)]
+
+
+@pytest.mark.django_db
 def test_get_unit_status_user_input(jobs_processing, jobs_user_input, transfer):
     """It should return USER_INPUT."""
     status = views.get_unit_status(transfer.uuid, "unitTransfer")

--- a/typings/prometheus_client/__init__.pyi
+++ b/typings/prometheus_client/__init__.pyi
@@ -1,4 +1,5 @@
 from . import multiprocess as multiprocess
+from . import values as values
 from .exposition import start_http_server as start_http_server
 from .metrics import Counter as Counter
 from .metrics import Gauge as Gauge
@@ -6,3 +7,7 @@ from .metrics import Histogram as Histogram
 from .metrics import Info as Info
 from .metrics import Summary as Summary
 from .registry import CollectorRegistry as CollectorRegistry
+
+def disable_created_metrics() -> None: ...
+def enable_created_metrics() -> None: ...
+def generate_latest(registry: CollectorRegistry = ...) -> bytes: ...

--- a/typings/prometheus_client/values.pyi
+++ b/typings/prometheus_client/values.pyi
@@ -1,0 +1,5 @@
+from typing import Any
+
+ValueClass: type[Any]
+
+def get_value_class() -> type[Any]: ...


### PR DESCRIPTION
This pull request fixes MCPClient worker recycling issues by explicitly tracking when replacement workers become ready, restarting live workers that never reach readiness, and moving MCPClient metrics out of Prometheus multiprocess mode into a parent-owned registry. This prevents recycled workers from accumulating Prometheus state files in `/tmp` while preserving existing MCPClient metric names.

More details here: https://gist.github.com/sevein/99af1c331371ca1f69ef853a6db3942a.

Backports:
- 1.17.x: https://github.com/artefactual/archivematica/tree/dev/mcpclient-fixes-1.17
- 1.18.x: https://github.com/artefactual/archivematica/tree/dev/mcpclient-fixes-1.18