### PR TITLE
Avoid closing active file query results

### DIFF
--- a/src/archivematica/MCPServer/server/packages.py
+++ b/src/archivematica/MCPServer/server/packages.py
@@ -531,6 +531,9 @@ def get_file_replacement_mapping(file_obj, unit_directory):
 class Package(metaclass=abc.ABCMeta):
     """A `Package` can be a Transfer, a SIP, or a DIP."""
 
+    # Limit file rows held in memory while avoiding long-lived DB cursors.
+    FILE_QUERYSET_BATCH_SIZE = 1000
+
     def __init__(self, current_path, uuid):
         self._current_path = current_path.replace(
             r"%sharedPath%", _get_setting("SHARED_DIRECTORY")
@@ -641,6 +644,25 @@ class Package(metaclass=abc.ABCMeta):
 
         return mapping
 
+    def _database_file_replacement_mappings(self, queryset):
+        """Yield file mappings without holding a database cursor open."""
+        queryset = queryset.order_by("uuid")
+        last_uuid = None
+
+        while True:
+            with auto_close_old_connections():
+                page_queryset = queryset
+                if last_uuid is not None:
+                    page_queryset = page_queryset.filter(uuid__gt=last_uuid)
+                file_objs = list(page_queryset[: self.FILE_QUERYSET_BATCH_SIZE])
+
+            if not file_objs:
+                break
+
+            for file_obj in file_objs:
+                last_uuid = file_obj.uuid
+                yield get_file_replacement_mapping(file_obj, self.current_path)
+
     def files(self, filter_filename_end=None, filter_subdir=None):
         """Generator that yields all files associated with the package or that
         should be associated with a package.
@@ -660,30 +682,25 @@ class Package(metaclass=abc.ABCMeta):
             if filter_subdir:
                 start_path = start_path + filter_subdir
 
-            files_returned_already = set()
-            if queryset.exists():
-                for file_obj in queryset.iterator():
-                    file_obj_mapped = get_file_replacement_mapping(
-                        file_obj, self.current_path
-                    )
-                    if not os.path.exists(file_obj_mapped.get("%inputFile%")):
-                        continue
-                    files_returned_already.add(file_obj_mapped.get("%inputFile%"))
-                    yield file_obj_mapped
+        files_returned_already = set()
 
-            for basedir, _, files in os.walk(start_path):
-                for file_name in files:
-                    if filter_filename_end and not file_name.endswith(
-                        filter_filename_end
-                    ):
-                        continue
-                    file_path = os.path.join(basedir, file_name)
-                    if file_path not in files_returned_already:
-                        yield {
-                            r"%relativeLocation%": file_path,
-                            r"%fileUUID%": "None",
-                            r"%fileGrpUse%": "",
-                        }
+        for file_obj_mapped in self._database_file_replacement_mappings(queryset):
+            if not os.path.exists(file_obj_mapped.get("%inputFile%")):
+                continue
+            files_returned_already.add(file_obj_mapped.get("%inputFile%"))
+            yield file_obj_mapped
+
+        for basedir, _, files in os.walk(start_path):
+            for file_name in files:
+                if filter_filename_end and not file_name.endswith(filter_filename_end):
+                    continue
+                file_path = os.path.join(basedir, file_name)
+                if file_path not in files_returned_already:
+                    yield {
+                        r"%relativeLocation%": file_path,
+                        r"%fileUUID%": "None",
+                        r"%fileGrpUse%": "",
+                    }
 
     @auto_close_old_connections()
     def set_variable(self, key, value, chain_link_id):

--- a/tests/MCPServer/test_package.py
+++ b/tests/MCPServer/test_package.py
@@ -1,11 +1,14 @@
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
 from django.core.exceptions import ValidationError
 
+import archivematica.MCPServer.server.packages as packages
 from archivematica.dashboard.main import models
 from archivematica.MCPServer.server.packages import DIP
 from archivematica.MCPServer.server.packages import SIP
@@ -263,6 +266,91 @@ def test_reload_file_list(tmp_path):
     # Clean up state and ensure test doesn't interfere with other transfers
     # expected to be in the database, e.g. in test_queues.py.
     models.File.objects.filter(transfer_id=str(transfer_uuid)).delete()
+
+
+def test_package_files_materializes_database_rows_in_batches(monkeypatch):
+    batch_size = 2
+
+    class FakeQuerySet:
+        def __init__(self, file_objs):
+            self.file_objs = list(file_objs)
+
+        def filter(self, **kwargs):
+            assert set(kwargs) == {"uuid__gt"}
+            file_objs = [
+                file_obj
+                for file_obj in self.file_objs
+                if file_obj.uuid > kwargs["uuid__gt"]
+            ]
+            return FakeQuerySet(file_objs)
+
+        def order_by(self, *fields):
+            assert fields == ("uuid",)
+            return FakeQuerySet(
+                sorted(self.file_objs, key=lambda file_obj: file_obj.uuid)
+            )
+
+        def __getitem__(self, index):
+            if isinstance(index, slice):
+                return FakeQuerySet(self.file_objs[index])
+            return self.file_objs[index]
+
+        def __iter__(self):
+            if len(self.file_objs) > batch_size:
+                raise AssertionError(
+                    "Package.files() must materialize bounded database pages"
+                )
+            return iter(self.file_objs)
+
+        def iterator(self):
+            raise AssertionError(
+                "Package.files() must not stream database rows with QuerySet.iterator()"
+            )
+
+        def exists(self):
+            return bool(self.file_objs)
+
+    class FakePackage(Package):
+        FILE_QUERYSET_BATCH_SIZE = 2
+        REPLACEMENT_PATH_STRING = "%transferDirectory%"
+
+        @property
+        def base_queryset(self):
+            return queryset
+
+        def queryset(self):
+            raise NotImplementedError
+
+        def reload(self):
+            raise NotImplementedError
+
+    file_objs = [
+        SimpleNamespace(uuid=uuid.UUID("00000000-0000-0000-0000-000000000001")),
+        SimpleNamespace(uuid=uuid.UUID("00000000-0000-0000-0000-000000000002")),
+        SimpleNamespace(uuid=uuid.UUID("00000000-0000-0000-0000-000000000003")),
+    ]
+    queryset = FakeQuerySet(file_objs)
+
+    monkeypatch.setattr(packages, "auto_close_old_connections", nullcontext)
+    monkeypatch.setattr(packages.os.path, "exists", lambda path: True)
+    monkeypatch.setattr(packages.os, "walk", lambda path: [])
+    monkeypatch.setattr(
+        packages,
+        "get_file_replacement_mapping",
+        lambda file_obj, current_path: {
+            "%inputFile%": f"{current_path}/{file_obj.uuid}",
+            "%fileUUID%": str(file_obj.uuid),
+        },
+    )
+
+    package = FakePackage("/transfer", uuid.uuid4())
+    files = list(package.files())
+
+    assert [file_obj["%fileUUID%"] for file_obj in files] == [
+        str(file_objs[0].uuid),
+        str(file_objs[1].uuid),
+        str(file_objs[2].uuid),
+    ]
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Package.files() returned database files directly from QuerySet.iterator(). ClientScriptJob.submit_tasks() consumes that generator while creating tasks, and task creation can run auto_close_old_connections() before Package.files() resumes. On MySQL, that can invalidate the active database result.

Load database files in UUID-ordered pages before yielding file mappings. Each page is fully read before task creation runs, so no active database result stays open across generator yields.

This trades one streaming query for bounded page queries. The extra database round trips are about one SELECT per 1000 database files, while memory stays bounded and pagination uses File.uuid, the primary key.

Fixes https://github.com/archivematica/Issues/issues/1793.