### PR TITLE
Use forkserver for MCPClient workers

### DIFF
--- a/src/archivematica/MCPClient/client/pool.py
+++ b/src/archivematica/MCPClient/client/pool.py
@@ -18,6 +18,7 @@ import logging.handlers
 import multiprocessing
 import threading
 import time
+from multiprocessing.process import BaseProcess
 from multiprocessing.synchronize import Event
 from types import ModuleType
 from typing import Optional
@@ -44,6 +45,12 @@ class QueueLike(Protocol[T]):
 
 
 LogQueue = QueueLike[logging.LogRecord]
+
+# Use forkserver so workers are not forked directly from the long-lived parent.
+# The parent has threads for logging, metrics, and pool maintenance; forking a
+# process with active threads and inherited locks is fragile. Forkserver still
+# gives us process isolation while starting children from a simpler process.
+MP_CONTEXT = multiprocessing.get_context("forkserver")
 
 # This is how the return value of the `_get_worker_init_args` method looks
 # below:
@@ -105,9 +112,9 @@ class WorkerPool:
     WORKER_RESTART_DELAY = 1.0
 
     def __init__(self) -> None:
-        self.log_queue: LogQueue = multiprocessing.Queue()
-        self.shutdown_event = multiprocessing.Event()
-        self.workers: list[multiprocessing.Process] = []
+        self.log_queue: LogQueue = MP_CONTEXT.Queue()
+        self.shutdown_event = MP_CONTEXT.Event()
+        self.workers: list[BaseProcess] = []
         self.job_modules = loader.load_job_modules(settings.CLIENT_MODULES_FILE)
         self.worker_function = run_gearman_worker
 
@@ -216,10 +223,10 @@ class WorkerPool:
 
         return restarted
 
-    def _start_worker(self, index: int) -> multiprocessing.Process:
+    def _start_worker(self, index: int) -> BaseProcess:
         """Start the new worker in a separate process."""
         worker_args, worker_kwargs = self._worker_init_args[index]
-        worker = multiprocessing.Process(
+        worker = MP_CONTEXT.Process(
             name=f"MCPClientWorker-{index}",
             target=self.worker_function,
             args=worker_args,

--- a/tests/MCPClient/test_pool.py
+++ b/tests/MCPClient/test_pool.py
@@ -1,0 +1,69 @@
+from typing import Any
+
+import pytest
+
+from archivematica.MCPClient.client import pool
+
+
+class FakeProcess:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.daemon = False
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.queues: list[object] = []
+        self.events: list[object] = []
+        self.processes: list[FakeProcess] = []
+
+    def Queue(self) -> object:
+        queue = object()
+        self.queues.append(queue)
+        return queue
+
+    def Event(self) -> object:
+        event = object()
+        self.events.append(event)
+        return event
+
+    def Process(self, **kwargs: Any) -> FakeProcess:
+        process = FakeProcess(**kwargs)
+        self.processes.append(process)
+        return process
+
+
+def test_worker_pool_uses_forkserver_context_for_shared_primitives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_context = FakeContext()
+    monkeypatch.setattr(pool, "MP_CONTEXT", fake_context)
+    monkeypatch.setattr(pool.settings, "WORKERS", 1)
+    monkeypatch.setattr(pool.settings, "CLIENT_MODULES_FILE", "clientModules.conf")
+    monkeypatch.setattr(
+        pool.loader, "load_job_modules", lambda path: {"copy_v0.0": None}
+    )
+    monkeypatch.setattr(pool.loader, "get_module_concurrency", lambda module: 1)
+
+    worker_pool = pool.WorkerPool()
+
+    assert worker_pool.log_queue is fake_context.queues[0]
+    assert worker_pool.shutdown_event is fake_context.events[0]
+
+    worker = worker_pool._start_worker(0)
+    fake_worker = fake_context.processes[0]
+
+    assert worker is fake_worker
+    assert fake_worker.started is True
+    assert fake_worker.kwargs["target"] is pool.run_gearman_worker
+    assert fake_worker.kwargs["args"] == (
+        worker_pool.log_queue,
+        ["copy_v0.0"],
+    )
+    assert fake_worker.kwargs["kwargs"] == {
+        "shutdown_event": worker_pool.shutdown_event
+    }


### PR DESCRIPTION
MCPClient keeps long-lived logging, metrics, and maintenance threads in the
parent process. Starting worker processes from a single forkserver context
avoids forking directly from that threaded parent while preserving process
isolation.

Create the worker queues, shutdown event, and worker processes from the same
context so all shared multiprocessing primitives are compatible.

Fixes https://github.com/archivematica/Issues/issues/1801.