### PR TITLE
Add CAS authentication overlay and integration tests

### DIFF
--- a/.github/workflows/cas-integration-test.yml
+++ b/.github/workflows/cas-integration-test.yml
@@ -1,0 +1,113 @@
+---
+name: "CAS Integration Test"
+on:
+  workflow_dispatch:
+env:
+  UBUNTU_VERSION: "24.04"
+  PYTHON_VERSION: "3.10"
+jobs:
+  cache-python-builder:
+    name: "Cache layers of the python-builder stage"
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: "Check out repository"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
+      - name: "Set up Docker Buildx"
+        uses: "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c" # v4.2.0
+        with:
+          driver-opts: |
+            network=host
+      - name: "Generate cache key from lockfile"
+        id: cache_key
+        run: |
+          echo "requirements_hash=${{ hashFiles('.python-version', 'pyproject.toml', 'uv.lock') }}" >> $GITHUB_OUTPUT
+      - name: "Build base layers"
+        uses: "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a" # v7.3.0
+        with:
+          context: .
+          file: ./hack/Dockerfile
+          target: python-builder
+          build-args: |
+            UBUNTU_VERSION=${{ env.UBUNTU_VERSION }}
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            BUILDKIT_INLINE_CACHE=1
+          push: false
+          cache-from: |
+            type=gha,scope=archivematica-tests-base-${{ env.UBUNTU_VERSION }}-${{ env.PYTHON_VERSION }}
+            type=gha,scope=archivematica-tests-${{ env.UBUNTU_VERSION }}-${{ env.PYTHON_VERSION }}-${{ steps.cache_key.outputs.requirements_hash }}
+          cache-to: |
+            type=gha,scope=archivematica-tests-base-${{ env.UBUNTU_VERSION }}-${{ env.PYTHON_VERSION }},mode=max
+            type=gha,scope=archivematica-tests-${{ env.UBUNTU_VERSION }}-${{ env.PYTHON_VERSION }}-${{ steps.cache_key.outputs.requirements_hash }},mode=max
+  test:
+    needs: [cache-python-builder]
+    name: "Test"
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: "Check out repository"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
+      - name: "Save user id"
+        id: user_id
+        run: |
+          echo "user_id=$(id -u)" >> $GITHUB_OUTPUT
+      - name: "Save group id"
+        id: group_id
+        run: |
+          echo "group_id=$(id -g)" >> $GITHUB_OUTPUT
+      - name: "Generate cache key from lockfile"
+        id: cache_key
+        run: |
+          echo "requirements_hash=${{ hashFiles('.python-version', 'pyproject.toml', 'uv.lock') }}" >> $GITHUB_OUTPUT
+      - name: "Set up buildx"
+        uses: "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c" # v4.2.0
+        with:
+          driver-opts: |
+            network=host
+      - name: "Build integration test image"
+        uses: "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a" # v7.3.0
+        with:
+          context: .
+          file: ./hack/Dockerfile
+          target: archivematica-dashboard-integration-tests
+          build-args: |
+            USER_ID=${{ steps.user_id.outputs.user_id }}
+            GROUP_ID=${{ steps.group_id.outputs.group_id }}
+            UBUNTU_VERSION=${{ env.UBUNTU_VERSION }}
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            BUILDKIT_INLINE_CACHE=1
+          tags: archivematica-dashboard-integration-tests:latest
+          push: false
+          load: true
+          cache-from: |
+            type=gha,scope=archivematica-tests-base-${{ env.UBUNTU_VERSION }}-${{ env.PYTHON_VERSION }}
+            type=gha,scope=archivematica-cas-integration-${{ env.UBUNTU_VERSION }}-${{ env.PYTHON_VERSION }}
+            type=gha,scope=archivematica-tests-${{ env.UBUNTU_VERSION }}-${{ env.PYTHON_VERSION }}-${{ steps.cache_key.outputs.requirements_hash }}
+          cache-to: |
+            type=gha,scope=archivematica-tests-base-${{ env.UBUNTU_VERSION }}-${{ env.PYTHON_VERSION }},mode=max
+            type=gha,scope=archivematica-cas-integration-${{ env.UBUNTU_VERSION }}-${{ env.PYTHON_VERSION }},mode=max
+            type=gha,scope=archivematica-tests-${{ env.UBUNTU_VERSION }}-${{ env.PYTHON_VERSION }}-${{ steps.cache_key.outputs.requirements_hash }},mode=max
+      - name: "Build CAS server image"
+        uses: "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a" # v7.3.0
+        with:
+          context: ./hack/etc/cas
+          tags: archivematica-cas:latest
+          push: false
+          load: true
+          cache-from: |
+            type=gha,scope=archivematica-cas-server
+          cache-to: |
+            type=gha,scope=archivematica-cas-server,mode=max
+      - name: "Run tests"
+        run: |
+          ./run.sh
+        shell: "bash"
+        working-directory: "tests/integration"
+        env:
+          USER_ID: ${{ steps.user_id.outputs.user_id }}
+          GROUP_ID: ${{ steps.group_id.outputs.group_id }}
+          UBUNTU_VERSION: ${{ env.UBUNTU_VERSION }}
+          PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
+          SKIP_DOCKER_BUILD: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
+          DOCKER_BUILDKIT: 1
+          PYTEST_ADDOPTS: -vv
+          INTEGRATION_SERVICE: archivematica-dashboard-cas

--- a/hack/README.md
+++ b/hack/README.md
@@ -24,6 +24,7 @@
 - [Cleaning up](#cleaning-up)
 - [Percona tuning](#percona-tuning)
 - [OIDC authentication](#oidc-authentication)
+- [CAS authentication](#cas-authentication)
 - [Instrumentation](#instrumentation)
   - [Running Prometheus and Grafana](#running-prometheus-and-grafana)
   - [Percona Monitoring and Management](#percona-monitoring-and-management)
@@ -527,6 +528,80 @@ Administrative user:
 
 - Username: `admin@example.com`
 - Password: `test`
+
+## CAS authentication
+
+Use the `docker-compose.cas.yml` overlay to start an [Apereo CAS] server and
+enable the Dashboard's and Storage Service's CAS authentication settings. The
+base development environment must be installed and bootstrapped first as
+described in the [Installation](#installation) section:
+
+```shell
+docker compose -f docker-compose.yml -f docker-compose.cas.yml up -d --build
+```
+
+The first build of the `cas` image takes several minutes: it downloads the
+[Apereo CAS WAR overlay] template pinned to the `CAS_OVERLAY_COMMIT` build
+argument (a commit of the overlay template's `7.3` branch that builds the CAS
+`7.3.8` stable release) and compiles it with the JSON service registry and
+JSON user store modules.
+Subsequent builds are cached. The CAS server configuration is mounted from
+`hack/etc/cas/` at runtime, so editing the properties, the registered services
+in `hack/etc/cas/services/` or the users in `hack/etc/cas/config/users.json`
+only requires restarting the `cas` service.
+
+CAS support in Archivematica uses `django-cas-ng`, whose migrations are only
+applied when CAS is enabled. If the environment was bootstrapped without the
+CAS overlay, apply the migrations once before logging in:
+
+```shell
+docker compose -f docker-compose.yml -f docker-compose.cas.yml run --rm --no-deps \
+  --entrypoint /src/src/archivematica/dashboard/manage.py \
+  archivematica-dashboard migrate --noinput
+
+docker compose -f docker-compose.yml -f docker-compose.cas.yml run --rm --no-deps \
+  --entrypoint /src/src/archivematica/storage_service/manage.py \
+  archivematica-storage-service migrate --noinput
+```
+
+This overlay is intended for local testing and demonstrations only. The CAS
+login interface is available at <http://cas.localhost:62082/cas/login> and the
+following users are predefined:
+
+All users share the password `test` and are members of the CAS groups
+released through the `memberOf` attribute:
+
+| Username   | CAS groups                | Dashboard role | Storage Service role |
+| ---------- | ------------------------- | -------------- | -------------------- |
+| `demo`     | `users`                   | Regular user   | Reader               |
+| `admin`    | `administrators`, `users` | Superuser      | Administrator        |
+| `manager`  | `managers`, `users`       | Regular user   | Manager              |
+| `reviewer` | `reviewers`, `users`      | Regular user   | Reviewer             |
+
+The overlay maps the CAS groups to roles through the
+`AUTH_CAS_CHECK_ADMIN_ATTRIBUTES` and `AUTH_CAS_*_ATTRIBUTE` settings. The
+Dashboard only supports mapping to its superuser flag; the Storage Service
+also supports the manager and reviewer roles and falls back to the reader
+role when no group matches.
+
+The `cas.localhost` hostname must resolve to the local host in the browser,
+which is the standard behaviour for `*.localhost` names in modern browsers and
+Linux distributions. The overlay also sets it as a Docker network alias so the
+Dashboard and Storage Service containers can use the same CAS URL for ticket
+validation. If `cas.localhost` does not resolve on your host, add the
+following entry to `/etc/hosts`:
+
+```text
+127.0.0.1 cas.localhost
+```
+
+Visiting the Dashboard at <http://127.0.0.1:62080> redirects to the CAS login
+page. After authenticating, open the Storage Service at
+<http://127.0.0.1:62081> in the same browser session to verify CAS single
+sign-on.
+
+[Apereo CAS]: https://apereo.github.io/cas/
+[Apereo CAS WAR overlay]: https://apereo.github.io/cas/7.3.x/installation/WAR-Overlay-Installation.html
 
 ## Instrumentation
 

--- a/hack/docker-compose.cas.yml
+++ b/hack/docker-compose.cas.yml
@@ -1,0 +1,79 @@
+---
+services:
+  archivematica-dashboard:
+    environment:
+      # Archivematica Dashboard qa/1.x CAS switch.
+      ARCHIVEMATICA_DASHBOARD_DASHBOARD_CAS_AUTHENTICATION: "true"
+      AUTH_CAS_SERVER_URL: "http://cas.localhost:62082/cas/"
+      AUTH_CAS_PROTOCOL_VERSION: "3"
+
+      # Make users in the administrators CAS group superusers.
+      AUTH_CAS_CHECK_ADMIN_ATTRIBUTES: "true"
+      AUTH_CAS_ADMIN_ATTRIBUTE: "memberOf"
+      AUTH_CAS_ADMIN_ATTRIBUTE_VALUE: "administrators"
+
+      # The development environment uses HTTP.
+      ARCHIVEMATICA_DASHBOARD_DASHBOARD_SESSION_COOKIE_SAMESITE: "Lax"
+      ARCHIVEMATICA_DASHBOARD_DASHBOARD_SESSION_COOKIE_SECURE: "false"
+      ARCHIVEMATICA_DASHBOARD_DASHBOARD_CSRF_COOKIE_SECURE: "false"
+    depends_on:
+      cas:
+        condition: service_healthy
+
+  archivematica-storage-service:
+    environment:
+      # Archivematica Storage Service qa/0.x CAS switch.
+      SS_CAS_AUTHENTICATION: "true"
+      AUTH_CAS_SERVER_URL: "http://cas.localhost:62082/cas/"
+      AUTH_CAS_PROTOCOL_VERSION: "3"
+
+      # Map the CAS groups to the Storage Service roles. Users that match
+      # none of the groups get the reader role.
+      AUTH_CAS_CHECK_ADMIN_ATTRIBUTES: "true"
+      AUTH_CAS_ADMIN_ATTRIBUTE: "memberOf"
+      AUTH_CAS_ADMIN_ATTRIBUTE_VALUE: "administrators"
+      AUTH_CAS_MANAGER_ATTRIBUTE: "memberOf"
+      AUTH_CAS_MANAGER_ATTRIBUTE_VALUE: "managers"
+      AUTH_CAS_REVIEWER_ATTRIBUTE: "memberOf"
+      AUTH_CAS_REVIEWER_ATTRIBUTE_VALUE: "reviewers"
+
+      # The development environment uses HTTP.
+      SESSION_COOKIE_SAMESITE: "Lax"
+      SESSION_COOKIE_SECURE: "false"
+      CSRF_COOKIE_SECURE: "false"
+    depends_on:
+      cas:
+        condition: service_healthy
+
+  cas:
+    image: "archivematica-cas"
+    build:
+      context: ./etc/cas
+      args:
+        # Head of the cas-overlay-template 7.3 branch (CAS 7.3.8).
+        CAS_OVERLAY_COMMIT: "${CAS_OVERLAY_COMMIT:-b244d192d9462068fc24625a75ebe19ed6fc34cd}"
+    volumes:
+      - "./etc/cas/config:/etc/cas/config:ro"
+      - "./etc/cas/services:/etc/cas/services:ro"
+    ports:
+      - "127.0.0.1:62082:62082"
+    networks:
+      default:
+        aliases:
+          # This makes AUTH_CAS_SERVER_URL resolvable from the AM containers.
+          # The same hostname is also used by the host browser.
+          - cas.localhost
+    healthcheck:
+      test:
+        - CMD
+        - curl
+        - --fail
+        - --silent
+        - --show-error
+        - --max-time
+        - "2"
+        - http://127.0.0.1:62082/cas/login
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 20s

--- a/hack/etc/cas/Dockerfile
+++ b/hack/etc/cas/Dockerfile
@@ -1,0 +1,41 @@
+# Local/test-only Apereo CAS server for Archivematica development.
+#
+# The image is environment-agnostic: the runtime configuration (including the
+# server port), the JSON service registry and the JSON user store are expected
+# to be mounted at /etc/cas/config and /etc/cas/services.
+#
+# The CAS version is determined by the pinned commit of the Apereo CAS WAR
+# overlay template below. The default commit is the head of the 7.3 branch as
+# of 2026-08-17 and builds the CAS 7.3.8 stable release, as declared by the
+# cas.version property in its gradle.properties file. To upgrade, pick a
+# commit from the target release branch in
+# https://github.com/apereo/cas-overlay-template and check its
+# gradle.properties file for the CAS version it builds.
+ARG CAS_OVERLAY_COMMIT=b244d192d9462068fc24625a75ebe19ed6fc34cd
+
+FROM alpine:3.22 AS overlay-generator
+ARG CAS_OVERLAY_COMMIT
+RUN apk add --no-cache curl tar ca-certificates
+WORKDIR /tmp
+RUN curl -fsSL --retry 5 --retry-delay 2 \
+      https://github.com/apereo/cas-overlay-template/archive/${CAS_OVERLAY_COMMIT}.tar.gz \
+    | tar -xz \
+    && mv cas-overlay-template-${CAS_OVERLAY_COMMIT} cas-overlay
+
+FROM eclipse-temurin:21-jdk-jammy AS builder
+COPY --from=overlay-generator /tmp/cas-overlay /cas-overlay
+WORKDIR /cas-overlay
+# json-service-registry: register services from /etc/cas/services JSON files.
+# generic: authenticate against the static JSON user store (users.json).
+RUN chmod +x gradlew && \
+    ./gradlew clean build -x test --no-daemon \
+      -PcasModules=json-service-registry,generic
+
+FROM eclipse-temurin:21-jre-jammy
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /cas-overlay/build/libs/cas.war /app/cas.war
+ENTRYPOINT ["java", "-jar", "/app/cas.war"]

--- a/hack/etc/cas/config/cas.properties
+++ b/hack/etc/cas/config/cas.properties
@@ -1,0 +1,21 @@
+# Local-only Apereo CAS configuration for Archivematica development.
+# Do not use this configuration in production.
+
+server.port=62082
+server.ssl.enabled=false
+
+# The same URL is used by host browsers and Docker containers.
+cas.server.name=http://cas.localhost:62082
+cas.server.prefix=${cas.server.name}/cas
+
+# Register only the two local Archivematica HTTP services.
+cas.service-registry.json.location=file:/etc/cas/services
+cas.service-registry.json.watcher-enabled=false
+cas.service-registry.core.init-default-services=false
+
+# Authenticate against the static JSON user store instead of the built-in
+# casuser account.
+cas.authn.accept.enabled=false
+cas.authn.json.location=file:/etc/cas/config/users.json
+
+logging.level.org.apereo.cas=INFO

--- a/hack/etc/cas/config/users.json
+++ b/hack/etc/cas/config/users.json
@@ -1,0 +1,43 @@
+{
+  "@class": "java.util.LinkedHashMap",
+  "demo": {
+    "@class": "org.apereo.cas.adaptors.generic.CasUserAccount",
+    "password": "test",
+    "attributes": {
+      "@class": "java.util.LinkedHashMap",
+      "mail": ["java.util.List", ["demo@example.com"]],
+      "memberOf": ["java.util.List", ["users"]]
+    },
+    "status": "OK"
+  },
+  "admin": {
+    "@class": "org.apereo.cas.adaptors.generic.CasUserAccount",
+    "password": "test",
+    "attributes": {
+      "@class": "java.util.LinkedHashMap",
+      "mail": ["java.util.List", ["admin@example.com"]],
+      "memberOf": ["java.util.List", ["administrators", "users"]]
+    },
+    "status": "OK"
+  },
+  "manager": {
+    "@class": "org.apereo.cas.adaptors.generic.CasUserAccount",
+    "password": "test",
+    "attributes": {
+      "@class": "java.util.LinkedHashMap",
+      "mail": ["java.util.List", ["manager@example.com"]],
+      "memberOf": ["java.util.List", ["managers", "users"]]
+    },
+    "status": "OK"
+  },
+  "reviewer": {
+    "@class": "org.apereo.cas.adaptors.generic.CasUserAccount",
+    "password": "test",
+    "attributes": {
+      "@class": "java.util.LinkedHashMap",
+      "mail": ["java.util.List", ["reviewer@example.com"]],
+      "memberOf": ["java.util.List", ["reviewers", "users"]]
+    },
+    "status": "OK"
+  }
+}

--- a/hack/etc/cas/services/archivematica-dashboard-1001.json
+++ b/hack/etc/cas/services/archivematica-dashboard-1001.json
@@ -1,0 +1,12 @@
+{
+  "@class": "org.apereo.cas.services.CasRegisteredService",
+  "serviceId": "^http://(localhost|127\\.0\\.0\\.1):62080/.*",
+  "name": "Archivematica Dashboard (development)",
+  "description": "Local Archivematica Dashboard qa/1.x CAS test service",
+  "id": 1001,
+  "evaluationOrder": 10,
+  "logoutType": "NONE",
+  "attributeReleasePolicy": {
+    "@class": "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  }
+}

--- a/hack/etc/cas/services/archivematica-storage-service-1002.json
+++ b/hack/etc/cas/services/archivematica-storage-service-1002.json
@@ -1,0 +1,12 @@
+{
+  "@class": "org.apereo.cas.services.CasRegisteredService",
+  "serviceId": "^http://(localhost|127\\.0\\.0\\.1):62081/.*",
+  "name": "Archivematica Storage Service (development)",
+  "description": "Local Archivematica Storage Service qa/0.x CAS test service",
+  "id": 1002,
+  "evaluationOrder": 20,
+  "logoutType": "NONE",
+  "attributeReleasePolicy": {
+    "@class": "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  }
+}

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,6 +1,28 @@
 ---
 name: am-integration
 
+x-dashboard-environment: &dashboard-environment
+  PYTEST_ADDOPTS: ${PYTEST_ADDOPTS:-}
+  RUN_INTEGRATION_TESTS: "true"
+  DJANGO_LIVE_TEST_SERVER_ADDRESS: "archivematica-dashboard:8000"
+  DJANGO_ALLOW_ASYNC_UNSAFE: true
+  FORWARDED_ALLOW_IPS: "*"
+  AM_GUNICORN_ACCESSLOG: "/dev/null"
+  DJANGO_SETTINGS_MODULE: "archivematica.dashboard.settings.testmysql"
+  ARCHIVEMATICA_DASHBOARD_DASHBOARD_GEARMAN_SERVER: "gearmand:4730"
+  ARCHIVEMATICA_DASHBOARD_DASHBOARD_ELASTICSEARCH_SERVER: "elasticsearch:9200"
+  ARCHIVEMATICA_DASHBOARD_DASHBOARD_PROMETHEUS_ENABLED: "1"
+  ARCHIVEMATICA_DASHBOARD_CLIENT_USER: "archivematica"
+  ARCHIVEMATICA_DASHBOARD_CLIENT_PASSWORD: "demo"
+  ARCHIVEMATICA_DASHBOARD_CLIENT_HOST: "mysql"
+  ARCHIVEMATICA_DASHBOARD_CLIENT_DATABASE: "MCP"
+  ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED: "${AM_SEARCH_ENABLED:-true}"
+  ARCHIVEMATICA_DASHBOARD_DASHBOARD_SESSION_COOKIE_SECURE: "false"
+  ARCHIVEMATICA_DASHBOARD_DASHBOARD_SESSION_COOKIE_SAMESITE: "Lax"
+  ARCHIVEMATICA_DASHBOARD_DASHBOARD_CSRF_COOKIE_SECURE: "false"
+  # /src is bind-mounted, so point Django staticfiles to the image-owned dist copy.
+  FRONTEND_DIST_DIR: "/opt/am-dashboard-dist"
+
 services:
 
   mysql:
@@ -37,24 +59,7 @@ services:
     command: ["pytest", "--browser", "firefox", "/src/tests/integration/"]
     hostname: "archivematica-dashboard"
     environment:
-      PYTEST_ADDOPTS: ${PYTEST_ADDOPTS:-}
-      RUN_INTEGRATION_TESTS: "true"
-      DJANGO_LIVE_TEST_SERVER_ADDRESS: "archivematica-dashboard:8000"
-      DJANGO_ALLOW_ASYNC_UNSAFE: true
-      FORWARDED_ALLOW_IPS: "*"
-      AM_GUNICORN_ACCESSLOG: "/dev/null"
-      DJANGO_SETTINGS_MODULE: "archivematica.dashboard.settings.testmysql"
-      ARCHIVEMATICA_DASHBOARD_DASHBOARD_GEARMAN_SERVER: "gearmand:4730"
-      ARCHIVEMATICA_DASHBOARD_DASHBOARD_ELASTICSEARCH_SERVER: "elasticsearch:9200"
-      ARCHIVEMATICA_DASHBOARD_DASHBOARD_PROMETHEUS_ENABLED: "1"
-      ARCHIVEMATICA_DASHBOARD_CLIENT_USER: "archivematica"
-      ARCHIVEMATICA_DASHBOARD_CLIENT_PASSWORD: "demo"
-      ARCHIVEMATICA_DASHBOARD_CLIENT_HOST: "mysql"
-      ARCHIVEMATICA_DASHBOARD_CLIENT_DATABASE: "MCP"
-      ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED: "${AM_SEARCH_ENABLED:-true}"
-      ARCHIVEMATICA_DASHBOARD_DASHBOARD_SESSION_COOKIE_SECURE: "false"
-      ARCHIVEMATICA_DASHBOARD_DASHBOARD_SESSION_COOKIE_SAMESITE: "Lax"
-      ARCHIVEMATICA_DASHBOARD_DASHBOARD_CSRF_COOKIE_SECURE: "false"
+      <<: *dashboard-environment
       ARCHIVEMATICA_DASHBOARD_OIDC_AUTHENTICATION: "true"
       OIDC_USE_PKCE: "true"
       OIDC_PKCE_CODE_CHALLENGE_METHOD: "S256"
@@ -86,8 +91,6 @@ services:
       OIDC_ACCESS_ATTRIBUTE_MAP_SECONDARY: >
         {"given_name": "first_name", "family_name": "last_name", "realm_access": "realm_access"}
       OIDC_RP_SIGN_ALGO: "RS256"
-      # /src is bind-mounted, so point Django staticfiles to the image-owned dist copy.
-      FRONTEND_DIST_DIR: "/opt/am-dashboard-dist"
     volumes:
       - "../../:/src"
     depends_on:
@@ -96,6 +99,25 @@ services:
     links:
       - "mysql"
       - "keycloak"
+
+  archivematica-dashboard-cas:
+    image: "archivematica-dashboard-integration-tests:latest"
+    entrypoint: ""
+    working_dir: "/src"
+    command: ["pytest", "--browser", "firefox", "/src/tests/integration/test_cas_auth.py"]
+    hostname: "archivematica-dashboard"
+    environment:
+      <<: *dashboard-environment
+      ARCHIVEMATICA_DASHBOARD_DASHBOARD_CAS_AUTHENTICATION: "true"
+      AUTH_CAS_SERVER_URL: "http://cas:8080/cas/"
+      AUTH_CAS_PROTOCOL_VERSION: "3"
+    volumes:
+      - "../../:/src"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      cas:
+        condition: service_healthy
 
   keycloak:
     image: "quay.io/keycloak/keycloak:26.7.1-0"
@@ -110,3 +132,28 @@ services:
       - 8080:8080
     volumes:
       - "./etc/keycloak/realm.json:/opt/keycloak/data/import/realm.json:ro"
+
+  cas:
+    image: "archivematica-cas"
+    build:
+      context: "../../hack/etc/cas"
+      args:
+        # Head of the cas-overlay-template 7.3 branch (CAS 7.3.8).
+        CAS_OVERLAY_COMMIT: "${CAS_OVERLAY_COMMIT:-b244d192d9462068fc24625a75ebe19ed6fc34cd}"
+    volumes:
+      - "./etc/cas/config:/etc/cas/config:ro"
+      - "./etc/cas/services:/etc/cas/services:ro"
+    healthcheck:
+      test:
+        - CMD
+        - curl
+        - --fail
+        - --silent
+        - --show-error
+        - --max-time
+        - "2"
+        - http://127.0.0.1:8080/cas/login
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 20s

--- a/tests/integration/etc/cas/config/cas.properties
+++ b/tests/integration/etc/cas/config/cas.properties
@@ -1,0 +1,20 @@
+# Apereo CAS configuration for the Archivematica integration tests.
+# Do not use this configuration in production.
+
+server.port=8080
+server.ssl.enabled=false
+
+cas.server.name=http://cas:8080
+cas.server.prefix=${cas.server.name}/cas
+
+# Register only the Dashboard live test server.
+cas.service-registry.json.location=file:/etc/cas/services
+cas.service-registry.json.watcher-enabled=false
+cas.service-registry.core.init-default-services=false
+
+# Authenticate against the static JSON user store instead of the built-in
+# casuser account.
+cas.authn.accept.enabled=false
+cas.authn.json.location=file:/etc/cas/config/users.json
+
+logging.level.org.apereo.cas=INFO

--- a/tests/integration/etc/cas/config/users.json
+++ b/tests/integration/etc/cas/config/users.json
@@ -1,0 +1,33 @@
+{
+  "@class": "java.util.LinkedHashMap",
+  "demo": {
+    "@class": "org.apereo.cas.adaptors.generic.CasUserAccount",
+    "password": "test",
+    "attributes": {
+      "@class": "java.util.LinkedHashMap",
+      "mail": ["java.util.List", ["demo@example.com"]],
+      "memberOf": ["java.util.List", ["users"]]
+    },
+    "status": "OK"
+  },
+  "admin": {
+    "@class": "org.apereo.cas.adaptors.generic.CasUserAccount",
+    "password": "test",
+    "attributes": {
+      "@class": "java.util.LinkedHashMap",
+      "mail": ["java.util.List", ["admin@example.com"]],
+      "memberOf": ["java.util.List", ["administrators", "users"]]
+    },
+    "status": "OK"
+  },
+  "sysadmin": {
+    "@class": "org.apereo.cas.adaptors.generic.CasUserAccount",
+    "password": "test",
+    "attributes": {
+      "@class": "java.util.LinkedHashMap",
+      "mail": ["java.util.List", ["sysadmin@example.com"]],
+      "memberOf": ["java.util.List", ["administrators"]]
+    },
+    "status": "OK"
+  }
+}

--- a/tests/integration/etc/cas/services/archivematica-dashboard-1001.json
+++ b/tests/integration/etc/cas/services/archivematica-dashboard-1001.json
@@ -1,0 +1,12 @@
+{
+  "@class": "org.apereo.cas.services.CasRegisteredService",
+  "serviceId": "^http://archivematica-dashboard:8000/.*",
+  "name": "Archivematica Dashboard (integration tests)",
+  "description": "Archivematica Dashboard live test server CAS service",
+  "id": 1001,
+  "evaluationOrder": 10,
+  "logoutType": "NONE",
+  "attributeReleasePolicy": {
+    "@class": "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  }
+}

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -4,8 +4,17 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd ${__dir}
 
+# Service that runs pytest. Use archivematica-dashboard-cas to run the CAS
+# authentication test suite instead of the default one.
+INTEGRATION_SERVICE="${INTEGRATION_SERVICE:-archivematica-dashboard}"
+
 if [ -z "${SKIP_DOCKER_BUILD}" ]; then
-    docker compose build archivematica-dashboard
+    if [ "${INTEGRATION_SERVICE}" == "archivematica-dashboard-cas" ]; then
+        # The CAS service reuses the image built by the default service.
+        docker compose build archivematica-dashboard cas
+    else
+        docker compose build "${INTEGRATION_SERVICE}"
+    fi
 
     status=$?
 
@@ -14,7 +23,7 @@ if [ -z "${SKIP_DOCKER_BUILD}" ]; then
     fi
 fi
 
-docker compose run --rm archivematica-dashboard
+docker compose run --rm "${INTEGRATION_SERVICE}"
 
 status=$?
 

--- a/tests/integration/test_cas_auth.py
+++ b/tests/integration/test_cas_auth.py
@@ -1,0 +1,242 @@
+import os
+import uuid
+
+import pytest
+from django.conf import settings as django_settings
+from django.contrib.auth.models import User
+from django.urls import reverse
+from playwright.sync_api import Page
+from playwright.sync_api import expect
+from pytest_django import Settings
+from pytest_django.live_server_helper import LiveServer
+
+if "RUN_INTEGRATION_TESTS" not in os.environ:
+    pytest.skip("Skipping integration tests", allow_module_level=True)
+
+if not django_settings.CAS_AUTHENTICATION:
+    pytest.skip("Skipping CAS integration tests", allow_module_level=True)
+
+
+def open_user_menu(page: Page) -> None:
+    user_menu = page.locator("li.user.dropdown")
+    expect(user_menu).to_be_visible()
+    user_menu.evaluate("node => node.classList.add('open')")
+
+
+def click_profile_from_user_menu(page: Page) -> None:
+    open_user_menu(page)
+    page.get_by_role("link", name="Your profile").click()
+
+
+def click_logout_from_user_menu(page: Page) -> None:
+    open_user_menu(page)
+    page.get_by_role("button", name="Log out").click()
+
+
+def log_in_via_cas(
+    page: Page, live_server: LiveServer, username: str, password: str
+) -> None:
+    page.goto(live_server.url)
+    page.locator("#username").fill(username)
+    page.locator("#password").fill(password)
+    page.locator("button[name=submitBtn]").click()
+
+
+def get_profile_details(page: Page, live_server: LiveServer) -> list[str]:
+    click_profile_from_user_menu(page)
+
+    assert page.url == f"{live_server.url}{reverse('accounts:profile')}"
+    details_text = page.locator("dl.dl-horizontal").text_content()
+    assert details_text is not None
+
+    return [i.strip() for i in details_text.splitlines() if i.strip()]
+
+
+@pytest.fixture
+def check_admin_attributes(settings: Settings) -> Settings:
+    settings.CAS_CHECK_ADMIN_ATTRIBUTES = True
+    settings.CAS_ADMIN_ATTRIBUTE = "memberOf"
+    settings.CAS_ADMIN_ATTRIBUTE_VALUE = "administrators"
+
+    return settings
+
+
+@pytest.mark.django_db
+def test_login_redirects_to_cas_server_login_page(
+    page: Page, live_server: LiveServer, dashboard_uuid: uuid.UUID, settings: Settings
+) -> None:
+    page.goto(live_server.url)
+
+    assert page.url.startswith(f"{settings.CAS_SERVER_URL}login")
+    expect(page.locator("#username")).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_cas_backend_creates_local_user(
+    page: Page,
+    live_server: LiveServer,
+    dashboard_uuid: uuid.UUID,
+    django_user_model: type[User],
+) -> None:
+    log_in_via_cas(page, live_server, "demo", "test")
+
+    assert page.url == f"{live_server.url}/transfer/"
+    assert get_profile_details(page, live_server) == [
+        "Username",
+        "demo",
+        "Name",
+        "E-mail",
+        "Admin",
+        "no",
+    ]
+
+    user = django_user_model.objects.get(username="demo")
+    assert not user.is_superuser
+
+
+@pytest.mark.django_db
+def test_cas_backend_authenticates_existing_user(
+    page: Page,
+    live_server: LiveServer,
+    dashboard_uuid: uuid.UUID,
+    django_user_model: type[User],
+) -> None:
+    django_user_model.objects.create(
+        username="demo",
+        email="demo@example.com",
+        first_name="Demo",
+        last_name="User",
+    )
+
+    log_in_via_cas(page, live_server, "demo", "test")
+
+    assert page.url == f"{live_server.url}/transfer/"
+    assert get_profile_details(page, live_server) == [
+        "Username",
+        "demo",
+        "Name",
+        "Demo User",
+        "E-mail",
+        "demo@example.com",
+        "Admin",
+        "no",
+    ]
+
+    assert django_user_model.objects.filter(username="demo").count() == 1
+
+
+@pytest.mark.django_db
+def test_admin_attribute_grants_administrator_role(
+    page: Page,
+    live_server: LiveServer,
+    dashboard_uuid: uuid.UUID,
+    django_user_model: type[User],
+    check_admin_attributes: Settings,
+) -> None:
+    # The admin user is a member of multiple CAS groups, so the memberOf
+    # attribute is parsed as a list.
+    log_in_via_cas(page, live_server, "admin", "test")
+
+    assert page.url == f"{live_server.url}/transfer/"
+    assert get_profile_details(page, live_server) == [
+        "Username",
+        "admin",
+        "Name",
+        "E-mail",
+        "Admin",
+        "yes",
+    ]
+
+    user = django_user_model.objects.get(username="admin")
+    assert user.is_superuser
+
+
+@pytest.mark.django_db
+def test_single_valued_admin_attribute_grants_administrator_role(
+    page: Page,
+    live_server: LiveServer,
+    dashboard_uuid: uuid.UUID,
+    django_user_model: type[User],
+    check_admin_attributes: Settings,
+) -> None:
+    # The sysadmin user is a member of a single CAS group, so the memberOf
+    # attribute is parsed as a string.
+    log_in_via_cas(page, live_server, "sysadmin", "test")
+
+    assert page.url == f"{live_server.url}/transfer/"
+
+    user = django_user_model.objects.get(username="sysadmin")
+    assert user.is_superuser
+
+
+@pytest.mark.django_db
+def test_missing_admin_attribute_removes_administrator_role(
+    page: Page,
+    live_server: LiveServer,
+    dashboard_uuid: uuid.UUID,
+    django_user_model: type[User],
+    check_admin_attributes: Settings,
+) -> None:
+    django_user_model.objects.create(username="demo", is_superuser=True)
+
+    log_in_via_cas(page, live_server, "demo", "test")
+
+    assert page.url == f"{live_server.url}/transfer/"
+    assert get_profile_details(page, live_server) == [
+        "Username",
+        "demo",
+        "Name",
+        "E-mail",
+        "Admin",
+        "no",
+    ]
+
+    user = django_user_model.objects.get(username="demo")
+    assert not user.is_superuser
+
+
+@pytest.mark.django_db
+def test_autoconfigure_email_sets_email_of_new_user(
+    page: Page,
+    live_server: LiveServer,
+    dashboard_uuid: uuid.UUID,
+    django_user_model: type[User],
+    settings: Settings,
+) -> None:
+    settings.CAS_AUTOCONFIGURE_EMAIL = True
+    settings.CAS_EMAIL_DOMAIN = "example.com"
+
+    log_in_via_cas(page, live_server, "demo", "test")
+
+    assert page.url == f"{live_server.url}/transfer/"
+    assert get_profile_details(page, live_server) == [
+        "Username",
+        "demo",
+        "Name",
+        "E-mail",
+        "demo@example.com",
+        "Admin",
+        "no",
+    ]
+
+    user = django_user_model.objects.get(username="demo")
+    assert user.email == "demo@example.com"
+
+
+@pytest.mark.django_db
+def test_logging_out_logs_out_user_from_cas_server(
+    page: Page, live_server: LiveServer, dashboard_uuid: uuid.UUID, settings: Settings
+) -> None:
+    log_in_via_cas(page, live_server, "demo", "test")
+
+    assert page.url == f"{live_server.url}/transfer/"
+
+    # Logging out redirects the user to the CAS server logout page.
+    click_logout_from_user_menu(page)
+    assert page.url.startswith(f"{settings.CAS_SERVER_URL}logout")
+
+    # The CAS single sign-on session is over, so authenticating again
+    # requires to submit the CAS login form.
+    page.goto(live_server.url)
+    assert page.url.startswith(f"{settings.CAS_SERVER_URL}login")
+    expect(page.locator("#username")).to_be_visible()


### PR DESCRIPTION
Add a docker-compose.cas.yml overlay that runs an Apereo CAS server with predefined demo and admin users for testing CAS authentication from a browser. The overlay turns on the existing CAS support in the Dashboard and the Storage Service and maps membership in the administrators CAS group to the superuser flag.

The CAS image is built from the Apereo CAS WAR overlay template pinned by commit (CAS 7.3.8) with the JSON service registry and JSON user store modules, since the published apereo/cas images are demo builds that do not include them. The runtime configuration, the registered services and the users are mounted from hack/etc/cas and can be edited without rebuilding the image.

Add a Playwright integration test suite covering the CAS behavior surface: login redirection, local user creation, existing user authentication, superuser promotion and demotion from CAS attributes, email autoconfiguration and CAS session termination on logout. CAS and OIDC cannot be enabled in the same Django process, so the suite runs through a dedicated Compose service selected with the INTEGRATION_SERVICE variable in tests/integration/run.sh, and the new manual CAS Integration Test workflow runs it in CI.