### PR TITLE
Update bagit for pool cleanup fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "agentarchives",
   "amclient",
   "ammcpc",
-  "bagit",
+  "bagit @ git+https://github.com/LibraryOfCongress/bagit-python.git@4bd2713cedbe1f8e634567c20ef0dded9622011d",
   "brotli",
   "clamav-client",
   "django-autoslug",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ attrs==26.1.0
     # via
     #   jsonschema
     #   referencing
-bagit==1.9.0
+bagit @ git+https://github.com/LibraryOfCongress/bagit-python.git@4bd2713cedbe1f8e634567c20ef0dded9622011d
     # via archivematica (pyproject.toml)
 brotli==1.2.0
     # via archivematica (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ attrs==26.1.0
     # via
     #   jsonschema
     #   referencing
-bagit==1.9.0
+bagit @ git+https://github.com/LibraryOfCongress/bagit-python.git@4bd2713cedbe1f8e634567c20ef0dded9622011d
     # via archivematica (pyproject.toml)
 brotli==1.2.0
     # via archivematica (pyproject.toml)


### PR DESCRIPTION
Use the requested bagit-python commit from upstream main to pick up the multiprocessing pool cleanup fix.

Fixes https://github.com/archivematica/Issues/issues/1802.