### PR TITLE
Close stale MCPServer worker connections

### DIFF
--- a/src/archivematica/MCPServer/server/packages.py
+++ b/src/archivematica/MCPServer/server/packages.py
@@ -2,6 +2,7 @@
 
 import abc
 import collections
+import functools
 import json
 import logging
 import os
@@ -306,9 +307,11 @@ def create_package(
 
 
 def _capture_transfer_failure(fn=None, *, mark_transfer_failed=False):
-    """Prevent transfer-start exceptions from escaping the executor."""
+    """Guard transfer-start worker connections and capture their failures."""
 
     def decorator(wrapped):
+        @auto_close_old_connections()
+        @functools.wraps(wrapped)
         def wrap(*args, **kwargs):
             try:
                 return wrapped(*args, **kwargs)

--- a/tests/MCPServer/test_package.py
+++ b/tests/MCPServer/test_package.py
@@ -766,7 +766,27 @@ def test_capture_transfer_failure_logs_other_exceptions():
     )
 
 
-@pytest.mark.django_db
+def test_capture_transfer_failure_closes_old_executor_connections():
+    """Transfer workers discard stale thread-local connections before work."""
+    calls = []
+
+    @_capture_transfer_failure
+    def fn():
+        calls.append("called")
+
+    with (
+        mock.patch(
+            "archivematica.archivematicaCommon.dbconns.close_old_connections"
+        ) as close_old_connections,
+        ThreadPoolExecutor(max_workers=1) as executor,
+    ):
+        executor.submit(fn).result(timeout=1)
+
+    close_old_connections.assert_called_once_with()
+    assert calls == ["called"]
+
+
+@pytest.mark.django_db(transaction=True)
 def test_capture_transfer_failure_marks_transfer_failed():
     transfer = models.Transfer.objects.create(
         status=models.PACKAGE_STATUS_PROCESSING,
@@ -783,7 +803,7 @@ def test_capture_transfer_failure_marks_transfer_failed():
     assert transfer.completed_at is not None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_capture_transfer_failure_preserves_old_transfer_status_by_default():
     transfer = models.Transfer.objects.create(
         status=models.PACKAGE_STATUS_UNKNOWN,


### PR DESCRIPTION
703d8573e1f5b9cab5a7d6ba1f1fd6d5a704e464 added a direct `transfer.save()` inside an unguarded executor worker. After inactivity, the worker attempts to execute it using a connection that MySQL has already closed.