### PR TITLE
Upgrade Gearman client and harden recovery

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
     - "django-stubs>=6,<7"
     - django-tastypie
     - elasticsearch>=8.0.0,<9.0.0
-    - gearman3 @ git+https://github.com/artefactual-labs/python-gearman.git@b68efc868c7a494dd6a2d2e820fb098a6da9f797
+    - gearman3 @ git+https://github.com/artefactual-labs/python-gearman.git@f216d89faead4ff5f7f1d51bf767881b2a30bb47
     - inotify-simple
     - jsonfield
     - lazy-paged-sequence

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "django-stubs-ext",
   "django-tastypie",
   "elasticsearch>=8.0.0,<9.0.0",
-  "gearman3 @ git+https://github.com/artefactual-labs/python-gearman.git@b68efc868c7a494dd6a2d2e820fb098a6da9f797",
+  "gearman3 @ git+https://github.com/artefactual-labs/python-gearman.git@f216d89faead4ff5f7f1d51bf767881b2a30bb47",
   "gevent",
   "gunicorn",
   "inotify-simple",

--- a/src/archivematica/MCPClient/client/gearman.py
+++ b/src/archivematica/MCPClient/client/gearman.py
@@ -2,7 +2,6 @@ import functools
 import logging
 import multiprocessing
 from datetime import datetime
-from multiprocessing.synchronize import Event
 from types import TracebackType
 from typing import Optional
 from typing import Union
@@ -12,6 +11,8 @@ from django.conf import settings
 from gearman.job import GearmanJob
 
 from archivematica.archivematicaCommon.archivematicaFunctions import escape
+from archivematica.archivematicaCommon.gearman import GearmanWorker
+from archivematica.archivematicaCommon.gearman import ShutdownEvent
 from archivematica.archivematicaCommon.gearman_encoder import JSONDataEncoder
 from archivematica.MCPClient.client import metrics
 from archivematica.MCPClient.client.job import Job
@@ -52,14 +53,14 @@ JobResults = dict[str, JobData]
 logger = logging.getLogger("archivematica.mcp.client.gearman")
 
 
-class MCPGearmanWorker(gearman.GearmanWorker):
+class MCPGearmanWorker(GearmanWorker):
     data_encoder = JSONDataEncoder
 
     def __init__(
         self,
         hosts: list[str],
         client_scripts: list[str],
-        shutdown_event: Optional[Event] = None,
+        shutdown_event: Optional[ShutdownEvent] = None,
         max_jobs_to_process: Optional[int] = None,
     ) -> None:
         super().__init__(hosts)

--- a/src/archivematica/MCPClient/client/pool.py
+++ b/src/archivematica/MCPClient/client/pool.py
@@ -17,7 +17,6 @@ import logging
 import logging.handlers
 import multiprocessing
 import threading
-import time
 from multiprocessing.process import BaseProcess
 from multiprocessing.synchronize import Event
 from types import ModuleType
@@ -32,6 +31,7 @@ django.setup()
 from django import db
 from django.conf import settings
 
+from archivematica.archivematicaCommon.gearman import ShutdownEvent
 from archivematica.MCPClient.client import loader
 from archivematica.MCPClient.client import metrics
 from archivematica.MCPClient.client.gearman import MCPGearmanWorker
@@ -84,7 +84,7 @@ def run_gearman_worker(
     log_queue: LogQueue,
     metrics_queue: MetricQueue,
     client_scripts: list[str],
-    shutdown_event: Optional[Event] = None,
+    shutdown_event: Optional[ShutdownEvent] = None,
 ) -> None:
     """Target function executed by child processes in the pool."""
     # Set up logging, as we're in a new process now.
@@ -101,6 +101,12 @@ def run_gearman_worker(
     # Reject connections of the parent, this process will have its own.
     db.connections.close_all()
 
+    if shutdown_event is None:
+        # Direct callers historically omitted this argument.  Give them the
+        # same indefinite worker behavior while WorkerPool supplies its shared
+        # process event for prompt coordinated shutdown.
+        shutdown_event = threading.Event()
+
     worker = MCPGearmanWorker(
         gearman_hosts,
         client_scripts,
@@ -108,7 +114,7 @@ def run_gearman_worker(
         max_jobs_to_process=max_jobs_to_process,
     )
     logger.debug("Worker process %s starting", process_id)
-    worker.work()
+    worker.work_with_reconnect(shutdown_event, logger)
     logger.debug("Worker process %s exiting", process_id)
 
 
@@ -218,7 +224,7 @@ class WorkerPool:
         """
         while not self.shutdown_event.is_set():
             self._restart_exited_workers()
-            time.sleep(self.WORKER_RESTART_DELAY)
+            self.shutdown_event.wait(self.WORKER_RESTART_DELAY)
 
     def _restart_exited_workers(self) -> bool:
         """Restart any worker processes which have exited due to reaching

--- a/src/archivematica/MCPServer/server/rpc_server.py
+++ b/src/archivematica/MCPServer/server/rpc_server.py
@@ -13,24 +13,22 @@ import inspect
 import logging
 import os
 import re
-import time
 from collections import OrderedDict
 from datetime import timezone as datetime_timezone
 from io import StringIO
 from socket import gethostname
 from typing import Literal
 
-import gearman
 from django.conf import settings as django_settings
 from django.db import connection
 from django.db.models import Exists
 from django.db.models import Min
 from django.db.models import OuterRef
 from django.utils.translation import gettext as _
-from gearman import GearmanWorker
 from lxml import etree
 
 from archivematica.archivematicaCommon.dbconns import auto_close_old_connections
+from archivematica.archivematicaCommon.gearman import GearmanWorker
 from archivematica.archivematicaCommon.gearman_encoder import JSONDataEncoder
 from archivematica.dashboard.main.idempotency import IdempotencyKeyConflictError
 from archivematica.dashboard.main.idempotency import IdempotencyRequestInProgressError
@@ -44,6 +42,7 @@ from archivematica.MCPServer.server.jobs.chain import get_job_class_for_link
 from archivematica.MCPServer.server.packages import create_package
 from archivematica.MCPServer.server.packages import get_approve_transfer_chain_id
 from archivematica.MCPServer.server.processing_config import get_processing_fields
+from archivematica.MCPServer.server.tasks import invalidate_task_backends
 
 logger = logging.getLogger("archivematica.mcp.server.rpc_server")
 
@@ -654,20 +653,8 @@ def _pull_choices(job_id, lang, jobs_awaiting_for_approval):
 def start(workflow, shutdown_event, package_queue, executor):
     worker = RPCServer(workflow, shutdown_event, package_queue, executor)
     logger.debug("Started RPC server.")
-
-    fail_max_sleep = 30
-    fail_sleep_incrementor = 2
-
-    while not shutdown_event.is_set():
-        fail_sleep = 1
-        try:
-            worker.work(poll_timeout=5.0)
-        except gearman.errors.ServerUnavailable as inst:
-            logger.error(
-                "Gearman server is unavailable: %s. Retrying in %d seconds.",
-                inst.args,
-                fail_sleep,
-            )
-            time.sleep(fail_sleep)
-            if fail_sleep < fail_max_sleep:
-                fail_sleep += fail_sleep_incrementor
+    worker.work_with_reconnect(
+        shutdown_event,
+        logger,
+        on_connection_unavailable=invalidate_task_backends,
+    )

--- a/src/archivematica/MCPServer/server/tasks/__init__.py
+++ b/src/archivematica/MCPServer/server/tasks/__init__.py
@@ -1,6 +1,7 @@
 from archivematica.MCPServer.server.tasks.backends import GearmanTaskBackend
 from archivematica.MCPServer.server.tasks.backends import TaskBackend
 from archivematica.MCPServer.server.tasks.backends import get_task_backend
+from archivematica.MCPServer.server.tasks.backends import invalidate_task_backends
 from archivematica.MCPServer.server.tasks.backends import reset_task_backend
 from archivematica.MCPServer.server.tasks.task import Task
 
@@ -9,5 +10,6 @@ __all__ = (
     "Task",
     "TaskBackend",
     "get_task_backend",
+    "invalidate_task_backends",
     "reset_task_backend",
 )

--- a/src/archivematica/MCPServer/server/tasks/backends/__init__.py
+++ b/src/archivematica/MCPServer/server/tasks/backends/__init__.py
@@ -10,6 +10,26 @@ from archivematica.MCPServer.server.tasks.backends.gearman_backend import (
 )
 
 backend_local = threading.local()
+_backend_generation = 0
+_backend_generation_lock = threading.Lock()
+
+
+def _current_backend_generation():
+    with _backend_generation_lock:
+        return _backend_generation
+
+
+def invalidate_task_backends():
+    """Arrange for every executor thread to replace its cached backend.
+
+    A thread-local backend can only be shut down safely by its owning thread.
+    Advancing a shared generation lets each executor thread discard its own
+    connection before it submits its next task.
+    """
+    global _backend_generation
+
+    with _backend_generation_lock:
+        _backend_generation += 1
 
 
 def get_task_backend():
@@ -20,8 +40,16 @@ def get_task_backend():
     """
     # In future, this could be a configuration setting, but for now it
     # is always gearman.
+    generation = _current_backend_generation()
+    if (
+        getattr(backend_local, "task_backend", None) is not None
+        and getattr(backend_local, "task_backend_generation", None) != generation
+    ):
+        reset_task_backend()
+
     if not getattr(backend_local, "task_backend", None):
         backend_local.task_backend = GearmanTaskBackend()
+        backend_local.task_backend_generation = generation
 
     return backend_local.task_backend
 
@@ -36,11 +64,14 @@ def reset_task_backend():
         backend.shutdown()
     finally:
         del backend_local.task_backend
+        if hasattr(backend_local, "task_backend_generation"):
+            del backend_local.task_backend_generation
 
 
 __all__ = (
     "GearmanTaskBackend",
     "TaskBackend",
     "get_task_backend",
+    "invalidate_task_backends",
     "reset_task_backend",
 )

--- a/src/archivematica/MCPServer/server/tasks/backends/gearman_backend.py
+++ b/src/archivematica/MCPServer/server/tasks/backends/gearman_backend.py
@@ -8,11 +8,11 @@ import logging
 import uuid
 
 from django.conf import settings
-from gearman import GearmanClient
 from gearman.constants import JOB_COMPLETE
 from gearman.constants import JOB_FAILED
 from gearman.constants import JOB_UNKNOWN
 
+from archivematica.archivematicaCommon.gearman import GearmanClient
 from archivematica.archivematicaCommon.gearman_encoder import JSONDataEncoder
 from archivematica.MCPServer.server import metrics
 from archivematica.MCPServer.server.tasks.backends.base import TaskBackend
@@ -70,7 +70,11 @@ class GearmanTaskBackend(TaskBackend):
     # Setting this too large will use more memory; setting it too small will hurt
     # throughput.  So the trick is to set it juuuust right.
     TASK_BATCH_SIZE = settings.BATCH_SIZE
-    MAX_RETRIES = 5
+    # python-gearman cannot distinguish a connection loss before gearmand
+    # accepted a submission from a loss after acceptance but before the
+    # JOB_CREATED response arrived.  Retrying either case can execute
+    # non-idempotent client scripts twice.
+    MAX_RETRIES = 0
 
     def __init__(self):
         self.client = MCPGearmanClient([settings.GEARMAN_SERVER])

--- a/src/archivematica/archivematicaCommon/gearman.py
+++ b/src/archivematica/archivematicaCommon/gearman.py
@@ -1,0 +1,127 @@
+"""Shared Gearman transport and worker-reconnection behavior.
+
+Gearman keeps its queue in memory.  Reconnecting workers is safe because they
+only advertise abilities and wait for new work.  Replaying producer requests is
+not safe: a connection can disappear after gearmand accepted the request but
+before the client received ``JOB_CREATED``.
+"""
+
+import logging
+import random
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Optional
+from typing import Protocol
+
+import gearman
+from gearman.connection import GearmanConnection as BaseGearmanConnection
+
+
+class ShutdownEvent(Protocol):
+    def is_set(self) -> bool: ...
+
+    def wait(self, timeout: float) -> bool: ...
+
+
+class GearmanConnection(BaseGearmanConnection):
+    """Gearman connection with bounded TCP attempts and liveness detection.
+
+    python-gearman applies these options to every socket that it creates.  With
+    the defaults, a silent peer should generally be detected about 90 seconds
+    after the last packet on platforms supporting the Linux keepalive options.
+    """
+
+    connect_timeout = 5.0
+    keepalive = True
+    keepalive_idle = 60
+    keepalive_interval = 10
+    keepalive_count = 3
+
+
+class GearmanClient(gearman.GearmanClient):
+    """Gearman client using :class:`GearmanConnection` for every socket."""
+
+    connection_class = GearmanConnection
+
+
+@dataclass
+class ExponentialBackoff:
+    """Exponential delay with bounded proportional jitter."""
+
+    initial_delay: float = 1.0
+    maximum_delay: float = 30.0
+    multiplier: float = 2.0
+    jitter: float = 0.2
+    random_uniform: Callable[[float, float], float] = random.uniform
+
+    def __post_init__(self) -> None:
+        self._next_delay = self.initial_delay
+
+    def reset(self) -> None:
+        self._next_delay = self.initial_delay
+
+    def next_delay(self) -> float:
+        base_delay = min(self._next_delay, self.maximum_delay)
+        spread = base_delay * self.jitter
+        delay = self.random_uniform(max(0.0, base_delay - spread), base_delay + spread)
+        self._next_delay = min(self.maximum_delay, self._next_delay * self.multiplier)
+        return min(delay, self.maximum_delay)
+
+
+class GearmanWorker(gearman.GearmanWorker):
+    """Gearman worker that reconnects without exiting its process."""
+
+    connection_class = GearmanConnection
+
+    def work_with_reconnect(
+        self,
+        shutdown_event: ShutdownEvent,
+        logger: logging.Logger,
+        *,
+        poll_timeout: float = 5.0,
+        stable_connection_time: float = 30.0,
+        backoff: Optional[ExponentialBackoff] = None,
+        monotonic: Callable[[], float] = time.monotonic,
+        on_connection_unavailable: Optional[Callable[[], None]] = None,
+    ) -> None:
+        """Work until shutdown, retrying only expected availability failures.
+
+        Ability and client-ID registration remain in python-gearman's handler
+        initial state, so its normal ``establish_connection`` path restores
+        both on each newly resolved connection.
+        """
+        retry_backoff = backoff or ExponentialBackoff()
+        unavailable = False
+
+        while not shutdown_event.is_set():
+            worker_connections = self.establish_worker_connections()
+
+            if worker_connections:
+                connection_started = monotonic()
+                if unavailable:
+                    logger.info(
+                        "Reconnected to Gearman; restoring worker registrations"
+                    )
+                    unavailable = False
+
+                try:
+                    self.work(poll_timeout=poll_timeout)
+                    return
+                except gearman.errors.ServerUnavailable as caught_error:
+                    connection_error = caught_error
+                    if monotonic() - connection_started >= stable_connection_time:
+                        retry_backoff.reset()
+            else:
+                connection_error = gearman.errors.ServerUnavailable(
+                    f"Found no valid connections in list: {self.connection_list!r}"
+                )
+
+            if not unavailable:
+                logger.warning("Gearman connection unavailable: %s", connection_error)
+                unavailable = True
+                if on_connection_unavailable is not None:
+                    on_connection_unavailable()
+
+            if shutdown_event.wait(retry_backoff.next_delay()):
+                return

--- a/src/archivematica/dashboard/contrib/mcp/client.py
+++ b/src/archivematica/dashboard/contrib/mcp/client.py
@@ -20,6 +20,7 @@ import gearman
 from django.conf import settings
 from django.utils.translation import get_language
 
+from archivematica.archivematicaCommon.gearman import GearmanClient as BaseGearmanClient
 from archivematica.archivematicaCommon.gearman_encoder import JSONDataEncoder
 from archivematica.dashboard.main.models import Job
 
@@ -87,7 +88,7 @@ class NoJobFoundError(RPCGearmanClientError):
         super().__init__(message)
 
 
-class GearmanClient(gearman.GearmanClient):
+class GearmanClient(BaseGearmanClient):
     data_encoder = JSONDataEncoder
 
 
@@ -115,14 +116,16 @@ class MCPClient:
         elif "user_id" not in data:
             data["user_id"] = self.user.id
         client = GearmanClient([self.server])
-        response = client.submit_job(
-            ability.encode(),
-            data,
-            background=False,
-            wait_until_complete=True,
-            poll_timeout=timeout,
-        )
-        client.shutdown()
+        try:
+            response = client.submit_job(
+                ability.encode(),
+                data,
+                background=False,
+                wait_until_complete=True,
+                poll_timeout=timeout,
+            )
+        finally:
+            client.shutdown()
         if response.state == gearman.JOB_CREATED:
             raise TimeoutError(timeout)
         elif response.state != gearman.JOB_COMPLETE:
@@ -140,8 +143,10 @@ class MCPClient:
         # Since `execute` is not using `_rpc_sync_call` yet, the user ID needs
         # to be added manually here.
         data["user_id"] = self.user.id
-        gm_client.submit_job(b"approveJob", data)
-        gm_client.shutdown()
+        try:
+            gm_client.submit_job(b"approveJob", data)
+        finally:
+            gm_client.shutdown()
         return
 
     def execute_unit(self, unit_id, choice, mscl_id=None):
@@ -161,10 +166,13 @@ class MCPClient:
 
     def list(self):
         gm_client = GearmanClient([self.server])
-        completed_job_request = gm_client.submit_job(
-            b"getJobsAwaitingApproval",
-            {},
-        )
+        try:
+            completed_job_request = gm_client.submit_job(
+                b"getJobsAwaitingApproval",
+                {},
+            )
+        finally:
+            gm_client.shutdown()
         if completed_job_request.state == gearman.JOB_COMPLETE:
             return completed_job_request.result
         elif completed_job_request.state == gearman.JOB_FAILED:

--- a/tests/MCPClient/test_pool.py
+++ b/tests/MCPClient/test_pool.py
@@ -1,4 +1,5 @@
 from typing import Any
+from unittest import mock
 
 import pytest
 
@@ -69,3 +70,48 @@ def test_worker_pool_uses_forkserver_context_for_shared_primitives(
     assert fake_worker.kwargs["kwargs"] == {
         "shutdown_event": worker_pool.shutdown_event
     }
+
+
+@mock.patch("archivematica.MCPClient.client.pool.MCPGearmanWorker")
+def test_worker_process_reconnects_without_returning_to_pool(gearman_worker):
+    shutdown_event = mock.Mock()
+    log_queue = mock.Mock()
+    metrics_queue = mock.Mock()
+
+    with (
+        mock.patch.object(pool.logging, "getLogger", return_value=mock.Mock()),
+        mock.patch.object(pool.logging.handlers, "QueueHandler"),
+        mock.patch.object(pool.metrics, "configure_event_queue"),
+        mock.patch.object(pool.db.connections, "close_all"),
+        mock.patch.object(pool.settings, "GEARMAN_SERVER", "gearman.service:4730"),
+        mock.patch.object(pool.settings, "MAX_TASKS_PER_CHILD", None),
+    ):
+        pool.run_gearman_worker(
+            log_queue,
+            metrics_queue,
+            ["ability-1"],
+            shutdown_event=shutdown_event,
+        )
+
+    gearman_worker.return_value.work_with_reconnect.assert_called_once_with(
+        shutdown_event, mock.ANY
+    )
+
+
+@mock.patch("archivematica.MCPClient.client.pool.MCPGearmanWorker")
+def test_direct_worker_process_gets_a_local_shutdown_event(gearman_worker):
+    with (
+        mock.patch.object(pool.logging, "getLogger", return_value=mock.Mock()),
+        mock.patch.object(pool.logging.handlers, "QueueHandler"),
+        mock.patch.object(pool.metrics, "configure_event_queue"),
+        mock.patch.object(pool.db.connections, "close_all"),
+        mock.patch.object(pool.settings, "GEARMAN_SERVER", "gearman.service:4730"),
+        mock.patch.object(pool.settings, "MAX_TASKS_PER_CHILD", None),
+    ):
+        pool.run_gearman_worker(mock.Mock(), mock.Mock(), ["ability-1"])
+
+    shutdown_event = gearman_worker.call_args.kwargs["shutdown_event"]
+    assert shutdown_event is not None
+    gearman_worker.return_value.work_with_reconnect.assert_called_once_with(
+        shutdown_event, mock.ANY
+    )

--- a/tests/MCPServer/test_gearman.py
+++ b/tests/MCPServer/test_gearman.py
@@ -1,10 +1,15 @@
 import math
+import threading
 import uuid
 from unittest import mock
 
 import gearman
 import pytest
 from django.utils import timezone
+from gearman.errors import ExceededConnectionAttempts
+from gearman.errors import ServerUnavailable
+from gearman.job import GearmanJob
+from gearman.job import GearmanJobRequest
 
 from archivematica.dashboard.main import models
 from archivematica.MCPServer.server import metrics
@@ -15,9 +20,13 @@ from archivematica.MCPServer.server.tasks import Task
 from archivematica.MCPServer.server.tasks import TaskBackend
 from archivematica.MCPServer.server.tasks.backends import backend_local
 from archivematica.MCPServer.server.tasks.backends import get_task_backend
+from archivematica.MCPServer.server.tasks.backends import invalidate_task_backends
 from archivematica.MCPServer.server.tasks.backends import reset_task_backend
 from archivematica.MCPServer.server.tasks.backends.gearman_backend import (
     GearmanTaskBatch,
+)
+from archivematica.MCPServer.server.tasks.backends.gearman_backend import (
+    MCPGearmanClient,
 )
 
 
@@ -68,6 +77,52 @@ def format_gearman_response(task_results):
         response["task_results"][task_uuid] = task_data
 
     return response
+
+
+def test_ambiguous_pre_acknowledgement_loss_is_not_replayed():
+    client = MCPGearmanClient([])
+    request = GearmanJobRequest(
+        GearmanJob(
+            connection=mock.Mock(),
+            handle=None,
+            task=b"non-idempotent-task",
+            unique=b"unique-task",
+            data={},
+        ),
+        max_attempts=1,
+    )
+    # This is python-gearman's state after it queued one submission and then
+    # lost the connection before receiving JOB_CREATED.
+    request.connection_attempts = 1
+    request.state = gearman.JOB_UNKNOWN
+
+    with pytest.raises(ExceededConnectionAttempts):
+        client.send_job_request(request)
+
+    assert request.connection_attempts == 1
+
+
+def test_post_acknowledgement_loss_is_not_replayed():
+    client = MCPGearmanClient([])
+    request = GearmanJobRequest(
+        GearmanJob(
+            connection=mock.Mock(),
+            handle=b"H:server:1",
+            task=b"non-idempotent-task",
+            unique=b"unique-task",
+            data={},
+        )
+    )
+    request.state = gearman.JOB_CREATED
+    client.poll_connections_until_stopped = mock.Mock(
+        side_effect=ServerUnavailable("connection lost")
+    )
+    client.send_job_request = mock.Mock()
+
+    with pytest.raises(ServerUnavailable):
+        client.wait_until_jobs_completed([request])
+
+    client.send_job_request.assert_not_called()
 
 
 @mock.patch(
@@ -359,6 +414,41 @@ def test_reset_task_backend_replaces_the_thread_local_backend():
     finally:
         if hasattr(backend_local, "task_backend"):
             del backend_local.task_backend
+
+
+def test_invalidation_replaces_backends_owned_by_all_executor_threads():
+    ready = threading.Barrier(3)
+    invalidated = threading.Barrier(3)
+    results = []
+
+    def use_backend_across_invalidation():
+        first = get_task_backend()
+        ready.wait()
+        invalidated.wait()
+        second = get_task_backend()
+        results.append((first, second))
+
+    with mock.patch(
+        "archivematica.MCPServer.server.tasks.backends.GearmanTaskBackend",
+        side_effect=lambda: mock.Mock(spec=TaskBackend),
+    ):
+        threads = [
+            threading.Thread(target=use_backend_across_invalidation) for _ in range(2)
+        ]
+        for thread in threads:
+            thread.start()
+
+        ready.wait()
+        invalidate_task_backends()
+        invalidated.wait()
+
+        for thread in threads:
+            thread.join(timeout=1)
+
+    assert len(results) == 2
+    for first, second in results:
+        assert first is not second
+        first.shutdown.assert_called_once_with()
 
 
 def test_reset_task_backend_forgets_backend_when_shutdown_fails():

--- a/tests/MCPServer/test_rpc_server.py
+++ b/tests/MCPServer/test_rpc_server.py
@@ -17,6 +17,19 @@ from archivematica.MCPServer.server.queues import PackageQueue
 TASK_PRODUCING_LINK_ID = "002716a1-ae29-4f36-98ab-0d97192669c4"
 
 
+@mock.patch("archivematica.MCPServer.server.rpc_server.RPCServer")
+def test_start_runs_rpc_worker_with_in_process_reconnection(rpc_server_class, wf):
+    shutdown_event = threading.Event()
+
+    rpc_server.start(wf, shutdown_event, mock.Mock(), mock.Mock())
+
+    rpc_server_class.return_value.work_with_reconnect.assert_called_once_with(
+        shutdown_event,
+        rpc_server.logger,
+        on_connection_unavailable=rpc_server.invalidate_task_backends,
+    )
+
+
 def test_datetime_to_unix_timestamp_preserves_utc_microseconds():
     value = datetime(
         2026,

--- a/tests/archivematicaCommon/test_gearman_common.py
+++ b/tests/archivematicaCommon/test_gearman_common.py
@@ -1,0 +1,285 @@
+import logging
+import select
+import socket
+import threading
+from unittest import mock
+
+import gearman
+import pytest
+from gearman.protocol import GEARMAN_COMMAND_CAN_DO
+from gearman.protocol import GEARMAN_COMMAND_PRE_SLEEP
+from gearman.protocol import GEARMAN_COMMAND_RESET_ABILITIES
+from gearman.protocol import GEARMAN_COMMAND_SET_CLIENT_ID
+
+from archivematica.archivematicaCommon.gearman import ExponentialBackoff
+from archivematica.archivematicaCommon.gearman import GearmanConnection
+from archivematica.archivematicaCommon.gearman import GearmanWorker
+
+
+class FakeSocket:
+    def __init__(self) -> None:
+        self.options = []
+        self.timeouts = []
+        self.closed = False
+
+    def setsockopt(self, level, option, value) -> None:
+        self.options.append((level, option, value))
+
+    def settimeout(self, timeout) -> None:
+        self.timeouts.append(timeout)
+
+    def setblocking(self, blocking) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_connection_uses_hostname_and_configures_each_new_socket(monkeypatch):
+    first_socket = FakeSocket()
+    second_socket = FakeSocket()
+    create_connection = mock.Mock(side_effect=(first_socket, second_socket))
+    monkeypatch.setattr(socket, "create_connection", create_connection)
+
+    connection = GearmanConnection("gearman.service", 4730)
+    connection.connect()
+    connection.close()
+    connection.connect()
+
+    assert create_connection.call_args_list == [
+        mock.call(
+            ("gearman.service", 4730),
+            timeout=GearmanConnection.connect_timeout,
+        ),
+        mock.call(
+            ("gearman.service", 4730),
+            timeout=GearmanConnection.connect_timeout,
+        ),
+    ]
+
+    for created_socket in (first_socket, second_socket):
+        assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in created_socket.options
+        if hasattr(socket, "TCP_KEEPIDLE"):
+            assert (
+                socket.IPPROTO_TCP,
+                socket.TCP_KEEPIDLE,
+                GearmanConnection.keepalive_idle,
+            ) in created_socket.options
+        if hasattr(socket, "TCP_KEEPINTVL"):
+            assert (
+                socket.IPPROTO_TCP,
+                socket.TCP_KEEPINTVL,
+                GearmanConnection.keepalive_interval,
+            ) in created_socket.options
+        if hasattr(socket, "TCP_KEEPCNT"):
+            assert (
+                socket.IPPROTO_TCP,
+                socket.TCP_KEEPCNT,
+                GearmanConnection.keepalive_count,
+            ) in created_socket.options
+        assert created_socket.timeouts == [0.0]
+
+
+def test_connection_detects_clean_tcp_close():
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        listener.bind(("127.0.0.1", 0))
+    except PermissionError:
+        listener.close()
+        pytest.skip("local TCP listeners are unavailable in this sandbox")
+    listener.listen()
+
+    def accept_and_close() -> None:
+        accepted_socket, _ = listener.accept()
+        accepted_socket.close()
+
+    server_thread = threading.Thread(target=accept_and_close)
+    server_thread.start()
+    connection = GearmanConnection(*listener.getsockname())
+
+    try:
+        connection.connect()
+        server_thread.join(timeout=1)
+        readable, _, _ = select.select([connection.gearman_socket], [], [], 1)
+
+        assert readable == [connection.gearman_socket]
+        with pytest.raises(gearman.errors.ConnectionError, match="remote disconnected"):
+            connection.read_data_from_socket()
+    finally:
+        connection.close()
+        listener.close()
+
+
+def test_exponential_backoff_applies_jitter_cap_and_reset():
+    backoff = ExponentialBackoff(
+        initial_delay=1,
+        maximum_delay=5,
+        multiplier=2,
+        jitter=0.2,
+        random_uniform=lambda low, high: high,
+    )
+
+    assert [backoff.next_delay() for _ in range(5)] == [1.2, 2.4, 4.8, 5, 5]
+
+    backoff.reset()
+
+    assert backoff.next_delay() == 1.2
+
+
+class FakeReconnectingWorker(GearmanWorker):
+    def __init__(self, connection_results, work_results=()) -> None:
+        self.connection_list = ["gearman.service:4730"]
+        self.connection_results = iter(connection_results)
+        self.work_results = iter(work_results)
+        self.poll_timeouts = []
+
+    def establish_worker_connections(self):
+        result = next(self.connection_results)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    def work(self, poll_timeout=60.0):
+        self.poll_timeouts.append(poll_timeout)
+        result = next(self.work_results, None)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+class RecordingEvent:
+    def __init__(self, stop_after_waits=None) -> None:
+        self.waits = []
+        self.stop_after_waits = stop_after_waits
+
+    def is_set(self) -> bool:
+        return False
+
+    def wait(self, timeout) -> bool:
+        self.waits.append(timeout)
+        return self.stop_after_waits == len(self.waits)
+
+
+def test_worker_recovers_without_repeated_outage_logs(caplog):
+    worker = FakeReconnectingWorker(([], [], [object()]))
+    event = RecordingEvent()
+    backoff = ExponentialBackoff(jitter=0)
+    unavailable = mock.Mock()
+
+    with caplog.at_level(logging.INFO):
+        worker.work_with_reconnect(
+            event,
+            logging.getLogger("test"),
+            backoff=backoff,
+            on_connection_unavailable=unavailable,
+        )
+
+    assert event.waits == [1.0, 2.0]
+    assert worker.poll_timeouts == [5.0]
+    outage_records = [
+        record
+        for record in caplog.records
+        if "connection unavailable" in record.message
+    ]
+    assert len(outage_records) == 1
+    unavailable.assert_called_once_with()
+    assert any("Reconnected to Gearman" in record.message for record in caplog.records)
+
+
+def test_worker_reconnects_after_established_connection_closes(caplog):
+    worker = FakeReconnectingWorker(
+        ([object()], [object()]),
+        (gearman.errors.ServerUnavailable("connection lost"), None),
+    )
+    event = RecordingEvent()
+
+    with caplog.at_level(logging.INFO):
+        worker.work_with_reconnect(
+            event,
+            logging.getLogger("test"),
+            backoff=ExponentialBackoff(jitter=0),
+        )
+
+    assert event.waits == [1.0]
+    assert worker.poll_timeouts == [5.0, 5.0]
+    assert (
+        sum("connection unavailable" in record.message for record in caplog.records)
+        == 1
+    )
+    assert any("Reconnected to Gearman" in record.message for record in caplog.records)
+
+
+def test_worker_backoff_is_interrupted_by_shutdown():
+    worker = FakeReconnectingWorker(([],))
+    event = RecordingEvent(stop_after_waits=1)
+
+    worker.work_with_reconnect(
+        event,
+        logging.getLogger("test"),
+        backoff=ExponentialBackoff(jitter=0),
+    )
+
+    assert event.waits == [1.0]
+
+
+def test_worker_resets_backoff_after_stable_connection():
+    worker = FakeReconnectingWorker(
+        ([object()],),
+        (gearman.errors.ServerUnavailable("connection lost"),),
+    )
+    event = RecordingEvent(stop_after_waits=1)
+    backoff = ExponentialBackoff(jitter=0)
+    backoff.next_delay()
+    backoff.next_delay()
+    monotonic = mock.Mock(side_effect=(0.0, 31.0))
+
+    worker.work_with_reconnect(
+        event,
+        logging.getLogger("test"),
+        backoff=backoff,
+        monotonic=monotonic,
+    )
+
+    assert event.waits == [1.0]
+
+
+def test_worker_does_not_contain_programming_errors():
+    worker = FakeReconnectingWorker((ValueError("broken worker"),))
+
+    with pytest.raises(ValueError, match="broken worker"):
+        worker.work_with_reconnect(threading.Event(), logging.getLogger("test"))
+
+
+def test_worker_does_not_contain_programming_errors_from_work_loop():
+    worker = FakeReconnectingWorker(([object()],), (ValueError("broken job"),))
+
+    with pytest.raises(ValueError, match="broken job"):
+        worker.work_with_reconnect(threading.Event(), logging.getLogger("test"))
+
+
+def test_worker_reregisters_id_and_all_abilities_on_new_connection():
+    worker = GearmanWorker([])
+    worker.set_client_id(b"worker-1")
+    worker.register_task(b"ability-1", mock.Mock())
+    worker.register_task(b"ability-2", mock.Mock())
+    connection = mock.Mock()
+    connection.connected = False
+    connection.connect.side_effect = lambda: setattr(connection, "connected", True)
+    connection.close.side_effect = lambda: setattr(connection, "connected", False)
+    worker.connection_list = [connection]
+
+    worker.establish_connection(connection)
+    first_registration = list(connection.send_command.call_args_list)
+    worker.handle_error(connection)
+    connection.send_command.reset_mock()
+    worker.establish_connection(connection)
+
+    expected_registration = [
+        mock.call(GEARMAN_COMMAND_SET_CLIENT_ID, {"client_id": b"worker-1"}),
+        mock.call(GEARMAN_COMMAND_RESET_ABILITIES, {}),
+        mock.call(GEARMAN_COMMAND_CAN_DO, {"task": b"ability-1"}),
+        mock.call(GEARMAN_COMMAND_CAN_DO, {"task": b"ability-2"}),
+        mock.call(GEARMAN_COMMAND_PRE_SLEEP, {}),
+    ]
+    assert first_registration == expected_registration
+    assert connection.send_command.call_args_list == expected_registration

--- a/tests/dashboard/test_mcp_client.py
+++ b/tests/dashboard/test_mcp_client.py
@@ -1,0 +1,26 @@
+from unittest import mock
+
+import pytest
+
+from archivematica.dashboard.contrib.mcp import client
+
+
+@pytest.mark.parametrize("method_name", ("_rpc_sync_call", "execute", "list"))
+@mock.patch("archivematica.dashboard.contrib.mcp.client.GearmanClient")
+def test_rpc_client_closes_connection_when_submission_fails(
+    gearman_client, method_name
+):
+    gearman_client.return_value.submit_job.side_effect = RuntimeError(
+        "Gearman connection lost"
+    )
+    mcp_client = client.MCPClient(mock.Mock(id=1))
+
+    with pytest.raises(RuntimeError, match="connection lost"):
+        if method_name == "_rpc_sync_call":
+            mcp_client._rpc_sync_call("getUnitsStatuses")
+        elif method_name == "execute":
+            mcp_client.execute("job-uuid", "approve")
+        else:
+            mcp_client.list()
+
+    gearman_client.return_value.shutdown.assert_called_once_with()

--- a/uv.lock
+++ b/uv.lock
@@ -123,7 +123,7 @@ requires-dist = [
     { name = "django-stubs-ext" },
     { name = "django-tastypie" },
     { name = "elasticsearch", specifier = ">=8.0.0,<9.0.0" },
-    { name = "gearman3", git = "https://github.com/artefactual-labs/python-gearman.git?rev=b68efc868c7a494dd6a2d2e820fb098a6da9f797" },
+    { name = "gearman3", git = "https://github.com/artefactual-labs/python-gearman.git?rev=f216d89faead4ff5f7f1d51bf767881b2a30bb47" },
     { name = "gevent" },
     { name = "gunicorn" },
     { name = "inotify-simple" },
@@ -1064,7 +1064,7 @@ wheels = [
 [[package]]
 name = "gearman3"
 version = "0.2.1"
-source = { git = "https://github.com/artefactual-labs/python-gearman.git?rev=b68efc868c7a494dd6a2d2e820fb098a6da9f797#b68efc868c7a494dd6a2d2e820fb098a6da9f797" }
+source = { git = "https://github.com/artefactual-labs/python-gearman.git?rev=f216d89faead4ff5f7f1d51bf767881b2a30bb47#f216d89faead4ff5f7f1d51bf767881b2a30bb47" }
 
 [[package]]
 name = "gevent"


### PR DESCRIPTION
Archivematica now upgrades python-gearman to [f216d89], which adds bounded connection attempts, hostname re-resolution, and TCP keepalive. The previous client could leave idle connections unaware of some Gearman replacements.

Gearman replacements also left MCP workers and task producers holding stale connections. Workers now reconnect in process with bounded jittered backoff, and MCPServer executor threads invalidate their cached producers after an outage. Dashboard clients consistently close their connections.

Ambiguous task submissions now fail visibly instead of being replayed. Later work establishes fresh connections and resumes after Gearman returns.

[f216d89]: https://github.com/artefactual-labs/python-gearman/commit/f216d89faead4ff5f7f1d51bf767881b2a30bb47