### PR TITLE
Measure coverage across the whole archivematica package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,10 @@ DJANGO_SETTINGS_MODULE="settings.test"
 norecursedirs = ".svn _build tmp* node_modules bower_components share .tox .venv"
 
 [tool.coverage.run]
+# The source path is resolved against the current directory. tox runs pytest
+# from the tests directories, so it exports COVERAGE_SOURCE_DIR (see setenv
+# below); the default works when running pytest from the repository root.
+source = ["${COVERAGE_SOURCE_DIR-src/archivematica}"]
 omit = [
     "**/src/archivematica/archivematicaCommon/externals/*",
     "**/migrations/*",
@@ -105,13 +109,6 @@ omit = [
     "**/tests/*",
     "**/wsgi.py",
     "**/manage.py",
-]
-include = [
-    "**/src/archivematica/archivematicaCommon/*",
-    "**/src/archivematica/dashboard/*",
-    "**/src/archivematica/MCPClient/*",
-    "**/src/archivematica/MCPClient/clientScripts/*",
-    "**/src/archivematica/MCPServer/*",
 ]
 branch = true
 
@@ -236,6 +233,9 @@ legacy_tox_ini = """
         DJANGO_SETTINGS_MODULE = {env:DJANGO_SETTINGS_MODULE:settings.test}
         PYTEST_ADDOPTS = {env:PYTEST_ADDOPTS:}
         UV_CACHE_DIR = {temp_dir}/uv-cache
+        # Coverage: pytest runs from the tests directories (see changedir), so
+        # [tool.coverage.run] source needs an absolute path.
+        COVERAGE_SOURCE_DIR = {toxinidir}/src/archivematica
         # Storage Service
         STORAGE_SERVICE_ROOT = {toxinidir}/hack/submodules/archivematica-storage-service
         # TOXENV-specific


### PR DESCRIPTION
The coverage configuration listed the archivematicaCommon, dashboard, MCPClient and MCPServer packages in an include list, so any module added outside them was silently left out of the reports; the search package was never measured.

Replace the list with a source directory pointing at src/archivematica. Coverage now measures every package under the namespace and also reports modules the test suite never imports, which an include list cannot do. A package name would not work here: archivematica is a namespace package shared with the Storage Service, and coverage only walks packages that have an __init__.py for unexecuted files.

The path is resolved against the current directory and tox runs pytest from the tests directories, so the tox environments export COVERAGE_SOURCE_DIR with the absolute path; the default keeps pytest working from the repository root.

The XML report now lists filenames relative to the source directory instead of absolute paths, and the overall percentage drops because never-imported modules are counted.