### PR TITLE
Batch antivirus database operations

### DIFF
--- a/src/archivematica/MCPClient/clientScripts/antivirus.py
+++ b/src/archivematica/MCPClient/clientScripts/antivirus.py
@@ -18,19 +18,25 @@
 import multiprocessing
 import os
 import uuid
+from collections.abc import Callable
+from collections.abc import Collection
+from collections.abc import Mapping
+from dataclasses import dataclass
+from functools import cache
 
 import django
 
 django.setup()
+from clamav_client.scanner import Scanner
 from clamav_client.scanner import get_scanner
 from django.conf import settings as mcpclient_settings
-from django.core.exceptions import ValidationError
 from django.db import transaction
 
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 from archivematica.archivematicaCommon.databaseFunctions import insertIntoEvents
 from archivematica.dashboard.main.models import Event
 from archivematica.dashboard.main.models import File
+from archivematica.MCPClient.client.job import Job
 
 logger = get_script_logger("archivematica.mcp.client.clamscan")
 
@@ -39,16 +45,62 @@ def concurrent_instances():
     return multiprocessing.cpu_count()
 
 
-def file_already_scanned(file_uuid):
-    return (
-        file_uuid != "None"
-        and Event.objects.filter(
-            file_uuid_id=file_uuid, event_type="virus check"
-        ).exists()
+def normalize_uuid(value: object) -> str | None:
+    """Return a canonical UUID string, or ``None`` for an invalid value."""
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    try:
+        return str(uuid.UUID(str(value)))
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+@dataclass(frozen=True)
+class AntivirusBatchData:
+    """File metadata and virus-check state loaded for an antivirus batch."""
+
+    file_sizes: Mapping[str, int | None]
+    scanned_file_uuids: Collection[str]
+
+
+def load_file_data(
+    jobs: Collection[Job],
+) -> AntivirusBatchData:
+    """Load file sizes and previous virus checks for a job batch."""
+    file_uuids: set[str] = set()
+    for job in jobs:
+        if len(job.args) <= 1:
+            continue
+        file_uuid = normalize_uuid(job.args[1])
+        if file_uuid is not None:
+            file_uuids.add(file_uuid)
+
+    file_sizes = {
+        str(file_uuid): size
+        for file_uuid, size in File.objects.filter(uuid__in=file_uuids).values_list(
+            "uuid", "size"
+        )
+    }
+    scanned_file_uuids = {
+        str(file_uuid)
+        for file_uuid in Event.objects.filter(
+            file_uuid_id__in=file_uuids, event_type="virus check"
+        ).values_list("file_uuid_id", flat=True)
+    }
+
+    return AntivirusBatchData(
+        file_sizes=file_sizes,
+        scanned_file_uuids=scanned_file_uuids,
     )
 
 
-def queue_event(file_uuid, date, scanner, passed, queue):
+def queue_event(
+    file_uuid: str | uuid.UUID,
+    date: str,
+    scanner: Scanner | None,
+    passed: bool | None,
+    queue: list[dict[str, object]],
+) -> None:
     if passed is None or file_uuid == "None":
         return
 
@@ -94,7 +146,7 @@ CONFIG_BUILDERS = {
 }
 
 
-def create_scanner():
+def create_scanner() -> Scanner:
     """Return the ClamAV client configured by the user and found in the
     installation's environment variables. Clamdscanner may perform quicker
     than Clamscanner given a larger number of objects. Return clamdscanner
@@ -116,29 +168,51 @@ def create_scanner():
     return get_scanner(config)
 
 
-def get_size(file_uuid, path):
-    # We're going to see this happening when files are not part of `objects/`.
-    if file_uuid != "None":
+def get_size(
+    file_uuid: str | uuid.UUID,
+    path: str,
+    file_sizes: Mapping[str, int | None],
+) -> int | None:
+    """Return a file size from batch data or the filesystem."""
+    normalized_file_uuid = normalize_uuid(file_uuid)
+
+    if normalized_file_uuid is not None:
         try:
-            return File.objects.get(uuid=file_uuid).size
-        except (File.DoesNotExist, ValidationError):
+            return file_sizes[normalized_file_uuid]
+        except KeyError:
+            # The file is not always represented in the database, such as
+            # files outside of `objects/`.
             pass
-    # Our fallback.
+
     try:
         return os.path.getsize(path)
     except Exception:
         return None
 
 
-def scan_file(event_queue, file_uuid, path, date):
-    if file_already_scanned(file_uuid):
+def scan_file(
+    event_queue: list[dict[str, object]],
+    file_uuid: str | uuid.UUID,
+    path: str,
+    date: str,
+    *,
+    batch_data: AntivirusBatchData,
+    scanner_factory: Callable[[], Scanner] | None = None,
+) -> int:
+    """Scan one file, queue its PREMIS event, and return its workflow status."""
+    normalized_file_uuid = normalize_uuid(file_uuid)
+    if (
+        normalized_file_uuid is not None
+        and normalized_file_uuid in batch_data.scanned_file_uuids
+    ):
         logger.info("Virus scan already performed, not running scan again")
         return 0
 
-    scanner, passed = None, False
+    scanner: Scanner | None = None
+    passed: bool | None = False
 
     try:
-        size = get_size(file_uuid, path)
+        size = get_size(file_uuid, path, batch_data.file_sizes)
         if size is None:
             logger.error("Getting file size returned: %s", size)
             return 1
@@ -166,7 +240,7 @@ def scan_file(event_queue, file_uuid, path, date):
             valid_scan = False
 
         if valid_scan:
-            scanner = create_scanner()
+            scanner = scanner_factory() if scanner_factory else create_scanner()
             info = scanner.info()
             logger.info(
                 "Using scanner %s (%s - %s)",
@@ -197,13 +271,28 @@ def scan_file(event_queue, file_uuid, path, date):
     return 1 if passed is False else 0
 
 
-def call(jobs):
-    event_queue = []
+def call(jobs: list[Job]) -> None:
+    """Process a batch of antivirus jobs."""
+    event_queue: list[dict[str, object]] = []
+    batch_data = load_file_data(jobs)
+
+    # TODO: Scanner.info() caches ClamAV definition metadata, so scanner reuse
+    # can record stale definitions if freshclam reloads them during a batch.
+    @cache
+    def scanner_factory() -> Scanner:
+        return create_scanner()
 
     for job in jobs:
         with job.JobContext(logger=logger):
-            job.set_status(scan_file(event_queue, *job.args[1:]))
+            job.set_status(
+                scan_file(
+                    event_queue,
+                    *job.args[1:],
+                    batch_data=batch_data,
+                    scanner_factory=scanner_factory,
+                )
+            )
 
     with transaction.atomic():
-        for e in event_queue:
-            insertIntoEvents(**e)
+        for event in event_queue:
+            insertIntoEvents(**event)

--- a/src/archivematica/MCPClient/clientScripts/antivirus.py
+++ b/src/archivematica/MCPClient/clientScripts/antivirus.py
@@ -30,10 +30,10 @@ django.setup()
 from clamav_client.scanner import Scanner
 from clamav_client.scanner import get_scanner
 from django.conf import settings as mcpclient_settings
-from django.db import transaction
 
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
-from archivematica.archivematicaCommon.databaseFunctions import insertIntoEvents
+from archivematica.archivematicaCommon.databaseFunctions import EventInput
+from archivematica.archivematicaCommon.databaseFunctions import insert_events
 from archivematica.dashboard.main.models import Event
 from archivematica.dashboard.main.models import File
 from archivematica.MCPClient.client.job import Job
@@ -99,7 +99,7 @@ def queue_event(
     date: str,
     scanner: Scanner | None,
     passed: bool | None,
-    queue: list[dict[str, object]],
+    queue: list[EventInput],
 ) -> None:
     if passed is None or file_uuid == "None":
         return
@@ -113,14 +113,13 @@ def queue_event(
     logger.info("Recording new event for file %s (outcome: %s)", file_uuid, outcome)
 
     queue.append(
-        {
-            "fileUUID": file_uuid,
-            "eventIdentifierUUID": str(uuid.uuid4()),
-            "eventType": "virus check",
-            "eventDateTime": date,
-            "eventDetail": event_detail,
-            "eventOutcome": outcome,
-        }
+        EventInput(
+            file_uuid=file_uuid,
+            event_type="virus check",
+            event_datetime=date,
+            event_detail=event_detail,
+            event_outcome=outcome,
+        )
     )
 
 
@@ -191,7 +190,7 @@ def get_size(
 
 
 def scan_file(
-    event_queue: list[dict[str, object]],
+    event_queue: list[EventInput],
     file_uuid: str | uuid.UUID,
     path: str,
     date: str,
@@ -273,7 +272,7 @@ def scan_file(
 
 def call(jobs: list[Job]) -> None:
     """Process a batch of antivirus jobs."""
-    event_queue: list[dict[str, object]] = []
+    event_queue: list[EventInput] = []
     batch_data = load_file_data(jobs)
 
     # TODO: Scanner.info() caches ClamAV definition metadata, so scanner reuse
@@ -293,6 +292,4 @@ def call(jobs: list[Job]) -> None:
                 )
             )
 
-    with transaction.atomic():
-        for event in event_queue:
-            insertIntoEvents(**event)
+    insert_events(event_queue)

--- a/src/archivematica/archivematicaCommon/databaseFunctions.py
+++ b/src/archivematica/archivematicaCommon/databaseFunctions.py
@@ -19,8 +19,13 @@ import logging
 import os
 import sys
 import uuid
+from collections.abc import Collection
+from collections.abc import Iterable
 from dataclasses import dataclass
+from dataclasses import field
+from typing import TypeAlias
 
+from django.db import transaction
 from django.db.models import Min
 from django.db.models import Q
 from django.utils import timezone
@@ -33,8 +38,11 @@ from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import FPCommandOutput
 from archivematica.dashboard.main.models import Identifier
 from archivematica.dashboard.main.models import Transfer
+from archivematica.dashboard.main.models import UnitVariable
 
 LOGGER = logging.getLogger("archivematica.common")
+DEFAULT_DATABASE_BATCH_SIZE = 1000
+_UnitKey: TypeAlias = tuple[str, str]
 
 
 def insertIntoFiles(
@@ -121,6 +129,181 @@ def getAMAgentsForFile(fileUUID):
     return Agent.objects.filter(
         Agent.objects.default_agents_query_keywords()
     ).values_list("pk", flat=True)
+
+
+@dataclass(frozen=True)
+class EventInput:
+    """Data needed to create a PREMIS event and its agent relationships.
+
+    When ``agent_ids`` is ``None``, the default and active agents associated
+    with the file are used. An explicit collection, including an empty one, is
+    used unchanged.
+    """
+
+    file_uuid: str | uuid.UUID
+    event_id: str | uuid.UUID = field(default_factory=uuid.uuid4)
+    event_type: str = ""
+    event_datetime: datetime.datetime | str | None = None
+    event_detail: str = ""
+    event_outcome: str = ""
+    event_outcome_detail: str = ""
+    agent_ids: Collection[int] | None = None
+
+
+def _normalize_uuid(value: str | uuid.UUID) -> str:
+    return str(uuid.UUID(str(value)))
+
+
+def _get_agent_ids_by_file(file_uuids: Collection[str]) -> dict[str, set[int]]:
+    """Return default and active agent IDs for existing files."""
+    normalized_file_uuids = set(file_uuids)
+    file_units: dict[str, _UnitKey | None] = {}
+    for file_uuid, sip_uuid, transfer_uuid in File.objects.filter(
+        uuid__in=normalized_file_uuids
+    ).values_list("uuid", "sip_id", "transfer_id"):
+        normalized_file_uuid = str(file_uuid)
+        if sip_uuid is not None:
+            file_units[normalized_file_uuid] = ("SIP", str(sip_uuid))
+        elif transfer_uuid is not None:
+            file_units[normalized_file_uuid] = ("Transfer", str(transfer_uuid))
+        else:
+            file_units[normalized_file_uuid] = None
+
+    for file_uuid in normalized_file_uuids - file_units.keys():
+        LOGGER.warning(
+            "File with UUID %s does not exist in database; unable to fetch Agents",
+            file_uuid,
+        )
+
+    if not file_units:
+        return {}
+
+    unit_keys = {unit_key for unit_key in file_units.values() if unit_key is not None}
+    active_agent_values: dict[_UnitKey, str | None] = {}
+    if unit_keys:
+        sip_uuids = {
+            unit_uuid for unit_type, unit_uuid in unit_keys if unit_type == "SIP"
+        }
+        transfer_uuids = {
+            unit_uuid for unit_type, unit_uuid in unit_keys if unit_type == "Transfer"
+        }
+        unit_query = Q()
+        if sip_uuids:
+            unit_query |= Q(unittype="SIP", unituuid__in=sip_uuids)
+        if transfer_uuids:
+            unit_query |= Q(unittype="Transfer", unituuid__in=transfer_uuids)
+
+        for unit_type, unit_uuid, agent_value in UnitVariable.objects.filter(
+            unit_query, variable="activeAgent"
+        ).values_list("unittype", "unituuid", "variablevalue"):
+            unit_key = (unit_type, str(unit_uuid))
+            if unit_key in active_agent_values:
+                raise UnitVariable.MultipleObjectsReturned(
+                    f"Multiple active agents found for {unit_type} {unit_uuid}"
+                )
+            active_agent_values[unit_key] = agent_value
+
+    default_agent_ids = set(
+        Agent.objects.filter(Agent.objects.default_agents_query_keywords()).values_list(
+            "pk", flat=True
+        )
+    )
+    active_agent_ids = {
+        str(agent_id): agent_id
+        for agent_id in Agent.objects.filter(
+            pk__in=active_agent_values.values()
+        ).values_list("pk", flat=True)
+    }
+
+    result: dict[str, set[int]] = {}
+    for file_uuid, unit_key in file_units.items():
+        agent_ids = set(default_agent_ids)
+        if unit_key is not None:
+            agent_value = active_agent_values.get(unit_key)
+            try:
+                agent_ids.add(active_agent_ids[str(agent_value)])
+            except KeyError:
+                pass
+        result[file_uuid] = agent_ids
+
+    return result
+
+
+# TODO: Adopt this helper in other MCPClient modules that create PREMIS events
+# in batches, starting with verify_checksum and change_object_names.
+def insert_events(
+    events: Iterable[EventInput],
+    *,
+    batch_size: int = DEFAULT_DATABASE_BATCH_SIZE,
+) -> list[Event]:
+    """Atomically create PREMIS events and agent relationships in batches.
+
+    The returned models follow the input order and include their database
+    primary keys.
+    """
+    if batch_size <= 0:
+        raise ValueError("batch_size must be greater than zero")
+
+    event_inputs = list(events)
+    if not event_inputs:
+        return []
+    file_uuids = {
+        _normalize_uuid(event.file_uuid)
+        for event in event_inputs
+        if event.agent_ids is None
+    }
+
+    with transaction.atomic():
+        agent_ids_by_file = _get_agent_ids_by_file(file_uuids)
+        event_agent_ids: dict[str, set[int]] = {}
+        event_models: list[Event] = []
+        for event in event_inputs:
+            event_id = _normalize_uuid(event.event_id)
+            file_uuid = _normalize_uuid(event.file_uuid)
+            event_models.append(
+                Event(
+                    event_id=event_id,
+                    file_uuid_id=file_uuid,
+                    event_type=event.event_type,
+                    event_datetime=event.event_datetime or timezone.now(),
+                    event_detail=event.event_detail,
+                    event_outcome=event.event_outcome,
+                    event_outcome_detail=event.event_outcome_detail,
+                )
+            )
+            if event.agent_ids is None:
+                event_agent_ids[event_id] = agent_ids_by_file.get(file_uuid, set())
+            else:
+                event_agent_ids[event_id] = set(event.agent_ids)
+
+        Event.objects.bulk_create(event_models, batch_size=batch_size)
+
+        event_pks: dict[str, int] = {}
+        for offset in range(0, len(event_models), batch_size):
+            event_ids = [
+                event.event_id for event in event_models[offset : offset + batch_size]
+            ]
+            event_pks.update(
+                {
+                    str(event_id): event_pk
+                    for event_id, event_pk in Event.objects.filter(
+                        event_id__in=event_ids
+                    ).values_list("event_id", "pk")
+                }
+            )
+
+        event_agents = []
+        for event in event_models:
+            event_id = str(event.event_id)
+            event.pk = event_pks[event_id]
+            event_agents.extend(
+                Event.agents.through(event_id=event.pk, agent_id=agent_id)
+                for agent_id in event_agent_ids[event_id]
+            )
+
+        Event.agents.through.objects.bulk_create(event_agents, batch_size=batch_size)
+
+    return event_models
 
 
 def insertIntoEvents(

--- a/tests/MCPClient/test_antivirus.py
+++ b/tests/MCPClient/test_antivirus.py
@@ -1,16 +1,25 @@
 """Tests for the antivirus.py client script."""
 
+import uuid
 from collections import OrderedDict
 from collections import namedtuple
+from contextlib import nullcontext
 from unittest import mock
 
 import pytest
+import pytest_django
 from clamav_client.scanner import ClamdScanner
 from clamav_client.scanner import ClamscanScanner
 from clamav_client.scanner import Scanner
 from clamav_client.scanner import ScanResult
 
+from archivematica.dashboard.main import models
+from archivematica.MCPClient.client.job import Job
+from archivematica.MCPClient.clientScripts.antivirus import AntivirusBatchData
+from archivematica.MCPClient.clientScripts.antivirus import call as antivirus_call
 from archivematica.MCPClient.clientScripts.antivirus import create_scanner
+from archivematica.MCPClient.clientScripts.antivirus import get_size
+from archivematica.MCPClient.clientScripts.antivirus import load_file_data
 from archivematica.MCPClient.clientScripts.antivirus import scan_file
 
 
@@ -37,11 +46,6 @@ args = OrderedDict()
 args["file_uuid"] = "ec26199f-72a4-4fd8-a94a-29144b02ddd8"
 args["path"] = "/path"
 args["date"] = "2019-12-01"
-
-
-class FileMock:
-    def __init__(self, size):
-        self.size = size
 
 
 class ScanResultMock(ScanResult):
@@ -78,45 +82,17 @@ class ScannerMock(Scanner):
         return "ClamAV 0.103.11/27400/Mon Sep 16 10:52:36 2024"
 
 
-def setup_test_scan_file_mocks(
-    create_scanner,
-    file_already_scanned_mock,
-    file_objects_get,
-    file_already_scanned=False,
-    file_size=1024,
-    scanner_should_except=False,
-    scanner_passed=False,
-):
-    file_already_scanned_mock.return_value = file_already_scanned
-    file_objects_get.return_value = FileMock(size=file_size)
-    deps = namedtuple("deps", ["file_already_scanned", "file_get", "scanner"])(
-        file_already_scanned=file_already_scanned_mock,
-        file_get=file_objects_get,
-        scanner=ScannerMock(should_except=scanner_should_except, passed=scanner_passed),
-    )
-
-    create_scanner.return_value = deps.scanner
-
-    return deps
-
-
-@mock.patch("archivematica.MCPClient.clientScripts.antivirus.file_already_scanned")
-@mock.patch("archivematica.dashboard.main.models.File.objects.get")
 @mock.patch("archivematica.MCPClient.clientScripts.antivirus.create_scanner")
-def test_scan_file_already_scanned(
-    create_scanner, file_objects_get, file_already_scanned_mock
-):
-    deps = setup_test_scan_file_mocks(
-        create_scanner,
-        file_already_scanned_mock,
-        file_objects_get,
-        file_already_scanned=True,
+def test_scan_file_already_scanned(create_scanner: mock.Mock) -> None:
+    batch_data = AntivirusBatchData(
+        file_sizes={args["file_uuid"]: 1024},
+        scanned_file_uuids={args["file_uuid"]},
     )
 
-    exit_code = scan_file([], **dict(args))
+    exit_code = scan_file([], **dict(args), batch_data=batch_data)
 
     assert exit_code == 0
-    deps.file_already_scanned.assert_called_once_with(args["file_uuid"])
+    create_scanner.assert_not_called()
 
 
 QueueEventParams = namedtuple("QueueEventParams", ["scanner_is_None", "passed"])
@@ -169,20 +145,17 @@ QueueEventParams = namedtuple("QueueEventParams", ["scanner_is_None", "passed"])
         ),
     ],
 )
-@mock.patch("archivematica.MCPClient.clientScripts.antivirus.file_already_scanned")
-@mock.patch("archivematica.dashboard.main.models.File.objects.get")
 @mock.patch("archivematica.MCPClient.clientScripts.antivirus.create_scanner")
 def test_scan_file(
     create_scanner,
-    file_objects_get,
-    file_already_scanned_mock,
     setup_kwargs,
     exit_code,
     queue_event_params,
     settings,
 ):
-    setup_test_scan_file_mocks(
-        create_scanner, file_already_scanned_mock, file_objects_get, **setup_kwargs
+    create_scanner.return_value = ScannerMock(
+        should_except=setup_kwargs.get("scanner_should_except", False),
+        passed=setup_kwargs.get("scanner_passed", False),
     )
 
     # Here the user configurable thresholds for maimum file size, and maximum
@@ -193,8 +166,12 @@ def test_scan_file(
     settings.CLAMAV_CLIENT_MAX_SCAN_SIZE = 84
 
     event_queue = []
+    batch_data = AntivirusBatchData(
+        file_sizes={args["file_uuid"]: setup_kwargs.get("file_size", 1024)},
+        scanned_file_uuids=set(),
+    )
 
-    ret = scan_file(event_queue, **dict(args))
+    ret = scan_file(event_queue, **dict(args), batch_data=batch_data)
 
     # The integer returned by scan_file() is going to be used as the exit code
     # of the antivirus.py script which is important for the AM workflow in order
@@ -211,8 +188,141 @@ def test_scan_file(
         event = event_queue[0]
         assert event["eventType"] == "virus check"
         assert event["fileUUID"] == args["file_uuid"]
-        assert (
-            event["eventOutcome"] == "Pass"
-            if setup_kwargs["scanner_passed"]
-            else "Fail"
+        assert event["eventOutcome"] == (
+            "Pass" if setup_kwargs["scanner_passed"] else "Fail"
         )
+
+
+@pytest.mark.django_db
+def test_load_file_data_batches_queries(
+    transfer: models.Transfer,
+    django_assert_num_queries: pytest_django.fixtures.DjangoAssertNumQueries,
+) -> None:
+    scanned_file = models.File.objects.create(
+        transfer=transfer,
+        originallocation=b"objects/scanned",
+        currentlocation=b"objects/scanned",
+        size=42,
+    )
+    unscanned_file = models.File.objects.create(
+        transfer=transfer,
+        originallocation=b"objects/unscanned",
+        currentlocation=b"objects/unscanned",
+        size=84,
+    )
+    models.Event.objects.create(file_uuid=scanned_file, event_type="virus check")
+    jobs = [
+        mock.Mock(args=["antivirus", str(scanned_file.uuid)]),
+        mock.Mock(args=["antivirus", str(unscanned_file.uuid).upper()]),
+        mock.Mock(args=["antivirus", "None"]),
+        mock.Mock(args=["antivirus", "not-a-uuid"]),
+        mock.Mock(args=["antivirus"]),
+    ]
+
+    with django_assert_num_queries(2):
+        batch_data = load_file_data(jobs)
+
+    assert batch_data.file_sizes == {
+        str(scanned_file.uuid): 42,
+        str(unscanned_file.uuid): 84,
+    }
+    assert batch_data.scanned_file_uuids == {str(scanned_file.uuid)}
+
+
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.os.path.getsize")
+def test_get_size_uses_batch_data(path_getsize: mock.Mock) -> None:
+    file_uuid = str(uuid.uuid4())
+
+    assert get_size(file_uuid, "/path", {file_uuid: 42}) == 42
+    assert get_size(file_uuid, "/path", {file_uuid: None}) is None
+
+    path_getsize.assert_not_called()
+
+
+@mock.patch(
+    "archivematica.MCPClient.clientScripts.antivirus.os.path.getsize",
+    return_value=84,
+)
+def test_get_size_uses_filesystem_for_file_missing_from_batch(
+    path_getsize: mock.Mock,
+) -> None:
+    file_uuid = str(uuid.uuid4())
+
+    assert get_size(file_uuid, "/path", {}) == 84
+
+    path_getsize.assert_called_once_with("/path")
+
+
+@mock.patch(
+    "archivematica.MCPClient.clientScripts.antivirus.transaction.atomic",
+    return_value=nullcontext(),
+)
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.insertIntoEvents")
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.load_file_data")
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.create_scanner")
+def test_call_reuses_scanner_and_batch_data(
+    create_scanner: mock.Mock,
+    load_file_data: mock.Mock,
+    insert_into_events: mock.Mock,
+    transaction_atomic: mock.Mock,
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    file_uuids = [str(uuid.uuid4()), str(uuid.uuid4())]
+    paths = ["/path/one", "/path/two"]
+    jobs = [
+        mock.Mock(
+            spec=Job,
+            args=["antivirus", file_uuid, path, args["date"]],
+            JobContext=mock.MagicMock(),
+        )
+        for file_uuid, path in zip(file_uuids, paths)
+    ]
+    scanner = ScannerMock(passed=True)
+    scanner.scan = mock.Mock(wraps=scanner.scan)
+    create_scanner.return_value = scanner
+    load_file_data.return_value = AntivirusBatchData(
+        file_sizes=dict.fromkeys(file_uuids, 42),
+        scanned_file_uuids=set(),
+    )
+    settings.CLAMAV_CLIENT_MAX_FILE_SIZE = 42
+    settings.CLAMAV_CLIENT_MAX_SCAN_SIZE = 84
+
+    antivirus_call(jobs)
+
+    load_file_data.assert_called_once_with(jobs)
+    create_scanner.assert_called_once_with()
+    assert scanner.scan.mock_calls == [mock.call(path) for path in paths]
+    for job in jobs:
+        job.set_status.assert_called_once_with(0)
+    assert insert_into_events.call_count == 2
+    transaction_atomic.assert_called_once_with()
+
+
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.transaction.atomic")
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.insertIntoEvents")
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.scan_file")
+@mock.patch(
+    "archivematica.MCPClient.clientScripts.antivirus.load_file_data",
+    side_effect=RuntimeError,
+)
+def test_call_propagates_batch_load_failure(
+    load_file_data: mock.Mock,
+    scan_file: mock.Mock,
+    insert_into_events: mock.Mock,
+    transaction_atomic: mock.Mock,
+) -> None:
+    job = mock.Mock(
+        spec=Job,
+        args=["antivirus", args["file_uuid"], args["path"], args["date"]],
+        JobContext=mock.MagicMock(),
+    )
+
+    with pytest.raises(RuntimeError):
+        antivirus_call([job])
+
+    load_file_data.assert_called_once_with([job])
+    scan_file.assert_not_called()
+    job.JobContext.assert_not_called()
+    job.set_status.assert_not_called()
+    insert_into_events.assert_not_called()
+    transaction_atomic.assert_not_called()

--- a/tests/MCPClient/test_antivirus.py
+++ b/tests/MCPClient/test_antivirus.py
@@ -12,6 +12,7 @@ from clamav_client.scanner import ClamdScanner
 from clamav_client.scanner import ClamscanScanner
 from clamav_client.scanner import Scanner
 from clamav_client.scanner import ScanResult
+from django.contrib.auth.models import User
 
 from archivematica.dashboard.main import models
 from archivematica.MCPClient.client.job import Job
@@ -186,10 +187,10 @@ def test_scan_file(
         assert len(event_queue) == 1
 
         event = event_queue[0]
-        assert event["eventType"] == "virus check"
-        assert event["fileUUID"] == args["file_uuid"]
-        assert event["eventOutcome"] == (
-            "Pass" if setup_kwargs["scanner_passed"] else "Fail"
+        assert event.event_type == "virus check"
+        assert event.file_uuid == args["file_uuid"]
+        assert (
+            event.event_outcome == "Pass" if setup_kwargs["scanner_passed"] else "Fail"
         )
 
 
@@ -253,18 +254,13 @@ def test_get_size_uses_filesystem_for_file_missing_from_batch(
     path_getsize.assert_called_once_with("/path")
 
 
-@mock.patch(
-    "archivematica.MCPClient.clientScripts.antivirus.transaction.atomic",
-    return_value=nullcontext(),
-)
-@mock.patch("archivematica.MCPClient.clientScripts.antivirus.insertIntoEvents")
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.insert_events")
 @mock.patch("archivematica.MCPClient.clientScripts.antivirus.load_file_data")
 @mock.patch("archivematica.MCPClient.clientScripts.antivirus.create_scanner")
 def test_call_reuses_scanner_and_batch_data(
     create_scanner: mock.Mock,
     load_file_data: mock.Mock,
-    insert_into_events: mock.Mock,
-    transaction_atomic: mock.Mock,
+    insert_events: mock.Mock,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     file_uuids = [str(uuid.uuid4()), str(uuid.uuid4())]
@@ -294,12 +290,65 @@ def test_call_reuses_scanner_and_batch_data(
     assert scanner.scan.mock_calls == [mock.call(path) for path in paths]
     for job in jobs:
         job.set_status.assert_called_once_with(0)
-    assert insert_into_events.call_count == 2
-    transaction_atomic.assert_called_once_with()
+    (event_queue,) = insert_events.call_args.args
+    assert len(event_queue) == 2
+    assert [event.file_uuid for event in event_queue] == file_uuids
 
 
-@mock.patch("archivematica.MCPClient.clientScripts.antivirus.transaction.atomic")
-@mock.patch("archivematica.MCPClient.clientScripts.antivirus.insertIntoEvents")
+@pytest.mark.django_db
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.create_scanner")
+def test_call_preserves_scan_and_event_behavior(
+    create_scanner: mock.Mock,
+    transfer: models.Transfer,
+    transfer_file: models.File,
+    user: User,
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    transfer_file.size = 42
+    transfer_file.save(update_fields=["size"])
+    scanned_file = models.File.objects.create(
+        transfer=transfer,
+        originallocation=b"objects/scanned",
+        currentlocation=b"objects/scanned",
+        size=42,
+    )
+    models.Event.objects.create(file_uuid=scanned_file, event_type="virus check")
+    paths = ["/path/scanned", "/path/unscanned"]
+    jobs = [
+        mock.Mock(
+            spec=Job,
+            args=["antivirus", str(file.uuid), path, args["date"]],
+            JobContext=mock.Mock(return_value=nullcontext()),
+        )
+        for file, path in zip([scanned_file, transfer_file], paths)
+    ]
+    scanner = ScannerMock(passed=True)
+    scanner.scan = mock.Mock(wraps=scanner.scan)
+    create_scanner.return_value = scanner
+    settings.CLAMAV_CLIENT_MAX_FILE_SIZE = 42
+    settings.CLAMAV_CLIENT_MAX_SCAN_SIZE = 84
+
+    antivirus_call(jobs)
+
+    scanner.scan.assert_called_once_with(paths[1])
+    create_scanner.assert_called_once_with()
+    for job in jobs:
+        job.set_status.assert_called_once_with(0)
+    assert (
+        models.Event.objects.filter(
+            file_uuid=scanned_file, event_type="virus check"
+        ).count()
+        == 1
+    )
+    event = models.Event.objects.get(file_uuid=transfer_file, event_type="virus check")
+    assert event.event_outcome == "Pass"
+    assert set(event.agents.values_list("pk", flat=True)) == {
+        2,
+        user.userprofile.agent_id,
+    }
+
+
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.insert_events")
 @mock.patch("archivematica.MCPClient.clientScripts.antivirus.scan_file")
 @mock.patch(
     "archivematica.MCPClient.clientScripts.antivirus.load_file_data",
@@ -308,8 +357,7 @@ def test_call_reuses_scanner_and_batch_data(
 def test_call_propagates_batch_load_failure(
     load_file_data: mock.Mock,
     scan_file: mock.Mock,
-    insert_into_events: mock.Mock,
-    transaction_atomic: mock.Mock,
+    insert_events: mock.Mock,
 ) -> None:
     job = mock.Mock(
         spec=Job,
@@ -324,5 +372,4 @@ def test_call_propagates_batch_load_failure(
     scan_file.assert_not_called()
     job.JobContext.assert_not_called()
     job.set_status.assert_not_called()
-    insert_into_events.assert_not_called()
-    transaction_atomic.assert_not_called()
+    insert_events.assert_not_called()

--- a/tests/archivematicaCommon/test_database_functions.py
+++ b/tests/archivematicaCommon/test_database_functions.py
@@ -2,6 +2,7 @@ import pathlib
 import uuid
 
 import pytest
+from django.db import IntegrityError
 from django.test import TestCase
 
 from archivematica.archivematicaCommon import databaseFunctions
@@ -156,6 +157,138 @@ class TestDatabaseFunctions(TestCase):
         ).agents
         assert agents.get(id=2)
         assert agents.get(id=5)
+
+    # insert_events
+
+    def test_insert_events_batches_writes_and_preserves_agents(self) -> None:
+        event_ids = [uuid.uuid4(), uuid.uuid4()]
+        event_inputs = [
+            databaseFunctions.EventInput(
+                file_uuid="88c8f115-80bc-4da4-a1e6-0158f5df13b9",
+                event_id=event_ids[0],
+                event_type="virus check",
+                event_detail="SIP detail",
+                event_outcome="Pass",
+            ),
+            databaseFunctions.EventInput(
+                file_uuid="1f4af873-8d60-4907-a92e-d1889e643524",
+                event_id=event_ids[1],
+                event_type="virus check",
+                event_detail="transfer detail",
+                event_outcome="Fail",
+            ),
+        ]
+
+        with self.assertNumQueries(9):
+            created_events = databaseFunctions.insert_events(event_inputs)
+
+        assert [event.pk for event in created_events] == list(
+            Event.objects.filter(event_id__in=event_ids)
+            .order_by("pk")
+            .values_list("pk", flat=True)
+        )
+        assert [str(event.event_id) for event in created_events] == [
+            str(event_id) for event_id in event_ids
+        ]
+
+        events = {
+            str(event.event_id): event
+            for event in Event.objects.filter(event_id__in=event_ids)
+        }
+        assert events[str(event_ids[0])].event_detail == "SIP detail"
+        assert events[str(event_ids[0])].event_outcome == "Pass"
+        assert set(events[str(event_ids[0])].agents.values_list("pk", flat=True)) == {
+            2,
+            5,
+        }
+        assert events[str(event_ids[1])].event_detail == "transfer detail"
+        assert events[str(event_ids[1])].event_outcome == "Fail"
+        assert set(events[str(event_ids[1])].agents.values_list("pk", flat=True)) == {
+            2,
+            10,
+        }
+
+    def test_insert_events_prefers_sip_agents_and_supports_explicit_agents(
+        self,
+    ) -> None:
+        event_ids = [uuid.uuid4(), uuid.uuid4(), uuid.uuid4()]
+
+        databaseFunctions.insert_events(
+            [
+                databaseFunctions.EventInput(
+                    file_uuid="dc569efe-c88f-4be3-94d3-d9eac0c5d410",
+                    event_id=event_ids[0],
+                ),
+                databaseFunctions.EventInput(
+                    file_uuid="d4e599bd-f9ab-48d4-9ae7-9e87d4ac1619",
+                    event_id=event_ids[1],
+                    agent_ids={11},
+                ),
+                databaseFunctions.EventInput(
+                    file_uuid="d4e599bd-f9ab-48d4-9ae7-9e87d4ac1619",
+                    event_id=event_ids[2],
+                    agent_ids=set(),
+                ),
+            ]
+        )
+
+        events = {
+            str(event.event_id): event
+            for event in Event.objects.filter(event_id__in=event_ids)
+        }
+        assert set(events[str(event_ids[0])].agents.values_list("pk", flat=True)) == {
+            2,
+            5,
+        }
+        assert set(events[str(event_ids[1])].agents.values_list("pk", flat=True)) == {
+            11
+        }
+        assert not events[str(event_ids[2])].agents.exists()
+
+    def test_insert_events_generates_defaults(self) -> None:
+        (event,) = databaseFunctions.insert_events(
+            iter(
+                [
+                    databaseFunctions.EventInput(
+                        file_uuid="d4e599bd-f9ab-48d4-9ae7-9e87d4ac1619"
+                    )
+                ]
+            )
+        )
+
+        saved_event = Event.objects.get(pk=event.pk)
+        assert saved_event.event_id is not None
+        assert saved_event.event_datetime is not None
+        assert saved_event.event_type == ""
+        assert saved_event.event_detail == ""
+        assert saved_event.event_outcome == ""
+        assert saved_event.event_outcome_detail == ""
+        assert set(saved_event.agents.values_list("pk", flat=True)) == {2}
+
+    def test_insert_events_is_atomic(self) -> None:
+        event_ids = [uuid.uuid4(), uuid.uuid4()]
+
+        with pytest.raises(IntegrityError):
+            databaseFunctions.insert_events(
+                [
+                    databaseFunctions.EventInput(
+                        file_uuid="d4e599bd-f9ab-48d4-9ae7-9e87d4ac1619",
+                        event_id=event_ids[0],
+                        agent_ids={11},
+                    ),
+                    databaseFunctions.EventInput(
+                        file_uuid="d4e599bd-f9ab-48d4-9ae7-9e87d4ac1619",
+                        event_id=event_ids[1],
+                        agent_ids={999999},
+                    ),
+                ]
+            )
+
+        assert not Event.objects.filter(event_id__in=event_ids).exists()
+
+    def test_insert_events_rejects_invalid_batch_size(self) -> None:
+        with pytest.raises(ValueError, match="batch_size must be greater than zero"):
+            databaseFunctions.insert_events([], batch_size=0)
 
 
 @pytest.fixture


### PR DESCRIPTION
This pull request reduces the database work performed by antivirus jobs by using the batch of files already supplied to each MCPClient worker. It:

- Loads file sizes and existing virus-check events once per batch.
- Creates PREMIS events and their agent associations in bulk.
- Resolves shared agent associations once instead of separately for every event.
- Reuses the configured antivirus scanner for the lifetime of the batch.

## Scanner reuse and observability

The scanner is created lazily and reused only for the lifetime of one worker batch. Its configuration and cached version or virus-definition metadata are therefore not refreshed between files in that batch; a subsequent batch creates a new scanner when needed.

This pull request does not add mid-batch refresh logic or new instrumentation for measuring batch sizes, database query counts, or scanner reuse. Those improvements can be addressed separately.

## Testing

The changes include focused regression tests and a database-backed test of the complete batch workflow, covering:

- Loading file sizes and existing virus-check events in batch.
- Reading file sizes from the filesystem for files not represented in the database.
- Propagating batch lookup failures before scanning or event insertion begins.
- Skipping previously scanned files.
- Scanning new files.
- Reusing the configured scanner within a batch.
- Creating PREMIS events with the expected agents.