### PR TITLE
Contain unexpected MCPServer job failures

### DIFF
--- a/src/archivematica/MCPServer/server/jobs/base.py
+++ b/src/archivematica/MCPServer/server/jobs/base.py
@@ -90,6 +90,12 @@ class Job(metaclass=abc.ABCMeta):
         )
 
     @auto_close_old_connections()
+    def mark_failed(self):
+        return models.Job.objects.filter(jobuuid=self.uuid).update(
+            currentstep=self.STATUS_FAILED
+        )
+
+    @auto_close_old_connections()
     def mark_complete(self):
         logger.debug(
             "%s %s done with exit code %s",

--- a/src/archivematica/MCPServer/server/jobs/client.py
+++ b/src/archivematica/MCPServer/server/jobs/client.py
@@ -15,6 +15,7 @@ from archivematica.MCPServer.server import metrics
 from archivematica.MCPServer.server.jobs.base import Job
 from archivematica.MCPServer.server.tasks import Task
 from archivematica.MCPServer.server.tasks import get_task_backend
+from archivematica.MCPServer.server.tasks import reset_task_backend
 
 logger = logging.getLogger("archivematica.mcp.server.jobs.client")
 
@@ -118,13 +119,22 @@ class ClientScriptJob(Job, metaclass=abc.ABCMeta):
             self.command_replacements.update(self.job_chain.context)
 
         self.task_backend = get_task_backend()
-        self.submit_tasks()
-        # Block until out of process tasks have completed
-        self.wait_for_task_results()
+        try:
+            self.submit_tasks()
+            # Block until out of process tasks have completed
+            self.wait_for_task_results()
 
-        self.update_status_from_exit_code()
+            self.update_status_from_exit_code()
 
-        return next(self.job_chain, None)
+            return next(self.job_chain, None)
+        except BaseException:
+            try:
+                reset_task_backend()
+            except BaseException:
+                logger.exception(
+                    "Unable to reset task backend after job %s failed", self.uuid
+                )
+            raise
 
     def submit_tasks(self):
         arguments = self.replace_values(self.arguments, self.command_replacements)

--- a/src/archivematica/MCPServer/server/metrics.py
+++ b/src/archivematica/MCPServer/server/metrics.py
@@ -21,6 +21,10 @@ gearman_active_jobs_gauge = Gauge(
 gearman_pending_jobs_gauge = Gauge(
     "mcpserver_gearman_pending_jobs", "Number of gearman jobs pending submission"
 )
+job_exception_counter = Counter(
+    "mcpserver_job_exception_total",
+    "Number of MCPServer jobs that stopped because of an unexpected exception",
+)
 task_counter = Counter(
     "mcpserver_task_total",
     "Number of tasks processed, labeled by task group, task name",

--- a/src/archivematica/MCPServer/server/queues.py
+++ b/src/archivematica/MCPServer/server/queues.py
@@ -13,6 +13,7 @@ from archivematica.MCPServer.server import metrics
 from archivematica.MCPServer.server.jobs import DecisionJob
 from archivematica.MCPServer.server.packages import DIP
 from archivematica.MCPServer.server.packages import SIP
+from archivematica.MCPServer.server.tasks import Task
 
 logger = logging.getLogger("archivematica.mcp.server.queues")
 
@@ -24,6 +25,11 @@ FAILED_PACKAGE_TERMINAL_LINK_IDS = frozenset(
         # the historical terminal-link default of Done.
         "e782473a-0c10-431f-8ab6-5d7238b2b70b",
     }
+)
+
+TASK_EXCEPTION_MESSAGE = (
+    "MCPServer stopped tracking this task because job {job_uuid} failed "
+    "unexpectedly; the final task result may be unknown. See MCPServer logs."
 )
 
 
@@ -187,7 +193,8 @@ class PackageQueue:
         metrics.active_jobs_gauge.inc()
 
         result = self.executor.submit(job.run)
-        result.add_done_callback(self._job_completed_callback)
+        job_done_callback = functools.partial(self._job_completed_callback, job)
+        result.add_done_callback(job_done_callback)
 
         if job.link.is_terminal:
             package_done_callback = functools.partial(
@@ -205,6 +212,9 @@ class PackageQueue:
         job in the chain. This function is called by an executor on completion
         of a Job.
         """
+        if future.cancelled() or future.exception() is not None:
+            return
+
         if future.result() is not None:
             logger.warning(
                 "Unexpectedly received another job on package completion. "
@@ -239,7 +249,7 @@ class PackageQueue:
         """
         return str(link.id) in FAILED_PACKAGE_TERMINAL_LINK_IDS
 
-    def _job_completed_callback(self, future):
+    def _job_completed_callback(self, job, future):
         """Schedule the next job in the chain.
 
         Retrieve the next job from the result from the previous job. If there is
@@ -247,6 +257,16 @@ class PackageQueue:
         called by an executor on completion of a Job.
         """
         metrics.active_jobs_gauge.dec()
+
+        if future.cancelled():
+            self._handle_job_failure(job, RuntimeError("Job future was cancelled"))
+            return
+
+        exception = future.exception()
+        if exception is not None:
+            self._handle_job_failure(job, exception)
+            return
+
         next_job = future.result()
 
         if not next_job:
@@ -256,6 +276,44 @@ class PackageQueue:
             self.queue_next_job()
         else:
             self.schedule_job(next_job)
+
+    def _handle_job_failure(self, job, exception):
+        """Record an unexpected job failure and release its package slot."""
+        logger.error(
+            "Unexpected error processing job %s (%s; link %s) for %s package %s",
+            job.uuid,
+            job.description,
+            job.link.id,
+            job.package.__class__.__name__,
+            job.package.uuid,
+            exc_info=(type(exception), exception, exception.__traceback__),
+        )
+
+        failure_actions = (
+            ("increment the job exception counter", metrics.job_exception_counter.inc),
+            ("mark the job as failed", job.mark_failed),
+            (
+                "mark unfinished tasks as failed",
+                functools.partial(
+                    Task.mark_unfinished_for_job_failed,
+                    job.uuid,
+                    TASK_EXCEPTION_MESSAGE.format(job_uuid=job.uuid),
+                ),
+            ),
+            ("mark the package as failed", job.package.mark_as_failed),
+            (
+                "deactivate the package",
+                functools.partial(self.deactivate_package, job.package),
+            ),
+            ("queue the next package", self.queue_next_job),
+        )
+        for description, action in failure_actions:
+            try:
+                action()
+            except Exception:
+                logger.exception(
+                    "Unable to %s after job %s failed", description, job.uuid
+                )
 
     def _put_package_nowait(self, package, job):
         """Queue a package and job for later processing."""

--- a/src/archivematica/MCPServer/server/tasks/__init__.py
+++ b/src/archivematica/MCPServer/server/tasks/__init__.py
@@ -1,6 +1,13 @@
 from archivematica.MCPServer.server.tasks.backends import GearmanTaskBackend
 from archivematica.MCPServer.server.tasks.backends import TaskBackend
 from archivematica.MCPServer.server.tasks.backends import get_task_backend
+from archivematica.MCPServer.server.tasks.backends import reset_task_backend
 from archivematica.MCPServer.server.tasks.task import Task
 
-__all__ = ("GearmanTaskBackend", "Task", "TaskBackend", "get_task_backend")
+__all__ = (
+    "GearmanTaskBackend",
+    "Task",
+    "TaskBackend",
+    "get_task_backend",
+    "reset_task_backend",
+)

--- a/src/archivematica/MCPServer/server/tasks/backends/__init__.py
+++ b/src/archivematica/MCPServer/server/tasks/backends/__init__.py
@@ -26,4 +26,21 @@ def get_task_backend():
     return backend_local.task_backend
 
 
-__all__ = ("GearmanTaskBackend", "TaskBackend", "get_task_backend")
+def reset_task_backend():
+    """Shut down and forget the backend owned by the current thread."""
+    backend = getattr(backend_local, "task_backend", None)
+    if backend is None:
+        return
+
+    try:
+        backend.shutdown()
+    finally:
+        del backend_local.task_backend
+
+
+__all__ = (
+    "GearmanTaskBackend",
+    "TaskBackend",
+    "get_task_backend",
+    "reset_task_backend",
+)

--- a/src/archivematica/MCPServer/server/tasks/backends/base.py
+++ b/src/archivematica/MCPServer/server/tasks/backends/base.py
@@ -22,3 +22,7 @@ class TaskBackend(metaclass=abc.ABCMeta):
         Note that task objects are not necessarily returned in the order
         they were submitted.
         """
+
+    def shutdown(self):
+        """Release resources held by this backend."""
+        return None

--- a/src/archivematica/MCPServer/server/tasks/backends/gearman_backend.py
+++ b/src/archivematica/MCPServer/server/tasks/backends/gearman_backend.py
@@ -78,6 +78,27 @@ class GearmanTaskBackend(TaskBackend):
         self.current_task_batches = {}  # job_uuid: GearmanTaskBatch
         self.pending_gearman_jobs = {}  # job_uuid: List[GearmanTaskBatch]
 
+    def shutdown(self):
+        """Close the client and discard state that cannot be resumed safely."""
+        pending_count = sum(
+            bool(len(batch)) for batch in self.current_task_batches.values()
+        )
+        active_count = sum(
+            not batch.collected
+            for batches in self.pending_gearman_jobs.values()
+            for batch in batches
+        )
+
+        try:
+            self.client.shutdown()
+        finally:
+            if pending_count:
+                metrics.gearman_pending_jobs_gauge.dec(pending_count)
+            if active_count:
+                metrics.gearman_active_jobs_gauge.dec(active_count)
+            self.current_task_batches.clear()
+            self.pending_gearman_jobs.clear()
+
     def submit_task(self, job, task):
         """Submit a `Task` (as part of the `Job` given) for processing.
 

--- a/src/archivematica/MCPServer/server/tasks/task.py
+++ b/src/archivematica/MCPServer/server/tasks/task.py
@@ -84,6 +84,16 @@ class Task:
             task.done = True
             task.write_output()
 
+    @classmethod
+    @auto_close_old_connections()
+    def mark_unfinished_for_job_failed(cls, job_uuid, message):
+        """Fail unfinished task rows after their MCPServer job stops."""
+        return models.Task.objects.filter(job_id=job_uuid, exitcode=None).update(
+            exitcode=1,
+            stderror=message,
+            endtime=timezone.now(),
+        )
+
     def to_db_model(self, job):
         """Returns an instance of the `Task` Django model."""
         job_uuid = job.uuid

--- a/tests/MCPServer/test_gearman.py
+++ b/tests/MCPServer/test_gearman.py
@@ -7,9 +7,18 @@ import pytest
 from django.utils import timezone
 
 from archivematica.dashboard.main import models
+from archivematica.MCPServer.server import metrics
+from archivematica.MCPServer.server.jobs import DirectoryClientScriptJob
 from archivematica.MCPServer.server.jobs import Job
 from archivematica.MCPServer.server.tasks import GearmanTaskBackend
 from archivematica.MCPServer.server.tasks import Task
+from archivematica.MCPServer.server.tasks import TaskBackend
+from archivematica.MCPServer.server.tasks.backends import backend_local
+from archivematica.MCPServer.server.tasks.backends import get_task_backend
+from archivematica.MCPServer.server.tasks.backends import reset_task_backend
+from archivematica.MCPServer.server.tasks.backends.gearman_backend import (
+    GearmanTaskBatch,
+)
 
 
 class MockJob(Job):
@@ -294,4 +303,113 @@ def test_gearman_multiple_batches(
     assert mock_client.return_value.submit_job.call_count == expected_batch_count
     assert mock_client.return_value.wait_until_any_job_completed.call_count == len(
         job_requests
+    )
+
+
+@mock.patch(
+    "archivematica.MCPServer.server.tasks.backends.gearman_backend.MCPGearmanClient"
+)
+def test_gearman_backend_shutdown_clears_state_and_reconciles_metrics(mock_client):
+    backend = GearmanTaskBackend()
+    unsent_batch = GearmanTaskBatch()
+    unsent_batch.tasks.append(mock.Mock())
+    empty_batch = GearmanTaskBatch()
+    active_batch = GearmanTaskBatch()
+    collected_batch = GearmanTaskBatch()
+    collected_batch.collected = True
+    backend.current_task_batches = {
+        uuid.uuid4(): unsent_batch,
+        uuid.uuid4(): empty_batch,
+    }
+    backend.pending_gearman_jobs = {
+        uuid.uuid4(): [active_batch, collected_batch],
+    }
+
+    with (
+        mock.patch.object(metrics.gearman_pending_jobs_gauge, "dec") as pending_dec,
+        mock.patch.object(metrics.gearman_active_jobs_gauge, "dec") as active_dec,
+    ):
+        backend.shutdown()
+
+    mock_client.return_value.shutdown.assert_called_once_with()
+    pending_dec.assert_called_once_with(1)
+    active_dec.assert_called_once_with(1)
+    assert backend.current_task_batches == {}
+    assert backend.pending_gearman_jobs == {}
+
+
+def test_reset_task_backend_replaces_the_thread_local_backend():
+    first_backend = mock.Mock(spec=TaskBackend)
+    second_backend = mock.Mock(spec=TaskBackend)
+    if hasattr(backend_local, "task_backend"):
+        del backend_local.task_backend
+
+    try:
+        with mock.patch(
+            "archivematica.MCPServer.server.tasks.backends.GearmanTaskBackend",
+            side_effect=(first_backend, second_backend),
+        ):
+            assert get_task_backend() is first_backend
+            assert get_task_backend() is first_backend
+
+            reset_task_backend()
+
+            first_backend.shutdown.assert_called_once_with()
+            assert get_task_backend() is second_backend
+    finally:
+        if hasattr(backend_local, "task_backend"):
+            del backend_local.task_backend
+
+
+def test_reset_task_backend_forgets_backend_when_shutdown_fails():
+    backend = mock.Mock(spec=TaskBackend)
+    backend.shutdown.side_effect = RuntimeError("shutdown failed")
+    backend_local.task_backend = backend
+
+    with pytest.raises(RuntimeError, match="shutdown failed"):
+        reset_task_backend()
+
+    assert not hasattr(backend_local, "task_backend")
+
+
+def test_client_script_job_resets_backend_without_masking_original_error(caplog):
+    package = mock.Mock()
+    package.uuid = uuid.uuid4()
+    package.get_replacement_mapping.return_value = {
+        r"%relativeLocation%": "/tmp/testfile"
+    }
+    link = mock.Mock()
+    link.id = uuid.uuid4()
+    link.get_label.side_effect = lambda name, language: {
+        "description": "A failing client job",
+        "group": "Testing",
+    }[name]
+    link.config = {
+        "arguments": '"%relativeLocation%"',
+        "execute": "test_v0",
+    }
+    job_chain = mock.Mock()
+    job_chain.context = {}
+    job = DirectoryClientScriptJob(job_chain, link, package)
+    backend = mock.Mock(spec=TaskBackend)
+    backend.submit_task.side_effect = KeyError("unknown Gearman job handle")
+
+    with (
+        mock.patch.object(job, "save_to_db"),
+        mock.patch(
+            "archivematica.MCPServer.server.jobs.client.get_task_backend",
+            return_value=backend,
+        ),
+        mock.patch(
+            "archivematica.MCPServer.server.jobs.client.reset_task_backend",
+            side_effect=RuntimeError("reset failed"),
+        ) as reset_backend,
+    ):
+        with pytest.raises(KeyError, match="unknown Gearman job handle"):
+            job.run()
+
+    reset_backend.assert_called_once_with()
+    assert any(
+        record.message.startswith("Unable to reset task backend")
+        for record in caplog.records
     )

--- a/tests/MCPServer/test_queues.py
+++ b/tests/MCPServer/test_queues.py
@@ -5,14 +5,17 @@ import uuid
 from unittest import mock
 
 import pytest
+from django.utils import timezone
 
 from archivematica.dashboard.main import models
+from archivematica.MCPServer.server import metrics
 from archivematica.MCPServer.server.jobs import DecisionJob
 from archivematica.MCPServer.server.jobs import Job
 from archivematica.MCPServer.server.packages import DIP
 from archivematica.MCPServer.server.packages import SIP
 from archivematica.MCPServer.server.packages import Transfer
 from archivematica.MCPServer.server.queues import FAILED_PACKAGE_TERMINAL_LINK_IDS
+from archivematica.MCPServer.server.queues import TASK_EXCEPTION_MESSAGE
 from archivematica.MCPServer.server.queues import PackageQueue
 from archivematica.MCPServer.server.workflow import Link
 
@@ -32,6 +35,26 @@ def _process_one_job(queue):
     assert callback_ran.wait(1.0)
 
 
+def _process_one_failed_job(queue, exception_type):
+    """Block until a failed job's cleanup callback has completed."""
+    cleanup_ran = threading.Event()
+    handle_job_failure = queue._handle_job_failure
+
+    def handle_job_failure_and_signal(*args):
+        try:
+            return handle_job_failure(*args)
+        finally:
+            cleanup_ran.set()
+
+    with mock.patch.object(
+        queue, "_handle_job_failure", new=handle_job_failure_and_signal
+    ):
+        future = queue.process_one_job(timeout=1.0)
+        with pytest.raises(exception_type):
+            future.result()
+        assert cleanup_ran.wait(1.0)
+
+
 class MockJob(Job):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -40,6 +63,12 @@ class MockJob(Job):
 
     def run(self, *args, **kwargs):
         self.job_ran.set()
+
+
+class FailingJob(MockJob):
+    def run(self, *args, **kwargs):
+        self.job_ran.set()
+        raise KeyError("unknown Gearman job handle")
 
 
 class MockDecisionJob(DecisionJob):
@@ -333,3 +362,127 @@ def test_failed_terminal_link_marks_package_failed(
     assert transfer_model.status == models.PACKAGE_STATUS_FAILED
     assert transfer_model.completed_at is not None
     assert transfer.uuid not in package_queue.active_packages
+
+
+@pytest.mark.django_db(transaction=True)
+def test_job_exception_fails_records_and_releases_next_package(
+    package_queue, tmp_path, workflow_link, sip, caplog
+):
+    package_id = uuid.uuid4()
+    models.Transfer.objects.create(
+        uuid=package_id,
+        status=models.PACKAGE_STATUS_PROCESSING,
+    )
+    transfer = Transfer(str(tmp_path), package_id)
+    failed_job = FailingJob(mock.Mock(), workflow_link, transfer)
+    queued_job = MockJob(mock.Mock(), workflow_link, sip)
+    job_model = models.Job.objects.create(
+        jobuuid=failed_job.uuid,
+        createdtime=timezone.now(),
+        currentstep=models.Job.STATUS_EXECUTING_COMMANDS,
+    )
+    unfinished_task = models.Task.objects.create(
+        taskuuid=uuid.uuid4(),
+        job=job_model,
+        createdtime=timezone.now(),
+    )
+    completed_at = timezone.now()
+    completed_task = models.Task.objects.create(
+        taskuuid=uuid.uuid4(),
+        job=job_model,
+        createdtime=timezone.now(),
+        endtime=completed_at,
+        exitcode=0,
+        stderror="completed",
+    )
+
+    package_queue.schedule_job(failed_job)
+    package_queue.schedule_job(queued_job)
+
+    with mock.patch.object(metrics.job_exception_counter, "inc") as counter_inc:
+        _process_one_failed_job(package_queue, KeyError)
+
+    transfer_model = models.Transfer.objects.get(pk=package_id)
+    job_model.refresh_from_db()
+    unfinished_task.refresh_from_db()
+    completed_task.refresh_from_db()
+
+    assert transfer_model.status == models.PACKAGE_STATUS_FAILED
+    assert transfer_model.completed_at is not None
+    assert job_model.currentstep == models.Job.STATUS_FAILED
+    assert unfinished_task.exitcode == 1
+    assert unfinished_task.endtime is not None
+    assert unfinished_task.stderror == TASK_EXCEPTION_MESSAGE.format(
+        job_uuid=failed_job.uuid
+    )
+    assert completed_task.exitcode == 0
+    assert completed_task.endtime == completed_at
+    assert completed_task.stderror == "completed"
+    assert transfer.uuid not in package_queue.active_packages
+    assert sip.uuid in package_queue.active_packages
+    assert package_queue.job_queue.qsize() == 1
+    assert package_queue.sip_queue.qsize() == 0
+    counter_inc.assert_called_once_with()
+
+    exception_record = next(
+        record
+        for record in caplog.records
+        if record.message.startswith("Unexpected error processing job")
+    )
+    assert str(failed_job.uuid) in exception_record.message
+    assert str(workflow_link.id) in exception_record.message
+    assert str(transfer.uuid) in exception_record.message
+    assert exception_record.exc_info[0] is KeyError
+
+
+def test_terminal_job_exception_is_not_marked_done(
+    package_queue, transfer, workflow_link
+):
+    workflow_link._src["end"] = True
+    failed_job = FailingJob(mock.Mock(), workflow_link, transfer)
+
+    with (
+        mock.patch.object(failed_job, "mark_failed"),
+        mock.patch(
+            "archivematica.MCPServer.server.queues.Task.mark_unfinished_for_job_failed"
+        ),
+        mock.patch.object(transfer, "mark_as_failed") as mark_as_failed,
+        mock.patch.object(transfer, "mark_as_done") as mark_as_done,
+    ):
+        package_queue.schedule_job(failed_job)
+        _process_one_failed_job(package_queue, KeyError)
+
+    mark_as_failed.assert_called_once_with()
+    mark_as_done.assert_not_called()
+    assert transfer.uuid not in package_queue.active_packages
+
+
+def test_failure_cleanup_errors_do_not_block_the_next_package(
+    package_queue, transfer, sip, workflow_link, caplog
+):
+    failed_job = FailingJob(mock.Mock(), workflow_link, transfer)
+    queued_job = MockJob(mock.Mock(), workflow_link, sip)
+    cleanup_error = RuntimeError("cleanup failed")
+
+    package_queue.schedule_job(failed_job)
+    package_queue.schedule_job(queued_job)
+
+    with (
+        mock.patch.object(
+            metrics.job_exception_counter, "inc", side_effect=cleanup_error
+        ),
+        mock.patch.object(failed_job, "mark_failed", side_effect=cleanup_error),
+        mock.patch(
+            "archivematica.MCPServer.server.queues.Task.mark_unfinished_for_job_failed",
+            side_effect=cleanup_error,
+        ),
+        mock.patch.object(transfer, "mark_as_failed", side_effect=cleanup_error),
+    ):
+        _process_one_failed_job(package_queue, KeyError)
+
+    assert transfer.uuid not in package_queue.active_packages
+    assert sip.uuid in package_queue.active_packages
+    assert package_queue.job_queue.qsize() == 1
+    assert (
+        sum(record.message.startswith("Unable to ") for record in caplog.records) == 4
+    )


### PR DESCRIPTION
Handle exceptions from PackageQueue job futures so one failed job cannot retain an active package slot and stall unrelated processing.

On failure, log the full exception; mark the job, unfinished tasks, and package as failed; release the package slot; start the next package; replace the worker's Gearman backend; and increment a Prometheus counter. Run each cleanup action independently so one error does not block the rest.

User-visible impact:

- Package: Processing indefinitely -> Failed with a completion time.
- Job: may remain executing -> Failed.
- Unfinished tasks: no result -> exit code 1 with an explanatory error.
- Queue: leaked slot and eventual stall -> release the slot and continue.
- Recovery: MCPServer restart -> no restart, but no automatic retry.
- Normal success and configured exit-code paths remain unchanged.

Gearman may already have accepted remote work before the connection is reset, so a task can still finish or leave side effects after the package fails. Report that uncertainty and avoid automatic retries of potentially non-idempotent work.

This contains failures such as the reported python-gearman unknown-handle KeyError. It does not fix the unconfirmed Gearman root cause.