### PR TITLE
Fix search document purge in purge_transient_processing_data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ ignore_errors = true
 module = [
     "archivematica.archivematicaCommon.transfer_source_retrieval",
     "archivematica.archivematicaCommon.executeOrRunSubProcess",
+    "archivematica.dashboard.main.management.commands.purge_transient_processing_data",
     "archivematica.MCPClient.client.*",
     "archivematica.MCPClient.clientScripts.characterize_file",
     "archivematica.MCPClient.clientScripts.has_packages",

--- a/src/archivematica/dashboard/main/management/commands/__init__.py
+++ b/src/archivematica/dashboard/main/management/commands/__init__.py
@@ -10,16 +10,16 @@ from archivematica.search.service import setup_search_service_from_conf
 
 
 class DashboardCommand(BaseCommand):
-    def success(self, message):
+    def success(self, message: str) -> None:
         self.stdout.write(self.style.SUCCESS(message))
 
-    def error(self, message):
+    def error(self, message: str) -> None:
         self.stdout.write(self.style.ERROR(message))
 
-    def warning(self, message):
+    def warning(self, message: str) -> None:
         self.stdout.write(self.style.WARNING(message))
 
-    def info(self, message):
+    def info(self, message: str) -> None:
         self.stdout.write(message)
 
 

--- a/src/archivematica/dashboard/main/management/commands/purge_transient_processing_data.py
+++ b/src/archivematica/dashboard/main/management/commands/purge_transient_processing_data.py
@@ -33,15 +33,21 @@ recently purged transfers.
 
 import logging
 import traceback
+from datetime import datetime
+from typing import Any
 
 from django.conf import settings as django_settings
 from django.core.management.base import CommandError
+from django.core.management.base import CommandParser
+from django.db.models import Model
+from django.db.models import QuerySet
 from django.utils import timezone
 from django.utils.dateparse import parse_duration
 
 import archivematica.search.constants
 from archivematica.dashboard.main import models
 from archivematica.dashboard.main.management.commands import DashboardCommand
+from archivematica.search.service import SearchService
 from archivematica.search.service import SearchServiceError
 from archivematica.search.service import setup_search_service_from_conf
 
@@ -49,7 +55,7 @@ from archivematica.search.service import setup_search_service_from_conf
 class Command(DashboardCommand):
     help = __doc__
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--dry-run",
             action="store_true",
@@ -88,8 +94,8 @@ class Command(DashboardCommand):
             ),
         )
 
-    def handle(self, *args, **options):
-        search_service = None
+    def handle(self, *args: Any, **options: Any) -> None:
+        search_service: SearchService | None = None
         if (
             not options["keep_searches"]
             and archivematica.search.constants.AIPS_INDEX
@@ -104,15 +110,14 @@ class Command(DashboardCommand):
                 raise CommandError(f"Unable to connect to the search service: {err}")
 
         # Build look-up options.
-        kwargs = {
-            "include_unknown": options["purge_unknown"],
-            "include_failed": not options["keep_failed"],
-        }
+        include_unknown: bool = options["purge_unknown"]
+        include_failed: bool = not options["keep_failed"]
+        completed_before: datetime | None = None
         if options["age"] != "0":
             duration = parse_duration(options["age"])
             if duration is None:
                 raise CommandError("Age could not be parsed.")
-            kwargs["completed_before"] = timezone.now() - duration
+            completed_before = timezone.now() - duration
 
         self.info("Purging expired idempotency records...")
         expired_idempotency_records = models.IdempotencyRecord.objects.filter(
@@ -122,9 +127,13 @@ class Command(DashboardCommand):
             self.delete_queryset(expired_idempotency_records, options["quiet"])
 
         self.info("Purging SIPs...")
-        sips = models.SIP.objects.done(**kwargs)
+        sips = models.SIP.objects.done(
+            completed_before=completed_before,
+            include_failed=include_failed,
+            include_unknown=include_unknown,
+        )
         for sip in sips:
-            package_id = sip.pk
+            package_id = sip.uuid
             if not options["quiet"]:
                 self.warning(f"» SIP {package_id} with status {sip.status_str}")
             if options["dry_run"]:
@@ -148,23 +157,23 @@ class Command(DashboardCommand):
                     models.SIP.objects.filter(pk=package_id),
                     options["quiet"],
                 )
-                if (
-                    not options["keep_searches"]
-                    and archivematica.search.constants.AIPS_INDEX
-                    in django_settings.SEARCH_ENABLED
-                ):
+                if search_service is not None:
                     if not options["quiet"]:
                         self.info("  Purging search documents...")
-                    search_service.delete_aip(package_id)
-                    search_service.delete_aip_files(package_id)
+                    search_service.delete_aip(str(package_id))
+                    search_service.delete_aip_files(str(package_id))
             except Exception as err:
                 self.error(f"  Error: {err}")
-                self.stdout.write(traceback.print_exc())
+                self.stdout.write(traceback.format_exc())
 
         self.info("Purging transfers...")
-        transfers = models.Transfer.objects.done(**kwargs)
+        transfers = models.Transfer.objects.done(
+            completed_before=completed_before,
+            include_failed=include_failed,
+            include_unknown=include_unknown,
+        )
         for transfer in transfers:
-            package_id = transfer.pk
+            package_id = transfer.uuid
             if not options["quiet"]:
                 self.warning(
                     f"» Transfer {package_id} with status {transfer.status_str}"
@@ -192,7 +201,7 @@ class Command(DashboardCommand):
                 self.error(f"  Error: {err}")
                 self.stdout.write(traceback.format_exc())
 
-    def delete_queryset(self, queryset, quiet):
+    def delete_queryset(self, queryset: QuerySet[Model], quiet: bool) -> None:
         result = queryset.delete()
         if not quiet and result and len(result) == 2:
             matches = result[1]

--- a/src/archivematica/dashboard/main/models.py
+++ b/src/archivematica/dashboard/main/models.py
@@ -25,6 +25,7 @@ import logging
 import os
 import re
 import uuid
+from datetime import datetime
 from typing import Any
 from typing import TypeVar
 
@@ -401,7 +402,12 @@ _PackageT = TypeVar("_PackageT", bound=models.Model)
 
 
 class PackageManager(models.Manager[_PackageT]):
-    def done(self, completed_before=None, include_failed=True, include_unknown=False):
+    def done(
+        self,
+        completed_before: datetime | None = None,
+        include_failed: bool = True,
+        include_unknown: bool = False,
+    ) -> models.QuerySet[_PackageT]:
         statuses = [PACKAGE_STATUS_DONE, PACKAGE_STATUS_COMPLETED_SUCCESSFULLY]
         if include_failed:
             statuses.append(PACKAGE_STATUS_FAILED)

--- a/tests/dashboard/main/test_command_purge_transient_processing_data.py
+++ b/tests/dashboard/main/test_command_purge_transient_processing_data.py
@@ -10,6 +10,7 @@ from django.utils.dateparse import parse_duration
 import archivematica.search.constants
 from archivematica.dashboard.main import models
 from archivematica.search.service import SearchService
+from archivematica.search.service import SearchServiceError
 
 
 @pytest.fixture
@@ -108,8 +109,22 @@ def test_purge_command_removes_search_documents(
 ):
     call_command("purge_transient_processing_data")
 
-    mock_search_service.delete_aip.assert_called_once_with(old_sip.pk)
-    mock_search_service.delete_aip_files.assert_called_once_with(old_sip.pk)
+    mock_search_service.delete_aip.assert_called_once_with(str(old_sip.uuid))
+    mock_search_service.delete_aip_files.assert_called_once_with(str(old_sip.uuid))
+
+
+@pytest.mark.django_db
+def test_purge_command_reports_search_errors_and_continues(
+    mock_search_service, search_enabled, old_sip, old_transfer, capsys
+):
+    mock_search_service.delete_aip.side_effect = SearchServiceError("boom")
+
+    call_command("purge_transient_processing_data")
+
+    captured = capsys.readouterr()
+    assert "Error: boom" in captured.out
+    assert "SearchServiceError: boom" in captured.out
+    assert models.Transfer.objects.filter(pk=old_transfer.pk).count() == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The command passed the package UUID object to SearchService.delete_aip and delete_aip_files, whose _delete_by_field treats any non-str value as a set of values to iterate, so purging search documents failed with "'UUID' object is not iterable". The error handler then crashed too, because it wrote the return value of traceback.print_exc(), which is None, to stdout. Pass the string form of the UUID, as every other caller does, and use traceback.format_exc() like the transfer loop.

The existing test did not catch this because it asserted the mocked service was called with the UUID object; it now expects the string. A new test makes the mocked service raise and checks that the error is reported and the remaining packages are still purged, since nothing exercised that handler before.

Add the command to the strict mypy list to prevent regressions. Supporting annotations and minor refactors let mypy check the affected code.

Connected to https://github.com/archivematica/Issues/issues/1814