### PR TITLE
Ignore deleted files when parsing METS during reingest

### DIFF
--- a/src/archivematica/MCPClient/clientScripts/parse_mets_to_db.py
+++ b/src/archivematica/MCPClient/clientScripts/parse_mets_to_db.py
@@ -53,6 +53,8 @@ def parse_files(job, root):
 
     for fe in filesec.findall(".//mets:file", namespaces=ns.NSMAP):
         filegrpuse = fe.getparent().get("USE")
+        if filegrpuse == "deleted":
+            continue
         job.pyprint("filegrpuse", filegrpuse)
 
         amdid = fe.get("ADMID")

--- a/tests/MCPClient/fixtures/mets_deleted_file_without_flocat.xml
+++ b/tests/MCPClient/fixtures/mets_deleted_file_without_flocat.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mets:mets
+  xmlns:mets="http://www.loc.gov/METS/"
+  xmlns:premis="http://www.loc.gov/premis/v3"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <mets:amdSec ID="amdSec_1">
+    <mets:techMD ID="techMD_1">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object>
+            <premis:objectIdentifier>
+              <premis:objectIdentifierValue>85aa559e-5a38-4be7-a814-708f738fd40c</premis:objectIdentifierValue>
+            </premis:objectIdentifier>
+            <premis:objectCharacteristics>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>11</premis:size>
+              <premis:format>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>%SIPDirectory%objects/preserved.txt</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="amdSec_2">
+    <mets:techMD ID="techMD_2">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object>
+            <premis:objectIdentifier>
+              <premis:objectIdentifierValue>534f0728-8b35-465c-b1c3-28d67653c349</premis:objectIdentifierValue>
+            </premis:objectIdentifier>
+            <premis:originalName>%SIPDirectory%objects/deleted.txt</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:fileSec>
+    <mets:fileGrp USE="preservation">
+      <mets:file ID="file-85aa559e-5a38-4be7-a814-708f738fd40c" ADMID="amdSec_1">
+        <mets:FLocat xlink:href="objects/preserved.txt"/>
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="deleted">
+      <mets:file ID="file-534f0728-8b35-465c-b1c3-28d67653c349" ADMID="amdSec_2"/>
+    </mets:fileGrp>
+  </mets:fileSec>
+</mets:mets>

--- a/tests/MCPClient/test_parse_mets_to_db.py
+++ b/tests/MCPClient/test_parse_mets_to_db.py
@@ -540,6 +540,36 @@ class TestParseFiles(TestCase):
         assert pres["derivation"] == self.PRES_INFO["derivation"]
         assert pres["derivation_event"] == self.PRES_INFO["derivation_event"]
 
+    def test_parse_file_info_ignores_deleted_files_without_flocat(self):
+        """It should ignore deleted file entries that have no physical location.
+
+        Reingest retains deleted entries in the METS as provenance tombstones after
+        their files have been removed from the AIP. They therefore have no FLocat
+        and should not be loaded into the database as files to process again.
+        """
+        root = etree.parse(
+            os.path.join(THIS_DIR, "fixtures", "mets_deleted_file_without_flocat.xml")
+        )
+
+        files = parse_mets_to_db.parse_files(mcp_job, root)
+
+        assert files == [
+            {
+                "uuid": "85aa559e-5a38-4be7-a814-708f738fd40c",
+                "original_path": "%SIPDirectory%objects/preserved.txt",
+                "current_path": "%SIPDirectory%objects/preserved.txt",
+                "use": "preservation",
+                "checksum": "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+                "checksumtype": "sha256",
+                "size": "11",
+                "format_version": fpr.models.FormatVersion.objects.get(
+                    uuid="61c8d737-e809-47a1-b89f-83c1239dae99"
+                ),
+                "derivation": None,
+                "derivation_event": None,
+            }
+        ]
+
     def test_parse_file_info_reingest(self):
         """
         It should parse the correct techMD in the amdSec.


### PR DESCRIPTION
Reingest retains deleted entries in the METS as provenance tombstones after their files have been removed from the AIP. They therefore have no FLocat and should not be loaded into the database as files to process again.

Connected to https://github.com/archivematica/Issues/issues/1044