### PR TITLE
Measure and shorten MCPClient transactions

### DIFF
--- a/src/archivematica/MCPClient/client/metrics.py
+++ b/src/archivematica/MCPClient/client/metrics.py
@@ -16,6 +16,7 @@ import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any
 from typing import Callable
 from typing import NamedTuple
@@ -82,6 +83,9 @@ class MetricEvent(NamedTuple):
 REGISTRY = CollectorRegistry()
 _EVENT_QUEUE: Optional[MetricQueue] = None
 _EVENT_QUEUE_LOCK = threading.RLock()
+_CURRENT_SCRIPT_NAME: ContextVar[Optional[str]] = ContextVar(
+    "mcpclient_script_name", default=None
+)
 _GAUGE_MAX_VALUES: dict[tuple[str, tuple[tuple[str, str], ...]], float] = {}
 _GAUGE_MAX_VALUES_LOCK = threading.RLock()
 _QUEUE_WRITE_FAILURE_LOGGED = False
@@ -118,6 +122,32 @@ task_execution_time_histogram = Histogram(
     "Histogram of worker task execution times in seconds, labeled by script",
     ["script_name"],
     buckets=TASK_DURATION_BUCKETS,
+    registry=REGISTRY,
+)
+database_transaction_duration_histogram = Histogram(
+    "mcpclient_database_transaction_duration_seconds",
+    "Duration of outer database transactions, labeled by client script",
+    ["script_name"],
+    buckets=(
+        0.01,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        1.0,
+        2.5,
+        5.0,
+        10.0,
+        30.0,
+        60.0,
+        300.0,
+        900.0,
+        3600.0,
+        7200.0,
+        14400.0,
+        28800.0,
+        float("inf"),
+    ),
     registry=REGISTRY,
 )
 
@@ -305,6 +335,9 @@ _COLLECTORS = {
     "job_error_counter": job_error_counter,
     "job_error_timestamp": job_error_timestamp,
     "task_execution_time_histogram": task_execution_time_histogram,
+    "database_transaction_duration_histogram": (
+        database_transaction_duration_histogram
+    ),
     "transfer_started_counter": transfer_started_counter,
     "transfer_started_timestamp": transfer_started_timestamp,
     "transfer_completed_counter": transfer_completed_counter,
@@ -360,6 +393,15 @@ def configure_event_queue(event_queue: Optional[MetricQueue]) -> None:
     global _EVENT_QUEUE
     with _EVENT_QUEUE_LOCK:
         _EVENT_QUEUE = event_queue
+
+
+@contextmanager
+def client_script_context(script_name: str) -> Iterator[None]:
+    token = _CURRENT_SCRIPT_NAME.set(script_name)
+    try:
+        yield
+    finally:
+        _CURRENT_SCRIPT_NAME.reset(token)
 
 
 def apply_event(event: MetricEvent) -> None:
@@ -576,6 +618,7 @@ def init_counter_labels() -> None:
     modules_config.read(settings.CLIENT_MODULES_FILE)
     for script_name, _ in modules_config.items("supportedBatchCommands"):
         task_execution_time_histogram.labels(script_name=script_name)
+        database_transaction_duration_histogram.labels(script_name=script_name)
         job_counter.labels(script_name=script_name)
         job_processed_timestamp.labels(script_name=script_name)
         job_error_counter.labels(script_name=script_name)
@@ -634,6 +677,18 @@ def job_failed(script_name: str) -> None:
     _inc("job_counter", labels)
     _inc("job_error_counter", labels)
     _set_to_current_time("job_error_timestamp", labels)
+
+
+@skip_if_prometheus_disabled
+def database_transaction_observed(duration: float) -> None:
+    script_name = _CURRENT_SCRIPT_NAME.get()
+    if script_name is None:
+        return
+    _observe(
+        "database_transaction_duration_histogram",
+        {"script_name": script_name},
+        duration,
+    )
 
 
 def _get_file_group(raw_file_group_use: str) -> str:

--- a/src/archivematica/MCPClient/client/transactions.py
+++ b/src/archivematica/MCPClient/client/transactions.py
@@ -1,0 +1,29 @@
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Optional
+
+from django.db import transaction
+
+from archivematica.MCPClient.client import metrics
+
+
+@contextmanager
+def atomic(
+    using: Optional[str] = None,
+    savepoint: bool = True,
+    durable: bool = False,
+) -> Iterator[None]:
+    """Open an atomic block and measure outer transaction duration."""
+    connection = transaction.get_connection(using)
+    is_outermost = not connection.in_atomic_block
+    entered = False
+    started_at = time.monotonic() if is_outermost else None
+
+    try:
+        with transaction.atomic(using=using, savepoint=savepoint, durable=durable):
+            entered = True
+            yield
+    finally:
+        if started_at is not None and entered:
+            metrics.database_transaction_observed(time.monotonic() - started_at)

--- a/src/archivematica/MCPClient/client/worker.py
+++ b/src/archivematica/MCPClient/client/worker.py
@@ -19,7 +19,8 @@ def run_task(task_name: str, job_module: ModuleType | None, jobs: list[Job]) -> 
             raise RuntimeError(
                 f"Cannot process task '{task_name}': no job module is registered for this task."
             )
-        job_module.call(jobs)
+        with metrics.client_script_context(task_name):
+            job_module.call(jobs)
     except Exception as err:
         logger.exception("*** TASK FAILED: %s***", task_name)
         Job.bulk_mark_failed(jobs, str(err))

--- a/src/archivematica/MCPClient/clientScripts/antivirus.py
+++ b/src/archivematica/MCPClient/clientScripts/antivirus.py
@@ -36,6 +36,7 @@ from archivematica.archivematicaCommon.databaseFunctions import EventInput
 from archivematica.archivematicaCommon.databaseFunctions import insert_events
 from archivematica.dashboard.main.models import Event
 from archivematica.dashboard.main.models import File
+from archivematica.MCPClient.client import transactions
 from archivematica.MCPClient.client.job import Job
 
 logger = get_script_logger("archivematica.mcp.client.clamscan")
@@ -292,4 +293,5 @@ def call(jobs: list[Job]) -> None:
                 )
             )
 
-    insert_events(event_queue)
+    with transactions.atomic():
+        insert_events(event_queue)

--- a/src/archivematica/MCPClient/clientScripts/assign_file_uuids.py
+++ b/src/archivematica/MCPClient/clientScripts/assign_file_uuids.py
@@ -33,7 +33,8 @@ import os
 import uuid
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -210,7 +211,7 @@ def assign_uuids_to_files_in_dir(**kwargs):
     transfer_uuid = kwargs["transfer_uuid"]
     for root, _, filenames in os.walk(target_dir):
         for file_chunk in chunk_iterable(filenames):
-            with transaction.atomic():
+            with transactions.atomic():
                 for filename in file_chunk:
                     if not filename:
                         continue

--- a/src/archivematica/MCPClient/clientScripts/assign_uuids_to_directories.py
+++ b/src/archivematica/MCPClient/clientScripts/assign_uuids_to_directories.py
@@ -36,7 +36,6 @@ import django
 django.setup()
 
 from django.core.exceptions import ValidationError
-from django.db import transaction
 
 from archivematica.archivematicaCommon.archivematicaFunctions import format_subdir_path
 from archivematica.archivematicaCommon.archivematicaFunctions import get_dir_uuids
@@ -44,6 +43,7 @@ from archivematica.archivematicaCommon.archivematicaFunctions import str2bool
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 from archivematica.dashboard.main.models import Directory
 from archivematica.dashboard.main.models import Transfer
+from archivematica.MCPClient.client import transactions
 
 logger = get_script_logger("archivematica.mcp.client.assignUUIDsToDirectories")
 
@@ -143,7 +143,7 @@ def call(jobs):
         default="No",
     )
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/bind_pid.py
+++ b/src/archivematica/MCPClient/clientScripts/bind_pid.py
@@ -43,7 +43,8 @@ import argparse
 from functools import wraps
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -138,7 +139,7 @@ def call(jobs):
         "file_uuid", type=str, help="The UUID of the file to bind a PID for."
     )
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/bind_pids.py
+++ b/src/archivematica/MCPClient/clientScripts/bind_pids.py
@@ -48,7 +48,6 @@ import django
 
 django.setup()
 from django.core.exceptions import ValidationError
-from django.db import transaction
 from lxml import etree
 
 from archivematica.archivematicaCommon import namespaces as ns
@@ -63,6 +62,7 @@ from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 from archivematica.dashboard.main.models import SIP
 from archivematica.dashboard.main.models import DashboardSetting
 from archivematica.dashboard.main.models import Directory
+from archivematica.MCPClient.client import transactions
 
 logger = get_script_logger("archivematica.mcp.client.bind_pids")
 
@@ -235,7 +235,7 @@ def call(jobs):
         "shared_path", type=str, help="The shared directory where SIPs are stored."
     )
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/change_object_names.py
+++ b/src/archivematica/MCPClient/clientScripts/change_object_names.py
@@ -22,8 +22,6 @@ import uuid
 import django
 
 django.setup()
-from django.db import transaction
-
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 from archivematica.archivematicaCommon.version import get_full_version
 from archivematica.dashboard.main.models import SIP
@@ -31,6 +29,7 @@ from archivematica.dashboard.main.models import Directory
 from archivematica.dashboard.main.models import Event
 from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import Transfer
+from archivematica.MCPClient.client import transactions
 from archivematica.MCPClient.clientScripts import change_names
 
 logger = get_script_logger("archivematica.mcp.client.changeObjectNames")
@@ -259,7 +258,7 @@ class NameChanger:
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 # job.args[4] (taskUUID) is unused.

--- a/src/archivematica/MCPClient/clientScripts/change_sip_name.py
+++ b/src/archivematica/MCPClient/clientScripts/change_sip_name.py
@@ -21,15 +21,14 @@ import sys
 import django
 
 django.setup()
-from django.db import transaction
-
 from archivematica.dashboard.main.models import SIP
 from archivematica.dashboard.main.models import Transfer
+from archivematica.MCPClient.client import transactions
 from archivematica.MCPClient.clientScripts.change_names import change_path
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 # job.args[3] (date) is unused.

--- a/src/archivematica/MCPClient/clientScripts/characterize_file.py
+++ b/src/archivematica/MCPClient/clientScripts/characterize_file.py
@@ -17,6 +17,7 @@ django.setup()
 
 from django.conf import settings as mcpclient_settings
 from django.core.exceptions import ValidationError
+from django.db import close_old_connections
 from lxml import etree
 
 from archivematica.archivematicaCommon.databaseFunctions import (
@@ -28,7 +29,6 @@ from archivematica.archivematicaCommon.executeOrRunSubProcess import executeOrRu
 from archivematica.dashboard.fpr.models import FormatVersion
 from archivematica.dashboard.fpr.models import FPRule
 from archivematica.dashboard.main.models import FPCommandOutput
-from archivematica.MCPClient.client import transactions
 from archivematica.MCPClient.client.job import Job
 from archivematica.MCPClient.clientScripts.lib import setup_dicts
 
@@ -80,12 +80,15 @@ def main(job: Job, file_uuid: uuid.UUID, sip_uuid: uuid.UUID) -> int:
             args = rd.to_gnu_options()
             command_to_execute = rule.command.command
 
-        exitstatus, stdout, stderr = executeOrRun(
-            rule.command.script_type,
-            command_to_execute,
-            arguments=args,
-            capture_output=True,
-        )
+        try:
+            exitstatus, stdout, stderr = executeOrRun(
+                rule.command.script_type,
+                command_to_execute,
+                arguments=args,
+                capture_output=True,
+            )
+        finally:
+            close_old_connections()
 
         job.write_output(stdout)
         job.write_error(stderr)
@@ -144,8 +147,7 @@ def parse_args(parser: argparse.ArgumentParser, job: Job) -> CharacterizeFileArg
 def call(jobs: list[Job]) -> None:
     parser = get_parser()
 
-    with transactions.atomic():
-        for job in jobs:
-            with job.JobContext():
-                args = parse_args(parser, job)
-                job.set_status(main(job, args.file_uuid, args.sip_uuid))
+    for job in jobs:
+        with job.JobContext():
+            args = parse_args(parser, job)
+            job.set_status(main(job, args.file_uuid, args.sip_uuid))

--- a/src/archivematica/MCPClient/clientScripts/characterize_file.py
+++ b/src/archivematica/MCPClient/clientScripts/characterize_file.py
@@ -17,7 +17,6 @@ django.setup()
 
 from django.conf import settings as mcpclient_settings
 from django.core.exceptions import ValidationError
-from django.db import transaction
 from lxml import etree
 
 from archivematica.archivematicaCommon.databaseFunctions import (
@@ -29,6 +28,7 @@ from archivematica.archivematicaCommon.executeOrRunSubProcess import executeOrRu
 from archivematica.dashboard.fpr.models import FormatVersion
 from archivematica.dashboard.fpr.models import FPRule
 from archivematica.dashboard.main.models import FPCommandOutput
+from archivematica.MCPClient.client import transactions
 from archivematica.MCPClient.client.job import Job
 from archivematica.MCPClient.clientScripts.lib import setup_dicts
 
@@ -144,7 +144,7 @@ def parse_args(parser: argparse.ArgumentParser, job: Job) -> CharacterizeFileArg
 def call(jobs: list[Job]) -> None:
     parser = get_parser()
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 args = parse_args(parser, job)

--- a/src/archivematica/MCPClient/clientScripts/check_for_access_directory.py
+++ b/src/archivematica/MCPClient/clientScripts/check_for_access_directory.py
@@ -20,7 +20,8 @@ import sys
 from optparse import OptionParser
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -140,7 +141,7 @@ def call(jobs):
     parser.add_option("-t", "--date", action="store", dest="date", default="")
     parser.add_option("-c", "--copy", dest="copy", action="store_true")
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 (opts, args) = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/check_for_service_directory.py
+++ b/src/archivematica/MCPClient/clientScripts/check_for_service_directory.py
@@ -20,7 +20,8 @@ import re
 from optparse import OptionParser
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -122,7 +123,7 @@ def call(jobs):
     )
     parser.add_option("-t", "--date", action="store", dest="date", default="")
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 (opts, args) = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/compress_aip.py
+++ b/src/archivematica/MCPClient/clientScripts/compress_aip.py
@@ -5,7 +5,8 @@ import sys
 
 import django
 from django.db import close_old_connections
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -156,7 +157,7 @@ def call(jobs):
     # compression processes.
     close_old_connections()
 
-    with transaction.atomic():
+    with transactions.atomic():
         for result in state:
             update_unit(result["sip_uuid"], result["location"])
             if "file" in result:

--- a/src/archivematica/MCPClient/clientScripts/create_aic_mets.py
+++ b/src/archivematica/MCPClient/clientScripts/create_aic_mets.py
@@ -6,9 +6,10 @@ import uuid
 from datetime import datetime
 
 import django
-from django.db import transaction
 from lxml import etree
 from lxml.builder import ElementMaker
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -165,7 +166,7 @@ def call(jobs):
     parser.add_argument("aic_uuid", action="store", type=str, help="%%SIPUUID%%")
     parser.add_argument("aic_dir", action="store", type=str, help="%%SIPDirectory%%")
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/create_sip_from_transfer_objects.py
+++ b/src/archivematica/MCPClient/clientScripts/create_sip_from_transfer_objects.py
@@ -25,7 +25,6 @@ import django
 django.setup()
 
 from django.core.exceptions import ValidationError
-from django.db import transaction
 
 from archivematica.archivematicaCommon import archivematicaFunctions
 from archivematica.dashboard.main.models import SIP
@@ -34,10 +33,11 @@ from archivematica.dashboard.main.models import Directory
 from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import Transfer
 from archivematica.dashboard.main.models import UnitVariable
+from archivematica.MCPClient.client import transactions
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 objectsDirectory = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/create_sips_from_trim_transfer_containers.py
+++ b/src/archivematica/MCPClient/clientScripts/create_sips_from_trim_transfer_containers.py
@@ -21,7 +21,8 @@ import sys
 import uuid
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -31,7 +32,7 @@ from archivematica.dashboard.main.models import File
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 objectsDirectory = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/dip_generation_helper.py
+++ b/src/archivematica/MCPClient/clientScripts/dip_generation_helper.py
@@ -12,7 +12,7 @@ from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 from archivematica.dashboard.main import models
 
 django.setup()
-from django.db import transaction
+from archivematica.MCPClient.client import transactions
 
 logger = get_script_logger("archivematica.mcp.client.moveTransfer")
 
@@ -136,7 +136,7 @@ def call(jobs):
     parser.add_argument("--sipUUID", required=True, help="%%SIPUUID%%")
     parser.add_argument("--sipPath", required=True, help="%%SIPDirectory%%")
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/email_fail_report.py
+++ b/src/archivematica/MCPClient/clientScripts/email_fail_report.py
@@ -22,13 +22,13 @@ from django.conf import settings as mcpclient_settings
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
 from django.db import connection
-from django.db import transaction
 from lxml import etree
 
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 from archivematica.archivematicaCommon.externals.HTML import HTML
 from archivematica.dashboard.main.models import Job
 from archivematica.dashboard.main.models import Report
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -250,7 +250,7 @@ def call(jobs):
                 job.set_status(1)
 
     # Generate report in plain text and store it in the database
-    with transaction.atomic():
+    with transactions.atomic():
         for args in reports_to_store:
             content = get_content_for(
                 args.unit_type, args.unit_name, args.unit_uuid, html=False

--- a/src/archivematica/MCPClient/clientScripts/extract_contents.py
+++ b/src/archivematica/MCPClient/clientScripts/extract_contents.py
@@ -4,7 +4,8 @@ import sys
 import uuid
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -271,7 +272,7 @@ def create_extracted_dir_uuids(
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 transfer_uuid = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/extract_maildir_attachments.py
+++ b/src/archivematica/MCPClient/clientScripts/extract_maildir_attachments.py
@@ -26,12 +26,12 @@ from lxml import etree
 
 django.setup()
 from django.core.exceptions import ValidationError
-from django.db import transaction
 
 from archivematica.archivematicaCommon.externals.extractMaildirAttachments import parse
 from archivematica.archivematicaCommon.fileOperations import addFileToTransfer
 from archivematica.archivematicaCommon.fileOperations import updateSizeAndChecksum
 from archivematica.dashboard.main.models import File
+from archivematica.MCPClient.client import transactions
 
 
 class State:
@@ -267,7 +267,7 @@ def handle_job(job):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 handle_job(job)

--- a/src/archivematica/MCPClient/clientScripts/extract_zipped_transfer.py
+++ b/src/archivematica/MCPClient/clientScripts/extract_zipped_transfer.py
@@ -23,11 +23,10 @@ import sys
 import django
 
 django.setup()
-from django.db import transaction
-
 from archivematica.archivematicaCommon.executeOrRunSubProcess import executeOrRun
 from archivematica.archivematicaCommon.fileOperations import get_extract_dir_name
 from archivematica.dashboard.main.models import Transfer
+from archivematica.MCPClient.client import transactions
 
 
 def extract(job, target, destinationDirectory):
@@ -69,7 +68,7 @@ def call(jobs):
     parser.add_argument("shared_path", type=str)
     parser.add_argument("--bag", action="store_true")
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/failed_sip_cleanup.py
+++ b/src/archivematica/MCPClient/clientScripts/failed_sip_cleanup.py
@@ -2,7 +2,8 @@
 import argparse
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -30,7 +31,7 @@ def call(jobs):
     parser.add_argument("fail_type", help=f'"{REJECTED}" or "{FAILED}"')
     parser.add_argument("sip_uuid", help="%%SIPUUID%%")
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/failed_transfer_cleanup.py
+++ b/src/archivematica/MCPClient/clientScripts/failed_transfer_cleanup.py
@@ -20,12 +20,11 @@ import django
 
 django.setup()
 
-from django.db import transaction
-
 import archivematica.archivematicaCommon.storageService as storage_service
 from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import Transfer
 from archivematica.MCPClient.client import metrics
+from archivematica.MCPClient.client import transactions
 from archivematica.MCPClient.client.job import Job
 
 REJECTED = "reject"
@@ -92,7 +91,7 @@ def call(jobs: Sequence[Job]) -> None:
     parser.add_argument("transfer_path", help="%%SIPDirectory%%")
     parser.add_argument("--allow-missing-path", action="store_true")
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/file_to_folder.py
+++ b/src/archivematica/MCPClient/clientScripts/file_to_folder.py
@@ -5,9 +5,8 @@ import sys
 import django
 
 django.setup()
-from django.db import transaction
-
 from archivematica.dashboard.main.models import Transfer
+from archivematica.MCPClient.client import transactions
 
 
 def main(job, transfer_path, transfer_uuid, shared_path):
@@ -53,7 +52,7 @@ def main(job, transfer_path, transfer_uuid, shared_path):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 transfer_path = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/identify_dspace_files.py
+++ b/src/archivematica/MCPClient/clientScripts/identify_dspace_files.py
@@ -18,10 +18,10 @@
 import os
 
 import django
-from django.db import transaction
 from lxml import etree
 
 from archivematica.archivematicaCommon import namespaces
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -63,7 +63,7 @@ def identify_dspace_files(
 
 
 def call(jobs: list[Job]) -> None:
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 mets_file = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/identify_dspace_mets_files.py
+++ b/src/archivematica/MCPClient/clientScripts/identify_dspace_mets_files.py
@@ -19,13 +19,12 @@ import django
 
 django.setup()
 
-from django.db import transaction
-
 from archivematica.dashboard.main.models import File
+from archivematica.MCPClient.client import transactions
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 metsFileUUID = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/identify_file_format.py
+++ b/src/archivematica/MCPClient/clientScripts/identify_file_format.py
@@ -10,6 +10,7 @@ import django
 
 django.setup()
 
+from django.db import close_old_connections
 from django.utils import timezone
 
 from archivematica.archivematicaCommon.databaseFunctions import insertIntoEvents
@@ -175,13 +176,16 @@ def main(
     # chain.
     _save_id_preference(file_, enabled_bool)
 
-    exitcode, output, err = executeOrRun(
-        command.script_type,
-        command.script,
-        arguments=[file_path],
-        printing=False,
-        capture_output=True,
-    )
+    try:
+        exitcode, output, err = executeOrRun(
+            command.script_type,
+            command.script,
+            arguments=[file_path],
+            printing=False,
+            capture_output=True,
+        )
+    finally:
+        close_old_connections()
     output = output.strip()
 
     if exitcode != 0:
@@ -190,41 +194,43 @@ def main(
         return ERROR
 
     job.print_output("Command output:", output)
-    # PUIDs are the same regardless of tool, so PUID-producing tools don't have "rules" per se - we just
-    # go straight to the FormatVersion table to see if there's a matching PUID
-    try:
-        if command.config == "PUID":
-            format_version = FormatVersion.active.get(pronom_id=output)
-        else:
-            rule = IDRule.active.get(command_output=output, command=command)
-            format_version = rule.format
-    except IDRule.DoesNotExist:
-        job.print_error(
-            f'Error: No FPR identification rule for tool output "{output}" found'
-        )
-        write_identification_event(file_uuid, command, success=False)
-        return ERROR
-    except IDRule.MultipleObjectsReturned:
-        job.print_error(
-            f'Error: Multiple FPR identification rules for tool output "{output}" found'
-        )
-        write_identification_event(file_uuid, command, success=False)
-        return ERROR
-    except FormatVersion.DoesNotExist:
-        job.print_error(f"Error: No FPR format record found for PUID {output}")
-        write_identification_event(file_uuid, command, success=False)
-        return ERROR
+    with transactions.atomic():
+        # PUIDs are the same regardless of tool, so PUID-producing tools don't
+        # have "rules" per se - we go straight to the FormatVersion table to
+        # see if there's a matching PUID.
+        try:
+            if command.config == "PUID":
+                format_version = FormatVersion.active.get(pronom_id=output)
+            else:
+                rule = IDRule.active.get(command_output=output, command=command)
+                format_version = rule.format
+        except IDRule.DoesNotExist:
+            job.print_error(
+                f'Error: No FPR identification rule for tool output "{output}" found'
+            )
+            write_identification_event(file_uuid, command, success=False)
+            return ERROR
+        except IDRule.MultipleObjectsReturned:
+            job.print_error(
+                f'Error: Multiple FPR identification rules for tool output "{output}" found'
+            )
+            write_identification_event(file_uuid, command, success=False)
+            return ERROR
+        except FormatVersion.DoesNotExist:
+            job.print_error(f"Error: No FPR format record found for PUID {output}")
+            write_identification_event(file_uuid, command, success=False)
+            return ERROR
 
-    (ffv, created) = FileFormatVersion.objects.get_or_create(
-        file_uuid=file_, defaults={"format_version": format_version}
-    )
-    if not created:  # Update the version if it wasn't created new
-        ffv.format_version = format_version
-        ffv.save()
-    job.print_output(f"{file_path} identified as a {format_version.description}")
+        (ffv, created) = FileFormatVersion.objects.get_or_create(
+            file_uuid=file_, defaults={"format_version": format_version}
+        )
+        if not created:  # Update the version if it wasn't created new
+            ffv.format_version = format_version
+            ffv.save()
+        job.print_output(f"{file_path} identified as a {format_version.description}")
 
-    write_identification_event(file_uuid, command, format=format_version.pronom_id)
-    write_file_id(file_uuid=file_uuid, format=format_version, output=output)
+        write_identification_event(file_uuid, command, format=format_version.pronom_id)
+        write_file_id(file_uuid=file_uuid, format=format_version, output=output)
 
     return SUCCESS
 
@@ -258,16 +264,15 @@ def parse_args(parser: argparse.ArgumentParser, job: Job) -> IdentifyFileFormatA
 def call(jobs: list[Job]) -> None:
     parser = get_parser()
 
-    with transactions.atomic():
-        for job in jobs:
-            with job.JobContext():
-                args = parse_args(parser, job)
-                job.set_status(
-                    main(
-                        job,
-                        args.idcommand,
-                        args.file_path,
-                        args.file_uuid,
-                        args.disable_reidentify,
-                    )
+    for job in jobs:
+        with job.JobContext():
+            args = parse_args(parser, job)
+            job.set_status(
+                main(
+                    job,
+                    args.idcommand,
+                    args.file_path,
+                    args.file_uuid,
+                    args.disable_reidentify,
                 )
+            )

--- a/src/archivematica/MCPClient/clientScripts/identify_file_format.py
+++ b/src/archivematica/MCPClient/clientScripts/identify_file_format.py
@@ -10,7 +10,6 @@ import django
 
 django.setup()
 
-from django.db import transaction
 from django.utils import timezone
 
 from archivematica.archivematicaCommon.databaseFunctions import insertIntoEvents
@@ -22,6 +21,7 @@ from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import FileFormatVersion
 from archivematica.dashboard.main.models import FileID
 from archivematica.dashboard.main.models import UnitVariable
+from archivematica.MCPClient.client import transactions
 from archivematica.MCPClient.client.job import Job
 
 SUCCESS = 0
@@ -258,7 +258,7 @@ def parse_args(parser: argparse.ArgumentParser, job: Job) -> IdentifyFileFormatA
 def call(jobs: list[Job]) -> None:
     parser = get_parser()
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 args = parse_args(parser, job)

--- a/src/archivematica/MCPClient/clientScripts/load_dublin_core.py
+++ b/src/archivematica/MCPClient/clientScripts/load_dublin_core.py
@@ -6,9 +6,8 @@ import sys
 import django
 
 django.setup()
-from django.db import transaction
-
 from archivematica.dashboard.main import models
+from archivematica.MCPClient.client import transactions
 
 # This is the UUID of SIP from the `MetadataAppliesToTypes` table
 INGEST_METADATA_TYPE = "3e48343d-e2d2-4956-aaa3-b54d26eb9761"
@@ -47,7 +46,7 @@ def main(job, sip_uuid, dc_path):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 sip_uuid = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/load_labels_from_csv.py
+++ b/src/archivematica/MCPClient/clientScripts/load_labels_from_csv.py
@@ -21,13 +21,12 @@ import os
 import django
 
 django.setup()
-from django.db import transaction
-
 from archivematica.dashboard.main.models import File
+from archivematica.MCPClient.client import transactions
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 transferUUID = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/load_premis_events_from_xml.py
+++ b/src/archivematica/MCPClient/clientScripts/load_premis_events_from_xml.py
@@ -5,7 +5,6 @@ import sys
 import uuid
 
 import metsrw
-from django.db import transaction
 from django.utils import dateparse
 from django.utils import timezone
 from lxml import etree
@@ -13,6 +12,7 @@ from lxml import etree
 from archivematica.dashboard.main.models import Agent
 from archivematica.dashboard.main.models import Event
 from archivematica.dashboard.main.models import File
+from archivematica.MCPClient.client import transactions
 
 logger = logging.getLogger(__name__)
 FAILURE = 1
@@ -837,5 +837,5 @@ def main(job):
 def call(jobs):
     for job in jobs:
         with job.JobContext(logger=logger):
-            with transaction.atomic():
+            with transactions.atomic():
                 job.set_status(main(job))

--- a/src/archivematica/MCPClient/clientScripts/manual_normalization_create_metadata_and_restructure.py
+++ b/src/archivematica/MCPClient/clientScripts/manual_normalization_create_metadata_and_restructure.py
@@ -15,7 +15,8 @@ import os
 import uuid
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -193,7 +194,7 @@ def main(job):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 job.set_status(main(job))

--- a/src/archivematica/MCPClient/clientScripts/manual_normalization_identify_files_included.py
+++ b/src/archivematica/MCPClient/clientScripts/manual_normalization_identify_files_included.py
@@ -17,7 +17,8 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 # fileOperations requires Django to be set up
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -25,7 +26,7 @@ from archivematica.archivematicaCommon.fileOperations import updateFileGrpUse
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 fileUUID = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/manual_normalization_move_access_files_to_dip.py
+++ b/src/archivematica/MCPClient/clientScripts/manual_normalization_move_access_files_to_dip.py
@@ -19,7 +19,8 @@ import os
 from optparse import OptionParser
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -145,7 +146,7 @@ def main(job):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 try:

--- a/src/archivematica/MCPClient/clientScripts/manual_normalization_remove_mn_directories.py
+++ b/src/archivematica/MCPClient/clientScripts/manual_normalization_remove_mn_directories.py
@@ -22,10 +22,9 @@ import django
 
 django.setup()
 
-from django.db import transaction
-
 from archivematica.archivematicaCommon import databaseFunctions
 from archivematica.dashboard.main.models import File
+from archivematica.MCPClient.client import transactions
 
 
 def recursivelyRemoveEmptyDirectories(job, dir):
@@ -44,7 +43,7 @@ def recursivelyRemoveEmptyDirectories(job, dir):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 SIPDirectory = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/move_sip.py
+++ b/src/archivematica/MCPClient/clientScripts/move_sip.py
@@ -22,10 +22,9 @@ import sys
 import django
 
 django.setup()
-from django.db import transaction
-
 from archivematica.archivematicaCommon.fileOperations import rename
 from archivematica.dashboard.main.models import SIP
+from archivematica.MCPClient.client import transactions
 
 
 def updateDB(dst, sip_uuid):
@@ -54,7 +53,7 @@ def moveSIP(job, src, dst, sipUUID, sharedDirectoryPath):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 src = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/move_transfer.py
+++ b/src/archivematica/MCPClient/clientScripts/move_transfer.py
@@ -32,10 +32,9 @@ from collections.abc import Sequence
 import django
 
 django.setup()
-from django.db import transaction
-
 from archivematica.archivematicaCommon.fileOperations import rename
 from archivematica.dashboard.main.models import Transfer
+from archivematica.MCPClient.client import transactions
 from archivematica.MCPClient.client.job import Job
 
 
@@ -77,7 +76,7 @@ def moveSIP(
 
 def call(jobs: Sequence[Job]) -> None:
     """Run move tasks using arguments emitted by workflow links."""
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 src = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/normalize.py
+++ b/src/archivematica/MCPClient/clientScripts/normalize.py
@@ -19,7 +19,6 @@ from archivematica.MCPClient.clientScripts import transcoder
 django.setup()
 from django.conf import settings as mcpclient_settings
 from django.core.exceptions import ValidationError
-from django.db import transaction
 
 from archivematica.archivematicaCommon import databaseFunctions
 from archivematica.archivematicaCommon import fileOperations
@@ -29,6 +28,7 @@ from archivematica.dashboard.main.models import Derivation
 from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import FileFormatVersion
 from archivematica.dashboard.main.models import FileID
+from archivematica.MCPClient.client import transactions
 from archivematica.MCPClient.client.job import Job
 from archivematica.MCPClient.clientScripts.lib import setup_dicts
 
@@ -629,7 +629,7 @@ def parse_args(parser: argparse.ArgumentParser, job: Job) -> NormalizeArgs:
 def call(jobs: list[Job]) -> None:
     parser = get_parser()
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 opts = parse_args(parser, job)

--- a/src/archivematica/MCPClient/clientScripts/normalize_report.py
+++ b/src/archivematica/MCPClient/clientScripts/normalize_report.py
@@ -8,7 +8,6 @@ from django.conf import settings as mcpclient_settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
-from django.db import transaction
 from django.template import Context
 from django.template import Template
 
@@ -19,6 +18,7 @@ from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import Job
 from archivematica.dashboard.main.models import Report
 from archivematica.dashboard.main.models import Task
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -199,7 +199,7 @@ def call(jobs):
     parser.add_argument("--uuid", required=True)
     parser.add_argument("--debug", action="store_true", default=False)
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/parse_mets_to_db.py
+++ b/src/archivematica/MCPClient/clientScripts/parse_mets_to_db.py
@@ -5,8 +5,9 @@ import os
 import uuid
 
 import django
-from django.db import transaction
 from lxml import etree
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -559,7 +560,7 @@ def call(jobs):
     parser.add_argument("sip_uuid", help="%%SIPUUID%%")
     parser.add_argument("sip_path", help="%%SIPDirectory%%")
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 job.pyprint("METS Reader")

--- a/src/archivematica/MCPClient/clientScripts/policy_check.py
+++ b/src/archivematica/MCPClient/clientScripts/policy_check.py
@@ -25,7 +25,6 @@ django.setup()
 
 from django.conf import settings as mcpclient_settings
 from django.core.exceptions import ValidationError
-from django.db import transaction
 from django.db.models import QuerySet
 
 from archivematica.archivematicaCommon import databaseFunctions
@@ -37,6 +36,7 @@ from archivematica.dashboard.main.models import SIP
 from archivematica.dashboard.main.models import Derivation
 from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import Transfer
+from archivematica.MCPClient.client import transactions
 from archivematica.MCPClient.client.job import Job
 from archivematica.MCPClient.clientScripts.lib import setup_dicts
 
@@ -488,7 +488,7 @@ class PolicyChecker:
 
 
 def call(jobs: list[Job]) -> None:
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 file_path = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/post_store_aip_hook.py
+++ b/src/archivematica/MCPClient/clientScripts/post_store_aip_hook.py
@@ -10,7 +10,6 @@ import requests
 django.setup()
 from django.conf import settings as mcpclient_settings
 from django.core.exceptions import ValidationError
-from django.db import transaction
 from django.db.models import Q
 
 from archivematica.archivematicaCommon import storageService as storage_service
@@ -19,6 +18,7 @@ from archivematica.archivematicaCommon.archivematicaFunctions import (
 )
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 from archivematica.dashboard.main import models
+from archivematica.MCPClient.client import transactions
 
 logger = get_script_logger("archivematica.mcp.client.post_store_aip_hook")
 
@@ -206,7 +206,7 @@ def call(jobs):
     parser = argparse.ArgumentParser()
     parser.add_argument("sip_uuid", help="%%SIPUUID%%")
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/remove_unneeded_files.py
+++ b/src/archivematica/MCPClient/clientScripts/remove_unneeded_files.py
@@ -11,7 +11,8 @@ import os
 import shutil
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -36,7 +37,7 @@ def remove_file(job, target_file, file_uuid):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 target = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/restructure_for_compliance.py
+++ b/src/archivematica/MCPClient/clientScripts/restructure_for_compliance.py
@@ -23,7 +23,6 @@ import django
 
 django.setup()
 from django.core.exceptions import ValidationError
-from django.db import transaction
 
 from archivematica.archivematicaCommon import bag
 from archivematica.archivematicaCommon.archivematicaFunctions import OPTIONAL_FILES
@@ -39,6 +38,7 @@ from archivematica.archivematicaCommon.archivematicaFunctions import (
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 from archivematica.dashboard.main.models import SIP
 from archivematica.dashboard.main.models import Transfer
+from archivematica.MCPClient.client import transactions
 
 logger = get_script_logger("archivematica.mcp.client.restructureForCompliance")
 
@@ -139,7 +139,7 @@ def restructure_transfer_aip(job, unit_path):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 try:

--- a/src/archivematica/MCPClient/clientScripts/restructure_for_compliance_sip.py
+++ b/src/archivematica/MCPClient/clientScripts/restructure_for_compliance_sip.py
@@ -7,14 +7,13 @@ import django
 
 django.setup()
 
-from django.db import transaction
-
 from archivematica.archivematicaCommon import archivematicaFunctions
 from archivematica.archivematicaCommon import fileOperations
 from archivematica.archivematicaCommon.archivematicaFunctions import OPTIONAL_FILES
 from archivematica.archivematicaCommon.archivematicaFunctions import (
     REQUIRED_DIRECTORIES,
 )
+from archivematica.MCPClient.client import transactions
 
 
 def restructureForComplianceFileUUIDsAssigned(
@@ -86,7 +85,7 @@ def call(jobs):
     parser.add_argument("target", help="%%SIPDirectory%%")
     parser.add_argument("sip_uuid", help="%%SIPUUID%%")
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/retry_normalize_remove_normalized.py
+++ b/src/archivematica/MCPClient/clientScripts/retry_normalize_remove_normalized.py
@@ -25,12 +25,12 @@ import django
 
 django.setup()
 
-from django.db import transaction
 from django.utils import timezone
 
 from archivematica.dashboard.main.models import Derivation
 from archivematica.dashboard.main.models import Event
 from archivematica.dashboard.main.models import File
+from archivematica.MCPClient.client import transactions
 
 
 def removeDIP(job, SIPDirectory, SIPUUID):
@@ -119,7 +119,7 @@ def call(jobs):
         "-a", "--access", action="store_true", dest="access", default=False
     )
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 (opts, args) = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/rights_from_csv.py
+++ b/src/archivematica/MCPClient/clientScripts/rights_from_csv.py
@@ -21,9 +21,8 @@ import os
 import django
 
 django.setup()
-from django.db import transaction
-
 from archivematica.dashboard.main import models
+from archivematica.MCPClient.client import transactions
 
 
 class RightsRowException(Exception):
@@ -413,7 +412,7 @@ class RightCsvReader:
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 transfer_uuid = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/save_dublin_core.py
+++ b/src/archivematica/MCPClient/clientScripts/save_dublin_core.py
@@ -5,9 +5,8 @@ import sys
 import django
 
 django.setup()
-from django.db import transaction
-
 from archivematica.dashboard.main import models
+from archivematica.MCPClient.client import transactions
 
 FIELDS = (
     "title",
@@ -52,7 +51,7 @@ def main(job, transfer_uuid, target_path):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 transfer_uuid = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/set_maildir_file_grp_use_and_file_ids.py
+++ b/src/archivematica/MCPClient/clientScripts/set_maildir_file_grp_use_and_file_ids.py
@@ -23,11 +23,11 @@ from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 
 django.setup()
 from django.db import connection
-from django.db import transaction
 
 from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import FileFormatVersion
 from archivematica.dashboard.main.models import FileID
+from archivematica.MCPClient.client import transactions
 
 logger = get_script_logger("archivematica.mcp.client.setMaildirFileGrpUseAndFileIDs")
 
@@ -96,7 +96,7 @@ def set_archivematica_maildir_files(sip_uuid, sip_path):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 sip_uuid = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/set_transfer_type.py
+++ b/src/archivematica/MCPClient/clientScripts/set_transfer_type.py
@@ -19,17 +19,16 @@ import django
 
 django.setup()
 
-from django.db import transaction
-
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 from archivematica.dashboard.main.models import Transfer
 from archivematica.MCPClient.client import metrics
+from archivematica.MCPClient.client import transactions
 
 logger = get_script_logger("archivematica.mcp.client.setTransferType")
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 transferUUID = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/store_aip.py
+++ b/src/archivematica/MCPClient/clientScripts/store_aip.py
@@ -24,7 +24,6 @@ import django
 
 django.setup()
 from django.core.exceptions import ValidationError
-from django.db import transaction
 from metsrw.plugins import premisrw
 
 from archivematica.archivematicaCommon import storageService as storage_service
@@ -35,6 +34,7 @@ from archivematica.dashboard.main.models import DublinCore
 from archivematica.dashboard.main.models import Event
 from archivematica.dashboard.main.models import UnitVariable
 from archivematica.MCPClient.client import metrics
+from archivematica.MCPClient.client import transactions
 
 logger = get_script_logger("archivematica.mcp.client.storeAIP")
 
@@ -310,7 +310,7 @@ def call(jobs):
     parser.add_argument("sip_name", type=str, help="%%SIPName%%")
     parser.add_argument("sip_type", type=str, help="%%SIPType%%")
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/store_aip.py
+++ b/src/archivematica/MCPClient/clientScripts/store_aip.py
@@ -15,6 +15,20 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+"""Store AIPs and DIPs while coordinating their package relationship.
+
+The AIP and DIP jobs can run in either order and in different MCPClient
+processes. If the AIP exists first, the DIP is stored with the AIP UUID as its
+related package. If the DIP arrives first, this module publishes its generated
+UUID in a ``relatedPackage`` UnitVariable for the later AIP job to consume.
+
+That UnitVariable is a cross-process publication point: once visible, an AIP
+worker assumes the DIP already exists in Storage Service. The DIP must therefore
+be stored before the marker is written. Storage Service requests can be slow or
+stall, so they must also remain outside database transactions; only the final
+marker write uses Django's autocommit transaction.
+"""
+
 import argparse
 import os
 from pprint import pformat
@@ -24,6 +38,7 @@ import django
 
 django.setup()
 from django.core.exceptions import ValidationError
+from django.db import close_old_connections
 from metsrw.plugins import premisrw
 
 from archivematica.archivematicaCommon import storageService as storage_service
@@ -34,7 +49,6 @@ from archivematica.dashboard.main.models import DublinCore
 from archivematica.dashboard.main.models import Event
 from archivematica.dashboard.main.models import UnitVariable
 from archivematica.MCPClient.client import metrics
-from archivematica.MCPClient.client import transactions
 
 logger = get_script_logger("archivematica.mcp.client.storeAIP")
 
@@ -133,6 +147,7 @@ def store_aip(job, aip_destination_uri, aip_path, sip_uuid, sip_name, sip_type):
     # having a unique UUID; assign a new one before uploading.
     # TODO allow mapping the AIP UUID to the DIP UUID for retrieval.
     related_package_uuid = None
+    publish_related_package = False
     if sip_type == "DIP":
         uuid = str(uuid4())
         job.pyprint(f"Checking if DIP {uuid} parent AIP has been created...")
@@ -146,15 +161,7 @@ def store_aip(job, aip_destination_uri, aip_path, sip_uuid, sip_name, sip_type):
             related_package_uuid = sip_uuid
             job.pyprint("Parent AIP exists so relationship can be created.")
         except IndexError:
-            UnitVariable.objects.create(
-                unittype="SIP",
-                unituuid=sip_uuid,
-                variable="relatedPackage",
-                variablevalue=uuid,
-            )
-            job.pyprint(
-                f"Noting DIP UUID {uuid} related to AIP so relationship can be created when AIP is stored."
-            )
+            publish_related_package = True
     else:
         uuid = sip_uuid
         try:
@@ -207,6 +214,23 @@ def store_aip(job, aip_destination_uri, aip_path, sip_uuid, sip_name, sip_type):
         errmsg = f"{sip_type} creation failed: {err}."
         logger.warning(errmsg)
         raise Exception(errmsg + " See logs for more details.")
+    finally:
+        close_old_connections()
+
+    # UnitVariable writes use autocommit. An AIP worker can therefore see this
+    # marker immediately and send the DIP UUID to Storage Service as an existing
+    # related package. Publish it only after Storage Service confirms that the
+    # DIP exists, while keeping the storage request outside a transaction.
+    if publish_related_package:
+        UnitVariable.objects.create(
+            unittype="SIP",
+            unituuid=sip_uuid,
+            variable="relatedPackage",
+            variablevalue=uuid,
+        )
+        job.pyprint(
+            f"Noting DIP UUID {uuid} related to AIP so relationship can be created when AIP is stored."
+        )
 
     message = f"Storage Service created {sip_type}:\n{pformat(new_file)}"
     logger.info(message)
@@ -310,17 +334,16 @@ def call(jobs):
     parser.add_argument("sip_name", type=str, help="%%SIPName%%")
     parser.add_argument("sip_type", type=str, help="%%SIPType%%")
 
-    with transactions.atomic():
-        for job in jobs:
-            with job.JobContext(logger=logger):
-                args = parser.parse_args(job.args[1:])
-                job.set_status(
-                    store_aip(
-                        job,
-                        args.aip_destination_uri,
-                        args.aip_filename,
-                        args.sip_uuid,
-                        args.sip_name,
-                        args.sip_type,
-                    )
+    for job in jobs:
+        with job.JobContext(logger=logger):
+            args = parser.parse_args(job.args[1:])
+            job.set_status(
+                store_aip(
+                    job,
+                    args.aip_destination_uri,
+                    args.aip_filename,
+                    args.sip_uuid,
+                    args.sip_name,
+                    args.sip_type,
                 )
+            )

--- a/src/archivematica/MCPClient/clientScripts/store_file_modification_dates.py
+++ b/src/archivematica/MCPClient/clientScripts/store_file_modification_dates.py
@@ -21,11 +21,11 @@ import os
 import django
 
 django.setup()
-from django.db import transaction
 from django.utils.timezone import get_current_timezone
 
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
 from archivematica.dashboard.main import models
+from archivematica.MCPClient.client import transactions
 
 logger = get_script_logger("archivematica.mcp.client.storeFileModificationDates")
 
@@ -65,7 +65,7 @@ def main(transfer_uuid, shared_directory_path, timezone):
 
 def call(jobs):
     timezone = get_current_timezone()
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 transfer_uuid = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/transcribe_file.py
+++ b/src/archivematica/MCPClient/clientScripts/transcribe_file.py
@@ -12,7 +12,6 @@ django.setup()
 
 from django.conf import settings as mcpclient_settings
 from django.core.exceptions import ValidationError
-from django.db import transaction
 from django.db.models import QuerySet
 from django.utils import timezone
 
@@ -24,6 +23,7 @@ from archivematica.dashboard.fpr.models import FPRule
 from archivematica.dashboard.main.models import Derivation
 from archivematica.dashboard.main.models import File
 from archivematica.dashboard.main.models import FileFormatVersion
+from archivematica.MCPClient.client import transactions
 from archivematica.MCPClient.client.job import Job
 from archivematica.MCPClient.clientScripts.lib import setup_dicts
 
@@ -210,7 +210,7 @@ def parse_args(parser: argparse.ArgumentParser, job: Job) -> TranscribeFileArgs:
 def call(jobs: list[Job]) -> None:
     parser = get_parser()
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 try:

--- a/src/archivematica/MCPClient/clientScripts/trim_create_rights_entries.py
+++ b/src/archivematica/MCPClient/clientScripts/trim_create_rights_entries.py
@@ -28,8 +28,6 @@ from dateutil.relativedelta import relativedelta
 from lxml import etree as etree
 
 django.setup()
-from django.db import transaction
-
 from archivematica.archivematicaCommon.fileOperations import getFileUUIDLike
 from archivematica.dashboard.main.models import RightsStatement
 from archivematica.dashboard.main.models import (
@@ -39,6 +37,7 @@ from archivematica.dashboard.main.models import RightsStatementOtherRightsInform
 from archivematica.dashboard.main.models import RightsStatementRightsGranted
 from archivematica.dashboard.main.models import RightsStatementRightsGrantedNote
 from archivematica.dashboard.main.models import RightsStatementRightsGrantedRestriction
+from archivematica.MCPClient.client import transactions
 
 
 def callWithException(exception):
@@ -83,7 +82,7 @@ def getDateTimeFromDateClosed(job, dateClosed):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 # job.args[2] (transferName) is unused.

--- a/src/archivematica/MCPClient/clientScripts/trim_restructure_for_compliance.py
+++ b/src/archivematica/MCPClient/clientScripts/trim_restructure_for_compliance.py
@@ -21,13 +21,12 @@ import django
 
 django.setup()
 
-from django.db import transaction
-
 from archivematica.archivematicaCommon import archivematicaFunctions
 from archivematica.archivematicaCommon import fileOperations
 from archivematica.archivematicaCommon.archivematicaFunctions import (
     REQUIRED_DIRECTORIES,
 )
+from archivematica.MCPClient.client import transactions
 
 
 def restructureTRIMForComplianceFileUUIDsAssigned(
@@ -113,7 +112,7 @@ def restructureTRIMForComplianceFileUUIDsAssigned(
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 transferUUID = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/trim_verify_checksums.py
+++ b/src/archivematica/MCPClient/clientScripts/trim_verify_checksums.py
@@ -23,15 +23,14 @@ import django
 from lxml import etree as etree
 
 django.setup()
-from django.db import transaction
-
 from archivematica.archivematicaCommon import databaseFunctions
 from archivematica.archivematicaCommon.archivematicaFunctions import get_file_checksum
 from archivematica.archivematicaCommon.fileOperations import getFileUUIDLike
+from archivematica.MCPClient.client import transactions
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 # job.args[2] (transferName) is unused.

--- a/src/archivematica/MCPClient/clientScripts/trim_verify_manifest.py
+++ b/src/archivematica/MCPClient/clientScripts/trim_verify_manifest.py
@@ -23,14 +23,13 @@ import uuid
 import django
 
 django.setup()
-from django.db import transaction
-
 from archivematica.archivematicaCommon import databaseFunctions
 from archivematica.archivematicaCommon.fileOperations import getFileUUIDLike
+from archivematica.MCPClient.client import transactions
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 transferUUID = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/update_size_and_checksum.py
+++ b/src/archivematica/MCPClient/clientScripts/update_size_and_checksum.py
@@ -20,7 +20,8 @@ import os
 import uuid
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -238,7 +239,7 @@ def call(jobs):
 
             job.set_status(0)
 
-    with transaction.atomic():
+    with transactions.atomic():
         for file_uuid, file_info, args in state:
             file_path = file_info.pop("filePath")
             derivation = file_info.pop("derivation", None)

--- a/src/archivematica/MCPClient/clientScripts/upload_archivesspace.py
+++ b/src/archivematica/MCPClient/clientScripts/upload_archivesspace.py
@@ -14,7 +14,8 @@ from archivematica.dashboard.main.models import File
 
 django.setup()
 from django.core.exceptions import ValidationError
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -296,7 +297,7 @@ def call(jobs):
 
     parser = get_parser(RESTRICTIONS_CHOICES, EAD_ACTUATE_CHOICES, EAD_SHOW_CHOICES)
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 args = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/upload_qubit.py
+++ b/src/archivematica/MCPClient/clientScripts/upload_qubit.py
@@ -33,9 +33,9 @@ django.setup()
 
 from django.conf import settings as mcpclient_settings
 from django.core.exceptions import ValidationError
-from django.db import transaction
 
 import archivematica.dashboard.main.models as models
+from archivematica.MCPClient.client import transactions
 
 logger = get_script_logger("archivematica.upload.qubit")
 
@@ -309,7 +309,7 @@ def call(jobs):
     )
     parser.add_option_group(options)
 
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 (opts, args) = parser.parse_args(job.args[1:])

--- a/src/archivematica/MCPClient/clientScripts/validate_file.py
+++ b/src/archivematica/MCPClient/clientScripts/validate_file.py
@@ -30,6 +30,7 @@ django.setup()
 
 from django.conf import settings as mcpclient_settings
 from django.core.exceptions import ValidationError
+from django.db import close_old_connections
 from django.db.models import QuerySet
 
 from archivematica.archivematicaCommon import databaseFunctions
@@ -199,12 +200,15 @@ class Validator:
             command_to_execute = rule.command.command
             args = [self.file_path]
         self.job.print_output("Running", rule.command.description)
-        exitstatus, stdout, stderr = executeOrRun(
-            type=rule.command.script_type,
-            text=command_to_execute,
-            printing=False,
-            arguments=args,
-        )
+        try:
+            exitstatus, stdout, stderr = executeOrRun(
+                type=rule.command.script_type,
+                text=command_to_execute,
+                printing=False,
+                arguments=args,
+            )
+        finally:
+            close_old_connections()
         if exitstatus != 0:
             self.job.print_error(
                 f"Command {rule.command.description} failed with exit status {exitstatus};"
@@ -243,13 +247,14 @@ class Validator:
         self.job.print_output(
             f"Creating {self.purpose} event for {self.file_path} ({self.file_uuid})"
         )
-        databaseFunctions.insertIntoEvents(
-            fileUUID=self.file_uuid,
-            eventType="validation",  # From PREMIS controlled vocab.
-            eventDetail=event_detail,
-            eventOutcome=validation_result.event_outcome_information,
-            eventOutcomeDetailNote=validation_result.event_outcome_detail_note,
-        )
+        with transactions.atomic():
+            databaseFunctions.insertIntoEvents(
+                fileUUID=self.file_uuid,
+                eventType="validation",  # From PREMIS controlled vocab.
+                eventDetail=event_detail,
+                eventOutcome=validation_result.event_outcome_information,
+                eventOutcomeDetailNote=validation_result.event_outcome_detail_note,
+            )
         return result
 
     def _save_stdout_to_logs_dir(self, stdout: Optional[str]) -> None:
@@ -383,14 +388,13 @@ def _get_file_type(argv: list[str]) -> str:
 
 
 def call(jobs: list[Job]) -> None:
-    with transactions.atomic():
-        for job in jobs:
-            with job.JobContext(logger=logger):
-                file_path = job.args[1]
-                file_uuid = job.args[2]
-                sip_uuid = job.args[3]
-                shared_path = _get_shared_path(job.args)
-                file_type = _get_file_type(job.args)
-                job.set_status(
-                    main(job, file_path, file_uuid, sip_uuid, shared_path, file_type)
-                )
+    for job in jobs:
+        with job.JobContext(logger=logger):
+            file_path = job.args[1]
+            file_uuid = job.args[2]
+            sip_uuid = job.args[3]
+            shared_path = _get_shared_path(job.args)
+            file_type = _get_file_type(job.args)
+            job.set_status(
+                main(job, file_path, file_uuid, sip_uuid, shared_path, file_type)
+            )

--- a/src/archivematica/MCPClient/clientScripts/validate_file.py
+++ b/src/archivematica/MCPClient/clientScripts/validate_file.py
@@ -30,7 +30,6 @@ django.setup()
 
 from django.conf import settings as mcpclient_settings
 from django.core.exceptions import ValidationError
-from django.db import transaction
 from django.db.models import QuerySet
 
 from archivematica.archivematicaCommon import databaseFunctions
@@ -42,6 +41,7 @@ from archivematica.dashboard.fpr.models import FPRule
 from archivematica.dashboard.main.models import SIP
 from archivematica.dashboard.main.models import Derivation
 from archivematica.dashboard.main.models import File
+from archivematica.MCPClient.client import transactions
 from archivematica.MCPClient.client.job import Job
 from archivematica.MCPClient.clientScripts.lib import setup_dicts
 
@@ -383,7 +383,7 @@ def _get_file_type(argv: list[str]) -> str:
 
 
 def call(jobs: list[Job]) -> None:
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext(logger=logger):
                 file_path = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/verify_aip.py
+++ b/src/archivematica/MCPClient/clientScripts/verify_aip.py
@@ -10,13 +10,13 @@ django.setup()
 from bagit import Bag
 from bagit import BagError
 from django.conf import settings as mcpclient_settings
-from django.db import transaction
 
 from archivematica.archivematicaCommon import databaseFunctions
 from archivematica.archivematicaCommon.archivematicaFunctions import get_setting
 from archivematica.archivematicaCommon.executeOrRunSubProcess import executeOrRun
 from archivematica.dashboard.main.models import SIP
 from archivematica.dashboard.main.models import File
+from archivematica.MCPClient.client import transactions
 
 
 class VerifyChecksumsError(Exception):
@@ -234,7 +234,7 @@ def verify_aip(job):
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 job.set_status(verify_aip(job))

--- a/src/archivematica/MCPClient/clientScripts/verify_aip.py
+++ b/src/archivematica/MCPClient/clientScripts/verify_aip.py
@@ -10,6 +10,7 @@ django.setup()
 from bagit import Bag
 from bagit import BagError
 from django.conf import settings as mcpclient_settings
+from django.db import close_old_connections
 
 from archivematica.archivematicaCommon import databaseFunctions
 from archivematica.archivematicaCommon.archivematicaFunctions import get_setting
@@ -46,13 +47,14 @@ def write_premis_event(
 ):
     """Write the AIP-level "fixity check" PREMIS event."""
     try:
-        databaseFunctions.insertIntoEvents(
-            fileUUID=sip_uuid,
-            eventType="fixity check",
-            eventDetail=f'program="python, bag"; module="hashlib.{checksum_type}()"',
-            eventOutcome=event_outcome,
-            eventOutcomeDetailNote=event_outcome_detail_note,
-        )
+        with transactions.atomic():
+            databaseFunctions.insertIntoEvents(
+                fileUUID=sip_uuid,
+                eventType="fixity check",
+                eventDetail=f'program="python, bag"; module="hashlib.{checksum_type}()"',
+                eventOutcome=event_outcome,
+                eventOutcomeDetailNote=event_outcome_detail_note,
+            )
     except Exception as err:
         job.pyprint(f"Failed to write PREMIS event to database. Error: {err}")
     else:
@@ -198,6 +200,7 @@ def verify_aip(job):
         except Exception as err:
             job.print_error(repr(err))
             job.pyprint(f'Error extracting AIP at "{aip_path}"', file=sys.stderr)
+            close_old_connections()
             return 1
 
     return_code = 0
@@ -209,6 +212,8 @@ def verify_aip(job):
     except BagError as err:
         job.print_error(f"Error validating BagIt package: {err}")
         return_code = 1
+    finally:
+        close_old_connections()
 
     if return_code == 0:
         try:
@@ -234,7 +239,6 @@ def verify_aip(job):
 
 
 def call(jobs):
-    with transactions.atomic():
-        for job in jobs:
-            with job.JobContext():
-                job.set_status(verify_aip(job))
+    for job in jobs:
+        with job.JobContext():
+            job.set_status(verify_aip(job))

--- a/src/archivematica/MCPClient/clientScripts/verify_and_restructure_transfer_bag.py
+++ b/src/archivematica/MCPClient/clientScripts/verify_and_restructure_transfer_bag.py
@@ -19,7 +19,8 @@ import os
 import sys
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 
@@ -144,7 +145,7 @@ def restructureBagForComplianceFileUUIDsAssigned(
 
 
 def call(jobs):
-    with transaction.atomic():
+    with transactions.atomic():
         for job in jobs:
             with job.JobContext():
                 target = job.args[1]

--- a/src/archivematica/MCPClient/clientScripts/verify_checksum.py
+++ b/src/archivematica/MCPClient/clientScripts/verify_checksum.py
@@ -34,7 +34,8 @@ import sys
 import uuid
 
 import django
-from django.db import transaction
+
+from archivematica.MCPClient.client import transactions
 
 django.setup()
 from archivematica.archivematicaCommon.custom_handlers import get_script_logger
@@ -219,7 +220,7 @@ def write_premis_event_per_file(file_uuids, transfer_uuid, event_detail):
     event_outcome = "pass"
     events = []
     agents = Transfer.objects.get(uuid=transfer_uuid).agents
-    with transaction.atomic():
+    with transactions.atomic():
         for file_obj in file_uuids:
             checksum_event = Event(
                 file_uuid=file_obj,

--- a/tests/MCPClient/test_antivirus.py
+++ b/tests/MCPClient/test_antivirus.py
@@ -254,6 +254,10 @@ def test_get_size_uses_filesystem_for_file_missing_from_batch(
     path_getsize.assert_called_once_with("/path")
 
 
+@mock.patch(
+    "archivematica.MCPClient.clientScripts.antivirus.transactions.atomic",
+    return_value=nullcontext(),
+)
 @mock.patch("archivematica.MCPClient.clientScripts.antivirus.insert_events")
 @mock.patch("archivematica.MCPClient.clientScripts.antivirus.load_file_data")
 @mock.patch("archivematica.MCPClient.clientScripts.antivirus.create_scanner")
@@ -261,6 +265,7 @@ def test_call_reuses_scanner_and_batch_data(
     create_scanner: mock.Mock,
     load_file_data: mock.Mock,
     insert_events: mock.Mock,
+    atomic: mock.Mock,
     settings: pytest_django.Settings,
 ) -> None:
     file_uuids = [str(uuid.uuid4()), str(uuid.uuid4())]
@@ -290,9 +295,35 @@ def test_call_reuses_scanner_and_batch_data(
     assert scanner.scan.mock_calls == [mock.call(path) for path in paths]
     for job in jobs:
         job.set_status.assert_called_once_with(0)
+    atomic.assert_called_once_with()
     (event_queue,) = insert_events.call_args.args
     assert len(event_queue) == 2
     assert [event.file_uuid for event in event_queue] == file_uuids
+
+
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.transactions.atomic")
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.insert_events")
+@mock.patch("archivematica.MCPClient.clientScripts.antivirus.load_file_data")
+def test_call_instruments_event_transaction(
+    load_file_data: mock.Mock,
+    insert_events: mock.Mock,
+    atomic: mock.Mock,
+) -> None:
+    load_file_data.return_value = AntivirusBatchData(
+        file_sizes={}, scanned_file_uuids=set()
+    )
+    calls = mock.Mock()
+    calls.attach_mock(atomic, "atomic")
+    calls.attach_mock(insert_events, "insert_events")
+
+    antivirus_call([])
+
+    assert calls.mock_calls == [
+        mock.call.atomic(),
+        mock.call.atomic().__enter__(),
+        mock.call.insert_events([]),
+        mock.call.atomic().__exit__(None, None, None),
+    ]
 
 
 @pytest.fixture

--- a/tests/MCPClient/test_characterize_file.py
+++ b/tests/MCPClient/test_characterize_file.py
@@ -1,11 +1,19 @@
 from unittest import mock
 
 import pytest
+from django.db import connection
 
 from archivematica.dashboard.fpr import models as fprmodels
 from archivematica.dashboard.main import models
 from archivematica.MCPClient.client.job import Job
 from archivematica.MCPClient.clientScripts import characterize_file
+
+
+@pytest.fixture(autouse=True)
+def mock_close_old_connections(monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
+    result = mock.Mock()
+    monkeypatch.setattr(characterize_file, "close_old_connections", result)
+    return result
 
 
 @pytest.fixture
@@ -37,6 +45,46 @@ def delete_characterization_rules() -> None:
     fprmodels.FPRule.objects.filter(
         purpose__in=["characterization", "default_characterization"]
     ).delete()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_characterization_does_not_wrap_commands_in_transactions(
+    sip_file: models.File,
+    sip: models.SIP,
+    rule_with_xml_output_format: fprmodels.FPRule,
+    sip_file_format_version: models.FileFormatVersion,
+    mock_close_old_connections: mock.Mock,
+) -> None:
+    del sip_file_format_version
+    stdout = "<mock>success</mock>"
+    job = mock.Mock(
+        args=["characterize_file", str(sip_file.uuid), str(sip.uuid)],
+        JobContext=mock.MagicMock(),
+        spec=Job,
+    )
+
+    def execute_rule(*args: object, **kwargs: object) -> tuple[int, str, str]:
+        assert connection.in_atomic_block is False
+        return 0, stdout, ""
+
+    def insert_output(*args: object, **kwargs: object) -> None:
+        assert connection.in_atomic_block is False
+
+    with (
+        mock.patch.object(characterize_file, "executeOrRun", side_effect=execute_rule),
+        mock.patch.object(
+            characterize_file,
+            "insertIntoFPCommandOutput",
+            side_effect=insert_output,
+        ) as insert_into_fp_command_output,
+    ):
+        characterize_file.call([job])
+
+    mock_close_old_connections.assert_called_once_with()
+    insert_into_fp_command_output.assert_called_once_with(
+        sip_file.uuid, stdout, rule_with_xml_output_format.uuid
+    )
+    job.set_status.assert_called_once_with(0)
 
 
 @pytest.mark.django_db

--- a/tests/MCPClient/test_identify_file_format.py
+++ b/tests/MCPClient/test_identify_file_format.py
@@ -2,11 +2,19 @@ import pathlib
 from unittest import mock
 
 import pytest
+from django.db import connection
 
 from archivematica.dashboard.fpr import models as fprmodels
 from archivematica.dashboard.main import models
 from archivematica.MCPClient.client.job import Job
 from archivematica.MCPClient.clientScripts import identify_file_format
+
+
+@pytest.fixture(autouse=True)
+def mock_close_old_connections(monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
+    result = mock.Mock()
+    monkeypatch.setattr(identify_file_format, "close_old_connections", result)
+    return result
 
 
 def _decode_binary_path(value: bytes | memoryview | None) -> str:
@@ -41,6 +49,46 @@ def job(sip_file: models.File, sip_file_path: pathlib.Path) -> mock.Mock:
         JobContext=mock.MagicMock(),
         spec=Job,
     )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_identification_limits_transaction_to_database_persistence(
+    job: mock.Mock,
+    format_version: fprmodels.FormatVersion,
+    idcommand: fprmodels.IDCommand,
+    mock_close_old_connections: mock.Mock,
+) -> None:
+    del idcommand
+    command_output = "fmt/111"
+    format_version.pronom_id = command_output
+    format_version.save()
+
+    def execute_rule(*args: object, **kwargs: object) -> tuple[int, str, str]:
+        assert connection.in_atomic_block is False
+        return 0, command_output, ""
+
+    def assert_in_transaction(*args: object, **kwargs: object) -> None:
+        assert connection.in_atomic_block is True
+
+    with (
+        mock.patch.object(
+            identify_file_format, "executeOrRun", side_effect=execute_rule
+        ),
+        mock.patch.object(
+            identify_file_format,
+            "write_identification_event",
+            side_effect=assert_in_transaction,
+        ),
+        mock.patch.object(
+            identify_file_format,
+            "write_file_id",
+            side_effect=assert_in_transaction,
+        ),
+    ):
+        identify_file_format.call([job])
+
+    mock_close_old_connections.assert_called_once_with()
+    job.set_status.assert_called_once_with(identify_file_format.SUCCESS)
 
 
 @pytest.mark.django_db

--- a/tests/MCPClient/test_metrics.py
+++ b/tests/MCPClient/test_metrics.py
@@ -53,6 +53,29 @@ def test_worker_metric_calls_are_queued(monkeypatch) -> None:
     ]
 
 
+def test_database_transaction_duration_is_queued_with_script_name(
+    monkeypatch,
+) -> None:
+    fake_queue = FakeQueue()
+    monkeypatch.setattr(metrics.settings, "PROMETHEUS_ENABLED", True)
+
+    metrics.configure_event_queue(fake_queue)
+    try:
+        with metrics.client_script_context("validatefile_v1.0"):
+            metrics.database_transaction_observed(1.5)
+    finally:
+        metrics.configure_event_queue(None)
+
+    assert fake_queue.items == [
+        metrics.MetricEvent(
+            "database_transaction_duration_histogram",
+            "observe",
+            (("script_name", "validatefile_v1.0"),),
+            1.5,
+        )
+    ]
+
+
 def test_worker_metric_queue_failures_are_logged_once(
     monkeypatch,
     caplog,
@@ -281,6 +304,7 @@ def test_registry_preserves_mcpclient_metric_contract(monkeypatch) -> None:
         "mcpclient_job_error_total": "counter",
         "mcpclient_job_error_timestamp": "gauge",
         "mcpclient_task_execution_time_seconds": "histogram",
+        "mcpclient_database_transaction_duration_seconds": "histogram",
         "mcpclient_transfer_started_total": "counter",
         "mcpclient_transfer_started_timestamp": "gauge",
         "mcpclient_transfer_completed_total": "counter",

--- a/tests/MCPClient/test_store_aip.py
+++ b/tests/MCPClient/test_store_aip.py
@@ -1,0 +1,112 @@
+from unittest import mock
+
+import pytest
+from django.db import connection
+
+from archivematica.dashboard.main.models import UnitVariable
+from archivematica.MCPClient.client.job import Job
+from archivematica.MCPClient.clientScripts import store_aip
+
+SIP_UUID = "1d98c9a0-4a7c-4c90-8c5d-3485e4bd6fd0"
+DIP_UUID = "b735fb7f-1387-45b5-949d-18a6a187a551"
+
+
+@pytest.fixture(autouse=True)
+def mock_close_old_connections(monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
+    result = mock.Mock()
+    monkeypatch.setattr(store_aip, "close_old_connections", result)
+    return result
+
+
+def store_dip(job: mock.Mock, create_file: object) -> int:
+    current_location = {
+        "path": "/var/archivematica/sharedDirectory/",
+        "resource_uri": "/api/v1/location/currently-processing/",
+    }
+    with (
+        mock.patch.object(
+            store_aip.storage_service,
+            "get_first_location",
+            return_value=current_location,
+        ),
+        mock.patch.object(
+            store_aip.storage_service, "get_file_info", side_effect=IndexError
+        ),
+        mock.patch.object(store_aip, "uuid4", return_value=DIP_UUID),
+        mock.patch.object(store_aip.os.path, "isdir", return_value=False),
+        mock.patch.object(store_aip.os.path, "getsize", return_value=123),
+        mock.patch.object(store_aip, "_create_file", side_effect=create_file),
+    ):
+        return store_aip.store_aip(
+            job,
+            "/api/v1/location/aip-store/",
+            "/var/archivematica/sharedDirectory/dip.7z",
+            SIP_UUID,
+            "test-dip",
+            "DIP",
+        )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_call_does_not_wrap_storage_service_request_in_transaction() -> None:
+    job = mock.Mock(
+        args=[
+            "storeAIP_v0.0",
+            "/api/v1/location/aip-store/",
+            "/path/to/aip.7z",
+            SIP_UUID,
+            "test-aip",
+            "SIP",
+        ],
+        JobContext=mock.MagicMock(),
+        spec=Job,
+    )
+
+    def assert_no_transaction(*args: object) -> int:
+        assert connection.in_atomic_block is False
+        return 0
+
+    with mock.patch.object(store_aip, "store_aip", side_effect=assert_no_transaction):
+        store_aip.call([job])
+
+    job.set_status.assert_called_once_with(0)
+
+
+@pytest.mark.django_db
+def test_related_package_is_published_after_dip_storage(
+    mock_close_old_connections: mock.Mock,
+) -> None:
+    job = mock.Mock(spec=Job)
+
+    def create_file(*args: object, **kwargs: object) -> dict[str, str]:
+        marker_exists = UnitVariable.objects.filter(
+            unituuid=SIP_UUID, variable="relatedPackage"
+        ).exists()
+        assert marker_exists is False
+        return {"status": "UPLOADED"}
+
+    assert store_dip(job, create_file) == 0
+
+    mock_close_old_connections.assert_called_once_with()
+    marker = UnitVariable.objects.get(unituuid=SIP_UUID, variable="relatedPackage")
+    assert marker.unittype == "SIP"
+    assert marker.variablevalue == DIP_UUID
+
+
+@pytest.mark.django_db
+def test_related_package_is_not_published_when_dip_storage_fails(
+    mock_close_old_connections: mock.Mock,
+) -> None:
+    job = mock.Mock(spec=Job)
+
+    def create_file(*args: object, **kwargs: object) -> None:
+        raise store_aip.StorageServiceCreateFileError("Storage is unavailable")
+
+    with pytest.raises(Exception, match="DIP creation failed"):
+        store_dip(job, create_file)
+
+    mock_close_old_connections.assert_called_once_with()
+    marker_exists = UnitVariable.objects.filter(
+        unituuid=SIP_UUID, variable="relatedPackage"
+    ).exists()
+    assert marker_exists is False

--- a/tests/MCPClient/test_transactions.py
+++ b/tests/MCPClient/test_transactions.py
@@ -1,0 +1,70 @@
+import ast
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from archivematica.MCPClient.client import transactions
+
+
+class FakeConnection:
+    in_atomic_block = False
+
+
+def test_client_scripts_do_not_import_django_transactions() -> None:
+    client_scripts = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "archivematica"
+        / "MCPClient"
+        / "clientScripts"
+    )
+    direct_imports = []
+
+    for path in client_scripts.glob("*.py"):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if node.module == "django.db" and any(
+                alias.name == "transaction" for alias in node.names
+            ):
+                direct_imports.append(path.name)
+            if node.module == "django.db.transaction" and any(
+                alias.name == "atomic" for alias in node.names
+            ):
+                direct_imports.append(path.name)
+
+    assert direct_imports == []
+
+
+def test_atomic_observes_only_outer_transaction(monkeypatch) -> None:
+    connection = FakeConnection()
+    observations = []
+    times = iter([10.0, 11.5])
+
+    @contextmanager
+    def fake_atomic(**kwargs: object):
+        del kwargs
+        was_in_atomic_block = connection.in_atomic_block
+        connection.in_atomic_block = True
+        try:
+            yield
+        finally:
+            connection.in_atomic_block = was_in_atomic_block
+
+    monkeypatch.setattr(
+        transactions.transaction, "get_connection", lambda using: connection
+    )
+    monkeypatch.setattr(transactions.transaction, "atomic", fake_atomic)
+    monkeypatch.setattr(transactions.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(
+        transactions.metrics,
+        "database_transaction_observed",
+        observations.append,
+    )
+
+    with transactions.atomic():
+        with transactions.atomic():
+            pass
+
+    assert observations == [pytest.approx(1.5)]

--- a/tests/MCPClient/test_validate_file.py
+++ b/tests/MCPClient/test_validate_file.py
@@ -6,11 +6,20 @@ from unittest import mock
 
 import pytest
 import pytest_django
+from django.db import connection
 
+from archivematica.archivematicaCommon import databaseFunctions
 from archivematica.dashboard.fpr import models as fprmodels
 from archivematica.dashboard.main import models
 from archivematica.MCPClient.client.job import Job
 from archivematica.MCPClient.clientScripts import validate_file
+
+
+@pytest.fixture(autouse=True)
+def mock_close_old_connections(monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
+    result = mock.Mock()
+    monkeypatch.setattr(validate_file, "close_old_connections", result)
+    return result
 
 
 def _decode_binary_path(value: bytes | memoryview | None) -> str:
@@ -63,6 +72,60 @@ def preservation_derivation(
             file_uuid=preservation_file, event_type="normalization"
         ),
     )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_validation_limits_transaction_to_event_write(
+    sip: models.SIP,
+    sip_file: models.File,
+    sip_file_format_version: models.FileFormatVersion,
+    fprule_validation: fprmodels.FPRule,
+    settings: pytest_django.Settings,
+    mock_close_old_connections: mock.Mock,
+) -> None:
+    del sip_file_format_version, fprule_validation
+    job = mock.Mock(
+        args=[
+            "archivematica.MCPClient.clientScripts.validate_file.py",
+            _decode_binary_path(sip_file.currentlocation),
+            str(sip_file.uuid),
+            str(sip.uuid),
+            str(settings.SHARED_DIRECTORY),
+            sip_file.filegrpuse,
+        ],
+        JobContext=mock.MagicMock(),
+        spec=Job,
+    )
+
+    def execute_rule(*args: object, **kwargs: object) -> tuple[int, str, str]:
+        assert connection.in_atomic_block is False
+        return (
+            0,
+            json.dumps(
+                {
+                    "eventOutcomeInformation": "pass",
+                    "eventOutcomeDetailNote": "a note",
+                }
+            ),
+            "",
+        )
+
+    def insert_event(*args: object, **kwargs: object) -> mock.Mock:
+        assert connection.in_atomic_block is True
+        return mock.Mock()
+
+    with (
+        mock.patch.object(validate_file, "executeOrRun", side_effect=execute_rule),
+        mock.patch.object(
+            databaseFunctions,
+            "insertIntoEvents",
+            side_effect=insert_event,
+        ),
+    ):
+        validate_file.call([job])
+
+    mock_close_old_connections.assert_called_once_with()
+    job.set_status.assert_called_once_with(validate_file.SUCCESS_CODE)
 
 
 @pytest.mark.django_db

--- a/tests/MCPClient/test_verify_aip.py
+++ b/tests/MCPClient/test_verify_aip.py
@@ -1,0 +1,131 @@
+import pathlib
+from unittest import mock
+
+import pytest
+from django.db import connection
+
+from archivematica.dashboard.main import models
+from archivematica.MCPClient.client.job import Job
+from archivematica.MCPClient.clientScripts import verify_aip
+
+
+@pytest.mark.django_db(transaction=True)
+def test_call_does_not_wrap_verification_in_transaction() -> None:
+    job = mock.Mock(JobContext=mock.MagicMock(), spec=Job)
+
+    def assert_no_transaction(job: Job) -> int:
+        assert connection.in_atomic_block is False
+        return 0
+
+    with mock.patch.object(verify_aip, "verify_aip", side_effect=assert_no_transaction):
+        verify_aip.call([job])
+
+    job.set_status.assert_called_once_with(0)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_write_premis_event_rolls_back_partial_writes(
+    sip_file: models.File,
+) -> None:
+    job = mock.Mock(spec=Job)
+
+    with mock.patch.object(
+        models.Event.agents.related_manager_cls,
+        "add",
+        side_effect=RuntimeError("agent relationship write failed"),
+    ):
+        result = verify_aip.write_premis_event(
+            job,
+            str(sip_file.uuid),
+            "sha256",
+            "Pass",
+            "Checksums match.",
+        )
+
+    assert result is None
+    assert not models.Event.objects.filter(
+        file_uuid=sip_file,
+        event_type="fixity check",
+    ).exists()
+    job.pyprint.assert_called_once_with(
+        "Failed to write PREMIS event to database. Error: "
+        "agent relationship write failed"
+    )
+
+
+def test_verify_aip_refreshes_connection_before_database_access(
+    tmp_path: pathlib.Path,
+) -> None:
+    sip_uuid = "5ea334b3-e44b-45f9-88e4-15b8e5619b81"
+    aip_path = tmp_path / "aip"
+    aip_path.mkdir()
+    job = mock.Mock(
+        args=["verifyAIP_v1.0", sip_uuid, str(aip_path)],
+        spec=Job,
+    )
+    bag = mock.Mock()
+    calls = []
+    bag.validate.side_effect = lambda **kwargs: calls.append("validate")
+
+    with (
+        mock.patch.object(verify_aip, "Bag", return_value=bag),
+        mock.patch.object(
+            verify_aip,
+            "close_old_connections",
+            side_effect=lambda: calls.append("close_old_connections"),
+        ),
+        mock.patch.object(
+            verify_aip,
+            "verify_checksums",
+            side_effect=lambda *args: calls.append("verify_checksums"),
+        ) as verify_checksums,
+    ):
+        assert verify_aip.verify_aip(job) == 0
+
+    assert calls == ["validate", "close_old_connections", "verify_checksums"]
+    bag.validate.assert_called_once_with(completeness_only=True)
+    verify_checksums.assert_called_once_with(job, bag, sip_uuid)
+
+
+def test_verify_aip_refreshes_connection_after_extraction_failure(
+    tmp_path: pathlib.Path,
+) -> None:
+    sip_uuid = "5ea334b3-e44b-45f9-88e4-15b8e5619b81"
+    aip_path = tmp_path / "aip.7z"
+    aip_path.touch()
+    job = mock.Mock(
+        args=["verifyAIP_v1.0", sip_uuid, str(aip_path)],
+        spec=Job,
+    )
+
+    with (
+        mock.patch.object(verify_aip, "extract_aip", side_effect=Exception),
+        mock.patch.object(verify_aip, "close_old_connections") as close_connections,
+    ):
+        assert verify_aip.verify_aip(job) == 1
+
+    close_connections.assert_called_once_with()
+
+
+def test_verify_aip_refreshes_connection_after_bag_failure(
+    tmp_path: pathlib.Path,
+) -> None:
+    sip_uuid = "5ea334b3-e44b-45f9-88e4-15b8e5619b81"
+    aip_path = tmp_path / "aip"
+    aip_path.mkdir()
+    job = mock.Mock(
+        args=["verifyAIP_v1.0", sip_uuid, str(aip_path)],
+        spec=Job,
+    )
+    bag = mock.Mock()
+    bag.validate.side_effect = verify_aip.BagError("Invalid bag")
+
+    with (
+        mock.patch.object(verify_aip, "Bag", return_value=bag),
+        mock.patch.object(verify_aip, "close_old_connections") as close_connections,
+        mock.patch.object(verify_aip, "verify_checksums") as verify_checksums,
+    ):
+        assert verify_aip.verify_aip(job) == 1
+
+    close_connections.assert_called_once_with()
+    verify_checksums.assert_not_called()


### PR DESCRIPTION
This pull request adds transaction-duration metrics labeled by client script and moves slow external commands, filesystem work, and Storage Service requests outside batch-wide transactions. Short atomic scopes remain where multi-write consistency is required, with stale connections refreshed after long-running operations.

I chose these client modules first because they can run for a long time while keeping a database transaction open. Most of that time is spent running external tools, working with files, or calling the Storage Service, which does not need an open transaction. Store AIP and Validation were the clearest problems, while Identification and Characterization were the next most important ones. Verify AIP was also an easy and safe improvement.

Related:
* https://github.com/archivematica/Issues/issues/313
* https://github.com/archivematica/Issues/issues/864

Prior work:
* https://github.com/archivematica/Issues/issues/1577
* https://github.com/archivematica/Issues/issues/1580
* https://github.com/archivematica/Issues/issues/52