### PR TITLE
Improve resilience of XML metadata validation

### DIFF
--- a/src/archivematica/MCPClient/clientScripts/archivematicaCreateMETSMetadataXML.py
+++ b/src/archivematica/MCPClient/clientScripts/archivematicaCreateMETSMetadataXML.py
@@ -189,7 +189,9 @@ class Resolver(etree.Resolver):
         url_scheme = urlparse(url).scheme
         if url_scheme in ("http", "https"):
             try:
-                response = requests.get(url)
+                # timeout to prevent indefinite hangs, see
+                # https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts
+                response = requests.get(url, timeout=10)
             except requests.RequestException:
                 return super().resolve(url, id, context)
             else:

--- a/src/archivematica/MCPClient/clientScripts/archivematicaCreateMETSMetadataXML.py
+++ b/src/archivematica/MCPClient/clientScripts/archivematicaCreateMETSMetadataXML.py
@@ -21,6 +21,7 @@
 import csv
 from importlib.metadata import version
 from pathlib import Path
+from urllib.error import URLError
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
@@ -52,7 +53,14 @@ def process_xml_metadata(mets, sip_dir, sip_uuid, sip_type, xml_validation):
             if not xml_path:
                 fsentry.delete_dmdsec("OTHER", xml_type)
                 continue
-            tree = etree.parse(str(xml_path))
+            try:
+                tree = etree.parse(str(xml_path))
+            except Exception as err:
+                xml_metadata_errors += [
+                    f"Could not parse metadata file: {xml_path}",
+                    err,
+                ]
+                continue
             try:
                 schema_uri = _get_schema_uri(tree, xml_validation)
             except ValueError as err:
@@ -230,7 +238,7 @@ def _validate_xml(tree, schema_uri):
                 schema = etree.RelaxNG(schema_contents)
             else:
                 return False, [f"Unknown XML validation schema type: {schema_type}"]
-    except etree.LxmlError as err:
+    except (etree.LxmlError, URLError) as err:
         return False, [f"Could not parse schema file: {schema_uri}", err]
     if not schema.validate(tree):
         return False, schema.error_log

--- a/tests/MCPClient/test_archivematicaCreateMETSMetadataXML.py
+++ b/tests/MCPClient/test_archivematicaCreateMETSMetadataXML.py
@@ -23,9 +23,10 @@ from archivematica.MCPClient.clientScripts.archivematicaCreateMETSMetadataXML im
 METADATA_DIR = Path("objects") / "metadata"
 TRANSFER_METADATA_DIR = METADATA_DIR / "transfers" / "transfer_a"
 TRANSFER_SOURCE_METADATA_CSV = TRANSFER_METADATA_DIR / "source-metadata.csv"
-VALID_XML = '<?xml version="1.0" encoding="UTF-8"?><foo><bar/></foo>'
-INVALID_XML = '<?xml version="1.0" encoding="UTF-8"?><foo/>'
-SCHEMAS = {
+DUMMY_EXTERNAL_SCHEMA_URI = "http://foo.com/my.xsd"
+DUMMY_SCHEMA_NAMESPACE = "http://foo.com/1.0"
+
+DUMMY_SCHEMAS = {
     "xsd": """<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="foo">
@@ -48,18 +49,21 @@ SCHEMAS = {
   </oneOrMore>
 </element>
 """,
-}
-IMPORTED_SCHEMA = """<?xml version="1.0" encoding="UTF-8"?>
+    "xsd_imported": f"""<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns="http://foo.com/1.0" targetNamespace="http://foo.com/1.0">
-</xs:schema>"""
+           xmlns="{DUMMY_SCHEMA_NAMESPACE}" targetNamespace="{DUMMY_SCHEMA_NAMESPACE}">
+</xs:schema>
+""",
+}
 
+VALID_XML = '<?xml version="1.0" encoding="UTF-8"?><foo><bar/></foo>'
+INVALID_XML = '<?xml version="1.0" encoding="UTF-8"?><foo/>'
 
 @pytest.fixture
 def make_schema_file(tmp_path):
     def _make_schema_file(schema_type):
         schema_path = tmp_path / (schema_type + "." + schema_type)
-        schema_path.write_text(SCHEMAS[schema_type])
+        schema_path.write_text(DUMMY_SCHEMAS[schema_type])
         return schema_path
 
     return _make_schema_file
@@ -150,7 +154,7 @@ def requests_get():
     # Return a mock response good enough to be parsed as an XML schema.
     with mock.patch(
         "requests.get",
-        return_value=mock.Mock(text=IMPORTED_SCHEMA),
+        return_value=mock.Mock(text=DUMMY_SCHEMAS["xsd_imported"]),
     ) as result:
         yield result
 
@@ -192,9 +196,9 @@ def etree_parse():
 @pytest.fixture
 def schema_with_remote_import(tmp_path):
     # Create a schema that imports a remote schema.
-    schema = """<?xml version="1.0" encoding="UTF-8"?>
+    schema = f"""<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:import namespace="http://foo.com/1.0" schemaLocation="http://foo.com/my.xsd" />
+  <xs:import namespace="{DUMMY_SCHEMA_NAMESPACE}" schemaLocation="{DUMMY_EXTERNAL_SCHEMA_URI}" />
   <xs:element name="foo">
     <xs:complexType>
       <xs:sequence>
@@ -228,7 +232,7 @@ def schema_with_local_import(tmp_path):
     schema_path.write_text(schema)
 
     local_schema = tmp_path / "my.xsd"
-    local_schema.write_text(IMPORTED_SCHEMA)
+    local_schema.write_text(DUMMY_SCHEMAS["xsd_imported"])
 
     return schema_path
 
@@ -618,7 +622,7 @@ def test_resolver(
         xml_validation,
     )
     assert not errors
-    requests_get.assert_called_once_with("http://foo.com/my.xsd")
+    requests_get.assert_called_once_with(DUMMY_EXTERNAL_SCHEMA_URI)
 
 
 @pytest.mark.django_db

--- a/tests/MCPClient/test_archivematicaCreateMETSMetadataXML.py
+++ b/tests/MCPClient/test_archivematicaCreateMETSMetadataXML.py
@@ -5,7 +5,9 @@ Tests for XML metadata management on the METS creation process:
 archivematicaCreateMETSMetadataXML.process_xml_metadata()
 """
 
+import re
 from importlib.metadata import version
+from os.path import abspath
 from pathlib import Path
 from unittest import mock
 from uuid import uuid4
@@ -23,8 +25,18 @@ from archivematica.MCPClient.clientScripts.archivematicaCreateMETSMetadataXML im
 METADATA_DIR = Path("objects") / "metadata"
 TRANSFER_METADATA_DIR = METADATA_DIR / "transfers" / "transfer_a"
 TRANSFER_SOURCE_METADATA_CSV = TRANSFER_METADATA_DIR / "source-metadata.csv"
+PLACEHOLDER_LOCAL_DIR = "INJECT_LOCAL_DIR_HERE"
+
 DUMMY_EXTERNAL_SCHEMA_URI = "http://foo.com/my.xsd"
+DUMMY_EXTERNAL_SCHEMA_URI_0 = "http://foo.com/layer0.xsd"
+DUMMY_EXTERNAL_SCHEMA_URI_1 = "http://foo.com/layer1.xsd"
+DUMMY_EXTERNAL_SCHEMA_URI_2 = "http://foo.com/layer2.xsd"
+DUMMY_EXTERNAL_SCHEMA_URI_3 = "http://foo.com/layer3.xsd"
 DUMMY_SCHEMA_NAMESPACE = "http://foo.com/1.0"
+DUMMY_SCHEMA_NAMESPACE_0 = "http://foo.com/layer0"
+DUMMY_SCHEMA_NAMESPACE_1 = "http://foo.com/layer1"
+DUMMY_SCHEMA_NAMESPACE_2 = "http://foo.com/layer2"
+DUMMY_SCHEMA_NAMESPACE_3 = "http://foo.com/layer3"
 
 DUMMY_SCHEMAS = {
     "xsd": """<?xml version="1.0" encoding="UTF-8"?>
@@ -54,10 +66,144 @@ DUMMY_SCHEMAS = {
            xmlns="{DUMMY_SCHEMA_NAMESPACE}" targetNamespace="{DUMMY_SCHEMA_NAMESPACE}">
 </xs:schema>
 """,
+    "xsd_with_ns": f"""<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="{DUMMY_SCHEMA_NAMESPACE}" elementFormDefault="qualified">
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="bar" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+""",
+    "xsd_with_ns_v2": f"""<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="{DUMMY_SCHEMA_NAMESPACE}" elementFormDefault="qualified">
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="bar2" type="xs:string"/>    <!-- modified for v2: simulate a breaking change -->
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+""",
+    "xsd_with_nested_imports_layer0": f"""<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="{DUMMY_SCHEMA_NAMESPACE_0}"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:layer1="{DUMMY_SCHEMA_NAMESPACE_1}"
+           elementFormDefault="qualified">
+  <xs:import namespace="{DUMMY_SCHEMA_NAMESPACE_1}" schemaLocation="file://{PLACEHOLDER_LOCAL_DIR}/layer1.xsd"/>
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="layer1:bar1"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+""",
+    "xsd_with_nested_imports_layer1": f"""<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="{DUMMY_SCHEMA_NAMESPACE_1}"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:layer2="{DUMMY_SCHEMA_NAMESPACE_2}"
+           elementFormDefault="qualified">
+  <xs:import namespace="{DUMMY_SCHEMA_NAMESPACE_2}" schemaLocation="file://{PLACEHOLDER_LOCAL_DIR}/layer2.xsd"/>
+  <xs:element name="bar1">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="layer2:bar2"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+""",
+    "xsd_with_nested_imports_layer2": f"""<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="{DUMMY_SCHEMA_NAMESPACE_2}"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:layer3="{DUMMY_SCHEMA_NAMESPACE_3}"
+           elementFormDefault="qualified">
+  <xs:import namespace="{DUMMY_SCHEMA_NAMESPACE_3}" schemaLocation="file://{PLACEHOLDER_LOCAL_DIR}/layer3.xsd"/>
+  <xs:element name="bar2">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="layer3:bar3"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+""",
+    "xsd_with_nested_imports_layer3": f"""<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="{DUMMY_SCHEMA_NAMESPACE_3}"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+  <xs:element name="bar3" type="xs:string"/>
+</xs:schema>
+""",
+    "xsd_with_nested_imports_layer3_circular": f"""<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="{DUMMY_SCHEMA_NAMESPACE_3}"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+  <xs:import namespace="{DUMMY_SCHEMA_NAMESPACE_1}" schemaLocation="file://{PLACEHOLDER_LOCAL_DIR}/layer1.xsd"/>
+  <xs:element name="bar3" type="xs:string"/>
+</xs:schema>
+""",
 }
 
 VALID_XML = '<?xml version="1.0" encoding="UTF-8"?><foo><bar/></foo>'
 INVALID_XML = '<?xml version="1.0" encoding="UTF-8"?><foo/>'
+XML_WITHOUT_NAMESPACE = VALID_XML
+XML_WITH_NAMESPACE_NO_SCHEMALOCATION = f"""<?xml version="1.0" encoding="UTF-8"?>
+<foo xmlns="{DUMMY_SCHEMA_NAMESPACE}">
+  <bar/>
+</foo>"""
+INVALID_XML_WITH_NAMESPACE_NO_SCHEMALOCATION = f"""<?xml version="1.0" encoding="UTF-8"?>
+<foo xmlns="{DUMMY_SCHEMA_NAMESPACE}">
+  <foofoo/>
+</foo>"""
+XML_WITH_NAMESPACE_AND_SCHEMALOCATION = f"""<?xml version="1.0" encoding="UTF-8"?>
+<foo xmlns="{DUMMY_SCHEMA_NAMESPACE}"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="{DUMMY_SCHEMA_NAMESPACE} {DUMMY_EXTERNAL_SCHEMA_URI}">
+  <bar/>
+</foo>"""
+BROKEN_XML_WITH_NAMESPACE_AND_SCHEMALOCATION = f"""<?xml version="1.0" encoding="UTF-8"?>
+<foo xmlns="{DUMMY_SCHEMA_NAMESPACE}"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="{DUMMY_SCHEMA_NAMESPACE} {DUMMY_EXTERNAL_SCHEMA_URI}">
+  <-- simulate broken xml: metadata got truncated, structure not well-formed -->
+  <bar>
+"""
+XML_WITH_NESTED_SCHEMA_IMPORTS = f"""<?xml version="1.0" encoding="UTF-8"?>
+<layer0:foo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns:layer0="{DUMMY_SCHEMA_NAMESPACE_0}"
+     xmlns:layer1="{DUMMY_SCHEMA_NAMESPACE_1}"
+     xmlns:layer2="{DUMMY_SCHEMA_NAMESPACE_2}"
+     xmlns:layer3="{DUMMY_SCHEMA_NAMESPACE_3}"
+     xsi:schemaLocation="{DUMMY_SCHEMA_NAMESPACE} {DUMMY_EXTERNAL_SCHEMA_URI}">
+  <layer1:bar1>
+    <layer2:bar2>
+      <layer3:bar3>foo</layer3:bar3>
+    </layer2:bar2>
+  </layer1:bar1>
+</layer0:foo>
+"""
+INVALID_XML_WITH_NESTED_SCHEMA_IMPORTS = f"""<?xml version="1.0" encoding="UTF-8"?>
+<layer0:foo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns:layer0="{DUMMY_SCHEMA_NAMESPACE_0}"
+     xmlns:layer1="{DUMMY_SCHEMA_NAMESPACE_1}"
+     xmlns:layer2="{DUMMY_SCHEMA_NAMESPACE_2}"
+     xmlns:layer3="{DUMMY_SCHEMA_NAMESPACE_3}"
+     xsi:schemaLocation="{DUMMY_SCHEMA_NAMESPACE} {DUMMY_EXTERNAL_SCHEMA_URI}">
+  <layer1:bar1>
+    <layer2:bar2>
+      <!-- simulate invalid nested metadata -->
+      <layer3:invalid_node/>
+    </layer2:bar2>
+  </layer1:bar1>
+</layer0:foo>
+"""
+
 
 @pytest.fixture
 def make_schema_file(tmp_path):
@@ -682,3 +828,239 @@ def test_resolver_with_local_import(
     )
     assert not errors
     requests_get.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "xml, schemas, xml_validation_factory, should_pass, expected_error",
+    [
+        # scenario 01 - XML metadata without namespace
+        #               XML_VALIDATION provides schema based on root element node
+        (
+            XML_WITHOUT_NAMESPACE,
+            {"custom.xsd": DUMMY_SCHEMAS["xsd"]},
+            lambda schema_paths: {"foo": str(schema_paths["custom.xsd"])},
+            True,
+            None,
+        ),
+        # scenario 02: XML metadata with namespace, but no schemaLocation hint
+        #              XML_VALIDATION provides schema based on namespace
+        (
+            XML_WITH_NAMESPACE_NO_SCHEMALOCATION,
+            {"custom.xsd": DUMMY_SCHEMAS["xsd_with_ns"]},
+            lambda schema_paths: {
+                f"{DUMMY_SCHEMA_NAMESPACE}": str(schema_paths["custom.xsd"])
+            },
+            True,
+            None,
+        ),
+        # scenario 03: XML metadata with namespace & schemaLocation hint
+        #              XML_VALIDATION provides schema based on namespace, overrules schemaLocation hint
+        (
+            XML_WITH_NAMESPACE_AND_SCHEMALOCATION,
+            {"custom.xsd": DUMMY_SCHEMAS["xsd_with_ns"]},
+            lambda schema_paths: {
+                f"{DUMMY_SCHEMA_NAMESPACE}": str(schema_paths["custom.xsd"])
+            },
+            True,
+            None,
+        ),
+        # scenario 04: XML metadata with namespace & schemaLocation hint, but metadata is invalid
+        #              XML_VALIDATION forces validation skip, overrules schemaLocation hint
+        (
+            XML_WITH_NAMESPACE_AND_SCHEMALOCATION,
+            {},
+            lambda schema_paths: {f"{DUMMY_SCHEMA_NAMESPACE}": None},
+            True,
+            None,
+        ),
+        # scenario 05: XML metadata is missing, empty file
+        #              parsing metadata should fail gracefully
+        (
+            "",
+            {},
+            lambda schema_paths: True,  # just enable xml validation
+            False,
+            "Could not parse metadata file",
+        ),
+        # scenario 06: XML metadata is broken, structure not well-formed
+        #              parsing metadata should fail gracefully
+        (
+            BROKEN_XML_WITH_NAMESPACE_AND_SCHEMALOCATION,
+            {"custom.xsd": DUMMY_SCHEMAS["xsd_with_ns"]},
+            lambda schema_paths: {
+                f"{DUMMY_SCHEMA_NAMESPACE}": str(schema_paths["custom.xsd"])
+            },
+            False,
+            "Could not parse metadata file",
+        ),
+        # scenario 07: XML metadata with namespace, but no schemaLocation hint, metadata is invalid
+        #              XML_VALIDATION provides schema based on namespace, metadata invalid against user provided schema
+        (
+            INVALID_XML_WITH_NAMESPACE_NO_SCHEMALOCATION,
+            {"custom.xsd": DUMMY_SCHEMAS["xsd_with_ns"]},
+            lambda schema_paths: {
+                f"{DUMMY_SCHEMA_NAMESPACE}": str(schema_paths["custom.xsd"])
+            },
+            False,
+            "foofoo.*element is not expected",
+        ),
+        # scenario 08: XML metadata with namespace & schemaLocation hint, metadata is valid against schemaLocation hint
+        #              XML_VALIDATION overrules schemaLocation hint, metadata invalid against user provided schema
+        (
+            XML_WITH_NAMESPACE_AND_SCHEMALOCATION,
+            {"custom.xsd": DUMMY_SCHEMAS["xsd_with_ns_v2"]},
+            lambda schema_paths: {
+                f"{DUMMY_SCHEMA_NAMESPACE}": str(schema_paths["custom.xsd"])
+            },
+            False,
+            "bar[^2].*element is not expected",
+        ),
+        # scenario 09: XML metadata with namespace
+        #              XML_VALIDATION provides schema based on namespace, but schema path is not absolute
+        (
+            XML_WITH_NAMESPACE_NO_SCHEMALOCATION,
+            {"custom.xsd": DUMMY_SCHEMAS["xsd_with_ns"]},
+            lambda schema_paths: {f"{DUMMY_SCHEMA_NAMESPACE}": "relative_path.xsd"},
+            False,
+            "schema local path.*must be absolute",
+        ),
+        # scenario 10: XML metadata with namespace
+        #              XML_VALIDATION provides schema based on namespace, but schema path is not accessable, parsing schema should fail gracefully
+        (
+            XML_WITH_NAMESPACE_NO_SCHEMALOCATION,
+            {"custom.xsd": DUMMY_SCHEMAS["xsd_with_ns"]},
+            lambda schema_paths: {
+                f"{DUMMY_SCHEMA_NAMESPACE}": abspath("does_not_exist.xsd")
+            },
+            False,
+            "Could not parse schema file|No such file or directory",
+        ),
+        # scenario 11: XML metadata without namespace
+        #              XML_VALIDATION does not provide a schema matching the root node
+        (
+            VALID_XML,
+            {"custom.xsd": DUMMY_SCHEMAS["xsd_with_ns"]},
+            lambda schema_paths: {
+                "not_dummy_schema_namespace": str(schema_paths["custom.xsd"])
+            },
+            False,
+            "XML validation schema not found for keys",
+        ),
+        # scenario 12: XML metadata with namespace, but namespace has multiple levels of imports
+        #              XML_VALIDATION does only provide schema for the initial namespace, missing schemas are handled by lxml using schemaLocation
+        (
+            XML_WITH_NESTED_SCHEMA_IMPORTS,
+            {
+                "layer0.xsd": DUMMY_SCHEMAS["xsd_with_nested_imports_layer0"],
+                "layer1.xsd": DUMMY_SCHEMAS["xsd_with_nested_imports_layer1"],
+                "layer2.xsd": DUMMY_SCHEMAS["xsd_with_nested_imports_layer2"],
+                "layer3.xsd": DUMMY_SCHEMAS["xsd_with_nested_imports_layer3"],
+            },
+            lambda schema_paths: {
+                f"{DUMMY_SCHEMA_NAMESPACE_0}": str(schema_paths["layer0.xsd"])
+            },  # XML_VALIDATION only handles layer 0 schema
+            True,
+            None,
+        ),
+        # scenario 13: XML metadata with namespace, but namespace has multiple layers of imports, some circular
+        #              XML_VALIDATION does only provide schema for the initial namespace, missing schemas are handled by lxml using schemaLocation
+        (
+            XML_WITH_NESTED_SCHEMA_IMPORTS,
+            {
+                "layer0.xsd": DUMMY_SCHEMAS["xsd_with_nested_imports_layer0"],
+                "layer1.xsd": DUMMY_SCHEMAS["xsd_with_nested_imports_layer1"],
+                "layer2.xsd": DUMMY_SCHEMAS["xsd_with_nested_imports_layer2"],
+                "layer3.xsd": DUMMY_SCHEMAS["xsd_with_nested_imports_layer3_circular"],
+            },
+            lambda schema_paths: {
+                f"{DUMMY_SCHEMA_NAMESPACE_0}": str(schema_paths["layer0.xsd"])
+            },  # XML_VALIDATION only handles layer0
+            True,
+            None,
+        ),
+        # scenario 14: XML metadata with namespace, but namespace has multiple layers of imports, metadata is invalid
+        #              XML_VALIDATION does only provide schema for the initial namespace, missing schemas are handled by lxml using schemaLocation
+        (
+            INVALID_XML_WITH_NESTED_SCHEMA_IMPORTS,
+            {
+                "layer0.xsd": DUMMY_SCHEMAS["xsd_with_nested_imports_layer0"],
+                "layer1.xsd": DUMMY_SCHEMAS["xsd_with_nested_imports_layer1"],
+                "layer2.xsd": DUMMY_SCHEMAS["xsd_with_nested_imports_layer2"],
+                "layer3.xsd": DUMMY_SCHEMAS["xsd_with_nested_imports_layer3"],
+            },
+            lambda schema_paths: {
+                f"{DUMMY_SCHEMA_NAMESPACE_0}": str(schema_paths["layer0.xsd"])
+            },  # XML_VALIDATION only handles layer0
+            False,
+            "invalid_node.*element is not expected",
+        ),
+    ],
+)
+def test_validation_in_additional_xml_scenarios(
+    settings,
+    make_metadata_file,
+    make_mock_mets,
+    sip,
+    sip_directory_path,
+    tmp_path,
+    xml,
+    schemas,
+    xml_validation_factory,
+    should_pass,
+    expected_error,
+):
+    # create xml metadata file to be validated
+    xml_file = "custom.xml"
+    xml_file_path = sip_directory_path / TRANSFER_METADATA_DIR / xml_file
+    xml = re.sub(
+        f"{PLACEHOLDER_LOCAL_DIR}", f"{tmp_path}", xml
+    )  # inject tmp_path if placeholder was set
+    xml_file_path.write_text(xml)
+
+    # create local schema files required for scenario
+    schema_paths = {}
+    for name, content in schemas.items():
+        schema_path = tmp_path / f"{name}"
+        content = re.sub(
+            f"{PLACEHOLDER_LOCAL_DIR}", f"{tmp_path}", content
+        )  # inject tmp_path into <import/> nodes, so lxml can find it
+        schema_path.write_text(content)
+        schema_paths[name] = (
+            schema_path  # map schema name to its path for xml_validation_factory
+        )
+
+    # generate XML_VALIDATION dictionary utilizing the created schema files
+    xml_validation = xml_validation_factory(schema_paths)
+
+    # enable internal xml validation with lxml
+    settings.METADATA_XML_VALIDATION_ENABLED = True
+
+    # create source-metadata.csv
+    source_metadata_csv_contents = f"filename,metadata,type\nobjects,{xml_file},mdtype"
+    metadata_csv_path = sip_directory_path / TRANSFER_SOURCE_METADATA_CSV
+    metadata_csv_path.write_text(source_metadata_csv_contents)
+
+    # mock package METS
+    metadata_file_rel_path = TRANSFER_METADATA_DIR / xml_file
+    metadata_file = make_metadata_file(metadata_file_rel_path)
+    mock_mets = make_mock_mets([str(metadata_file.uuid)])
+
+    # test
+    mock_mets, errors = process_xml_metadata(
+        mock_mets,
+        sip_directory_path,
+        sip.uuid,
+        "sip_type",
+        xml_validation,
+    )
+    if should_pass:
+        assert not errors, (
+            f"Scenario should have passed without errors, but: '{errors}'"
+        )
+    else:
+        assert errors, "Scenario should have failed with errors, but has none."
+        error_found = any(re.search(expected_error, str(err)) for err in errors)
+        assert error_found, (
+            f"Scenario did not contain expected error '{expected_error}', only: '{errors}'"
+        )

--- a/tests/MCPClient/test_archivematicaCreateMETSMetadataXML.py
+++ b/tests/MCPClient/test_archivematicaCreateMETSMetadataXML.py
@@ -768,7 +768,7 @@ def test_resolver(
         xml_validation,
     )
     assert not errors
-    requests_get.assert_called_once_with(DUMMY_EXTERNAL_SCHEMA_URI)
+    requests_get.assert_called_once_with(DUMMY_EXTERNAL_SCHEMA_URI, timeout=10)
 
 
 @pytest.mark.django_db

--- a/tests/MCPClient/test_archivematicaCreateMETSMetadataXML.py
+++ b/tests/MCPClient/test_archivematicaCreateMETSMetadataXML.py
@@ -302,7 +302,7 @@ def test_validation(
     objects_fsentry = mock_mets.get_file(label="objects")
     metadata_fsentry = mock_mets.get_file(file_uuid=str(metadata_file.uuid))
     if should_pass:
-        # Use ANY to avoid comparision with etree.Element, but confirm element tag.
+        # Use ANY to avoid comparison with etree.Element, but confirm element tag.
         objects_fsentry.add_dmdsec.assert_called_once_with(
             mock.ANY, "OTHER", othermdtype="mdtype", status="original"
         )
@@ -351,7 +351,7 @@ def test_skipped_validation(
     objects_fsentry = mock_mets.get_file(label="objects")
     metadata_fsentry = mock_mets.get_file(file_uuid=str(metadata_file.uuid))
     assert not errors
-    # Use ANY to avoid comparision with etree.Element, but confirm element tag.
+    # Use ANY to avoid comparison with etree.Element, but confirm element tag.
     objects_fsentry.add_dmdsec.assert_called_once_with(
         mock.ANY, "OTHER", othermdtype="mdtype", status="original"
     )
@@ -576,7 +576,7 @@ def test_reingest(
     objects_fsentry = mock_mets.get_file(label="objects")
     metadata_fsentry = mock_mets.get_file(file_uuid=str(metadata_file.uuid))
     assert not errors
-    # Use ANY to avoid comparision with etree.Element, but confirm element tag.
+    # Use ANY to avoid comparison with etree.Element, but confirm element tag.
     objects_fsentry.add_dmdsec.assert_called_once_with(
         mock.ANY, "OTHER", othermdtype="mdtype", status="update"
     )


### PR DESCRIPTION
https://github.com/archivematica/Issues/issues/1810

- Extended XML metadata validation tests with additional scenarios
- Added timeout to prevent GET requests to hang indefinitely (https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts)
- Gracefully handled failed metadata parsing and added info about the failed file
- Gracefully handled failed schema access by catching schema URL errors as well

Notes:
1. Some of the scenarios may already be covered in other test functions, but my focus was on XML validation.
2. I wasn't able to reproduce a scenario where a custom XML catalog is used by `lxml` to resolve schemas with nested imports.
  * Setting `XML_CATALOG_FILES` dynamically at runtime (with `monkeypatch.setenv`) doesn't seem to affect `lxml` at all.
  * Also, appending a custom resolver to the default resolver for in-memory schemas at runtime (with `etree.get_default_parser().resolvers.add`) has no effect on `lxml`. Ignoring the default resolver might be a security mechanism in `lxml` or related to caching.
  * The only way I found to test schemas with nested imports was to use `schemaLocation` hints with purely local paths in every used schema.