### PR TITLE
Include pending deletion requests in storage totals

### DIFF
--- a/src/archivematica/dashboard/components/archival_storage/views.py
+++ b/src/archivematica/dashboard/components/archival_storage/views.py
@@ -51,6 +51,7 @@ from archivematica.dashboard.components.archival_storage.atom import (
     upload_dip_metadata_to_atom,
 )
 from archivematica.search.service import AIPNotFoundError
+from archivematica.search.service import SearchService
 from archivematica.search.service import SortSpec
 from archivematica.search.service import setup_search_service_from_conf
 
@@ -722,45 +723,13 @@ def send_thumbnail(request, fileuuid):
     return helpers.send_file(request, thumbnail_path, allow_missing=True)
 
 
-def aips_pending_deletion():
-    aip_uuids = []
-    try:
-        aips = storage_service.get_file_info(
-            status=archivematica.search.constants.STATUS_DELETE_REQUESTED
-        )
-    except Exception as e:
-        # TODO this should be messages.warning, but we need 'request' here
-        logger.warning(
-            f"Error retrieving AIPs pending deletion: is the storage server running?  Error: {e}"
-        )
-    else:
-        for aip in aips:
-            aip_uuids.append(aip["uuid"])
-    return aip_uuids
-
-
-def elasticsearch_query_excluding_aips_pending_deletion(uuid_field_name):
-    # add UUIDs of AIPs pending deletion, if any, to boolean query
-    must_not_haves = []
-
-    for aip_uuid in aips_pending_deletion():
-        must_not_haves.append({"term": {uuid_field_name: aip_uuid}})
-
-    if len(must_not_haves):
-        query = {"query": {"bool": {"must_not": must_not_haves}}}
-    else:
-        query = {"query": {"match_all": {}}}
-
-    return query
-
-
-def aip_file_count(search_service):
-    query = elasticsearch_query_excluding_aips_pending_deletion("AIPUUID")
+def aip_file_count(search_service: SearchService) -> int:
+    query = {"query": {"match_all": {}}}
     return search_service.count_aip_files(query)
 
 
-def total_size_of_aips(search_service):
-    query = elasticsearch_query_excluding_aips_pending_deletion("uuid")
+def total_size_of_aips(search_service: SearchService) -> str:
+    query = {"query": {"match_all": {}}}
     query["_source"] = "size"
     query["aggs"] = {"total": {"sum": {"field": "size"}}}
     results = search_service.search_aips(query, size=0)

--- a/tests/dashboard/components/archival_storage/test_archival_storage.py
+++ b/tests/dashboard/components/archival_storage/test_archival_storage.py
@@ -29,12 +29,14 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.http import HttpResponseNotFound
 from django.http import StreamingHttpResponse
+from django.template.defaultfilters import filesizeformat
 from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 
 from archivematica.dashboard.components import helpers
 from archivematica.dashboard.components.archival_storage import atom
+from archivematica.dashboard.components.archival_storage import views
 from archivematica.search.service import AIPNotFoundError
 from archivematica.search.service import SearchService
 
@@ -269,6 +271,44 @@ def test_search_rejects_unsupported_file_mime(dashboard_uuid, admin_client):
 
     assert response.status_code == 400
     assert response.content == b"Please use ?mimeType=text/csv"
+
+
+def test_aip_file_count_includes_aips_pending_deletion(mock_search_service):
+    mock_search_service.count_aip_files.return_value = 42
+
+    with mock.patch(
+        "archivematica.dashboard.components.archival_storage.views.storage_service.get_file_info"
+    ) as get_file_info:
+        assert views.aip_file_count(mock_search_service) == 42
+
+    mock_search_service.count_aip_files.assert_called_once_with(
+        {"query": {"match_all": {}}}
+    )
+    get_file_info.assert_not_called()
+
+
+def test_total_size_of_aips_includes_aips_pending_deletion(mock_search_service):
+    total_mb = 2.5
+    mock_search_service.search_aips.return_value = {
+        "aggregations": {"total": {"value": total_mb}}
+    }
+
+    with mock.patch(
+        "archivematica.dashboard.components.archival_storage.views.storage_service.get_file_info"
+    ) as get_file_info:
+        assert views.total_size_of_aips(mock_search_service) == filesizeformat(
+            total_mb * (1024 * 1024)
+        )
+
+    mock_search_service.search_aips.assert_called_once_with(
+        {
+            "query": {"match_all": {}},
+            "_source": "size",
+            "aggs": {"total": {"sum": {"field": "size"}}},
+        },
+        size=0,
+    )
+    get_file_info.assert_not_called()
 
 
 @mock.patch(


### PR DESCRIPTION
The Archival Storage summary totals were excluding AIPs with pending deletion requests by fetching every matching package from the Storage Service and adding one Elasticsearch must_not term per UUID. Large installations could exceed Elasticsearch's max clause count and fail to load the tab.

Use match_all queries for the total size and indexed file count calculations so pending deletion requests remain included in the storage-management totals and the summary no longer depends on building a large exclusion query.

Connected to https://github.com/archivematica/Issues/issues/1792