### PR TITLE
Verify OIDC JWT claims

### DIFF
--- a/src/archivematica/dashboard/components/accounts/backends.py
+++ b/src/archivematica/dashboard/components/accounts/backends.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 from django_auth_ldap.backend import LDAPBackend
 from django_cas_ng.backends import CASBackend
+from jwt import PyJWKClient
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 from shibboleth.backends import ShibbolethRemoteUserBackend
 
@@ -127,15 +128,11 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
         self, access_token: str, id_token: str, verified_id: dict[str, Any]
     ) -> dict[str, Any]:
         """
-        Extract user details from JSON web tokens
+        Extract user details from OIDC token claims.
         These map to fields on the user field.
         """
 
-        def decode_token(token):
-            return jwt.decode(token, options={"verify_signature": False})
-
-        access_info = decode_token(access_token)
-        id_info = decode_token(id_token)
+        access_info = self.verify_access_token(access_token, verified_id)
 
         info: dict[str, Any] = {}
 
@@ -144,10 +141,59 @@ class CustomOIDCBackend(OIDCAuthenticationBackend):
                 info.setdefault(user_attr, access_info[oidc_attr])
 
         for oidc_attr, user_attr in settings.OIDC_ID_ATTRIBUTE_MAP.items():
-            if oidc_attr in id_info:
-                info.setdefault(user_attr, id_info[oidc_attr])
+            if oidc_attr in verified_id:
+                info.setdefault(user_attr, verified_id[oidc_attr])
 
         return info
+
+    def verify_access_token(
+        self, access_token: str, verified_id: dict[str, Any]
+    ) -> dict[str, Any]:
+        issuer = verified_id.get("iss")
+        if not isinstance(issuer, str) or not issuer:
+            raise jwt.InvalidIssuerError("Verified ID token is missing issuer.")
+
+        signing_key = self.get_access_token_signing_key(access_token)
+        payload = jwt.decode(
+            access_token,
+            signing_key,
+            algorithms=[self.OIDC_RP_SIGN_ALGO],
+            issuer=issuer,
+            options={"verify_aud": False},
+        )
+        self.verify_access_token_audience(payload)
+        return payload
+
+    def get_access_token_signing_key(self, access_token: str) -> Any:
+        if self.OIDC_RP_SIGN_ALGO.startswith("HS"):
+            return self.OIDC_RP_CLIENT_SECRET
+
+        if not self.OIDC_OP_JWKS_ENDPOINT:
+            raise ImproperlyConfigured(
+                "OIDC_OP_JWKS_ENDPOINT must be set to verify access tokens."
+            )
+
+        return (
+            PyJWKClient(self.OIDC_OP_JWKS_ENDPOINT)
+            .get_signing_key_from_jwt(access_token)
+            .key
+        )
+
+    def verify_access_token_audience(self, payload: dict[str, Any]) -> None:
+        audiences = payload.get("aud")
+        if isinstance(audiences, str):
+            audiences = [audiences]
+        if not isinstance(audiences, list):
+            audiences = []
+
+        authorized_party = payload.get("azp")
+        if self.OIDC_RP_CLIENT_ID not in audiences and (
+            not isinstance(authorized_party, str)
+            or authorized_party != self.OIDC_RP_CLIENT_ID
+        ):
+            raise jwt.InvalidAudienceError(
+                "Access token was not issued for this client."
+            )
 
     def create_user(self, user_info: dict[str, Any]) -> Optional[User]:
         role = self.get_user_role(user_info)

--- a/tests/dashboard/test_oidc.py
+++ b/tests/dashboard/test_oidc.py
@@ -1,3 +1,8 @@
+import base64
+import json
+from typing import Any
+
+import jwt
 import pytest
 import pytest_django
 from django.contrib.auth.models import User
@@ -5,12 +10,24 @@ from django.contrib.auth.models import User
 from archivematica.dashboard.components.accounts.backends import CustomOIDCBackend
 
 
+def _unsigned_jwt(payload: dict[str, object]) -> str:
+    header: dict[str, object] = {"typ": "JWT", "alg": "none"}
+
+    def encode(segment: dict[str, object]) -> str:
+        encoded = base64.urlsafe_b64encode(json.dumps(segment).encode()).rstrip(b"=")
+        return encoded.decode()
+
+    return f"{encode(header)}.{encode(payload)}."
+
+
 @pytest.fixture
 def settings(settings: pytest_django.Settings) -> pytest_django.Settings:
     settings.OIDC_OP_TOKEN_ENDPOINT = "https://example.com/token"
     settings.OIDC_OP_USER_ENDPOINT = "https://example.com/user"
+    settings.OIDC_OP_JWKS_ENDPOINT = "https://example.com/jwks"
     settings.OIDC_RP_CLIENT_ID = "rp_client_id"
     settings.OIDC_RP_CLIENT_SECRET = "rp_client_secret"
+    settings.OIDC_RP_SIGN_ALGO = "RS256"
     settings.OIDC_ACCESS_ATTRIBUTE_MAP = {
         "given_name": "first_name",
         "family_name": "last_name",
@@ -27,6 +44,16 @@ def settings(settings: pytest_django.Settings) -> pytest_django.Settings:
     settings.OIDC_USERNAME_ALGO = lambda email: email
 
     return settings
+
+
+def _set_verified_access_claims(
+    monkeypatch: pytest.MonkeyPatch, claims: dict[str, object]
+) -> None:
+    monkeypatch.setattr(
+        CustomOIDCBackend,
+        "verify_access_token",
+        lambda self, access_token, verified_id: claims,
+    )
 
 
 @pytest.mark.django_db
@@ -281,16 +308,23 @@ def test_create_user_admin_from_claims_simple_role(
 
 
 @pytest.mark.django_db
-def test_get_userinfo(settings: pytest_django.Settings) -> None:
+def test_get_userinfo(
+    settings: pytest_django.Settings, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # Encoded at https://www.jsonwebtoken.io/
     # {"email": "test@example.com"}
     id_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJqdGkiOiI1M2QyMzUzMy04NDk0LTQyZWQtYTJiZC03Mzc2MjNmMjUzZjciLCJpYXQiOjE1NzMwMzE4NDQsImV4cCI6MTU3MzAzNTQ0NH0.m3nHgvj_DyVJMcW5eyYuUss1Y0PNzJV2O3bX0b_DCmI"
     # {"given_name": "Test", "family_name": "User"}
     access_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJnaXZlbl9uYW1lIjoiVGVzdCIsImZhbWlseV9uYW1lIjoiVXNlciIsImp0aSI6ImRhZjIwNTNiLWE4MTgtNDE1Yy1hM2Y1LTkxYWVhMTMxYjljZCIsImlhdCI6MTU3MzAzMTk3OSwiZXhwIjoxNTczMDM1NTc5fQ.cGcmt7d9IuKndvrqPpAH3Dvb3KyCOMqixUWgS7sg8r4"
     backend = CustomOIDCBackend()
+    _set_verified_access_claims(
+        monkeypatch, {"given_name": "Test", "family_name": "User"}
+    )
 
     info = backend.get_userinfo(
-        access_token=access_token, id_token=id_token, verified_id={}
+        access_token=access_token,
+        id_token=id_token,
+        verified_id={"email": "test@example.com", "iss": "https://example.com"},
     )
 
     assert info["email"] == "test@example.com"
@@ -307,7 +341,7 @@ def test_get_or_create_user_does_not_create_user_when_disabled(
     monkeypatch.setattr(
         backend,
         "get_userinfo",
-        lambda access_token, id_token, payload: {"email": "new@example.com"},
+        lambda access_token, id_token, verified_id: {"email": "new@example.com"},
     )
 
     user = backend.get_or_create_user(
@@ -332,7 +366,7 @@ def test_get_or_create_user_returns_existing_user_when_creation_disabled(
     monkeypatch.setattr(
         backend,
         "get_userinfo",
-        lambda access_token, id_token, payload: {"email": "existing@example.com"},
+        lambda access_token, id_token, verified_id: {"email": "existing@example.com"},
     )
 
     user = backend.get_or_create_user(
@@ -343,3 +377,164 @@ def test_get_or_create_user_returns_existing_user_when_creation_disabled(
 
     assert user == existing_user
     assert User.objects.count() == 1
+
+
+def test_get_userinfo_uses_verified_id_claims_for_id_token_attributes(
+    settings: pytest_django.Settings, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    id_token = _unsigned_jwt({"email": "forged@example.com"})
+    access_token = _unsigned_jwt(
+        {"given_name": "Test", "family_name": "User", "realm_access": {}}
+    )
+    backend = CustomOIDCBackend()
+    _set_verified_access_claims(
+        monkeypatch, {"given_name": "Test", "family_name": "User"}
+    )
+
+    info = backend.get_userinfo(
+        access_token=access_token,
+        id_token=id_token,
+        verified_id={"email": "verified@example.com", "iss": "https://example.com"},
+    )
+
+    assert info["email"] == "verified@example.com"
+
+
+def test_get_userinfo_does_not_require_raw_id_token_to_be_decodable_after_verification(
+    settings: pytest_django.Settings, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    access_token = _unsigned_jwt({"given_name": "Test", "family_name": "User"})
+    backend = CustomOIDCBackend()
+    _set_verified_access_claims(
+        monkeypatch, {"given_name": "Test", "family_name": "User"}
+    )
+
+    info = backend.get_userinfo(
+        access_token=access_token,
+        id_token="not-a-jwt",
+        verified_id={"email": "verified@example.com", "iss": "https://example.com"},
+    )
+
+    assert info["email"] == "verified@example.com"
+    assert info["first_name"] == "Test"
+    assert info["last_name"] == "User"
+
+
+def test_get_userinfo_does_not_accept_unverified_access_token_claims(
+    settings: pytest_django.Settings, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    id_token = _unsigned_jwt({"email": "forged@example.com"})
+    access_token = _unsigned_jwt(
+        {
+            "given_name": "Forged",
+            "family_name": "User",
+            "realm_access": {"roles": ["admin"]},
+        }
+    )
+    backend = CustomOIDCBackend()
+
+    def reject_access_token(
+        self: CustomOIDCBackend, access_token: str, verified_id: dict[str, Any]
+    ) -> dict[str, Any]:
+        raise jwt.InvalidSignatureError("Invalid access token signature.")
+
+    monkeypatch.setattr(
+        CustomOIDCBackend,
+        "verify_access_token",
+        reject_access_token,
+    )
+
+    with pytest.raises(jwt.InvalidSignatureError):
+        backend.get_userinfo(
+            access_token=access_token,
+            id_token=id_token,
+            verified_id={"email": "verified@example.com", "iss": "https://example.com"},
+        )
+
+
+def test_verify_access_token_validates_signature_issuer_expiry_algorithm_and_audience(
+    settings: pytest_django.Settings, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend = CustomOIDCBackend()
+    decode_kwargs: dict[str, Any] = {}
+
+    class SigningKey:
+        key = "signing-key"
+
+    class JWKClient:
+        def __init__(self, jwks_endpoint: str) -> None:
+            decode_kwargs["jwks_endpoint"] = jwks_endpoint
+
+        def get_signing_key_from_jwt(self, access_token: str) -> SigningKey:
+            decode_kwargs["signing_key_token"] = access_token
+            return SigningKey()
+
+    def decode(
+        token: str,
+        key: Any,
+        algorithms: list[str],
+        issuer: str,
+        options: dict[str, Any],
+    ) -> dict[str, Any]:
+        decode_kwargs.update(
+            {
+                "token": token,
+                "key": key,
+                "algorithms": algorithms,
+                "issuer": issuer,
+                "options": options,
+            }
+        )
+        return {
+            "aud": ["rp_client_id"],
+            "exp": 1573035579,
+            "given_name": "Test",
+        }
+
+    monkeypatch.setattr(
+        "archivematica.dashboard.components.accounts.backends.PyJWKClient", JWKClient
+    )
+    monkeypatch.setattr(
+        "archivematica.dashboard.components.accounts.backends.jwt.decode", decode
+    )
+
+    payload = backend.verify_access_token(
+        "access-token", {"iss": "https://example.com/issuer"}
+    )
+
+    assert payload["given_name"] == "Test"
+    assert decode_kwargs == {
+        "jwks_endpoint": "https://example.com/jwks",
+        "signing_key_token": "access-token",
+        "token": "access-token",
+        "key": "signing-key",
+        "algorithms": ["RS256"],
+        "issuer": "https://example.com/issuer",
+        "options": {"verify_aud": False},
+    }
+
+
+def test_verify_access_token_rejects_missing_issuer(
+    settings: pytest_django.Settings,
+) -> None:
+    backend = CustomOIDCBackend()
+
+    with pytest.raises(jwt.InvalidIssuerError):
+        backend.verify_access_token("access-token", {})
+
+
+def test_verify_access_token_accepts_keycloak_authorized_party(
+    settings: pytest_django.Settings,
+) -> None:
+    backend = CustomOIDCBackend()
+
+    backend.verify_access_token_audience({"aud": ["account"], "azp": "rp_client_id"})
+
+
+def test_verify_access_token_rejects_wrong_audience(
+    settings: pytest_django.Settings,
+) -> None:
+    backend = CustomOIDCBackend()
+
+    with pytest.raises(jwt.InvalidAudienceError):
+        backend.verify_access_token_audience({"aud": ["other"], "azp": "other"})


### PR DESCRIPTION
Use verified ID token claims for ID-token mapped attributes and verify access tokens before mapping access-token claims.

Access token validation now checks the signature, configured signing algorithm, expiry, issuer, and client targeting. Client targeting accepts either an aud value matching OIDC_RP_CLIENT_ID or azp value matching OIDC_RP_CLIENT_ID.